### PR TITLE
Update import paths to use the new module name format

### DIFF
--- a/cpu/cpu_usage_collector.go
+++ b/cpu/cpu_usage_collector.go
@@ -11,7 +11,7 @@ import (
 	"github.com/HdrHistogram/hdrhistogram-go"
 	"github.com/cilium/ebpf/ringbuf"
 
-	"perf-agent/metrics"
+	"github.com/dpsoft/perf-agent/metrics"
 )
 
 type CPUUsageCollector struct {

--- a/cpu/pmu_monitor.go
+++ b/cpu/pmu_monitor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 
-	"perf-agent/metrics"
+	"github.com/dpsoft/perf-agent/metrics"
 )
 
 // PMUMonitor handles PMU hardware counter monitoring

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module perf-agent
+module github.com/dpsoft/perf-agent
 
 go 1.24.0
 

--- a/main.go
+++ b/main.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	"perf-agent/metrics"
-	"perf-agent/perfagent"
+	"github.com/dpsoft/perf-agent/metrics"
+	"github.com/dpsoft/perf-agent/perfagent"
 )
 
 var (

--- a/offcpu/profiler.go
+++ b/offcpu/profiler.go
@@ -11,8 +11,8 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 
-	"perf-agent/internal/blazesym"
-	"perf-agent/pprof"
+	"github.com/dpsoft/perf-agent/internal/blazesym"
+	"github.com/dpsoft/perf-agent/pprof"
 )
 
 // Profiler handles off-CPU profiling with stack traces

--- a/perfagent/agent.go
+++ b/perfagent/agent.go
@@ -11,10 +11,10 @@ import (
 	"github.com/iovisor/gobpf/pkg/cpuonline"
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 
-	"perf-agent/cpu"
-	"perf-agent/metrics"
-	"perf-agent/offcpu"
-	"perf-agent/profile"
+	"github.com/dpsoft/perf-agent/cpu"
+	"github.com/dpsoft/perf-agent/metrics"
+	"github.com/dpsoft/perf-agent/offcpu"
+	"github.com/dpsoft/perf-agent/profile"
 )
 
 // Agent is the main performance monitoring agent.

--- a/perfagent/integration_test.go
+++ b/perfagent/integration_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"perf-agent/perfagent"
+	"github.com/dpsoft/perf-agent/perfagent"
 
 	"github.com/google/pprof/profile"
 	"github.com/stretchr/testify/require"

--- a/perfagent/options.go
+++ b/perfagent/options.go
@@ -4,7 +4,7 @@ package perfagent
 import (
 	"io"
 
-	"perf-agent/metrics"
+	"github.com/dpsoft/perf-agent/metrics"
 )
 
 // Config holds the configuration for the performance agent.

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -13,9 +13,9 @@ import (
 	"github.com/cilium/ebpf/link"
 	"golang.org/x/sys/unix"
 
-	"perf-agent/internal/blazesym"
+	"github.com/dpsoft/perf-agent/internal/blazesym"
 
-	"perf-agent/pprof"
+	"github.com/dpsoft/perf-agent/pprof"
 )
 
 // Profiler handles CPU profiling with stack traces

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,11 +1,11 @@
-module perf-agent/test
+module github.com/dpsoft/perf-agent/test
 
 go 1.24.0
 
 require (
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad
 	github.com/stretchr/testify v1.11.1
-	perf-agent v0.0.0
+	github.com/dpsoft/perf-agent v0.0.0
 )
 
 require (
@@ -23,4 +23,4 @@ require (
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.73 // indirect
 )
 
-replace perf-agent => ../
+replace github.com/dpsoft/perf-agent => ../

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"perf-agent/perfagent"
+	"github.com/dpsoft/perf-agent/perfagent"
 
 	"github.com/google/pprof/profile"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
This pull request updates the Go module path for the project and all internal imports to use the canonical GitHub repository path (`github.com/dpsoft/perf-agent`). This ensures proper module resolution and compatibility with Go tooling. The changes also update the test module and its dependencies to match the new import path.

**Module path updates:**

* Changed the module path in `go.mod` and `test/go.mod` from `perf-agent` to `github.com/dpsoft/perf-agent`, and updated the test dependency and replace directive accordingly. (F2445edL1, [[1]](diffhunk://#diff-25e9c6800a800713f0b8f25b203c4f9186120896512a0f9f0dee725e372a5b17L1-R8) [[2]](diffhunk://#diff-25e9c6800a800713f0b8f25b203c4f9186120896512a0f9f0dee725e372a5b17L26-R26)

**Internal import path updates:**

* Updated all internal import statements throughout the codebase to use the new `github.com/dpsoft/perf-agent/...` path instead of the previous local `perf-agent/...` path in files such as `cpu_usage_collector.go`, `pmu_monitor.go`, `main.go`, `profiler.go`, `agent.go`, `integration_test.go`, `options.go`, and `profile/profiler.go`. [[1]](diffhunk://#diff-fca8f87e57787215ffe3954ec0274eee7b0915cb63ae41064978c28354383e17L14-R14) [[2]](diffhunk://#diff-9d12a7b7131ae0b078cdb163084aec28842185182849f57584fa807ec69426f9L12-R12) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L14-R15) [[4]](diffhunk://#diff-bcfd0655c22882d5333d8012d05f23f95a6d9e5d33668de7f9dd48ca68778456L14-R15) [[5]](diffhunk://#diff-de7db19e1c82222f14473c277c13eb43432ac69c57291a216bdf962c38233242L14-R17) [[6]](diffhunk://#diff-25369e6f7ea86d75acb62862ed078aea3b6291d114bf2ff1b19f890f637339feL12-R12) [[7]](diffhunk://#diff-cf6e77f276547e361bf0e318c442178a7b8d39bf79802a18117426eaa8f4654aL7-R7) [[8]](diffhunk://#diff-4b4f1afc069b2e65556c0bf763bfa267f2a129081164329934aa993fad8cb9fcL16-R18) [[9]](diffhunk://#diff-8118e44ac15fb5ab2e2ece2ab52fd23062a10b5cc9c55ee5b3620a1242cff27cL15-R15)

These changes are necessary for proper Go module usage and to allow external consumers to import the project using its canonical repository path.