### PR TITLE
Preserve file, line, module, and inline frames in pprof output

### DIFF
--- a/docs/dwarf-unwinding-design.md
+++ b/docs/dwarf-unwinding-design.md
@@ -1,0 +1,119 @@
+# DWARF-based stack unwinding — design spec
+
+**Status:** deferred / not scheduled
+**Author:** design context captured 2026-04-21
+**Related:** branch `feat/pprof-frame-refactor` (inline-frame expansion landed; this is the next step beyond that)
+
+## Problem
+
+perf-agent's eBPF collector uses frame-pointer (FP) walking via `bpf_get_stackid(ctx, &stackmap, BPF_F_USER_STACK)` in `bpf/perf.bpf.c` and `bpf/offcpu.bpf.c`. This walks the `rbp` chain: at each frame, `[rbp]` holds the caller's `rbp`, `[rbp+8]` holds the return address.
+
+The chain breaks whenever any function in the call path was compiled without a `push rbp; mov rbp, rsp` prologue. Everything deeper than the first FP-less frame is invisible.
+
+**Where this bites in practice:**
+
+- Pre-built Rust `libstd` / `liballoc` / `libcore` (shipped via rustup) has FPs elided. Any user code whose hot path sits beneath a libstd call is invisible.
+- Much of glibc (distro-dependent) is built without FPs.
+- C++ release builds almost always use `-fomit-frame-pointer`.
+- Workloads that call through any shared library the user didn't compile themselves.
+
+**What it looks like:** shallow stacks (1–5 frames) on deep call graphs, hot functions orphaned from thread entry points, narrow-tall flamegraphs.
+
+**What inline-frame expansion solves (and doesn't):**
+
+The branch `feat/pprof-frame-refactor` added inline-frame expansion via `blazesym.Sym.Inlined`. This recovers user code that was *inlined* into a visible frame (our Rust test case: `cpu_intensive_work` was inlined into `FnOnce::call_once{{vtable.shim}}`).
+
+It does **not** recover real, non-inlined frames hidden behind FP-less code. A Rust workload with `#[inline(never)] cpu_intensive_work` sitting below a libstd call would still be invisible.
+
+## Approach options
+
+### Option A: DWARF unwinding inside eBPF (parca-agent / pyroscope-ebpf model)
+
+- **Where:** userspace parses every loaded ELF's `.eh_frame` into compact lookup tables, ships those into BPF maps keyed by `(binary, PC range)`. The eBPF program does the unwinding at sample time using the maps.
+- **Scope:** large. `/proc/<pid>/maps` watcher, ELF `.eh_frame` parser, table compiler, BPF-side walker implementing a subset of DWARF CFI (PLT stubs, common cases; bail to raw-stack on exotic CFI expressions), map eviction on exec/mmap.
+- **Reference:** parca-agent has ~5k lines of Go + eBPF dedicated to this. Not a weekend project.
+- **Wins:** fast at sample time (no per-sample userspace cost), scales to system-wide mode at high sample rate.
+- **When to pick:** only if perf-agent becomes a product where high-volume always-on system-wide profiling matters.
+
+### Option B: raw stack capture + userspace unwinding (recommended next step)
+
+- **Where:** kernel copies the top-of-stack bytes + register set into a ring buffer per sample. Userspace does the DWARF unwinding using blazesym (which already implements it).
+- **How:** swap current `perf_event_open(PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CPU_CLOCK)` sampling for `perf_event_open` with `sample_type = PERF_SAMPLE_CALLCHAIN | PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER`. `sample_regs_user` = the x86_64 GPR mask blazesym needs. `sample_stack_user` = ~8KB. Read from perf ring buffer via `perf_event_open` mmap + `BPF_RINGBUF_OUTPUT` or userspace `perf_event` consumer.
+- **Scope:** medium. A week of focused work:
+  - New userspace perf-event reader (replace/augment the eBPF-only collector for CPU mode).
+  - Pass `(regs, stack_bytes)` to blazesym's unwinder API.
+  - Integrate results into the existing `Frame` pipeline.
+  - Off-CPU mode keeps `bpf_get_stackid` + inline expansion, since off-CPU samples from `sched_switch` don't have the same perf-event ergonomics.
+- **Wins:** correct stacks on everything blazesym can unwind (FP-less Rust, stripped C++, most of glibc). Bounded implementation. No kernel-side DWARF parsing.
+- **Costs:**
+  - ~8KB per sample through the ring buffer. At 99 Hz × N CPUs that's ~100–800 KB/s. Manageable.
+  - Userspace CPU spent unwinding competes with the workload. Measure against the existing FP path.
+  - Doesn't work in `BPF_F_USER_STACK` style for arbitrary eBPF hook points — only the perf-event sample path gets `PERF_SAMPLE_STACK_USER`. So this improves CPU profiling but not, say, off-CPU via `sched_switch` tracepoint (that path keeps FP walking).
+
+### Option C: `--call-graph dwarf` style with kernel help only
+
+Not really a separate option — the kernel doesn't do DWARF unwinding on its own. `perf record --call-graph dwarf` is actually Option B under the hood (kernel captures stack bytes, `perf report` unwinds them).
+
+## Recommendation
+
+**Option B.** Medium scope, uses infrastructure (blazesym) we already depend on, solves the concrete limitation for CPU profiling. If a future use case demands always-on system-wide at scale, Option A becomes worth revisiting.
+
+## Scope for Option B (when picked up)
+
+### Changes
+
+1. **New CPU sampling path** in `profile/`:
+   - Replace `newPerfEvent` (profile/profiler.go:249) with a `perf_event_open` that requests `PERF_SAMPLE_CALLCHAIN | PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER`.
+   - `sample_regs_user` mask: the x86_64 GPRs blazesym needs (RIP, RBP, RSP, plus general-purpose for register restoration during unwinding — check blazesym's expected format).
+   - `sample_stack_user` size: start with 8192. Make configurable.
+   - Consume perf ring buffer via mmap + `perf_event_poll`.
+
+2. **Userspace unwinder** in a new `unwind/` package:
+   - Accept `(pid, regs, stack_bytes)` per sample.
+   - Call blazesym's unwinding API. Check current blazesym Go binding — may need extension if raw-stack unwind isn't exposed yet (as of this writing the Go binding covers `SymbolizeProcessAbsAddrs` but has incomplete coverage of normalize/unwind APIs).
+   - Produce `[]uint64` instruction pointers, then feed into the existing `symbolize` path.
+
+3. **Keep the eBPF path** for off-CPU mode — `sched_switch` tracepoint samples don't have the perf-event stack-sample ergonomics. Off-CPU keeps FP walking + inline expansion.
+
+4. **Feature flag / fallback**:
+   - CLI option `--unwind {fp,dwarf}` defaulting to `fp` during rollout, then flipping after validation.
+   - If DWARF unwinder fails on a sample (exotic CFI, missing debug info), fall back to whatever the kernel's `PERF_SAMPLE_CALLCHAIN` produced for that sample.
+
+### Architecture diagram (text)
+
+```
+Before:
+  perf_event → eBPF (bpf_get_stackid, FP walk) → stackmap → userspace → blazesym → Frame
+
+After (Option B):
+  perf_event (SAMPLE_REGS_USER|SAMPLE_STACK_USER) → perf ring buffer
+      → userspace unwinder (regs, stack, blazesym DWARF) → []PC
+      → blazesym symbolize → Frame
+```
+
+## Success criteria
+
+1. **Rust workload with `#[inline(never)] cpu_intensive_work`**: `cpu_intensive_work` visible in the profile even when it sits below a libstd call.
+2. **C++ release build** (any reasonable sample, e.g. a `-O2 -fomit-frame-pointer` benchmark): user functions visible through at least one shared-library frame.
+3. **No regression** on Go, Python (PYTHONPERFSUPPORT), Node (--perf-basic-prof) — stacks remain at least as deep as the FP+inline path.
+4. **Overhead budget:** DWARF-unwind CPU profiler at 99 Hz, per-PID mode, adds ≤ 2× the CPU cost of the current FP path. Measure with a dedicated benchmark.
+
+## Out of scope
+
+- Kernel-side DWARF (Option A). Revisit only if sample-rate scaling becomes a product requirement.
+- Off-CPU DWARF unwinding. Off-CPU stays on FP + inline expansion.
+- PMU mode. Already doesn't use stacks.
+- Windows/macOS. Not relevant.
+
+## Open questions (decide when picked up)
+
+1. **blazesym binding coverage** — Does `github.com/libbpf/blazesym/go` expose a raw-stack unwind API today? If not, either extend the Go binding upstream or call the C API via CGO. Check `libblazesym_c.a` surface — `blaze_symbolizer_*` vs. the normalize/unwind entry points.
+2. **Kernel version floor** — `PERF_SAMPLE_STACK_USER` has been available since Linux 3.7, so no concern there. But confirm the `sample_regs_user` register encoding blazesym expects matches what the kernel supplies on the target arches (amd64 first, arm64 later).
+3. **Ring-buffer backpressure** — if userspace unwinding can't keep up, do we drop samples, queue them to disk, or reduce sample rate? Prototype under synthetic load and decide.
+4. **Integration with the `Frame` type** — inline expansion already handled by `blazeSymToFrames`. The unwinder returns `[]uint64` PCs; each PC goes through `SymbolizeProcessAbsAddrs` and then `blazeSymToFrames`. No change to `Frame` needed.
+
+## Pre-work before picking this up
+
+- Benchmark the current FP-only path: samples per second per CPU, ring-buffer bytes/sec.
+- Write a synthetic workload with deliberate FP-less frames (e.g. C library built with `-fomit-frame-pointer` wrapping user code) — this becomes the regression test.
+- Verify blazesym's raw-stack unwind API is mature enough, or file an upstream issue.

--- a/offcpu/profiler.go
+++ b/offcpu/profiler.go
@@ -25,11 +25,33 @@ type Profiler struct {
 
 // stackBuilder accumulates symbolized stack frames
 type stackBuilder struct {
-	stack []string
+	stack []pprof.Frame
 }
 
-func (s *stackBuilder) append(sym string) {
-	s.stack = append(s.stack, sym)
+func (s *stackBuilder) append(f pprof.Frame) {
+	s.stack = append(s.stack, f)
+}
+
+// blazeSymToFrames mirrors the converter in profile/profiler.go: expands
+// inlined call chains into separate leaf-first Frames.
+func blazeSymToFrames(s blazesym.Sym) []pprof.Frame {
+	out := make([]pprof.Frame, 0, 1+len(s.Inlined))
+	for i := len(s.Inlined) - 1; i >= 0; i-- {
+		in := s.Inlined[i]
+		f := pprof.Frame{Name: in.Name, Module: s.Module}
+		if in.CodeInfo != nil {
+			f.File = in.CodeInfo.File
+			f.Line = in.CodeInfo.Line
+		}
+		out = append(out, f)
+	}
+	outer := pprof.Frame{Name: s.Name, Module: s.Module}
+	if s.CodeInfo != nil {
+		outer.File = s.CodeInfo.File
+		outer.Line = s.CodeInfo.Line
+	}
+	out = append(out, outer)
+	return out
 }
 
 // NewProfiler creates a new off-CPU profiler
@@ -67,7 +89,10 @@ func NewProfiler(pid int, systemWide bool, tags []string) (*Profiler, error) {
 		return nil, fmt.Errorf("attach tp_btf sched_switch: %w", err)
 	}
 
-	symbolizer, err := blazesym.NewSymbolizer(blazesym.SymbolizerWithCodeInfo(true))
+	symbolizer, err := blazesym.NewSymbolizer(
+		blazesym.SymbolizerWithCodeInfo(true),
+		blazesym.SymbolizerWithInlinedFns(true),
+	)
 	if err != nil {
 		_ = tp.Close()
 		_ = objs.Close()
@@ -161,7 +186,9 @@ func (pr *Profiler) Collect(w io.Writer) error {
 				break
 			}
 
-			sb.append(symbol[0].Name)
+			for _, f := range blazeSymToFrames(symbol[0]) {
+				sb.append(f)
+			}
 		}
 
 		end := len(sb.stack)

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -175,18 +175,12 @@ type frameKey struct {
 	Line   uint32
 }
 
-// functionKey is the subset of frameKey that identifies a pprof Function
-// (Line is per-location, not per-function).
-type functionKey struct {
-	Name   string
-	File   string
-	Module string
-}
-
 func (f Frame) locationKey() frameKey {
 	return frameKey{Name: f.Name, File: f.File, Module: f.Module, Line: f.Line}
 }
 
+// functionKey returns the (Name, File, Module) subset of frameKey that
+// identifies a pprof Function — Line is per-location, not per-function.
 func (f Frame) functionKey() frameKey {
 	return frameKey{Name: f.Name, File: f.File, Module: f.Module}
 }

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -3,6 +3,8 @@ package pprof
 import (
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -44,11 +46,35 @@ type SamplesCollector interface {
 	CollectProfiles(callback CollectProfilesCallback) error
 }
 
+// Frame is a single symbolized stack frame. Only Name is required; the other
+// fields are populated when the symbolizer can provide them (DWARF for native
+// binaries, perf-map decoding for Python/Node runtimes).
+type Frame struct {
+	Name   string
+	File   string
+	Line   uint32
+	Module string
+}
+
+// FrameFromName is a convenience constructor for callers that only know the
+// function name (synthetic "[unknown]" frames, tests).
+func FrameFromName(name string) Frame { return Frame{Name: name} }
+
+// FramesFromNames converts a []string of symbol names into []Frame. Intended
+// for tests and for callers migrating incrementally.
+func FramesFromNames(names []string) []Frame {
+	out := make([]Frame, len(names))
+	for i, n := range names {
+		out[i] = Frame{Name: n}
+	}
+	return out
+}
+
 type ProfileSample struct {
 	Pid         uint32
 	SampleType  SampleType
 	Aggregation SampleAggregation
-	Stack       []string
+	Stack       []Frame
 	Value       uint64
 	Value2      uint64
 }
@@ -116,10 +142,9 @@ func (b *ProfileBuilders) BuilderForSample(sample *ProfileSample) *ProfileBuilde
 		period = 512 * 1024 // todo
 	}
 	builder := &ProfileBuilder{
-		locations:          make(map[string]*profile.Location),
-		functions:          make(map[string]*profile.Function),
+		locations:          make(map[frameKey]*profile.Location),
+		functions:          make(map[frameKey]*profile.Function),
 		sampleHashToSample: make(map[uint64]*profile.Sample),
-		//Labels:             labels
 		Profile: &profile.Profile{
 			Mapping: []*profile.Mapping{
 				{
@@ -140,9 +165,35 @@ func (b *ProfileBuilders) BuilderForSample(sample *ProfileSample) *ProfileBuilde
 	return res
 }
 
+// frameKey dedupes locations and functions. Line is included so two PCs at
+// different source lines within the same function produce distinct locations
+// (otherwise the first-seen line would silently win for all samples).
+type frameKey struct {
+	Name   string
+	File   string
+	Module string
+	Line   uint32
+}
+
+// functionKey is the subset of frameKey that identifies a pprof Function
+// (Line is per-location, not per-function).
+type functionKey struct {
+	Name   string
+	File   string
+	Module string
+}
+
+func (f Frame) locationKey() frameKey {
+	return frameKey{Name: f.Name, File: f.File, Module: f.Module, Line: f.Line}
+}
+
+func (f Frame) functionKey() frameKey {
+	return frameKey{Name: f.Name, File: f.File, Module: f.Module}
+}
+
 type ProfileBuilder struct {
-	locations          map[string]*profile.Location
-	functions          map[string]*profile.Function
+	locations          map[frameKey]*profile.Location
+	functions          map[frameKey]*profile.Function
 	sampleHashToSample map[uint64]*profile.Sample
 	Profile            *profile.Profile
 	tmpLocations       []*profile.Location
@@ -152,8 +203,8 @@ type ProfileBuilder struct {
 func (p *ProfileBuilder) CreateSample(inputSample *ProfileSample) {
 	sample := p.newSample(inputSample)
 	p.addValue(inputSample, sample)
-	for i, s := range inputSample.Stack {
-		sample.Location[i] = p.addLocation(s)
+	for i, f := range inputSample.Stack {
+		sample.Location[i] = p.addLocation(f)
 	}
 	p.Profile.Sample = append(p.Profile.Sample, sample)
 }
@@ -161,8 +212,8 @@ func (p *ProfileBuilder) CreateSample(inputSample *ProfileSample) {
 func (p *ProfileBuilder) CreateSampleOrAddValue(inputSample *ProfileSample) {
 	p.tmpLocations = p.tmpLocations[:0]
 	p.tmpLocationIDs = p.tmpLocationIDs[:0]
-	for _, s := range inputSample.Stack {
-		loc := p.addLocation(s)
+	for _, f := range inputSample.Stack {
+		loc := p.addLocation(f)
 		p.tmpLocations = append(p.tmpLocations, loc)
 		p.tmpLocationIDs = append(p.tmpLocationIDs, loc.ID)
 	}
@@ -179,40 +230,47 @@ func (p *ProfileBuilder) CreateSampleOrAddValue(inputSample *ProfileSample) {
 	p.Profile.Sample = append(p.Profile.Sample, sample)
 }
 
-func (p *ProfileBuilder) addLocation(function string) *profile.Location {
-	loc, ok := p.locations[function]
-	if ok {
+func (p *ProfileBuilder) addLocation(frame Frame) *profile.Location {
+	// Runtimes that symbolize via perf-maps pack name+file into a single
+	// string in Frame.Name. Decode here so pprof's Function.Filename and
+	// Line fields populate for any known runtime.
+	frame = decodePerfMapFrame(frame)
+
+	key := frame.locationKey()
+	if loc, ok := p.locations[key]; ok {
 		return loc
 	}
 
 	id := uint64(len(p.Profile.Location) + 1)
-	loc = &profile.Location{
+	loc := &profile.Location{
 		ID:      id,
 		Mapping: p.Profile.Mapping[0],
 		Line: []profile.Line{
 			{
-				Function: p.addFunction(function),
+				Function: p.addFunction(frame),
+				Line:     int64(frame.Line),
 			},
 		},
 	}
 	p.Profile.Location = append(p.Profile.Location, loc)
-	p.locations[function] = loc
+	p.locations[key] = loc
 	return loc
 }
 
-func (p *ProfileBuilder) addFunction(function string) *profile.Function {
-	f, ok := p.functions[function]
-	if ok {
+func (p *ProfileBuilder) addFunction(frame Frame) *profile.Function {
+	key := frame.functionKey()
+	if f, ok := p.functions[key]; ok {
 		return f
 	}
 
 	id := uint64(len(p.Profile.Function) + 1)
-	f = &profile.Function{
-		ID:   id,
-		Name: function,
+	f := &profile.Function{
+		ID:       id,
+		Name:     frame.Name,
+		Filename: frame.File,
 	}
 	p.Profile.Function = append(p.Profile.Function, f)
-	p.functions[function] = f
+	p.functions[key] = f
 	return f
 }
 
@@ -269,5 +327,133 @@ func (p *ProfileBuilder) addValue(inputSample *ProfileSample, sample *profile.Sa
 func Reverse[S ~[]E, E any](s S) {
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]
+	}
+}
+
+// decodePerfMapFrame expands a Frame whose Name was produced by a runtime
+// perf-map (where the symbolizer returns the raw map line as a single
+// string) into a richer Frame with File/Line populated.
+//
+// Applied only when File is still empty (DWARF-symbolized frames already
+// have File/Line set). Runtimes without a matching case fall through
+// unchanged — strictly more information than before, never less.
+//
+// TODO(blazesym): once the Go binding exposes structured perf-map symbol
+// info, remove this and pull fields directly from blazesym.
+//
+// Recognized formats:
+//
+//	Python 3.12+ (PYTHONPERFSUPPORT):
+//	    py::<qualname>:<absolute_file.py>
+//
+//	Node.js (--perf-basic-prof):
+//	    LazyCompile:~<name> <file.js>:<line>:<col>
+//	    Function:<name>     <file.js>:<line>:<col>
+//	    Builtin:<name>                (no file/line)
+func decodePerfMapFrame(f Frame) Frame {
+	if f.File != "" || f.Name == "" {
+		return f
+	}
+	if dec, ok := decodePython(f.Name); ok {
+		return mergeFrame(f, dec)
+	}
+	if dec, ok := decodeNode(f.Name); ok {
+		return mergeFrame(f, dec)
+	}
+	return f
+}
+
+func mergeFrame(base, dec Frame) Frame {
+	if dec.Name != "" {
+		base.Name = dec.Name
+	}
+	if dec.File != "" {
+		base.File = dec.File
+	}
+	if dec.Line != 0 {
+		base.Line = dec.Line
+	}
+	return base
+}
+
+// decodePython parses "py::<qual>:<file.py>" emitted by CPython's
+// PYTHONPERFSUPPORT. The qualname itself can contain "::" (e.g.
+// "py::Class.method"), so we anchor on ":/" — Linux absolute paths always
+// start with "/".
+func decodePython(raw string) (Frame, bool) {
+	if !strings.HasPrefix(raw, "py::") {
+		return Frame{}, false
+	}
+	if idx := strings.LastIndex(raw, ":/"); idx != -1 {
+		return Frame{Name: raw[:idx], File: raw[idx+1:]}, true
+	}
+	// Prefix matched but no path — keep name as-is.
+	return Frame{Name: raw}, true
+}
+
+// decodeNode parses Node.js --perf-basic-prof lines. Returns ok=true when the
+// shape is recognized, even if file/line are absent (Builtin:, Code:, Script:).
+//
+// Modern Node (v16+) emits "JS:<tier><name> <file>:<line>:<col>" where <tier>
+// is a single marker character (~ lazy, ^ sparkplug, + baseline/other,
+// * optimized). Older versions emit "LazyCompile:~<name>" or "Function:<name>".
+// Builtin:/Code:/Script: carry no file info.
+func decodeNode(raw string) (Frame, bool) {
+	var prefix string
+	switch {
+	case strings.HasPrefix(raw, "JS:"):
+		prefix = "JS:"
+	case strings.HasPrefix(raw, "LazyCompile:"):
+		prefix = "LazyCompile:"
+	case strings.HasPrefix(raw, "Function:"):
+		prefix = "Function:"
+	case strings.HasPrefix(raw, "Builtin:"), strings.HasPrefix(raw, "Code:"), strings.HasPrefix(raw, "Script:"):
+		return Frame{Name: raw}, true
+	default:
+		return Frame{}, false
+	}
+	tail := raw[len(prefix):]
+	// Format: "<name> <file>:<line>:<col>" or "<name> <file>:<line>".
+	sp := strings.IndexByte(tail, ' ')
+	if sp == -1 {
+		return Frame{Name: raw}, true
+	}
+	name := prefix + tail[:sp]
+	loc := tail[sp+1:]
+
+	// Rightmost ":<num>" is either line (no col) or col (with line preceding).
+	// Parse both numeric suffixes; the leftmost of the two is the line.
+	file, line := parseTrailingFileLine(loc)
+	return Frame{Name: name, File: file, Line: line}, true
+}
+
+// parseTrailingFileLine splits "<file>:<line>" or "<file>:<line>:<col>" into
+// file and line. Returns line=0 if no numeric suffix is found.
+func parseTrailingFileLine(s string) (file string, line uint32) {
+	file = s
+	var nums [2]uint32
+	var found int
+	for found < 2 {
+		colon := strings.LastIndexByte(file, ':')
+		if colon == -1 || colon == len(file)-1 {
+			break
+		}
+		n, err := strconv.ParseUint(file[colon+1:], 10, 32)
+		if err != nil {
+			break
+		}
+		nums[found] = uint32(n)
+		found++
+		file = file[:colon]
+	}
+	switch found {
+	case 0:
+		return s, 0
+	case 1:
+		// "<file>:<line>" — the single parsed number is the line.
+		return file, nums[0]
+	default:
+		// "<file>:<line>:<col>" — nums[1] was parsed second (leftmost), so it's the line.
+		return file, nums[1]
 	}
 }

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -38,7 +38,7 @@ func TestSampleTypes(t *testing.T) {
 			builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
 			builders.AddSample(&ProfileSample{
 				SampleType: tt.sampleType,
-				Stack:      []string{"main"},
+				Stack:      FramesFromNames([]string{"main"}),
 				Value:      100,
 			})
 
@@ -56,7 +56,7 @@ func TestAddSampleCreatesLocationsAndFunctions(t *testing.T) {
 	builders.AddSample(&ProfileSample{
 		SampleType:  SampleTypeCpu,
 		Aggregation: SampleAggregated,
-		Stack:       []string{"main", "foo", "bar"},
+		Stack:       FramesFromNames([]string{"main", "foo", "bar"}),
 		Value:       100,
 	})
 
@@ -65,7 +65,6 @@ func TestAddSampleCreatesLocationsAndFunctions(t *testing.T) {
 		assert.Len(t, b.Profile.Function, 3)
 		assert.Len(t, b.Profile.Sample, 1)
 
-		// Verify function names
 		funcNames := make([]string, len(b.Profile.Function))
 		for i, f := range b.Profile.Function {
 			funcNames[i] = f.Name
@@ -79,20 +78,17 @@ func TestAddSampleCreatesLocationsAndFunctions(t *testing.T) {
 func TestSampleAggregation(t *testing.T) {
 	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
 
-	// Add same stack twice with SampleAggregated=false (should dedup)
 	for i := 0; i < 3; i++ {
 		builders.AddSample(&ProfileSample{
 			SampleType:  SampleTypeCpu,
-			Aggregation: false, // Not aggregated - should merge
-			Stack:       []string{"main", "handler"},
+			Aggregation: false,
+			Stack:       FramesFromNames([]string{"main", "handler"}),
 			Value:       100,
 		})
 	}
 
 	for _, b := range builders.Builders {
-		// Should have only 1 sample (merged)
 		assert.Len(t, b.Profile.Sample, 1)
-		// Value should be accumulated
 		assert.Equal(t, int64(300*b.Profile.Period), b.Profile.Sample[0].Value[0])
 	}
 }
@@ -103,21 +99,19 @@ func TestPerPIDProfile(t *testing.T) {
 		PerPIDProfile: true,
 	})
 
-	// Add samples from different PIDs
 	builders.AddSample(&ProfileSample{
 		Pid:        1000,
 		SampleType: SampleTypeCpu,
-		Stack:      []string{"main"},
+		Stack:      FramesFromNames([]string{"main"}),
 		Value:      100,
 	})
 	builders.AddSample(&ProfileSample{
 		Pid:        2000,
 		SampleType: SampleTypeCpu,
-		Stack:      []string{"worker"},
+		Stack:      FramesFromNames([]string{"worker"}),
 		Value:      200,
 	})
 
-	// Should have 2 separate builders
 	assert.Len(t, builders.Builders, 2)
 }
 
@@ -127,7 +121,7 @@ func TestProfileWriteAndParse(t *testing.T) {
 	builders.AddSample(&ProfileSample{
 		SampleType:  SampleTypeCpu,
 		Aggregation: SampleAggregated,
-		Stack:       []string{"main", "processRequest", "doWork"},
+		Stack:       FramesFromNames([]string{"main", "processRequest", "doWork"}),
 		Value:       500,
 	})
 
@@ -137,7 +131,6 @@ func TestProfileWriteAndParse(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Parse the profile back
 	parsed, err := profile.Parse(&buf)
 	require.NoError(t, err)
 
@@ -150,21 +143,19 @@ func TestProfileWriteAndParse(t *testing.T) {
 func TestOffCpuValueNotScaled(t *testing.T) {
 	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
 
-	// Off-CPU values should NOT be multiplied by period
 	builders.AddSample(&ProfileSample{
 		SampleType:  SampleTypeOffCpu,
 		Aggregation: SampleAggregated,
-		Stack:       []string{"main"},
-		Value:       1000000, // 1ms in nanoseconds
+		Stack:       FramesFromNames([]string{"main"}),
+		Value:       1000000,
 	})
 
 	for _, b := range builders.Builders {
-		// Value should be exactly what we passed (not scaled)
 		assert.Equal(t, int64(1000000), b.Profile.Sample[0].Value[0])
 	}
 }
 
-// === NEW COMMENTS/TAGS TESTS ===
+// === COMMENTS/TAGS TESTS ===
 
 func TestProfileComments(t *testing.T) {
 	comments := []string{"env=prod", "version=1.2.3", "service=api"}
@@ -176,7 +167,7 @@ func TestProfileComments(t *testing.T) {
 
 	builders.AddSample(&ProfileSample{
 		SampleType: SampleTypeCpu,
-		Stack:      []string{"main"},
+		Stack:      FramesFromNames([]string{"main"}),
 		Value:      100,
 	})
 
@@ -193,7 +184,7 @@ func TestProfileCommentsEmpty(t *testing.T) {
 
 	builders.AddSample(&ProfileSample{
 		SampleType: SampleTypeCpu,
-		Stack:      []string{"main"},
+		Stack:      FramesFromNames([]string{"main"}),
 		Value:      100,
 	})
 
@@ -212,7 +203,7 @@ func TestProfileWriteWithComments(t *testing.T) {
 
 	builders.AddSample(&ProfileSample{
 		SampleType: SampleTypeCpu,
-		Stack:      []string{"main"},
+		Stack:      FramesFromNames([]string{"main"}),
 		Value:      100,
 	})
 
@@ -222,8 +213,226 @@ func TestProfileWriteWithComments(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Parse and verify comments survived round-trip
 	parsed, err := profile.Parse(&buf)
 	require.NoError(t, err)
 	assert.Equal(t, comments, parsed.Comments)
+}
+
+// === PERF-MAP FRAME DECODER TESTS ===
+
+func TestDecodePerfMapFrame_Python(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       Frame
+		wantName string
+		wantFile string
+	}{
+		{
+			name:     "stdlib function",
+			in:       Frame{Name: "py::Queue.put:/usr/lib/python3.12/queue.py"},
+			wantName: "py::Queue.put",
+			wantFile: "/usr/lib/python3.12/queue.py",
+		},
+		{
+			name:     "nested class method",
+			in:       Frame{Name: "py::Condition.__enter__:/usr/lib/python3.12/threading.py"},
+			wantName: "py::Condition.__enter__",
+			wantFile: "/usr/lib/python3.12/threading.py",
+		},
+		{
+			name:     "site-packages deep path",
+			in:       Frame{Name: "py::HttpClient.send_request:/app/python3.12/site-packages/newrelic/common/agent_http.py"},
+			wantName: "py::HttpClient.send_request",
+			wantFile: "/app/python3.12/site-packages/newrelic/common/agent_http.py",
+		},
+		{
+			name:     "locals qualifier",
+			in:       Frame{Name: "py::parse_url.<locals>.ensure_type:/app/python3.12/site-packages/newrelic/packages/urllib3/util/url.py"},
+			wantName: "py::parse_url.<locals>.ensure_type",
+			wantFile: "/app/python3.12/site-packages/newrelic/packages/urllib3/util/url.py",
+		},
+		{
+			name:     "prefix only, no path",
+			in:       Frame{Name: "py::something_without_path"},
+			wantName: "py::something_without_path",
+			wantFile: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodePerfMapFrame(tt.in)
+			assert.Equal(t, tt.wantName, got.Name)
+			assert.Equal(t, tt.wantFile, got.File)
+		})
+	}
+}
+
+func TestDecodePerfMapFrame_Node(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       Frame
+		wantName string
+		wantFile string
+		wantLine uint32
+	}{
+		{
+			name:     "LazyCompile with line and column",
+			in:       Frame{Name: "LazyCompile:~cpuWork /tmp/nodeapp.js:4:18"},
+			wantName: "LazyCompile:~cpuWork",
+			wantFile: "/tmp/nodeapp.js",
+			wantLine: 4,
+		},
+		{
+			name:     "JS optimized tier (modern Node v16+)",
+			in:       Frame{Name: "JS:*cpuWork /home/user/app.js:12:17"},
+			wantName: "JS:*cpuWork",
+			wantFile: "/home/user/app.js",
+			wantLine: 12,
+		},
+		{
+			name:     "JS lazy tier",
+			in:       Frame{Name: "JS:~handler /app/server.js:42:1"},
+			wantName: "JS:~handler",
+			wantFile: "/app/server.js",
+			wantLine: 42,
+		},
+		{
+			name:     "JS sparkplug tier",
+			in:       Frame{Name: "JS:^render /app/view.js:7"},
+			wantName: "JS:^render",
+			wantFile: "/app/view.js",
+			wantLine: 7,
+		},
+		{
+			name:     "Function with line only",
+			in:       Frame{Name: "Function:handler /app/server.js:42"},
+			wantName: "Function:handler",
+			wantFile: "/app/server.js",
+			wantLine: 42,
+		},
+		{
+			name:     "Builtin with no file info",
+			in:       Frame{Name: "Builtin:ArrayForEach"},
+			wantName: "Builtin:ArrayForEach",
+			wantFile: "",
+			wantLine: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodePerfMapFrame(tt.in)
+			assert.Equal(t, tt.wantName, got.Name)
+			assert.Equal(t, tt.wantFile, got.File)
+			assert.Equal(t, tt.wantLine, got.Line)
+		})
+	}
+}
+
+func TestDecodePerfMapFrame_PassThrough(t *testing.T) {
+	// Native frames (DWARF-resolved) already have File populated — the
+	// decoder must leave them untouched.
+	native := Frame{Name: "main.processRequest", File: "/app/main.go", Line: 42}
+	assert.Equal(t, native, decodePerfMapFrame(native))
+
+	// Unknown runtime (Java-style) returned as-is.
+	java := Frame{Name: "HashMap::get"}
+	assert.Equal(t, java, decodePerfMapFrame(java))
+
+	// Plain native symbol without file returns unchanged.
+	plain := Frame{Name: "memcpy"}
+	assert.Equal(t, plain, decodePerfMapFrame(plain))
+}
+
+func TestAddSamplePopulatesFilenameFromPythonPerfMap(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	builders.AddSample(&ProfileSample{
+		SampleType:  SampleTypeCpu,
+		Aggregation: SampleAggregated,
+		Stack: []Frame{
+			{Name: "py::Queue.put:/usr/lib/python3.12/queue.py"},
+			{Name: "main.handler", File: "/app/main.go", Line: 12},
+		},
+		Value: 100,
+	})
+	for _, b := range builders.Builders {
+		byName := make(map[string]*profile.Function, len(b.Profile.Function))
+		for _, f := range b.Profile.Function {
+			byName[f.Name] = f
+		}
+		pyFunc, ok := byName["py::Queue.put"]
+		require.True(t, ok, "python function should be indexed by decoded name")
+		assert.Equal(t, "/usr/lib/python3.12/queue.py", pyFunc.Filename)
+
+		goFunc, ok := byName["main.handler"]
+		require.True(t, ok)
+		assert.Equal(t, "/app/main.go", goFunc.Filename)
+	}
+}
+
+func TestAddSamplePreservesLineFromFrame(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	builders.AddSample(&ProfileSample{
+		SampleType:  SampleTypeCpu,
+		Aggregation: SampleAggregated,
+		Stack: []Frame{
+			{Name: "main.handler", File: "/app/main.go", Line: 42},
+		},
+		Value: 100,
+	})
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Location, 1)
+		loc := b.Profile.Location[0]
+		require.Len(t, loc.Line, 1)
+		assert.Equal(t, int64(42), loc.Line[0].Line)
+	}
+}
+
+// Regression test for the frameKey-excludes-Line bug: two samples in the
+// same function at different source lines must produce two distinct
+// Locations (but share a single Function).
+func TestAddSameFunctionDifferentLinesMakesDistinctLocations(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	builders.AddSample(&ProfileSample{
+		SampleType:  SampleTypeCpu,
+		Aggregation: SampleAggregated,
+		Stack:       []Frame{{Name: "main.handler", File: "/app/main.go", Line: 10}},
+		Value:       100,
+	})
+	builders.AddSample(&ProfileSample{
+		SampleType:  SampleTypeCpu,
+		Aggregation: SampleAggregated,
+		Stack:       []Frame{{Name: "main.handler", File: "/app/main.go", Line: 42}},
+		Value:       100,
+	})
+	for _, b := range builders.Builders {
+		assert.Len(t, b.Profile.Location, 2, "different lines should produce distinct locations")
+		assert.Len(t, b.Profile.Function, 1, "same function should dedupe")
+
+		var lines []int64
+		for _, loc := range b.Profile.Location {
+			require.Len(t, loc.Line, 1)
+			lines = append(lines, loc.Line[0].Line)
+		}
+		assert.ElementsMatch(t, []int64{10, 42}, lines)
+	}
+}
+
+// Same function name from different modules must not collapse.
+func TestAddSameNameDifferentModulesMakesDistinctFunctions(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	builders.AddSample(&ProfileSample{
+		SampleType:  SampleTypeCpu,
+		Aggregation: SampleAggregated,
+		Stack:       []Frame{{Name: "compress", Module: "/usr/lib/libz.so.1"}},
+		Value:       100,
+	})
+	builders.AddSample(&ProfileSample{
+		SampleType:  SampleTypeCpu,
+		Aggregation: SampleAggregated,
+		Stack:       []Frame{{Name: "compress", Module: "/opt/custom/libfoo.so"}},
+		Value:       100,
+	})
+	for _, b := range builders.Builders {
+		assert.Len(t, b.Profile.Function, 2, "same name in different modules must not collapse")
+	}
 }

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -35,11 +35,39 @@ type perfEvent struct {
 
 // stackBuilder accumulates symbolized stack frames
 type stackBuilder struct {
-	stack []string
+	stack []pprof.Frame
 }
 
-func (s *stackBuilder) append(sym string) {
-	s.stack = append(s.stack, sym)
+func (s *stackBuilder) append(f pprof.Frame) {
+	s.stack = append(s.stack, f)
+}
+
+// blazeSymToFrames converts a blazesym.Sym into one or more pprof.Frames.
+// When the PC is inside a chain of inlined function calls, the chain is
+// expanded into separate Frames in leaf-first order (innermost inline first,
+// outer real function last), matching the append order of a leaf-first stack.
+//
+// blazesym reports Inlined in outer→inner order (see
+// blazesym/src/symbolize/mod.rs:408), so we walk it in reverse to get
+// leaf-first output.
+func blazeSymToFrames(s blazesym.Sym) []pprof.Frame {
+	out := make([]pprof.Frame, 0, 1+len(s.Inlined))
+	for i := len(s.Inlined) - 1; i >= 0; i-- {
+		in := s.Inlined[i]
+		f := pprof.Frame{Name: in.Name, Module: s.Module}
+		if in.CodeInfo != nil {
+			f.File = in.CodeInfo.File
+			f.Line = in.CodeInfo.Line
+		}
+		out = append(out, f)
+	}
+	outer := pprof.Frame{Name: s.Name, Module: s.Module}
+	if s.CodeInfo != nil {
+		outer.File = s.CodeInfo.File
+		outer.Line = s.CodeInfo.Line
+	}
+	out = append(out, outer)
+	return out
 }
 
 // NewProfiler creates a new CPU profiler with the specified sample rate in Hz
@@ -96,7 +124,10 @@ func NewProfiler(pid int, systemWide bool, cpus []uint, tags []string, sampleRat
 		perfEvents = append(perfEvents, pe)
 	}
 
-	symbolizer, err := blazesym.NewSymbolizer(blazesym.SymbolizerWithCodeInfo(true))
+	symbolizer, err := blazesym.NewSymbolizer(
+		blazesym.SymbolizerWithCodeInfo(true),
+		blazesym.SymbolizerWithInlinedFns(true),
+	)
 	if err != nil {
 		for _, pe := range perfEvents {
 			_ = pe.Close()
@@ -195,7 +226,9 @@ func (pr *Profiler) Collect(w io.Writer) error {
 				break
 			}
 
-			sb.append(symbol[0].Name)
+			for _, f := range blazeSymToFrames(symbol[0]) {
+				sb.append(f)
+			}
 		}
 
 		end := len(sb.stack)


### PR DESCRIPTION
- pprof.ProfileSample.Stack becomes []Frame. Locations are keyed by (Name, File, Module, Line); functions by (Name, File, Module). Same function at different source lines now produces distinct locations instead of silently collapsing to the first-seen line.

- Add perf-map decoder for Python (py::name:/path.py) and Node (LazyCompile:/Function:/JS: prefixes, including modern Node v16+ JS:<tier><name> format). Populates Function.Filename from the perf-map path rather than leaving it packed into Name.

- Profile and offcpu collectors use SymbolizerWithInlinedFns(true) and expand blazesym.Sym.Inlined into leaf-first Frames via blazeSymToFrames. Recovers user code that LLVM inlined into a visible outer frame — verified on Rust release builds (cpu_intensive_work now appears).

- Add regression tests for line-dedup and module-dedup, and decoder tests for Python / Node perf-map formats.

- docs/dwarf-unwinding-design.md captures follow-up scope for the frame-pointer limitation that remains beyond this change.