### PR TITLE
feat(inject): Python perf-trampoline injector via ptrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,33 @@ The `procmap.Resolver` sits between the walkers and pprof. It lazily reads `/pro
 
 Either `--pid` or `-a/--all` is required. At least one of `--profile`, `--offcpu`, or `--pmu` must be specified.
 
+### Profiling running Python processes
+
+For Python 3.12+ processes, perf-agent can activate the perf trampoline at
+profile start without restarting the target — no need for `python -X perf`:
+
+```bash
+sudo perf-agent --profile --pid $(pgrep -f myapp.py) \
+                --duration 30s --inject-python
+```
+
+The trampoline emits Python qualnames to `/tmp/perf-<PID>.map`, which
+perf-agent reads via blazesym to attach human-readable names to JIT'd
+frames. perf-agent automatically deactivates the trampoline at end of
+profile, so the per-call overhead does not persist past the profiling
+window.
+
+For system-wide injection (`-a`), perf-agent activates every detected
+Python 3.12+ process and tolerates per-process failures (e.g., processes
+built without `--enable-perf-trampoline`):
+
+```bash
+sudo perf-agent --profile -a --duration 30s --inject-python
+```
+
+Requires `CAP_SYS_PTRACE` (already in the standard cap set).
+See [docs/python-profiling.md](docs/python-profiling.md) for details.
+
 ## Output
 
 ### Output File Naming

--- a/bench/cmd/scenario/main.go
+++ b/bench/cmd/scenario/main.go
@@ -37,14 +37,18 @@ func modeFromFlag(s string) dwarfagent.Mode {
 func main() {
 	var (
 		scenario     = flag.String("scenario", "", "pid-large | system-wide-mixed (required)")
-		processes    = flag.Int("processes", 30, "fleet size for system-wide-mixed")
-		runs         = flag.Int("runs", 5, "iterations per scenario")
-		dropCache    = flag.Bool("drop-cache", false, "drop page cache between runs (root-only)")
-		outPath      = flag.String("out", "", "output JSON path (default ./bench-{scenario}-{ts}.json)")
-		workloadDir  = flag.String("workloads-dir", "", "test/workloads dir (default auto-detect)")
-		unwind       = flag.String("unwind", "auto", "unwind mode passed to dwarfagent: auto (lazy) | dwarf (eager)")
-		injectPython = flag.Bool("inject-python", false, "Enable Python trampoline injection for the profiled fleet (requires CAP_SYS_PTRACE)")
+		processes   = flag.Int("processes", 30, "fleet size for system-wide-mixed")
+		runs        = flag.Int("runs", 5, "iterations per scenario")
+		dropCache   = flag.Bool("drop-cache", false, "drop page cache between runs (root-only)")
+		outPath     = flag.String("out", "", "output JSON path (default ./bench-{scenario}-{ts}.json)")
+		workloadDir = flag.String("workloads-dir", "", "test/workloads dir (default auto-detect)")
+		unwind      = flag.String("unwind", "auto", "unwind mode passed to dwarfagent: auto (lazy) | dwarf (eager)")
 	)
+	// NOTE: --inject-python was previously plumbed here, but the bench
+	// constructs dwarfagent.NewProfilerWithMode directly rather than going
+	// through perfagent.Agent, so the flag had no behavioural effect — it
+	// only landed in the JSON. Re-add when the bench is reworked around
+	// perfagent.Agent (which owns the python.Manager wiring).
 	flag.Parse()
 
 	if *scenario == "" {
@@ -68,9 +72,8 @@ func main() {
 	}
 
 	doc := &schema.Document{
-		Scenario:     *scenario,
-		StartedAt:    time.Now().UTC(),
-		InjectPython: *injectPython,
+		Scenario:  *scenario,
+		StartedAt: time.Now().UTC(),
 		Config: schema.Config{
 			Processes:  *processes,
 			Runs:       *runs,
@@ -82,9 +85,9 @@ func main() {
 
 	switch *scenario {
 	case "pid-large":
-		runPIDLarge(doc, dir, *runs, *dropCache, *unwind, *injectPython)
+		runPIDLarge(doc, dir, *runs, *dropCache, *unwind)
 	case "system-wide-mixed":
-		runSystemWideMixed(doc, dir, *processes, *runs, *dropCache, *unwind, *injectPython)
+		runSystemWideMixed(doc, dir, *processes, *runs, *dropCache, *unwind)
 	default:
 		_, _ = fmt.Fprintf(os.Stderr, "unknown scenario %q\n", *scenario)
 		os.Exit(2)
@@ -107,7 +110,7 @@ func main() {
 
 // runPIDLarge spawns one Rust workload, attaches dwarfagent --pid,
 // and records per-binary timings across N runs.
-func runPIDLarge(doc *schema.Document, workloadDir string, runs int, dropCache bool, unwind string, injectPython bool) {
+func runPIDLarge(doc *schema.Document, workloadDir string, runs int, dropCache bool, unwind string) {
 	doc.Config.WorkloadMix = map[string]int{"rust": 1}
 
 	flt, err := fleet.Spawn(fleet.Opts{
@@ -134,14 +137,14 @@ func runPIDLarge(doc *schema.Document, workloadDir string, runs int, dropCache b
 				log.Printf("drop_caches: %v (continuing — measurement is warm-cache for this run)", err)
 			}
 		}
-		run := measureOnePID(pid, i, unwind, injectPython)
+		run := measureOnePID(pid, i, unwind)
 		doc.Runs = append(doc.Runs, run)
 	}
 }
 
 // measureOnePID times one NewProfilerWithMode(pid=...) call and the
 // per-binary breakdown collected via OnCompile.
-func measureOnePID(pid, runN int, unwind string, injectPython bool) schema.Run {
+func measureOnePID(pid, runN int, unwind string) schema.Run {
 	var (
 		mu      sync.Mutex
 		entries []schema.Binary
@@ -181,7 +184,7 @@ func measureOnePID(pid, runN int, unwind string, injectPython bool) schema.Run {
 
 // runSystemWideMixed spawns a fleet matching the proportional mix and
 // times newSession in system-wide mode for each run.
-func runSystemWideMixed(doc *schema.Document, workloadDir string, processes, runs int, dropCache bool, unwind string, injectPython bool) {
+func runSystemWideMixed(doc *schema.Document, workloadDir string, processes, runs int, dropCache bool, unwind string) {
 	mix := computeMix(processes)
 	doc.Config.WorkloadMix = mix
 
@@ -201,7 +204,7 @@ func runSystemWideMixed(doc *schema.Document, workloadDir string, processes, run
 				log.Printf("drop_caches: %v", err)
 			}
 		}
-		run := measureSystemWide(i, unwind, injectPython)
+		run := measureSystemWide(i, unwind)
 		doc.Runs = append(doc.Runs, run)
 	}
 }
@@ -218,7 +221,7 @@ func computeMix(n int) map[string]int {
 }
 
 // measureSystemWide times one NewProfilerWithMode in systemWide=true mode.
-func measureSystemWide(runN int, unwind string, injectPython bool) schema.Run {
+func measureSystemWide(runN int, unwind string) schema.Run {
 	var (
 		mu      sync.Mutex
 		entries []schema.Binary

--- a/bench/cmd/scenario/main.go
+++ b/bench/cmd/scenario/main.go
@@ -36,13 +36,14 @@ func modeFromFlag(s string) dwarfagent.Mode {
 
 func main() {
 	var (
-		scenario    = flag.String("scenario", "", "pid-large | system-wide-mixed (required)")
-		processes   = flag.Int("processes", 30, "fleet size for system-wide-mixed")
-		runs        = flag.Int("runs", 5, "iterations per scenario")
-		dropCache   = flag.Bool("drop-cache", false, "drop page cache between runs (root-only)")
-		outPath     = flag.String("out", "", "output JSON path (default ./bench-{scenario}-{ts}.json)")
-		workloadDir = flag.String("workloads-dir", "", "test/workloads dir (default auto-detect)")
-		unwind      = flag.String("unwind", "auto", "unwind mode passed to dwarfagent: auto (lazy) | dwarf (eager)")
+		scenario     = flag.String("scenario", "", "pid-large | system-wide-mixed (required)")
+		processes    = flag.Int("processes", 30, "fleet size for system-wide-mixed")
+		runs         = flag.Int("runs", 5, "iterations per scenario")
+		dropCache    = flag.Bool("drop-cache", false, "drop page cache between runs (root-only)")
+		outPath      = flag.String("out", "", "output JSON path (default ./bench-{scenario}-{ts}.json)")
+		workloadDir  = flag.String("workloads-dir", "", "test/workloads dir (default auto-detect)")
+		unwind       = flag.String("unwind", "auto", "unwind mode passed to dwarfagent: auto (lazy) | dwarf (eager)")
+		injectPython = flag.Bool("inject-python", false, "Enable Python trampoline injection for the profiled fleet (requires CAP_SYS_PTRACE)")
 	)
 	flag.Parse()
 
@@ -67,8 +68,9 @@ func main() {
 	}
 
 	doc := &schema.Document{
-		Scenario:  *scenario,
-		StartedAt: time.Now().UTC(),
+		Scenario:     *scenario,
+		StartedAt:    time.Now().UTC(),
+		InjectPython: *injectPython,
 		Config: schema.Config{
 			Processes:  *processes,
 			Runs:       *runs,
@@ -80,9 +82,9 @@ func main() {
 
 	switch *scenario {
 	case "pid-large":
-		runPIDLarge(doc, dir, *runs, *dropCache, *unwind)
+		runPIDLarge(doc, dir, *runs, *dropCache, *unwind, *injectPython)
 	case "system-wide-mixed":
-		runSystemWideMixed(doc, dir, *processes, *runs, *dropCache, *unwind)
+		runSystemWideMixed(doc, dir, *processes, *runs, *dropCache, *unwind, *injectPython)
 	default:
 		_, _ = fmt.Fprintf(os.Stderr, "unknown scenario %q\n", *scenario)
 		os.Exit(2)
@@ -105,7 +107,7 @@ func main() {
 
 // runPIDLarge spawns one Rust workload, attaches dwarfagent --pid,
 // and records per-binary timings across N runs.
-func runPIDLarge(doc *schema.Document, workloadDir string, runs int, dropCache bool, unwind string) {
+func runPIDLarge(doc *schema.Document, workloadDir string, runs int, dropCache bool, unwind string, injectPython bool) {
 	doc.Config.WorkloadMix = map[string]int{"rust": 1}
 
 	flt, err := fleet.Spawn(fleet.Opts{
@@ -132,14 +134,14 @@ func runPIDLarge(doc *schema.Document, workloadDir string, runs int, dropCache b
 				log.Printf("drop_caches: %v (continuing — measurement is warm-cache for this run)", err)
 			}
 		}
-		run := measureOnePID(pid, i, unwind)
+		run := measureOnePID(pid, i, unwind, injectPython)
 		doc.Runs = append(doc.Runs, run)
 	}
 }
 
 // measureOnePID times one NewProfilerWithMode(pid=...) call and the
 // per-binary breakdown collected via OnCompile.
-func measureOnePID(pid, runN int, unwind string) schema.Run {
+func measureOnePID(pid, runN int, unwind string, injectPython bool) schema.Run {
 	var (
 		mu      sync.Mutex
 		entries []schema.Binary
@@ -179,7 +181,7 @@ func measureOnePID(pid, runN int, unwind string) schema.Run {
 
 // runSystemWideMixed spawns a fleet matching the proportional mix and
 // times newSession in system-wide mode for each run.
-func runSystemWideMixed(doc *schema.Document, workloadDir string, processes, runs int, dropCache bool, unwind string) {
+func runSystemWideMixed(doc *schema.Document, workloadDir string, processes, runs int, dropCache bool, unwind string, injectPython bool) {
 	mix := computeMix(processes)
 	doc.Config.WorkloadMix = mix
 
@@ -199,7 +201,7 @@ func runSystemWideMixed(doc *schema.Document, workloadDir string, processes, run
 				log.Printf("drop_caches: %v", err)
 			}
 		}
-		run := measureSystemWide(i, unwind)
+		run := measureSystemWide(i, unwind, injectPython)
 		doc.Runs = append(doc.Runs, run)
 	}
 }
@@ -216,7 +218,7 @@ func computeMix(n int) map[string]int {
 }
 
 // measureSystemWide times one NewProfilerWithMode in systemWide=true mode.
-func measureSystemWide(runN int, unwind string) schema.Run {
+func measureSystemWide(runN int, unwind string, injectPython bool) schema.Run {
 	var (
 		mu      sync.Mutex
 		entries []schema.Binary

--- a/bench/internal/schema/schema.go
+++ b/bench/internal/schema/schema.go
@@ -19,14 +19,15 @@ type Document struct {
 	Config        Config    `json:"config"`
 	System        System    `json:"system"`
 	StartedAt     time.Time `json:"started_at"`
+	InjectPython  bool      `json:"inject_python,omitempty"`
 	Runs          []Run     `json:"runs"`
 }
 
 type Config struct {
-	Processes  int            `json:"processes"`
-	Runs       int            `json:"runs"`
-	DropCache  bool           `json:"drop_cache"`
-	UnwindMode string         `json:"unwind_mode,omitzero"`
+	Processes   int            `json:"processes"`
+	Runs        int            `json:"runs"`
+	DropCache   bool           `json:"drop_cache"`
+	UnwindMode  string         `json:"unwind_mode,omitzero"`
 	WorkloadMix map[string]int `json:"workload_mix,omitempty"`
 }
 

--- a/bench/internal/schema/schema.go
+++ b/bench/internal/schema/schema.go
@@ -19,7 +19,6 @@ type Document struct {
 	Config        Config    `json:"config"`
 	System        System    `json:"system"`
 	StartedAt     time.Time `json:"started_at"`
-	InjectPython  bool      `json:"inject_python,omitempty"`
 	Runs          []Run     `json:"runs"`
 }
 

--- a/docs/python-profiling.md
+++ b/docs/python-profiling.md
@@ -1,0 +1,110 @@
+# Python profiling with perf-agent
+
+perf-agent supports two paths for Python frame symbolization:
+
+1. **DWARF unwinding through the interpreter** (default for any Python).
+   Profiles work; frames render with C-level names
+   (`_PyEval_EvalFrameDefault`, etc.) — no Python-level qualnames.
+
+2. **Perf trampoline** (`--inject-python`, Python 3.12+). Activates
+   CPython's built-in perf integration so perf-agent can resolve every
+   JIT'd Python function to its qualname.
+
+## Quickstart
+
+```bash
+# Profile a running Python web server for 30 seconds
+sudo perf-agent --profile --pid $(pgrep -f gunicorn) \
+                --duration 30s --inject-python \
+                --profile-output gunicorn.pb.gz
+
+# Visualize
+go tool pprof -http :8080 gunicorn.pb.gz
+```
+
+## How it works
+
+When `--inject-python` is set, perf-agent:
+
+1. Walks `/proc` (or just the target PID) and identifies CPython 3.12+
+   processes via libpython SONAME and ELF symbol presence.
+2. For each candidate, attaches via `ptrace`, calls
+   `PyGILState_Ensure` → `PyRun_SimpleString("import sys; sys.activate_stack_trampoline('perf')")` → `PyGILState_Release`,
+   and detaches.
+3. The trampoline emits perf-map entries to `/tmp/perf-<PID>.map`.
+4. perf-agent samples and reads the perf-map via blazesym to attach
+   Python names to frames.
+5. On profile end, the same ptrace dance runs
+   `sys.deactivate_stack_trampoline()` so the trampoline overhead does
+   not persist.
+
+## When injection is skipped
+
+| Reason | Cause |
+|---|---|
+| `not_python` | Target is not a CPython process (e.g., Go binary). |
+| `python_too_old` | libpython version < 3.12 (`activate_stack_trampoline` is 3.12+). |
+| `no_perf_trampoline` | CPython compiled without `--enable-perf-trampoline` (e.g., some Alpine builds). |
+| `no_libpython_symbols` | Statically-linked CPython without exported PyGILState/PyRun symbols. |
+
+In `--pid N` mode (strict), any of these failures aborts the run.
+In `-a` mode (lenient), failures are logged and the profile continues
+for all targets where injection succeeded.
+
+## Continuous profiling
+
+Activation is idempotent: each run activates → profiles → deactivates.
+The `/tmp/perf-<PID>.map` file persists between runs (we don't delete
+it), and the next activation appends new entries. This is the supported
+pattern for continuous profiling.
+
+If the target was launched with `python -X perf`, the deactivate-at-end
+will turn the trampoline off; users who want to keep `-X perf` always-on
+should not pass `--inject-python`.
+
+## Container and namespace caveats
+
+v1 uses host-side PIDs. If perf-agent runs outside a container and
+targets a Python process inside one:
+
+- The host PID works for ptrace and detection
+  (`/proc/<pid>/maps` + on-disk libpython path).
+- The perf-map file `/tmp/perf-<host_pid>.map` is created on the host —
+  the container itself does not see it. This matches `python -X perf`
+  behavior under host-mounted `/tmp`.
+- For exotic mount namespace setups, detection may fail with "library
+  not found on disk" — log + skip in lenient mode.
+
+A future PR can add namespace-aware path resolution; the seam is small
+(one function: "given pid, give me the on-disk libpython path"). File
+an issue if you hit this.
+
+## Performance impact
+
+The CPython 3.12 perf trampoline adds 1–5% per-call overhead on hot
+Python workloads, depending on call shape. For typical web servers and
+pipelines, overhead is in the noise. perf-agent's deactivation pass at
+end of profile removes this overhead immediately.
+
+## Disabling injection
+
+Don't pass `--inject-python`. Profiles still work — Python frames just
+render with C interpreter names instead of qualnames.
+
+## Troubleshooting
+
+**`ptrace_eperm` errors:** the target's
+`/proc/sys/kernel/yama/ptrace_scope` is restricting ptrace. Set `0`
+(or `1` for same-uid attach), or grant `CAP_SYS_PTRACE` to perf-agent
+(already in the standard cap set).
+
+**`ESRCH` during deactivate:** the target exited during the profile.
+Harmless; logged with `pid=N reason=process_gone`.
+
+**`/tmp/perf-PID.map` missing after activation:** the target may not
+have called any new Python code during the profile, so the trampoline
+had nothing to emit. Lengthen `--duration`.
+
+**Statically-linked Python skipped (`no_libpython_symbols`):** the
+binary's symbol table is stripped. Distributions that ship
+`python-build-standalone` sometimes do this. No workaround in v1.

--- a/docs/superpowers/plans/2026-04-28-python-perf-injector.md
+++ b/docs/superpowers/plans/2026-04-28-python-perf-injector.md
@@ -1,0 +1,2894 @@
+# Python perf-trampoline injector — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--inject-python` flag to `perf-agent --profile` that, via `ptrace`, calls `sys.activate_stack_trampoline("perf")` inside running CPython 3.12+ processes at startup and `sys.deactivate_stack_trampoline()` at shutdown — so users get Python JIT names in their profiles without restarting targets with `python -X perf`.
+
+**Architecture:** A new `inject/` package tree with three subpackages: `inject/elfsym/` (shared ELF symbol resolution — any compiled runtime), `inject/ptraceop/` (shared low-level ptrace primitives — any C-ABI runtime), and `inject/python/` (Python-specific detector + manager + payload). A `python.Manager` runs in `perfagent.Agent.Start()` to detect Python 3.12+ targets and call `ptraceop.Injector.RemoteActivate()`, which performs a three-call ptrace dance (`PyGILState_Ensure` → `PyRun_SimpleString` → `PyGILState_Release`) inside one ptrace session per target. The manager tracks activated PIDs in memory and runs a bounded 5-second deactivation pass on shutdown.
+
+**Tech Stack:** Go 1.25+, `golang.org/x/sys/unix` for ptrace and `process_vm_writev`, `debug/elf` stdlib for symbol resolution, `log/slog` for structured logging. No new C dependencies. Tests use `testing` stdlib + the synthetic `/proc` and ELF fixture patterns established in PR #11.
+
+**Worktree:** All work happens in `/home/diego/github/perf-agent/.worktrees/python-perf-injector` on branch `feat/python-perf-injector`. Each task starts with `cd /home/diego/github/perf-agent/.worktrees/python-perf-injector && git rev-parse --abbrev-ref HEAD` to verify the branch is `feat/python-perf-injector`.
+
+**Modern Go conventions:** Use `t.Context()` for tests that need a context, `wg.Go()` instead of `wg.Add(1) + go func()`, `errors.Is` for sentinel errors, `for range N` for count-based loops, `strings.SplitSeq` for one-shot splits.
+
+**CGO env (every test/build that touches blazesym):**
+```
+CGO_CFLAGS="-I /usr/include/bpf -I /usr/include/pcap -I /home/diego/github/blazesym/capi/include"
+CGO_LDFLAGS="-L /home/diego/github/blazesym/target/release -Wl,-Bstatic -lblazesym_c -Wl,-Bdynamic"
+```
+
+---
+
+## Task overview
+
+| # | Task | Files | Test type |
+|---|---|---|---|
+| 1 | Sentinel errors + payload encoding | `inject/python/{errors,payload}.go` + tests | unit |
+| 2 | SONAME parsing | `inject/elfsym/soname.go` + test | unit |
+| 3 | ELF symbol resolution | `inject/elfsym/elfsym.go` + test | unit |
+| 4 | Detection ladder | `inject/python/detector.go` + test | unit |
+| 5 | ptraceop arch-generic + amd64 | `inject/ptraceop/{ptraceop,regs_amd64}.go` + test | unit (frame setup) |
+| 6 | ptraceop arm64 | `inject/ptraceop/regs_arm64.go` + test | unit |
+| 7 | Manager: lifecycle, dedupe, stats | `inject/python/{python,manager}.go` + test | unit |
+| 8 | Wire into perfagent.Agent | `perfagent/agent.go`, `perfagent/options.go`, `main.go` | unit + manual |
+| 9 | Mmap-watcher new-exec hook | `unwind/ehmaps/tracker.go` + `perfagent/agent.go` | unit |
+| 10 | Bench harness flag | `bench/cmd/scenario/main.go`, `bench/internal/schema/schema.go` | unit |
+| 11 | Integration tests | `test/integration_inject_python_test.go` | caps-gated integration |
+| 12 | Documentation | `README.md`, `docs/python-profiling.md` | n/a |
+
+---
+
+## Task 1: Sentinel errors + payload encoding
+
+**Files:**
+- Create: `inject/python/errors.go`
+- Create: `inject/python/payload.go`
+- Test: `inject/python/payload_test.go`
+
+This task ships two small, self-contained files. Errors are referenced by all later tasks; payload encoding has no dependencies.
+
+- [ ] **Step 1: Verify worktree and branch**
+
+```bash
+cd /home/diego/github/perf-agent/.worktrees/python-perf-injector
+git rev-parse --abbrev-ref HEAD
+```
+Expected: `feat/python-perf-injector`
+
+- [ ] **Step 2: Create the errors file**
+
+Create `inject/python/errors.go`:
+
+```go
+// Package python implements injection of CPython 3.12+'s perf trampoline
+// (sys.activate_stack_trampoline) into running processes via ptrace, so that
+// perf-agent can resolve Python JIT frames to qualnames without requiring the
+// target to be launched with `python -X perf`.
+package python
+
+import "errors"
+
+// Detection-result sentinels. All are non-fatal: detection returns one of
+// these (wrapped) when a process should be skipped without aborting the run.
+var (
+	// ErrNotPython is returned when the target is not a CPython process.
+	// Examples: a Go binary, a non-Python executable, or a process whose
+	// libpython/exe lacks the interpreter symbols we need.
+	ErrNotPython = errors.New("not a python process")
+
+	// ErrPythonTooOld is returned when a Python process is detected but its
+	// libpython SONAME indicates a version older than 3.12. The
+	// sys.activate_stack_trampoline primitive does not exist on older versions.
+	ErrPythonTooOld = errors.New("python version too old (need 3.12+)")
+
+	// ErrNoPerfTrampoline is returned when libpython is 3.12+ but was compiled
+	// without --enable-perf-trampoline, detected by absence of the
+	// _PyPerf_Callbacks symbol in .dynsym/.symtab.
+	ErrNoPerfTrampoline = errors.New("python built without --enable-perf-trampoline")
+
+	// ErrStaticallyLinkedNoSymbols is returned when neither libpython nor
+	// /proc/<pid>/exe exposes the libpython internal symbols needed for
+	// remote calls (PyRun_SimpleString, PyGILState_Ensure, PyGILState_Release).
+	ErrStaticallyLinkedNoSymbols = errors.New("python interpreter symbols not resolvable")
+
+	// ErrPreexisting is recorded (not returned to callers) when /tmp/perf-<pid>.map
+	// already exists at activation time, indicating the trampoline was activated
+	// by a prior perf-agent run or by user code. We skip both activation and
+	// deactivation in this case to avoid stomping on prior state.
+	ErrPreexisting = errors.New("perf trampoline already active (preexisting marker)")
+)
+```
+
+- [ ] **Step 3: Create the payload file**
+
+Create `inject/python/payload.go`:
+
+```go
+package python
+
+// activatePayload is the C string written into the target process's address
+// space. PyRun_SimpleString reads it as a NUL-terminated cstring.
+//
+// We import sys explicitly each time rather than relying on it already being
+// imported, because PyRun_SimpleString runs in a fresh "main" namespace.
+var activatePayload = []byte("import sys; sys.activate_stack_trampoline('perf')\x00")
+
+var deactivatePayload = []byte("import sys; sys.deactivate_stack_trampoline()\x00")
+
+// ActivatePayload returns the byte slice (NUL-terminated) to write into the
+// target's address space before calling PyRun_SimpleString. Caller must NOT
+// mutate the returned slice.
+func ActivatePayload() []byte { return activatePayload }
+
+// DeactivatePayload returns the byte slice (NUL-terminated) for the
+// shutdown deactivation call. Caller must NOT mutate the returned slice.
+func DeactivatePayload() []byte { return deactivatePayload }
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `inject/python/payload_test.go`:
+
+```go
+package python
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncodeActivatePayload(t *testing.T) {
+	got := ActivatePayload()
+	want := []byte("import sys; sys.activate_stack_trampoline('perf')\x00")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("ActivatePayload mismatch:\n  got  %q\n  want %q", got, want)
+	}
+	if got[len(got)-1] != 0 {
+		t.Fatalf("ActivatePayload not NUL-terminated; last byte = 0x%x", got[len(got)-1])
+	}
+}
+
+func TestEncodeDeactivatePayload(t *testing.T) {
+	got := DeactivatePayload()
+	want := []byte("import sys; sys.deactivate_stack_trampoline()\x00")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("DeactivatePayload mismatch:\n  got  %q\n  want %q", got, want)
+	}
+	if got[len(got)-1] != 0 {
+		t.Fatalf("DeactivatePayload not NUL-terminated; last byte = 0x%x", got[len(got)-1])
+	}
+}
+
+func TestPayloadsAreImmutable(t *testing.T) {
+	// Sanity check: caller mutation must not corrupt the package state.
+	// We verify by reading the slice twice and checking equality after the first
+	// call; if a caller did mutate, the second call would return the mutated
+	// version. Slices are aliased to the package-level vars by design — the
+	// "must not mutate" contract is documented; this test just records it.
+	a := ActivatePayload()
+	b := ActivatePayload()
+	if !bytes.Equal(a, b) {
+		t.Fatalf("ActivatePayload returned different slices on consecutive calls")
+	}
+}
+```
+
+- [ ] **Step 5: Run the tests — expect failure (package doesn't exist yet to the test runner if we forgot something)**
+
+```bash
+go test ./inject/python/...
+```
+Expected: PASS (we wrote both source and tests; this verifies the package compiles and tests pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add inject/python/errors.go inject/python/payload.go inject/python/payload_test.go
+git commit -m "inject/python: sentinel errors and trampoline payload encoding"
+```
+
+---
+
+## Task 2: SONAME parsing for libpython
+
+**Files:**
+- Create: `inject/elfsym/soname.go`
+- Test: `inject/elfsym/soname_test.go`
+
+A small pure-function package: given a path-like string (`/usr/lib/x86_64-linux-gnu/libpython3.12.so.1.0`), return the major+minor Python version, or report "not a Python SONAME". The version filter (>= 3.12) lives here so the detector can short-circuit cleanly.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `inject/elfsym/soname_test.go`:
+
+```go
+package elfsym
+
+import "testing"
+
+func TestParseLibpythonSONAME(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		wantMajor   int
+		wantMinor   int
+		wantIsPy    bool
+	}{
+		{"py312_typical", "/usr/lib/x86_64-linux-gnu/libpython3.12.so.1.0", 3, 12, true},
+		{"py312_no_minor_suffix", "/usr/lib/libpython3.12.so", 3, 12, true},
+		{"py313_future", "/usr/lib/libpython3.13.so.1.0", 3, 13, true},
+		{"py399_far_future", "/usr/lib/libpython3.99.so", 3, 99, true},
+		{"py311_too_old", "/usr/lib/libpython3.11.so.1.0", 3, 11, true},
+		{"py27_legacy", "/usr/lib/libpython2.7.so", 2, 7, true},
+		{"non_python_lib", "/usr/lib/libfoo.so.1", 0, 0, false},
+		{"non_python_lib_with_python_substr", "/opt/mypython-helper.so", 0, 0, false},
+		{"empty", "", 0, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			major, minor, ok := ParseLibpythonSONAME(tc.path)
+			if ok != tc.wantIsPy {
+				t.Fatalf("ParseLibpythonSONAME(%q): ok=%v, want %v", tc.path, ok, tc.wantIsPy)
+			}
+			if major != tc.wantMajor || minor != tc.wantMinor {
+				t.Fatalf("ParseLibpythonSONAME(%q): major=%d minor=%d, want %d %d",
+					tc.path, major, minor, tc.wantMajor, tc.wantMinor)
+			}
+		})
+	}
+}
+
+func TestIsPython312Plus(t *testing.T) {
+	tests := []struct {
+		major int
+		minor int
+		want  bool
+	}{
+		{3, 12, true},
+		{3, 13, true},
+		{3, 99, true},
+		{4, 0, true},
+		{3, 11, false},
+		{3, 10, false},
+		{2, 7, false},
+		{0, 0, false},
+	}
+	for _, tc := range tests {
+		got := IsPython312Plus(tc.major, tc.minor)
+		if got != tc.want {
+			t.Fatalf("IsPython312Plus(%d,%d) = %v, want %v",
+				tc.major, tc.minor, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure (package doesn't exist)**
+
+```bash
+go test ./inject/elfsym/...
+```
+Expected: FAIL with "no Go files" or "package not found".
+
+- [ ] **Step 3: Implement the parser**
+
+Create `inject/elfsym/soname.go`:
+
+```go
+// Package elfsym provides ELF symbol resolution and SONAME parsing primitives
+// shared across language-specific injectors (inject/python, future inject/nodejs,
+// etc.). Pure stdlib (debug/elf + regexp); no CGO, no external dependencies.
+package elfsym
+
+import (
+	"path/filepath"
+	"regexp"
+	"strconv"
+)
+
+// libpythonRE matches typical CPython library SONAMEs, e.g.:
+//   libpython3.12.so
+//   libpython3.12.so.1.0
+//   libpython2.7.so
+// It is deliberately liberal — caller decides whether the version is
+// acceptable via IsPython312Plus.
+var libpythonRE = regexp.MustCompile(`^libpython(\d+)\.(\d+)\.so(?:\..*)?$`)
+
+// ParseLibpythonSONAME extracts the major and minor version from a libpython
+// shared-library path. It accepts either a bare basename or a full path; only
+// the basename is matched against the libpython regex. Returns (major, minor,
+// true) on a successful match; (0, 0, false) otherwise.
+func ParseLibpythonSONAME(path string) (major, minor int, ok bool) {
+	if path == "" {
+		return 0, 0, false
+	}
+	base := filepath.Base(path)
+	m := libpythonRE.FindStringSubmatch(base)
+	if m == nil {
+		return 0, 0, false
+	}
+	maj, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	min, err := strconv.Atoi(m[2])
+	if err != nil {
+		return 0, 0, false
+	}
+	return maj, min, true
+}
+
+// IsPython312Plus reports whether the given (major, minor) version is at least
+// 3.12 — the minimum CPython version that ships sys.activate_stack_trampoline.
+func IsPython312Plus(major, minor int) bool {
+	if major > 3 {
+		return true
+	}
+	if major == 3 && minor >= 12 {
+		return true
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./inject/elfsym/...
+```
+Expected: PASS for both `TestParseLibpythonSONAME` and `TestIsPython312Plus`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add inject/elfsym/soname.go inject/elfsym/soname_test.go
+git commit -m "inject/elfsym: parse libpython SONAME and version-gate at 3.12+"
+```
+
+---
+
+## Task 3: ELF symbol resolution
+
+**Files:**
+- Create: `inject/elfsym/elfsym.go`
+- Test: `inject/elfsym/elfsym_test.go`
+
+Resolve a list of named symbols against an on-disk ELF file. Tries `.dynsym` first (always present in shared libs); falls back to `.symtab` (may be stripped). Returns absolute file offsets — caller adds the load base to get remote addresses.
+
+- [ ] **Step 1: Write the failing test using a synthetic ELF**
+
+Create `inject/elfsym/elfsym_test.go`:
+
+```go
+package elfsym
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// We don't hand-craft ELF bytes (too fragile across Go versions); instead, we
+// exercise the resolver against a real binary on the test host. The Go runtime
+// itself is always available via runtime.GOROOT()'s "go" tool, but we use the
+// Go test binary itself to keep things simple — it is a real ELF with a
+// symbol table.
+
+func TestResolveSymbols_DynsymHit(t *testing.T) {
+	// Use libc, which is universally available on Linux and has stable
+	// symbol names. We probe one known symbol: "malloc".
+	libc := findLibcPath(t)
+	resolved, err := ResolveSymbols(libc, []string{"malloc"})
+	if err != nil {
+		t.Fatalf("ResolveSymbols(%q): %v", libc, err)
+	}
+	if resolved["malloc"] == 0 {
+		t.Fatalf("ResolveSymbols(%q): malloc not resolved (got 0)", libc)
+	}
+}
+
+func TestResolveSymbols_MissingByName(t *testing.T) {
+	libc := findLibcPath(t)
+	resolved, err := ResolveSymbols(libc, []string{"this_symbol_does_not_exist_xyz"})
+	if err != nil {
+		t.Fatalf("ResolveSymbols: unexpected error: %v", err)
+	}
+	if v, present := resolved["this_symbol_does_not_exist_xyz"]; present {
+		t.Fatalf("expected symbol absent; got address 0x%x", v)
+	}
+}
+
+func TestResolveSymbols_MultipleSymbols(t *testing.T) {
+	libc := findLibcPath(t)
+	resolved, err := ResolveSymbols(libc, []string{"malloc", "free", "this_does_not_exist"})
+	if err != nil {
+		t.Fatalf("ResolveSymbols: %v", err)
+	}
+	if resolved["malloc"] == 0 {
+		t.Fatal("malloc not resolved")
+	}
+	if resolved["free"] == 0 {
+		t.Fatal("free not resolved")
+	}
+	if _, present := resolved["this_does_not_exist"]; present {
+		t.Fatal("nonexistent symbol unexpectedly present")
+	}
+}
+
+func TestResolveSymbols_FileDoesNotExist(t *testing.T) {
+	_, err := ResolveSymbols("/path/that/definitely/does/not/exist", []string{"malloc"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent file; got nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected wrapped os.ErrNotExist; got %v", err)
+	}
+}
+
+// findLibcPath locates a libc.so.6 on the test host. Skips if not found.
+func findLibcPath(t *testing.T) string {
+	candidates := []string{
+		"/lib/x86_64-linux-gnu/libc.so.6",
+		"/lib/aarch64-linux-gnu/libc.so.6",
+		"/lib64/libc.so.6",
+		"/usr/lib/x86_64-linux-gnu/libc.so.6",
+		"/usr/lib/aarch64-linux-gnu/libc.so.6",
+		"/usr/lib64/libc.so.6",
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	// Fallback: glob /usr/lib*/libc.so.6
+	matches, _ := filepath.Glob("/usr/lib*/libc.so*")
+	for _, m := range matches {
+		if _, err := os.Stat(m); err == nil {
+			return m
+		}
+	}
+	t.Skip("libc.so.6 not found on test host; skipping ELF resolver test")
+	return ""
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure (no package)**
+
+```bash
+go test ./inject/elfsym/...
+```
+Expected: FAIL — `ResolveSymbols` undefined.
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `inject/elfsym/elfsym.go`:
+
+```go
+package elfsym
+
+import (
+	"debug/elf"
+	"fmt"
+)
+
+// ResolveSymbols opens the ELF file at path and resolves each symbol name in
+// names to its file-offset value (the symbol's st_value). Returned map only
+// contains entries for symbols that were found; missing symbols are silently
+// absent. The caller adds the runtime load base to each value to compute the
+// remote process's address.
+//
+// .dynsym is searched first (the dynamic symbol table is always present in
+// shared libraries and required at runtime). If a name is not found there
+// AND .symtab is present (i.e. binary not stripped), .symtab is searched as a
+// fallback. This matters for some Python distributions that intentionally
+// strip non-API symbols from .dynsym but leave .symtab intact.
+//
+// Returns os.ErrNotExist (wrapped) if path does not exist; other errors are
+// wrapped with context.
+func ResolveSymbols(path string, names []string) (map[string]uint64, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open ELF %q: %w", path, err)
+	}
+	defer f.Close()
+
+	out := make(map[string]uint64, len(names))
+	want := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		want[n] = struct{}{}
+	}
+
+	// Try .dynsym first.
+	if dynsyms, derr := f.DynamicSymbols(); derr == nil {
+		for _, sym := range dynsyms {
+			if _, needed := want[sym.Name]; needed && sym.Value != 0 {
+				out[sym.Name] = sym.Value
+			}
+		}
+	}
+
+	// Fall back to .symtab for any names still unresolved.
+	stillMissing := false
+	for _, n := range names {
+		if _, ok := out[n]; !ok {
+			stillMissing = true
+			break
+		}
+	}
+	if stillMissing {
+		if syms, serr := f.Symbols(); serr == nil {
+			for _, sym := range syms {
+				if _, needed := want[sym.Name]; needed {
+					if _, already := out[sym.Name]; already {
+						continue
+					}
+					if sym.Value != 0 {
+						out[sym.Name] = sym.Value
+					}
+				}
+			}
+		}
+	}
+
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./inject/elfsym/...
+```
+Expected: PASS for `TestResolveSymbols_DynsymHit`, `TestResolveSymbols_MissingByName`, `TestResolveSymbols_MultipleSymbols`, `TestResolveSymbols_FileDoesNotExist`. (May skip on hosts without libc.so.6.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add inject/elfsym/elfsym.go inject/elfsym/elfsym_test.go
+git commit -m "inject/elfsym: ELF symbol resolution with dynsym→symtab fallback"
+```
+
+---
+
+## Task 4: Detection ladder
+
+**Files:**
+- Create: `inject/python/detector.go`
+- Test: `inject/python/detector_test.go`
+
+The detector wires `/proc/<pid>/maps` parsing, SONAME matching, and ELF symbol resolution into the ladder defined in spec §5. Output is a `*Target` (success) or one of the sentinel errors from Task 1.
+
+- [ ] **Step 1: Define the Target type**
+
+Create `inject/python/detector.go` (initial — extended later in same task):
+
+```go
+package python
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/dpsoft/perf-agent/inject/elfsym"
+)
+
+// Target describes a Python 3.12+ process that detection has confirmed is
+// suitable for trampoline injection. All address fields are absolute remote
+// addresses (load_base + symbol_offset) ready to be passed to ptraceop.
+type Target struct {
+	PID              uint32
+	LibPythonPath    string // on-disk path used for ELF parsing
+	LoadBase         uint64 // address from /proc/<pid>/maps for libpython
+	PyGILEnsureAddr  uint64
+	PyGILReleaseAddr uint64
+	PyRunStringAddr  uint64
+	Major, Minor     int // detected libpython version
+}
+
+// Detector inspects a process and reports whether it is a Python 3.12+
+// candidate suitable for trampoline injection.
+type Detector interface {
+	Detect(pid uint32) (*Target, error)
+}
+
+// requiredSymbols are resolved by the detector; addresses are recorded on Target.
+var requiredSymbols = []string{
+	"PyGILState_Ensure",
+	"PyGILState_Release",
+	"PyRun_SimpleString",
+}
+
+// markerSymbol is a presence-only check; if absent in the symbol table, the
+// target was compiled without --enable-perf-trampoline.
+const markerSymbol = "_PyPerf_Callbacks"
+
+// New /proc-based Detector. procRoot is configurable for testing; production
+// callers pass "/proc".
+func NewDetector(procRoot string, log *slog.Logger) Detector {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &procDetector{procRoot: procRoot, log: log}
+}
+
+type procDetector struct {
+	procRoot string
+	log      *slog.Logger
+}
+
+// Detect implements Detector. Errors are sentinel-wrapped (errors.Is friendly):
+//   ErrNotPython, ErrPythonTooOld, ErrNoPerfTrampoline, ErrStaticallyLinkedNoSymbols.
+// Any other error (e.g. EACCES on /proc) is returned as a hard error for the
+// caller to decide whether to abort.
+func (d *procDetector) Detect(pid uint32) (*Target, error) {
+	mapsPath := filepath.Join(d.procRoot, strconv.FormatUint(uint64(pid), 10), "maps")
+	f, err := os.Open(mapsPath)
+	if err != nil {
+		// /proc/<pid>/maps disappeared — process exited between scan and detect.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w: process gone", ErrNotPython)
+		}
+		return nil, fmt.Errorf("open %s: %w", mapsPath, err)
+	}
+	defer f.Close()
+
+	libpythonPath, libpythonBase, ok := scanForLibpython(f)
+	if ok {
+		return d.resolveDynamic(pid, libpythonPath, libpythonBase)
+	}
+
+	// Fall back to /proc/<pid>/exe (statically-linked CPython).
+	return d.resolveStatic(pid)
+}
+
+// scanForLibpython walks the maps file looking for an executable mapping whose
+// path matches a libpython SONAME. Returns the on-disk path and the load
+// (start) address, or ("", 0, false).
+func scanForLibpython(maps *os.File) (string, uint64, bool) {
+	sc := bufio.NewScanner(maps)
+	for sc.Scan() {
+		line := sc.Text()
+		// Format: "addrStart-addrEnd perms offset dev inode pathname"
+		// We want executable mappings (perms includes 'x') with a path that
+		// matches the libpython regex.
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		perms := fields[1]
+		if !strings.Contains(perms, "x") {
+			continue
+		}
+		path := fields[5]
+		if _, _, isPy := elfsym.ParseLibpythonSONAME(path); !isPy {
+			continue
+		}
+		// Parse start address.
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		startHex := fields[0][:dash]
+		start, err := strconv.ParseUint(startHex, 16, 64)
+		if err != nil {
+			continue
+		}
+		return path, start, true
+	}
+	return "", 0, false
+}
+
+// resolveDynamic handles the case where libpython is mapped as a shared lib.
+// libpath is the on-disk path; loadBase is the runtime mapping start.
+func (d *procDetector) resolveDynamic(pid uint32, libpath string, loadBase uint64) (*Target, error) {
+	major, minor, _ := elfsym.ParseLibpythonSONAME(libpath)
+	if !elfsym.IsPython312Plus(major, minor) {
+		return nil, fmt.Errorf("%w: detected %d.%d", ErrPythonTooOld, major, minor)
+	}
+	resolved, err := elfsym.ResolveSymbols(libpath, append([]string{markerSymbol}, requiredSymbols...))
+	if err != nil {
+		return nil, fmt.Errorf("resolve symbols in %s: %w", libpath, err)
+	}
+	if _, ok := resolved[markerSymbol]; !ok {
+		return nil, fmt.Errorf("%w: %s missing in %s", ErrNoPerfTrampoline, markerSymbol, libpath)
+	}
+	for _, sym := range requiredSymbols {
+		if _, ok := resolved[sym]; !ok {
+			return nil, fmt.Errorf("%w: %s missing in %s", ErrStaticallyLinkedNoSymbols, sym, libpath)
+		}
+	}
+	return &Target{
+		PID:              pid,
+		LibPythonPath:    libpath,
+		LoadBase:         loadBase,
+		PyGILEnsureAddr:  loadBase + resolved["PyGILState_Ensure"],
+		PyGILReleaseAddr: loadBase + resolved["PyGILState_Release"],
+		PyRunStringAddr:  loadBase + resolved["PyRun_SimpleString"],
+		Major:            major,
+		Minor:            minor,
+	}, nil
+}
+
+// resolveStatic handles statically-linked CPython, where libpython symbols are
+// in the executable itself rather than a shared library.
+func (d *procDetector) resolveStatic(pid uint32) (*Target, error) {
+	exePath := filepath.Join(d.procRoot, strconv.FormatUint(uint64(pid), 10), "exe")
+	// Resolve the symlink to get the real on-disk path for ELF parsing.
+	realExe, err := os.Readlink(exePath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: readlink %s: %v", ErrNotPython, exePath, err)
+	}
+	resolved, err := elfsym.ResolveSymbols(realExe, append([]string{markerSymbol}, requiredSymbols...))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrNotPython, err)
+	}
+	for _, sym := range requiredSymbols {
+		if _, ok := resolved[sym]; !ok {
+			return nil, fmt.Errorf("%w: %s missing in %s", ErrNotPython, sym, realExe)
+		}
+	}
+	if _, ok := resolved[markerSymbol]; !ok {
+		return nil, fmt.Errorf("%w: %s missing in %s", ErrNoPerfTrampoline, markerSymbol, realExe)
+	}
+	// For static binaries, find the executable's load base from /proc/<pid>/maps.
+	mapsPath := filepath.Join(d.procRoot, strconv.FormatUint(uint64(pid), 10), "maps")
+	f, err := os.Open(mapsPath)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", mapsPath, err)
+	}
+	defer f.Close()
+	loadBase := scanForExeBase(f, realExe)
+	if loadBase == 0 {
+		return nil, fmt.Errorf("%w: cannot find exe load base in %s", ErrNotPython, mapsPath)
+	}
+	return &Target{
+		PID:              pid,
+		LibPythonPath:    realExe,
+		LoadBase:         loadBase,
+		PyGILEnsureAddr:  loadBase + resolved["PyGILState_Ensure"],
+		PyGILReleaseAddr: loadBase + resolved["PyGILState_Release"],
+		PyRunStringAddr:  loadBase + resolved["PyRun_SimpleString"],
+		Major:            0, // static path; SONAME version unknown
+		Minor:            0,
+	}, nil
+}
+
+// scanForExeBase finds the lowest start address of an executable mapping whose
+// path matches realExe. Used for statically-linked CPython where load base
+// must be derived from the exe's own mapping.
+func scanForExeBase(maps *os.File, realExe string) uint64 {
+	var lowest uint64 = 0
+	sc := bufio.NewScanner(maps)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 6 {
+			continue
+		}
+		if !strings.Contains(fields[1], "x") {
+			continue
+		}
+		if fields[5] != realExe {
+			continue
+		}
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		start, err := strconv.ParseUint(fields[0][:dash], 16, 64)
+		if err != nil {
+			continue
+		}
+		if lowest == 0 || start < lowest {
+			lowest = start
+		}
+	}
+	return lowest
+}
+```
+
+- [ ] **Step 2: Write the failing tests using a synthetic /proc tree**
+
+Create `inject/python/detector_test.go`:
+
+```go
+package python
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// buildSyntheticProc creates a /proc-like tree under tmp for one PID, with a
+// maps file containing the given lines and an exe symlink pointing at exeTarget.
+// Returns the procRoot path.
+func buildSyntheticProc(t *testing.T, pid uint32, mapsLines []string, exeTarget string) string {
+	t.Helper()
+	root := t.TempDir()
+	pidDir := filepath.Join(root, fmt.Sprintf("%d", pid))
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mapsContent := ""
+	for _, l := range mapsLines {
+		mapsContent += l + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "maps"), []byte(mapsContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if exeTarget != "" {
+		if err := os.Symlink(exeTarget, filepath.Join(pidDir, "exe")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// findRealLibpython finds a libpython3.12+ on the test host, or skips.
+// Used because we need a real ELF with the trampoline symbols for detect tests.
+func findRealLibpython(t *testing.T) (path string, major, minor int) {
+	t.Helper()
+	candidates := []string{
+		"/usr/lib/x86_64-linux-gnu/libpython3.12.so.1.0",
+		"/usr/lib/x86_64-linux-gnu/libpython3.13.so.1.0",
+		"/usr/lib/aarch64-linux-gnu/libpython3.12.so.1.0",
+		"/usr/lib/libpython3.12.so.1.0",
+		"/usr/lib64/libpython3.12.so.1.0",
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			// Confirm symbols (not all distros build with --enable-perf-trampoline).
+			return c, 0, 0
+		}
+	}
+	matches, _ := filepath.Glob("/usr/lib*/libpython3.1*.so*")
+	for _, m := range matches {
+		return m, 0, 0
+	}
+	t.Skip("no libpython3.12+ found on test host")
+	return "", 0, 0
+}
+
+func TestDetect_DynamicLinkedPython312(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only test")
+	}
+	libpath, _, _ := findRealLibpython(t)
+	pid := uint32(12345)
+	mapsLine := fmt.Sprintf("00400000-00500000 r-xp 00000000 00:00 0 %s", libpath)
+	root := buildSyntheticProc(t, pid, []string{mapsLine}, "")
+
+	d := NewDetector(root, nil)
+	got, err := d.Detect(pid)
+	if err != nil {
+		// libpython might not have been built with --enable-perf-trampoline on
+		// this host. Accept ErrNoPerfTrampoline as a valid skip.
+		if errors.Is(err, ErrNoPerfTrampoline) {
+			t.Skipf("host libpython lacks --enable-perf-trampoline: %v", err)
+		}
+		t.Fatalf("Detect: %v", err)
+	}
+	if got.PID != pid {
+		t.Errorf("PID = %d, want %d", got.PID, pid)
+	}
+	if got.LibPythonPath != libpath {
+		t.Errorf("LibPythonPath = %q, want %q", got.LibPythonPath, libpath)
+	}
+	if got.LoadBase != 0x00400000 {
+		t.Errorf("LoadBase = 0x%x, want 0x00400000", got.LoadBase)
+	}
+	if got.PyGILEnsureAddr == 0 || got.PyRunStringAddr == 0 || got.PyGILReleaseAddr == 0 {
+		t.Errorf("symbol addrs not populated: %+v", got)
+	}
+}
+
+func TestDetect_NonPython(t *testing.T) {
+	pid := uint32(22222)
+	// Maps with no libpython: a Go binary scenario.
+	root := buildSyntheticProc(t, pid, []string{
+		"00400000-00500000 r-xp 00000000 00:00 0 /usr/bin/cat",
+	}, "/usr/bin/cat")
+
+	d := NewDetector(root, nil)
+	_, err := d.Detect(pid)
+	if err == nil {
+		t.Fatal("expected error for non-python; got nil")
+	}
+	if !errors.Is(err, ErrNotPython) && !errors.Is(err, ErrNoPerfTrampoline) {
+		t.Fatalf("expected ErrNotPython or ErrNoPerfTrampoline; got %v", err)
+	}
+}
+
+func TestDetect_PythonTooOld(t *testing.T) {
+	pid := uint32(33333)
+	// Synthetic libpython 3.11 path; the file doesn't need to exist for the
+	// SONAME check to fire — that's the early gate.
+	mapsLine := "00400000-00500000 r-xp 00000000 00:00 0 /usr/lib/libpython3.11.so.1.0"
+	root := buildSyntheticProc(t, pid, []string{mapsLine}, "")
+
+	d := NewDetector(root, nil)
+	_, err := d.Detect(pid)
+	if err == nil {
+		t.Fatal("expected ErrPythonTooOld")
+	}
+	if !errors.Is(err, ErrPythonTooOld) {
+		t.Fatalf("expected ErrPythonTooOld; got %v", err)
+	}
+}
+
+func TestDetect_ProcessGone(t *testing.T) {
+	pid := uint32(99999)
+	// Don't create any /proc/<pid> entry — simulates process exit.
+	root := t.TempDir()
+	d := NewDetector(root, nil)
+	_, err := d.Detect(pid)
+	if err == nil {
+		t.Fatal("expected error for missing /proc/<pid>")
+	}
+	if !errors.Is(err, ErrNotPython) {
+		t.Fatalf("expected ErrNotPython (wrapping process-gone); got %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests — expect pass**
+
+```bash
+go test ./inject/python/...
+```
+Expected: PASS for `TestDetect_NonPython`, `TestDetect_PythonTooOld`, `TestDetect_ProcessGone`. `TestDetect_DynamicLinkedPython312` may skip if no libpython3.12+ is installed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add inject/python/detector.go inject/python/detector_test.go
+git commit -m "inject/python: detection ladder (SONAME match + ELF symbol resolve)"
+```
+
+---
+
+## Task 5: ptraceop arch-generic + amd64 register frame
+
+**Files:**
+- Create: `inject/ptraceop/ptraceop.go`
+- Create: `inject/ptraceop/regs_amd64.go`
+- Test: `inject/ptraceop/regs_amd64_test.go`
+
+This is the biggest task. We split into three files:
+- `ptraceop.go` — public types (`Injector`, `SymbolAddrs`), `RemoteActivate`/`RemoteDeactivate` orchestrators, internal helpers (attach, detach, write, the per-call inner loop). Compiles on any GOARCH (no arch-specific code here).
+- `regs_amd64.go` — build-tagged `setupCallFrame` and `extractReturn` for amd64 System V.
+- `regs_arm64.go` — Task 6.
+
+Real `ptrace` is not exercised by unit tests — those run only in integration. Unit tests cover the per-arch register-frame logic.
+
+- [ ] **Step 1: Implement the arch-generic skeleton**
+
+Create `inject/ptraceop/ptraceop.go`:
+
+```go
+// Package ptraceop provides low-level ptrace primitives for remote function
+// invocation: attach, save registers, write a payload, run a sequence of
+// remote function calls (each returning via SIGSEGV at address 0), restore
+// registers, detach. Language-agnostic — Python uses it today; future runtimes
+// (Node.js if extending V8 internals, JVM via JNI shims, etc.) can reuse it.
+package ptraceop
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// SymbolAddrs holds the absolute remote addresses of the three CPython
+// functions we need to call. ptraceop deliberately does not depend on
+// inject/python — naming is Python-flavored but the struct is just three
+// uint64s; future runtimes can pass equivalent triples.
+type SymbolAddrs struct {
+	PyGILEnsure  uint64
+	PyGILRelease uint64
+	PyRunString  uint64
+}
+
+// Injector performs ptrace-based remote function calls.
+type Injector struct {
+	log *slog.Logger
+}
+
+// New creates an Injector. log may be nil (uses slog.Default()).
+func New(log *slog.Logger) *Injector {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Injector{log: log}
+}
+
+// RemoteActivate runs the three-call sequence
+// (PyGILState_Ensure → PyRun_SimpleString(payload) → PyGILState_Release)
+// inside one ptrace session. Returns nil on success, a wrapped error otherwise.
+//
+// The payload must be NUL-terminated; the caller (typically inject/python)
+// supplies python.ActivatePayload() or python.DeactivatePayload().
+func (i *Injector) RemoteActivate(pid uint32, addrs SymbolAddrs, payload []byte) error {
+	return i.runSequence(pid, addrs, payload)
+}
+
+// RemoteDeactivate is identical to RemoteActivate; the only difference is the
+// payload string. Kept as a separate method for callsite clarity.
+func (i *Injector) RemoteDeactivate(pid uint32, addrs SymbolAddrs, payload []byte) error {
+	return i.runSequence(pid, addrs, payload)
+}
+
+// runSequence implements the full attach → 3 calls → detach sequence from
+// design §6.2.
+func (i *Injector) runSequence(pid uint32, addrs SymbolAddrs, payload []byte) error {
+	if pid == 0 {
+		return errors.New("ptraceop: pid is zero")
+	}
+	if len(payload) == 0 {
+		return errors.New("ptraceop: empty payload")
+	}
+	if payload[len(payload)-1] != 0 {
+		return errors.New("ptraceop: payload not NUL-terminated")
+	}
+	if addrs.PyGILEnsure == 0 || addrs.PyGILRelease == 0 || addrs.PyRunString == 0 {
+		return errors.New("ptraceop: SymbolAddrs has zero entry")
+	}
+
+	// Step 1-2: attach + waitpid.
+	if err := unix.PtraceAttach(int(pid)); err != nil {
+		return fmt.Errorf("ptrace attach pid=%d: %w", pid, err)
+	}
+	defer func() {
+		// Best-effort detach. If we error before reaching the explicit detach
+		// below, this ensures the target is resumed.
+		_ = unix.PtraceDetach(int(pid))
+	}()
+
+	var status unix.WaitStatus
+	if _, err := unix.Wait4(int(pid), &status, 0, nil); err != nil {
+		return fmt.Errorf("waitpid for attach stop pid=%d: %w", pid, err)
+	}
+	if !status.Stopped() {
+		return fmt.Errorf("expected stopped after attach pid=%d, got status %v", pid, status)
+	}
+
+	// Step 3: save original registers.
+	var orig unix.PtraceRegs
+	if err := unix.PtraceGetRegs(int(pid), &orig); err != nil {
+		return fmt.Errorf("ptrace getregs pid=%d: %w", pid, err)
+	}
+
+	// Step 4: find stack mapping and verify headroom.
+	stackLow, ok := stackLowAddr(pid)
+	if !ok {
+		return fmt.Errorf("cannot determine stack mapping for pid=%d", pid)
+	}
+	currentSP := stackPointer(orig)
+	if currentSP < stackLow+1024 {
+		// Headroom check failed; spec §6.4 specifies remote-mmap fallback.
+		// v1 ships without the fallback (rare in practice); we fail with a
+		// clear sentinel-style message so the caller can decide.
+		return fmt.Errorf("ptraceop: insufficient stack headroom (sp=0x%x, low=0x%x); remote-mmap fallback not implemented in v1",
+			currentSP, stackLow)
+	}
+
+	// Step 5-6: choose payload_addr, write payload to stack.
+	payloadAddr := (currentSP - 256) &^ 0xF
+	if _, err := unix.PtracePokeData(int(pid), uintptr(payloadAddr), payload); err != nil {
+		return fmt.Errorf("ptrace pokedata payload pid=%d: %w", pid, err)
+	}
+
+	// Step 7-9: three remote calls (Ensure → Run → Release).
+	gstate, err := i.remoteCall(pid, orig, addrs.PyGILEnsure, payloadAddr, 0)
+	if err != nil {
+		return fmt.Errorf("PyGILState_Ensure: %w", err)
+	}
+	runResult, runErr := i.remoteCall(pid, orig, addrs.PyRunString, payloadAddr, payloadAddr)
+	// Always release the GIL we acquired, even if PyRun_SimpleString failed.
+	if _, relErr := i.remoteCall(pid, orig, addrs.PyGILRelease, payloadAddr, gstate); relErr != nil {
+		i.log.Warn("PyGILState_Release failed after attempted activation",
+			"pid", pid, "err", relErr)
+	}
+	if runErr != nil {
+		return fmt.Errorf("PyRun_SimpleString: %w", runErr)
+	}
+	if runResult != 0 {
+		return fmt.Errorf("PyRun_SimpleString returned non-zero: %d (likely activation refused at runtime)", runResult)
+	}
+
+	// Step 10-11: restore registers, detach (defer above handles detach).
+	if err := unix.PtraceSetRegs(int(pid), &orig); err != nil {
+		return fmt.Errorf("ptrace setregs restore pid=%d: %w", pid, err)
+	}
+	if err := unix.PtraceDetach(int(pid)); err != nil {
+		return fmt.Errorf("ptrace detach pid=%d: %w", pid, err)
+	}
+	return nil
+}
+
+// remoteCall performs one remote function invocation:
+//  1. Build call frame from orig with fnAddr/arg, return-addr=0 (SIGSEGV
+//     sentinel), payload_addr-derived stack pointer.
+//  2. PtraceSetRegs.
+//  3. PtraceCont with signal=0.
+//  4. Wait4 for SIGSEGV (or other terminal stop).
+//  5. Read regs, return the call's return value.
+//
+// payloadAddr is used to derive a fresh stack pointer for each call so that
+// successive calls don't trample each other's frames.
+func (i *Injector) remoteCall(pid uint32, orig unix.PtraceRegs, fnAddr, payloadAddr, arg1 uint64) (uint64, error) {
+	frame, err := setupCallFrame(orig, fnAddr, arg1, payloadAddr)
+	if err != nil {
+		return 0, fmt.Errorf("setup call frame: %w", err)
+	}
+	// Some arches (amd64) require us to write the sentinel return address (0)
+	// to *(SP) before the call. setupCallFrame returns the SP that needs the
+	// sentinel; we write a 0 word there.
+	zero := make([]byte, 8)
+	if _, err := unix.PtracePokeData(int(pid), uintptr(stackPointer(frame)), zero); err != nil {
+		return 0, fmt.Errorf("write return-addr sentinel: %w", err)
+	}
+	if err := unix.PtraceSetRegs(int(pid), &frame); err != nil {
+		return 0, fmt.Errorf("setregs: %w", err)
+	}
+	if err := unix.PtraceCont(int(pid), 0); err != nil {
+		return 0, fmt.Errorf("ptrace cont: %w", err)
+	}
+	var status unix.WaitStatus
+	if _, err := unix.Wait4(int(pid), &status, 0, nil); err != nil {
+		return 0, fmt.Errorf("wait4 after remote call: %w", err)
+	}
+	if !status.Stopped() {
+		return 0, fmt.Errorf("expected stop after remote call; got status %v", status)
+	}
+	if sig := status.StopSignal(); sig != unix.SIGSEGV {
+		return 0, fmt.Errorf("expected SIGSEGV sentinel; got signal %v", sig)
+	}
+	var post unix.PtraceRegs
+	if err := unix.PtraceGetRegs(int(pid), &post); err != nil {
+		return 0, fmt.Errorf("getregs post-call: %w", err)
+	}
+	return extractReturn(post), nil
+}
+
+// stackLowAddr reads /proc/<pid>/maps and returns the low address of the
+// [stack] mapping.
+func stackLowAddr(pid uint32) (uint64, bool) {
+	mapsPath := filepath.Join("/proc", strconv.FormatUint(uint64(pid), 10), "maps")
+	f, err := os.Open(mapsPath)
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+	buf := make([]byte, 64*1024)
+	n, _ := f.Read(buf)
+	for _, line := range strings.Split(string(buf[:n]), "\n") {
+		if !strings.Contains(line, "[stack]") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 1 {
+			continue
+		}
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		low, err := strconv.ParseUint(fields[0][:dash], 16, 64)
+		if err != nil {
+			continue
+		}
+		return low, true
+	}
+	return 0, false
+}
+```
+
+- [ ] **Step 2: Implement amd64 register-frame setup**
+
+Create `inject/ptraceop/regs_amd64.go`:
+
+```go
+//go:build amd64
+
+package ptraceop
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// setupCallFrame builds a register frame for one remote function call on
+// amd64 System V. The frame:
+//   - RIP = fnAddr (entry of remote function)
+//   - RDI = arg1   (first integer/pointer arg)
+//   - RSP = payloadAddr - 8, 16-byte aligned post-write of return-addr sentinel
+//   - *(RSP) gets a 0 written to it by the caller, serving as the return
+//     address; when the function returns, target jumps to 0 → SIGSEGV →
+//     ptrace catches it.
+//
+// All other registers are inherited from orig — we only edit what we must.
+func setupCallFrame(orig unix.PtraceRegs, fnAddr, arg1, payloadAddr uint64) (unix.PtraceRegs, error) {
+	frame := orig
+	frame.Rip = fnAddr
+	frame.Rdi = arg1
+	// SP layout: ... [return-addr sentinel = 0] [payload string]
+	// We choose RSP = payloadAddr - 8 so *(RSP) holds the sentinel.
+	// Then ensure 16-byte alignment after the simulated CALL push: in System V,
+	// at function entry, RSP must be 8 mod 16 (CALL pushes the return addr
+	// making RSP %16 == 8). We achieve that by ensuring (payloadAddr - 8) % 16 == 8,
+	// i.e., payloadAddr % 16 == 0. The caller chose payloadAddr aligned to 16,
+	// so we're good.
+	frame.Rsp = payloadAddr - 8
+	if frame.Rsp%16 != 8 {
+		return unix.PtraceRegs{}, fmt.Errorf("RSP alignment broken: 0x%x %% 16 = %d (want 8)",
+			frame.Rsp, frame.Rsp%16)
+	}
+	return frame, nil
+}
+
+// extractReturn reads the integer return value from a post-call register set.
+// On amd64 System V, integer/pointer returns are in RAX.
+func extractReturn(post unix.PtraceRegs) uint64 {
+	return post.Rax
+}
+
+// stackPointer returns the SP register value for arch-generic code.
+func stackPointer(r unix.PtraceRegs) uint64 {
+	return r.Rsp
+}
+```
+
+- [ ] **Step 3: Write the failing test for amd64 frame setup**
+
+Create `inject/ptraceop/regs_amd64_test.go`:
+
+```go
+//go:build amd64
+
+package ptraceop
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSetupCallFrame_amd64(t *testing.T) {
+	orig := unix.PtraceRegs{
+		Rip: 0xdeadbeef00,
+		Rdi: 0x11,
+		Rsi: 0x22,
+		Rsp: 0x7ffffff00000,
+		Rax: 0xaaaa,
+	}
+	const fnAddr = 0x12340000
+	const arg1 = 0xCAFEBABE
+	const payloadAddr = 0x7ffffff00100 // 16-byte aligned
+
+	frame, err := setupCallFrame(orig, fnAddr, arg1, payloadAddr)
+	if err != nil {
+		t.Fatalf("setupCallFrame error: %v", err)
+	}
+	if frame.Rip != fnAddr {
+		t.Errorf("RIP = 0x%x, want 0x%x", frame.Rip, fnAddr)
+	}
+	if frame.Rdi != arg1 {
+		t.Errorf("RDI = 0x%x, want 0x%x", frame.Rdi, arg1)
+	}
+	if frame.Rsp != payloadAddr-8 {
+		t.Errorf("RSP = 0x%x, want 0x%x", frame.Rsp, payloadAddr-8)
+	}
+	if frame.Rsp%16 != 8 {
+		t.Errorf("RSP alignment broken: 0x%x %% 16 = %d", frame.Rsp, frame.Rsp%16)
+	}
+	// Other registers should be inherited from orig.
+	if frame.Rsi != orig.Rsi {
+		t.Errorf("RSI clobbered: got 0x%x, want 0x%x", frame.Rsi, orig.Rsi)
+	}
+	if frame.Rax != orig.Rax {
+		t.Errorf("RAX clobbered: got 0x%x, want 0x%x", frame.Rax, orig.Rax)
+	}
+}
+
+func TestSetupCallFrame_amd64_BadAlignment(t *testing.T) {
+	orig := unix.PtraceRegs{Rsp: 0x7ffffff00000}
+	const payloadAddr = 0x7ffffff00104 // NOT 16-byte aligned
+	_, err := setupCallFrame(orig, 0x1000, 0, payloadAddr)
+	if err == nil {
+		t.Fatal("expected alignment error; got nil")
+	}
+}
+
+func TestExtractReturn_amd64(t *testing.T) {
+	post := unix.PtraceRegs{Rax: 0xCAFEF00D}
+	got := extractReturn(post)
+	if got != 0xCAFEF00D {
+		t.Errorf("extractReturn = 0x%x, want 0xCAFEF00D", got)
+	}
+}
+
+func TestStackPointer_amd64(t *testing.T) {
+	r := unix.PtraceRegs{Rsp: 0xC0DEFACE}
+	if got := stackPointer(r); got != 0xC0DEFACE {
+		t.Errorf("stackPointer = 0x%x, want 0xC0DEFACE", got)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./inject/ptraceop/...
+```
+Expected: PASS for `TestSetupCallFrame_amd64`, `TestSetupCallFrame_amd64_BadAlignment`, `TestExtractReturn_amd64`, `TestStackPointer_amd64`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add inject/ptraceop/ptraceop.go inject/ptraceop/regs_amd64.go inject/ptraceop/regs_amd64_test.go
+git commit -m "inject/ptraceop: arch-generic remote-call sequence + amd64 frame setup"
+```
+
+---
+
+## Task 6: ptraceop arm64 register frame
+
+**Files:**
+- Create: `inject/ptraceop/regs_arm64.go`
+- Test: `inject/ptraceop/regs_arm64_test.go`
+
+Mirror image of Task 5's amd64 file but for AAPCS64. On arm64, args are in X0-X7, return in X0, PC is the program counter, LR (X30) is the link register (return address).
+
+- [ ] **Step 1: Implement arm64 register-frame setup**
+
+Create `inject/ptraceop/regs_arm64.go`:
+
+```go
+//go:build arm64
+
+package ptraceop
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// setupCallFrame builds a register frame for one remote function call on
+// arm64 AAPCS64. The frame:
+//   - PC = fnAddr (entry of remote function)
+//   - X0 = arg1
+//   - X30 (LR) = 0 (sentinel — when function returns via RET, target
+//     jumps to 0 → SIGSEGV → ptrace catches it)
+//   - SP = payloadAddr - 16, 16-byte aligned (AAPCS64 requires 16-byte SP at
+//     all public interfaces)
+//
+// All other registers are inherited from orig.
+func setupCallFrame(orig unix.PtraceRegs, fnAddr, arg1, payloadAddr uint64) (unix.PtraceRegs, error) {
+	frame := orig
+	frame.Pc = fnAddr
+	frame.Regs[0] = arg1
+	frame.Regs[30] = 0 // LR (X30) — return address sentinel
+	frame.Sp = payloadAddr - 16
+	if frame.Sp%16 != 0 {
+		return unix.PtraceRegs{}, fmt.Errorf("SP alignment broken: 0x%x %% 16 = %d (want 0)",
+			frame.Sp, frame.Sp%16)
+	}
+	return frame, nil
+}
+
+// extractReturn reads the integer return value from a post-call register set.
+// On arm64 AAPCS64, integer/pointer returns are in X0.
+func extractReturn(post unix.PtraceRegs) uint64 {
+	return post.Regs[0]
+}
+
+// stackPointer returns the SP register value for arch-generic code.
+func stackPointer(r unix.PtraceRegs) uint64 {
+	return r.Sp
+}
+```
+
+- [ ] **Step 2: Write the failing test for arm64**
+
+Create `inject/ptraceop/regs_arm64_test.go`:
+
+```go
+//go:build arm64
+
+package ptraceop
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSetupCallFrame_arm64(t *testing.T) {
+	var orig unix.PtraceRegs
+	orig.Pc = 0xdeadbeef00
+	orig.Sp = 0x7ffffff00000
+	orig.Regs[0] = 0x11
+	orig.Regs[1] = 0x22
+	orig.Regs[30] = 0xCCCC // some other LR
+	const fnAddr = 0x12340000
+	const arg1 = 0xCAFEBABE
+	const payloadAddr = 0x7ffffff00100 // 16-byte aligned
+
+	frame, err := setupCallFrame(orig, fnAddr, arg1, payloadAddr)
+	if err != nil {
+		t.Fatalf("setupCallFrame error: %v", err)
+	}
+	if frame.Pc != fnAddr {
+		t.Errorf("PC = 0x%x, want 0x%x", frame.Pc, fnAddr)
+	}
+	if frame.Regs[0] != arg1 {
+		t.Errorf("X0 = 0x%x, want 0x%x", frame.Regs[0], arg1)
+	}
+	if frame.Regs[30] != 0 {
+		t.Errorf("LR (X30) = 0x%x, want 0 (sentinel)", frame.Regs[30])
+	}
+	if frame.Sp != payloadAddr-16 {
+		t.Errorf("SP = 0x%x, want 0x%x", frame.Sp, payloadAddr-16)
+	}
+	if frame.Sp%16 != 0 {
+		t.Errorf("SP not 16-aligned: 0x%x", frame.Sp)
+	}
+	if frame.Regs[1] != orig.Regs[1] {
+		t.Errorf("X1 clobbered: 0x%x, want 0x%x", frame.Regs[1], orig.Regs[1])
+	}
+}
+
+func TestSetupCallFrame_arm64_BadAlignment(t *testing.T) {
+	var orig unix.PtraceRegs
+	orig.Sp = 0x7ffffff00000
+	const payloadAddr = 0x7ffffff00108 // NOT 16-aligned
+	_, err := setupCallFrame(orig, 0x1000, 0, payloadAddr)
+	if err == nil {
+		t.Fatal("expected alignment error; got nil")
+	}
+}
+
+func TestExtractReturn_arm64(t *testing.T) {
+	var post unix.PtraceRegs
+	post.Regs[0] = 0xCAFEF00D
+	got := extractReturn(post)
+	if got != 0xCAFEF00D {
+		t.Errorf("extractReturn = 0x%x, want 0xCAFEF00D", got)
+	}
+}
+
+func TestStackPointer_arm64(t *testing.T) {
+	var r unix.PtraceRegs
+	r.Sp = 0xC0DEFACE
+	if got := stackPointer(r); got != 0xC0DEFACE {
+		t.Errorf("stackPointer = 0x%x, want 0xC0DEFACE", got)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests — expect pass when running on arm64; on amd64 the file is skipped (build tag)**
+
+```bash
+go test ./inject/ptraceop/...
+```
+Expected: PASS on both archs (the build-tagged file compiles only on the matching arch; tests on the *other* arch run only the other file).
+
+To cross-check arm64 compiles cleanly on an amd64 host:
+
+```bash
+GOOS=linux GOARCH=arm64 go build ./inject/ptraceop/...
+```
+Expected: clean build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add inject/ptraceop/regs_arm64.go inject/ptraceop/regs_arm64_test.go
+git commit -m "inject/ptraceop: arm64 frame setup (AAPCS64)"
+```
+
+---
+
+## Task 7: Manager — lifecycle, dedupe, stats
+
+**Files:**
+- Create: `inject/python/python.go` (Manager, Options, Stats)
+- Create: `inject/python/manager.go` (ActivateAll, DeactivateAll, ActivateLate)
+- Test: `inject/python/manager_test.go`
+
+The Manager owns the in-memory tracked-PID set, runs the strict/lenient policy, runs the bounded-time deactivation pass on shutdown, and dedupes late-arriving exec events.
+
+- [ ] **Step 1: Define the public surface (python.go)**
+
+Create `inject/python/python.go`:
+
+```go
+package python
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Options configures a Manager.
+type Options struct {
+	// StrictPerPID makes ActivateAll fail-fast on the first error. Used for
+	// --pid N --inject-python; lenient (false) for -a --inject-python.
+	StrictPerPID bool
+
+	// Logger receives structured log lines for every detect/activate/deactivate
+	// event. nil → slog.Default().
+	Logger *slog.Logger
+
+	// PreexistingMarkerCheck overrides the default check for "is this PID's
+	// trampoline already active?" — set in tests to a stub. Production passes
+	// nil and gets the default /tmp/perf-<pid>.map check.
+	PreexistingMarkerCheck func(pid uint32) bool
+
+	// Injector overrides the default ptraceop-based injector. Tests inject
+	// stubs; production passes nil and gets the real ptraceop.Injector.
+	Injector LowLevelInjector
+
+	// Detector overrides the default /proc-based detector. Tests inject stubs;
+	// production passes nil.
+	Detector Detector
+
+	// DeactivateDeadline caps the total time spent in DeactivateAll. Default
+	// 5 seconds.
+	DeactivateDeadline time.Duration
+}
+
+// LowLevelInjector is the contract Manager uses for the ptrace dance. The
+// production implementation wraps inject/ptraceop.Injector; tests can stub it.
+type LowLevelInjector interface {
+	RemoteActivate(pid uint32, addrs SymbolAddrsForTarget) error
+	RemoteDeactivate(pid uint32, addrs SymbolAddrsForTarget) error
+}
+
+// SymbolAddrsForTarget is the data the LowLevelInjector needs to perform one
+// remote-call sequence — independent of inject/ptraceop's exact struct layout
+// to keep the test boundary clean.
+type SymbolAddrsForTarget struct {
+	PyGILEnsure  uint64
+	PyGILRelease uint64
+	PyRunString  uint64
+}
+
+// Stats holds counters that operators inspect after a run. All counters are
+// safe for concurrent use.
+type Stats struct {
+	Activated          atomic.Uint64
+	Deactivated        atomic.Uint64
+	SkippedNotPython   atomic.Uint64
+	SkippedTooOld      atomic.Uint64
+	SkippedNoTramp     atomic.Uint64
+	SkippedNoSymbols   atomic.Uint64
+	SkippedPreexisting atomic.Uint64
+	ActivateFailed     atomic.Uint64
+	DeactivateFailed   atomic.Uint64
+}
+
+// Manager orchestrates Python perf-trampoline injection across a profile run:
+// detection ladder, strict/lenient policy, in-memory tracked-PID set, bounded
+// shutdown deactivation, and idempotent late-arrival activation.
+type Manager struct {
+	opts Options
+	log  *slog.Logger
+
+	mu       sync.Mutex
+	tracked  map[uint32]*trackedTarget
+	pending  sync.Map // pid uint32 → struct{} (in-flight late activation)
+
+	stats Stats
+}
+
+type trackedTarget struct {
+	target      *Target
+	activatedAt time.Time
+	preexisting bool
+}
+
+// NewManager constructs a Manager. opts.Logger may be nil. opts.Detector and
+// opts.Injector default to /proc + ptraceop in production; tests inject stubs.
+func NewManager(opts Options) *Manager {
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	if opts.DeactivateDeadline == 0 {
+		opts.DeactivateDeadline = 5 * time.Second
+	}
+	if opts.PreexistingMarkerCheck == nil {
+		opts.PreexistingMarkerCheck = defaultPreexistingMarkerCheck
+	}
+	return &Manager{
+		opts:    opts,
+		log:     opts.Logger,
+		tracked: make(map[uint32]*trackedTarget),
+	}
+}
+
+// Stats returns a snapshot pointer (not a copy — atomic counters are observed
+// in-place). Callers should treat it as read-only.
+func (m *Manager) Stats() *Stats { return &m.stats }
+
+// ActivateAll runs detection and activation for the given PIDs. Returns nil
+// in lenient mode (errors are logged + counted); returns the first error in
+// strict mode. Caller blocks on this; it is fine to call once at profile
+// start before BPF attach.
+func (m *Manager) ActivateAll(pids []uint32) error {
+	for _, pid := range pids {
+		if err := m.activateOne(pid); err != nil {
+			if m.opts.StrictPerPID {
+				return err
+			}
+		}
+	}
+	m.logSummary()
+	return nil
+}
+
+// ActivateLate is the mmap-watcher hook for new exec events during -a mode.
+// Always lenient (logs + counts on error). Idempotent: dedupes by tracked
+// and pending sets.
+func (m *Manager) ActivateLate(pid uint32) {
+	if _, loaded := m.pending.LoadOrStore(pid, struct{}{}); loaded {
+		return // in-flight activation for this pid
+	}
+	defer m.pending.Delete(pid)
+
+	m.mu.Lock()
+	_, already := m.tracked[pid]
+	m.mu.Unlock()
+	if already {
+		return
+	}
+	_ = m.activateOne(pid) // lenient: errors logged inside
+}
+
+// DeactivateAll runs the bounded shutdown deactivation pass. Skips entries
+// marked preexisting; tolerates ESRCH (process gone). Honors ctx cancellation
+// AND the configured deactivation deadline (5s default).
+func (m *Manager) DeactivateAll(ctx context.Context) {
+	deadline, cancel := context.WithTimeout(ctx, m.opts.DeactivateDeadline)
+	defer cancel()
+
+	snapshot := m.snapshotTracked()
+	for pid, tt := range snapshot {
+		select {
+		case <-deadline.Done():
+			m.log.Warn("python deactivate cancelled (deadline or ctx)",
+				"abandoned", len(snapshot)-int(m.stats.Deactivated.Load()))
+			return
+		default:
+		}
+		if tt.preexisting {
+			continue
+		}
+		addrs := SymbolAddrsForTarget{
+			PyGILEnsure:  tt.target.PyGILEnsureAddr,
+			PyGILRelease: tt.target.PyGILReleaseAddr,
+			PyRunString:  tt.target.PyRunStringAddr,
+		}
+		if err := m.opts.Injector.RemoteDeactivate(pid, addrs); err != nil {
+			if isProcessGone(err) {
+				continue
+			}
+			m.log.Warn("python deactivate failed", "pid", pid, "err", err)
+			m.stats.DeactivateFailed.Add(1)
+			continue
+		}
+		m.stats.Deactivated.Add(1)
+	}
+}
+```
+
+- [ ] **Step 2: Implement the activation logic (manager.go)**
+
+Create `inject/python/manager.go`:
+
+```go
+package python
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// activateOne runs detection + activation for one PID. Always returns nil in
+// lenient mode after logging; returns wrapped error in strict mode.
+func (m *Manager) activateOne(pid uint32) error {
+	target, err := m.opts.Detector.Detect(pid)
+	if err != nil {
+		m.recordSkipReason(err)
+		m.log.Warn("python inject skipped",
+			"pid", pid, "reason", reasonString(err))
+		if m.opts.StrictPerPID {
+			return fmt.Errorf("inject pid=%d: %w", pid, err)
+		}
+		return nil
+	}
+
+	if m.opts.PreexistingMarkerCheck(pid) {
+		m.mu.Lock()
+		m.tracked[pid] = &trackedTarget{target: target, preexisting: true, activatedAt: time.Now()}
+		m.mu.Unlock()
+		m.stats.SkippedPreexisting.Add(1)
+		m.log.Warn("python inject skipped",
+			"pid", pid, "reason", "preexisting_perf_map")
+		return nil
+	}
+
+	addrs := SymbolAddrsForTarget{
+		PyGILEnsure:  target.PyGILEnsureAddr,
+		PyGILRelease: target.PyGILReleaseAddr,
+		PyRunString:  target.PyRunStringAddr,
+	}
+	if err := m.opts.Injector.RemoteActivate(pid, addrs); err != nil {
+		m.stats.ActivateFailed.Add(1)
+		m.log.Warn("python inject failed", "pid", pid, "err", err)
+		if m.opts.StrictPerPID {
+			return fmt.Errorf("activate pid=%d: %w", pid, err)
+		}
+		return nil
+	}
+	m.mu.Lock()
+	m.tracked[pid] = &trackedTarget{target: target, activatedAt: time.Now()}
+	m.mu.Unlock()
+	m.stats.Activated.Add(1)
+	m.log.Info("python inject activated",
+		"pid", pid, "libpython", target.LibPythonPath,
+		"version", fmt.Sprintf("%d.%d", target.Major, target.Minor))
+	return nil
+}
+
+func (m *Manager) recordSkipReason(err error) {
+	switch {
+	case errors.Is(err, ErrPythonTooOld):
+		m.stats.SkippedTooOld.Add(1)
+	case errors.Is(err, ErrNoPerfTrampoline):
+		m.stats.SkippedNoTramp.Add(1)
+	case errors.Is(err, ErrStaticallyLinkedNoSymbols):
+		m.stats.SkippedNoSymbols.Add(1)
+	case errors.Is(err, ErrNotPython):
+		m.stats.SkippedNotPython.Add(1)
+	default:
+		m.stats.SkippedNotPython.Add(1) // unknown errors classified as "not python"
+	}
+}
+
+func reasonString(err error) string {
+	switch {
+	case errors.Is(err, ErrPythonTooOld):
+		return "python_too_old"
+	case errors.Is(err, ErrNoPerfTrampoline):
+		return "no_perf_trampoline"
+	case errors.Is(err, ErrStaticallyLinkedNoSymbols):
+		return "no_libpython_symbols"
+	case errors.Is(err, ErrNotPython):
+		return "not_python"
+	default:
+		return "other"
+	}
+}
+
+func (m *Manager) snapshotTracked() map[uint32]*trackedTarget {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[uint32]*trackedTarget, len(m.tracked))
+	for k, v := range m.tracked {
+		out[k] = v
+	}
+	return out
+}
+
+func (m *Manager) logSummary() {
+	m.log.Info("python inject summary",
+		"activated", m.stats.Activated.Load(),
+		"skipped",
+		m.stats.SkippedNotPython.Load()+
+			m.stats.SkippedTooOld.Load()+
+			m.stats.SkippedNoTramp.Load()+
+			m.stats.SkippedNoSymbols.Load()+
+			m.stats.SkippedPreexisting.Load(),
+		"failed", m.stats.ActivateFailed.Load(),
+	)
+}
+
+// defaultPreexistingMarkerCheck returns true iff /tmp/perf-<pid>.map exists
+// and is non-empty. This is the conservative idempotency check from spec §7.2.
+func defaultPreexistingMarkerCheck(pid uint32) bool {
+	path := "/tmp/perf-" + strconv.FormatUint(uint64(pid), 10) + ".map"
+	st, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return st.Size() > 0
+}
+
+// isProcessGone returns true if the error is a "no such process" (ESRCH),
+// indicating the target exited between our snapshot and the deactivate call.
+func isProcessGone(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.ESRCH)
+}
+```
+
+- [ ] **Step 3: Write the failing tests for Manager**
+
+Create `inject/python/manager_test.go`:
+
+```go
+package python
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// stubDetector implements Detector by mapping PID → result.
+type stubDetector struct {
+	results map[uint32]stubResult
+}
+
+type stubResult struct {
+	target *Target
+	err    error
+}
+
+func (s *stubDetector) Detect(pid uint32) (*Target, error) {
+	r, ok := s.results[pid]
+	if !ok {
+		return nil, ErrNotPython
+	}
+	return r.target, r.err
+}
+
+// stubInjector counts and optionally errors.
+type stubInjector struct {
+	mu              sync.Mutex
+	activated       []uint32
+	deactivated     []uint32
+	activateErr     error
+	deactivateErr   error
+	deactivateDelay time.Duration
+}
+
+func (s *stubInjector) RemoteActivate(pid uint32, _ SymbolAddrsForTarget) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activateErr != nil {
+		return s.activateErr
+	}
+	s.activated = append(s.activated, pid)
+	return nil
+}
+
+func (s *stubInjector) RemoteDeactivate(pid uint32, _ SymbolAddrsForTarget) error {
+	if s.deactivateDelay > 0 {
+		time.Sleep(s.deactivateDelay)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.deactivateErr != nil {
+		return s.deactivateErr
+	}
+	s.deactivated = append(s.deactivated, pid)
+	return nil
+}
+
+func newTestManager(t *testing.T, det Detector, inj LowLevelInjector, strict bool) *Manager {
+	t.Helper()
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewManager(Options{
+		StrictPerPID:           strict,
+		Logger:                 silent,
+		Detector:               det,
+		Injector:               inj,
+		PreexistingMarkerCheck: func(uint32) bool { return false },
+	})
+}
+
+func makeTarget(pid uint32) *Target {
+	return &Target{
+		PID:              pid,
+		LibPythonPath:    "/fake/libpython3.12.so",
+		LoadBase:         0x400000,
+		PyGILEnsureAddr:  0x401000,
+		PyGILReleaseAddr: 0x402000,
+		PyRunStringAddr:  0x403000,
+		Major:            3,
+		Minor:            12,
+	}
+}
+
+func TestActivateAll_StrictExitsOnFirstError(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+		200: {err: ErrPythonTooOld},
+		300: {target: makeTarget(300)},
+	}}
+	inj := &stubInjector{}
+	m := newTestManager(t, det, inj, true)
+
+	err := m.ActivateAll([]uint32{100, 200, 300})
+	if err == nil {
+		t.Fatal("expected strict error; got nil")
+	}
+	if !errors.Is(err, ErrPythonTooOld) {
+		t.Fatalf("expected ErrPythonTooOld; got %v", err)
+	}
+	// 100 was activated before the error on 200; 300 must NOT have been attempted.
+	if got := m.stats.Activated.Load(); got != 1 {
+		t.Errorf("Activated = %d, want 1", got)
+	}
+	for _, p := range inj.activated {
+		if p == 300 {
+			t.Errorf("strict mode should not have activated pid 300")
+		}
+	}
+}
+
+func TestActivateAll_LenientContinuesOnError(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+		200: {err: ErrPythonTooOld},
+		300: {target: makeTarget(300)},
+	}}
+	inj := &stubInjector{}
+	m := newTestManager(t, det, inj, false)
+
+	if err := m.ActivateAll([]uint32{100, 200, 300}); err != nil {
+		t.Fatalf("lenient ActivateAll returned error: %v", err)
+	}
+	if got := m.stats.Activated.Load(); got != 2 {
+		t.Errorf("Activated = %d, want 2", got)
+	}
+	if got := m.stats.SkippedTooOld.Load(); got != 1 {
+		t.Errorf("SkippedTooOld = %d, want 1", got)
+	}
+}
+
+func TestActivateAll_PreexistingMarkerSkips(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{}
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(Options{
+		Logger:                 silent,
+		Detector:               det,
+		Injector:               inj,
+		PreexistingMarkerCheck: func(pid uint32) bool { return pid == 100 },
+	})
+	if err := m.ActivateAll([]uint32{100}); err != nil {
+		t.Fatalf("ActivateAll: %v", err)
+	}
+	if got := m.stats.SkippedPreexisting.Load(); got != 1 {
+		t.Errorf("SkippedPreexisting = %d, want 1", got)
+	}
+	if got := m.stats.Activated.Load(); got != 0 {
+		t.Errorf("Activated = %d, want 0", got)
+	}
+	// Now Deactivate — preexisting must be skipped (not in tracked? actually it
+	// IS in tracked but with preexisting=true, and deactivation skips it).
+	m.DeactivateAll(t.Context())
+	if got := m.stats.Deactivated.Load(); got != 0 {
+		t.Errorf("Deactivated = %d, want 0 (preexisting must be skipped)", got)
+	}
+}
+
+func TestDeactivateAll_HonorsDeadline(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+		200: {target: makeTarget(200)},
+		300: {target: makeTarget(300)},
+	}}
+	// Inject delay so the second-or-later Deactivate hits the deadline.
+	inj := &stubInjector{deactivateDelay: 100 * time.Millisecond}
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(Options{
+		Logger:                 silent,
+		Detector:               det,
+		Injector:               inj,
+		PreexistingMarkerCheck: func(uint32) bool { return false },
+		DeactivateDeadline:     50 * time.Millisecond,
+	})
+	if err := m.ActivateAll([]uint32{100, 200, 300}); err != nil {
+		t.Fatalf("ActivateAll: %v", err)
+	}
+	start := time.Now()
+	m.DeactivateAll(t.Context())
+	elapsed := time.Since(start)
+	if elapsed > 250*time.Millisecond {
+		t.Errorf("DeactivateAll took %v; deadline should have capped near 50-150ms", elapsed)
+	}
+}
+
+func TestDeactivateAll_ToleratesESRCH(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{deactivateErr: syscall.ESRCH}
+	m := newTestManager(t, det, inj, false)
+	if err := m.ActivateAll([]uint32{100}); err != nil {
+		t.Fatalf("ActivateAll: %v", err)
+	}
+	m.DeactivateAll(t.Context())
+	if got := m.stats.DeactivateFailed.Load(); got != 0 {
+		t.Errorf("DeactivateFailed = %d on ESRCH; want 0", got)
+	}
+}
+
+func TestActivateLate_DedupesViaTracked(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{}
+	m := newTestManager(t, det, inj, false)
+
+	if err := m.ActivateAll([]uint32{100}); err != nil {
+		t.Fatalf("ActivateAll: %v", err)
+	}
+	// Now late-arrival event for the same PID — must not trigger second activation.
+	m.ActivateLate(100)
+	if got := atomic.LoadUint64((*uint64)(&inj.activated[0])); got != 0 && len(inj.activated) > 1 {
+		t.Errorf("ActivateLate triggered duplicate activation: %v", inj.activated)
+	}
+	if len(inj.activated) != 1 {
+		t.Errorf("activate count = %d, want 1", len(inj.activated))
+	}
+}
+
+func TestActivateLate_DedupesViaPending(t *testing.T) {
+	// Two concurrent ActivateLate calls for the same PID — only one must
+	// reach the injector.
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{}
+	m := newTestManager(t, det, inj, false)
+
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Go(func() { m.ActivateLate(100) })
+	}
+	wg.Wait()
+	if len(inj.activated) > 1 {
+		t.Errorf("ActivateLate not deduped under concurrency: %v", inj.activated)
+	}
+}
+
+// Compile-time check: ensure context is imported correctly.
+var _ = context.Background
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+go test ./inject/python/...
+```
+Expected: PASS for all eight Manager tests plus the earlier payload + detector tests.
+
+- [ ] **Step 5: Wire ptraceop adapter (so production passes a real Injector)**
+
+Append to `inject/python/python.go`:
+
+```go
+// adaptPtraceOp wraps inject/ptraceop.Injector to satisfy LowLevelInjector.
+// We deliberately decouple via this small adapter so manager_test can stub
+// LowLevelInjector without importing ptraceop.
+type ptraceopAdapter struct {
+	inj           ptraceopInjector
+	activatePyld  []byte
+	deactivPyld   []byte
+}
+
+// ptraceopInjector is the slice of inject/ptraceop.Injector we depend on.
+type ptraceopInjector interface {
+	RemoteActivate(pid uint32, addrs ptraceopSymbolAddrs, payload []byte) error
+	RemoteDeactivate(pid uint32, addrs ptraceopSymbolAddrs, payload []byte) error
+}
+
+// ptraceopSymbolAddrs mirrors inject/ptraceop.SymbolAddrs to keep the import
+// boundary one-way (inject/python imports ptraceop; not vice versa).
+type ptraceopSymbolAddrs struct {
+	PyGILEnsure  uint64
+	PyGILRelease uint64
+	PyRunString  uint64
+}
+
+func (a *ptraceopAdapter) RemoteActivate(pid uint32, addrs SymbolAddrsForTarget) error {
+	return a.inj.RemoteActivate(pid, ptraceopSymbolAddrs{
+		PyGILEnsure:  addrs.PyGILEnsure,
+		PyGILRelease: addrs.PyGILRelease,
+		PyRunString:  addrs.PyRunString,
+	}, a.activatePyld)
+}
+
+func (a *ptraceopAdapter) RemoteDeactivate(pid uint32, addrs SymbolAddrsForTarget) error {
+	return a.inj.RemoteDeactivate(pid, ptraceopSymbolAddrs{
+		PyGILEnsure:  addrs.PyGILEnsure,
+		PyGILRelease: addrs.PyGILRelease,
+		PyRunString:  addrs.PyRunString,
+	}, a.deactivPyld)
+}
+```
+
+The actual wiring of `ptraceopInjector` to `inject/ptraceop.Injector` happens in Task 8 (perfagent), where we have a clear place to do the import. The interface in this file is purely structural.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add inject/python/python.go inject/python/manager.go inject/python/manager_test.go
+git commit -m "inject/python: Manager with strict/lenient policy, dedupe, bounded shutdown"
+```
+
+---
+
+## Task 8: Wire into perfagent.Agent
+
+**Files:**
+- Modify: `perfagent/options.go` (add InjectPython option, validation)
+- Modify: `perfagent/agent.go` (Agent.pyInjector field, Start/Stop integration, PythonInjectStats accessor)
+- Modify: `main.go` (--inject-python flag)
+
+This connects the inject/python package to the rest of perf-agent.
+
+- [ ] **Step 1: Read the current perfagent options + agent files to understand integration points**
+
+```bash
+sed -n '1,80p' perfagent/options.go
+sed -n '1,120p' perfagent/agent.go
+grep -n "inject-python\|InjectPython" perfagent/*.go main.go
+```
+
+- [ ] **Step 2: Add the option, the agent field, and the lifecycle wiring**
+
+The implementer will modify:
+
+In `perfagent/options.go`, add:
+
+```go
+// WithInjectPython enables Python perf-trampoline injection during profiling.
+// Caller must hold cap_sys_ptrace. Strict mode (--pid N) returns an error on
+// any per-target failure; lenient mode (-a) logs and continues.
+func WithInjectPython(enabled bool) Option {
+	return func(o *Config) { o.InjectPython = enabled }
+}
+```
+
+And add an `InjectPython bool` field to whatever the Config struct is named. Validation: if `o.InjectPython` is true AND mode is not `--profile` (off-cpu/PMU), return a structured error.
+
+In `perfagent/agent.go`, near the existing field declarations, add:
+
+```go
+import (
+	"github.com/dpsoft/perf-agent/inject/python"
+	"github.com/dpsoft/perf-agent/inject/ptraceop"
+)
+
+type Agent struct {
+	// ...existing fields...
+	pyInjector *python.Manager
+}
+```
+
+In the agent constructor (where Config is consumed and the Agent is built), if `cfg.InjectPython` is true, construct the Manager:
+
+```go
+if cfg.InjectPython {
+	low := &ptraceopBridge{inj: ptraceop.New(cfg.Logger)}
+	a.pyInjector = python.NewManager(python.Options{
+		StrictPerPID: cfg.PID != 0, // single-PID is strict; -a is lenient
+		Logger:       cfg.Logger,
+		Detector:     python.NewDetector("/proc", cfg.Logger),
+		Injector:     low,
+	})
+}
+```
+
+Add the bridge type in `perfagent/agent.go`:
+
+```go
+// ptraceopBridge adapts ptraceop.Injector to the python.LowLevelInjector
+// interface, supplying the activate/deactivate payloads from the inject/python
+// package.
+type ptraceopBridge struct {
+	inj *ptraceop.Injector
+}
+
+func (b *ptraceopBridge) RemoteActivate(pid uint32, addrs python.SymbolAddrsForTarget) error {
+	return b.inj.RemoteActivate(pid, ptraceop.SymbolAddrs{
+		PyGILEnsure:  addrs.PyGILEnsure,
+		PyGILRelease: addrs.PyGILRelease,
+		PyRunString:  addrs.PyRunString,
+	}, python.ActivatePayload())
+}
+
+func (b *ptraceopBridge) RemoteDeactivate(pid uint32, addrs python.SymbolAddrsForTarget) error {
+	return b.inj.RemoteDeactivate(pid, ptraceop.SymbolAddrs{
+		PyGILEnsure:  addrs.PyGILEnsure,
+		PyGILRelease: addrs.PyGILRelease,
+		PyRunString:  addrs.PyRunString,
+	}, python.DeactivatePayload())
+}
+```
+
+Modify `Agent.Start()` (or its equivalent) to run injection BEFORE BPF attach:
+
+```go
+func (a *Agent) Start(ctx context.Context) error {
+	if a.pyInjector != nil {
+		pids := a.scanPythonTargets()
+		if err := a.pyInjector.ActivateAll(pids); err != nil {
+			return fmt.Errorf("python injection: %w", err)
+		}
+	}
+	// ...existing BPF attach code...
+}
+
+// scanPythonTargets returns the PIDs to consider for injection. For --pid mode,
+// just [a.cfg.PID]. For -a mode, walks /proc and returns all numeric PID
+// directories (Detect filters down to actual Python processes).
+func (a *Agent) scanPythonTargets() []uint32 {
+	if a.cfg.PID != 0 {
+		return []uint32{a.cfg.PID}
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	pids := make([]uint32, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		v, err := strconv.ParseUint(e.Name(), 10, 32)
+		if err != nil {
+			continue
+		}
+		pids = append(pids, uint32(v))
+	}
+	return pids
+}
+```
+
+Modify `Agent.Stop()`:
+
+```go
+func (a *Agent) Stop(ctx context.Context) error {
+	// ...existing profile finalization...
+	if a.pyInjector != nil {
+		a.pyInjector.DeactivateAll(ctx)
+	}
+	// ...existing close code...
+}
+```
+
+Add the public stats accessor:
+
+```go
+// PythonInjectStats returns counters for the Python injector. Returns a
+// zero-value Stats pointer if --inject-python was not enabled.
+func (a *Agent) PythonInjectStats() *python.Stats {
+	if a.pyInjector == nil {
+		return &python.Stats{}
+	}
+	return a.pyInjector.Stats()
+}
+```
+
+In `main.go`, add the flag and wire it through:
+
+```go
+injectPython := flag.Bool("inject-python", false,
+	"Inject sys.activate_stack_trampoline('perf') into running CPython 3.12+ targets via ptrace. Requires cap_sys_ptrace. Off by default.")
+// ...later, when constructing the Agent:
+opts = append(opts, perfagent.WithInjectPython(*injectPython))
+```
+
+Add the validation:
+- `--inject-python` with `--offcpu` or `--pmu` (without `--profile`): return error.
+- `--inject-python` without `--pid` and without `-a`: return same error as today (already handled by existing pid/all checks).
+- `--inject-python` with neither `--profile` nor `--pid`/`-a`: error.
+
+The cap precheck uses `unix.PrctlRetInt(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_IS_SET, unix.CAP_SYS_PTRACE, 0, 0)` style — but in this codebase, look at how the existing cap checks are done (`cpu/cpu.go` has a precedent). Use the same helper.
+
+- [ ] **Step 3: Build and verify it compiles**
+
+```bash
+make generate
+CGO_CFLAGS="-I /usr/include/bpf -I /usr/include/pcap -I /home/diego/github/blazesym/capi/include" \
+CGO_LDFLAGS="-L /home/diego/github/blazesym/target/release -Wl,-Bstatic -lblazesym_c -Wl,-Bdynamic" \
+go build .
+```
+Expected: clean build.
+
+- [ ] **Step 4: Run unit tests for affected packages**
+
+```bash
+CGO_CFLAGS="-I /usr/include/bpf -I /usr/include/pcap -I /home/diego/github/blazesym/capi/include" \
+CGO_LDFLAGS="-L /home/diego/github/blazesym/target/release -Wl,-Bstatic -lblazesym_c -Wl,-Bdynamic" \
+go test ./inject/... ./perfagent/...
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add perfagent/options.go perfagent/agent.go main.go
+git commit -m "perfagent: wire --inject-python flag into Agent lifecycle"
+```
+
+---
+
+## Task 9: Mmap-watcher new-exec hook for late arrivals
+
+**Files:**
+- Modify: `unwind/ehmaps/tracker.go` (or wherever the mmap watcher lives — check via grep)
+- Modify: `perfagent/agent.go` (subscribe to new-exec events)
+
+For `-a --inject-python`, processes that exec during the run also need injection. The mmap watcher already detects new execs for CFI; we add a parallel hook for the Python injector.
+
+- [ ] **Step 1: Map the existing watcher API**
+
+```bash
+grep -rn "OnNewExec\|NewMmapWatcher\|MmapWatcher" unwind/ perfagent/
+```
+
+- [ ] **Step 2: Add the hook**
+
+If the watcher already exposes a `OnNewExec(func(pid uint32))` callback, wire `Agent` to register `a.pyInjector.ActivateLate` if `pyInjector != nil`. If it does not, extend it minimally.
+
+If the watcher uses a channel (e.g., `Watcher.NewExecChan() <-chan uint32`), spawn a small drainer goroutine in `Agent.Start()`:
+
+```go
+if a.pyInjector != nil && a.cfg.PID == 0 {  // -a mode only
+	a.lateExecWG.Go(func() {
+		ch := a.watcher.NewExecChan()
+		for {
+			select {
+			case <-a.ctx.Done():
+				return
+			case pid, ok := <-ch:
+				if !ok {
+					return
+				}
+				a.pyInjector.ActivateLate(pid)
+			}
+		}
+	})
+}
+```
+
+The exact shape depends on the existing watcher API; the goal is "every new exec invokes ActivateLate" and "the goroutine ends cleanly on ctx cancel."
+
+- [ ] **Step 3: Add a unit test for the dedupe path**
+
+If the watcher exposes a way to inject a synthetic new-exec event in tests, write `TestLateExecHook_InvokesActivateLate` in `inject/python/manager_test.go`. Otherwise, the integration test in Task 11 covers this end-to-end.
+
+- [ ] **Step 4: Build + test**
+
+```bash
+go test ./inject/... ./perfagent/... ./unwind/...
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add unwind/ehmaps/tracker.go perfagent/agent.go
+git commit -m "perfagent: subscribe inject/python to mmap-watcher new-exec events"
+```
+
+---
+
+## Task 10: Bench harness flag
+
+**Files:**
+- Modify: `bench/cmd/scenario/main.go` (add `--inject-python` flag, plumb to Agent)
+- Modify: `bench/internal/schema/schema.go` (add `InjectPython bool` field on Document)
+
+- [ ] **Step 1: Read the existing flag definitions**
+
+```bash
+sed -n '1,60p' bench/cmd/scenario/main.go
+grep -n "Document\|UnwindMode" bench/internal/schema/schema.go
+```
+
+- [ ] **Step 2: Add the schema field**
+
+In `bench/internal/schema/schema.go`, on the Document struct, add:
+
+```go
+// InjectPython records whether --inject-python was enabled for this run.
+// Persisted in the bench JSON for cross-run comparison; absent or false on
+// runs predating the feature.
+InjectPython bool `json:"inject_python,omitempty"`
+```
+
+- [ ] **Step 3: Add the bench flag and plumb it**
+
+In `bench/cmd/scenario/main.go`, add a flag:
+
+```go
+injectPython := flag.Bool("inject-python", false, "Enable Python trampoline injection for the profiled fleet")
+```
+
+Pass it through to the Agent constructor:
+
+```go
+opts = append(opts, perfagent.WithInjectPython(*injectPython))
+```
+
+Persist into the schema:
+
+```go
+doc.InjectPython = *injectPython
+```
+
+- [ ] **Step 4: Build + test**
+
+```bash
+go build ./bench/...
+go test ./bench/...
+```
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/cmd/scenario/main.go bench/internal/schema/schema.go
+git commit -m "bench: --inject-python flag + InjectPython field on Document"
+```
+
+---
+
+## Task 11: Integration tests (caps-gated)
+
+**Files:**
+- Create: `test/integration_inject_python_test.go`
+
+Three integration tests per spec §9.2.
+
+- [ ] **Step 1: Read existing integration test infrastructure**
+
+```bash
+sed -n '1,60p' test/integration_test.go
+grep -n "func Test\|capsOK\|setcap" test/integration_test.go
+```
+
+- [ ] **Step 2: Implement TestInjectPython_ActivatesTrampoline**
+
+Create `test/integration_inject_python_test.go`:
+
+```go
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInjectPython_ActivatesTrampoline(t *testing.T) {
+	skipIfNoPerfAgentCaps(t)
+	skipIfNoPython312Plus(t)
+
+	// 1. Launch python WITHOUT -X perf
+	pyCmd := exec.Command("python3", "test/workloads/python/cpu_bound.py", "10", "2")
+	if err := pyCmd.Start(); err != nil {
+		t.Fatalf("start python workload: %v", err)
+	}
+	pid := pyCmd.Process.Pid
+	t.Cleanup(func() { _ = pyCmd.Process.Kill(); _ = pyCmd.Wait() })
+
+	// 2. Wait for warmup
+	time.Sleep(1 * time.Second)
+
+	// 3. Run perf-agent --profile --inject-python
+	profileOut := filepath.Join(t.TempDir(), "profile.pb.gz")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pa := exec.CommandContext(ctx, "../perf-agent",
+		"--profile",
+		"--inject-python",
+		"--pid", fmt.Sprintf("%d", pid),
+		"--duration", "5s",
+		"--profile-output", profileOut,
+	)
+	out, err := pa.CombinedOutput()
+	if err != nil {
+		t.Fatalf("perf-agent failed: %v\n%s", err, out)
+	}
+
+	// 4. Assert /tmp/perf-<PID>.map exists
+	perfMap := fmt.Sprintf("/tmp/perf-%d.map", pid)
+	st, err := os.Stat(perfMap)
+	if err != nil {
+		t.Fatalf("perf map %s not created: %v\nperf-agent output:\n%s", perfMap, err, out)
+	}
+	if st.Size() == 0 {
+		t.Fatalf("perf map %s is empty", perfMap)
+	}
+	pmContent, _ := os.ReadFile(perfMap)
+	if !strings.Contains(string(pmContent), "py::") {
+		t.Errorf("perf map missing py:: entries:\n%s", pmContent)
+	}
+
+	// 5. Assert profile has Python frame names
+	pprofTop := exec.CommandContext(ctx, "go", "tool", "pprof", "-top", "-nodecount=20", profileOut)
+	topOut, err := pprofTop.CombinedOutput()
+	if err != nil {
+		t.Logf("pprof -top error (non-fatal): %v", err)
+	}
+	if !strings.Contains(string(topOut), "py::") &&
+		!strings.Contains(string(topOut), "cpu_bound.py") {
+		t.Errorf("profile lacks Python frame names:\n%s", topOut)
+	}
+
+	// 6. perf-map size should not grow after perf-agent exits (deactivation ran)
+	size1 := fileSize(t, perfMap)
+	time.Sleep(1 * time.Second)
+	size2 := fileSize(t, perfMap)
+	if size2 != size1 {
+		t.Errorf("perf-map grew after perf-agent exit (deactivation didn't run): %d → %d",
+			size1, size2)
+	}
+}
+
+func TestInjectPython_StrictFailsOnNonPython(t *testing.T) {
+	skipIfNoPerfAgentCaps(t)
+
+	// Launch a Go workload (not Python)
+	goCmd := exec.Command("test/workloads/go/cpu_bound")
+	if err := goCmd.Start(); err != nil {
+		t.Fatalf("start go workload: %v", err)
+	}
+	pid := goCmd.Process.Pid
+	t.Cleanup(func() { _ = goCmd.Process.Kill(); _ = goCmd.Wait() })
+
+	time.Sleep(500 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pa := exec.CommandContext(ctx, "../perf-agent",
+		"--profile", "--inject-python",
+		"--pid", fmt.Sprintf("%d", pid),
+		"--duration", "2s",
+	)
+	out, err := pa.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit; got success\noutput:\n%s", out)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected ExitError; got %T: %v", err, err)
+	}
+	if !strings.Contains(string(out), "not_python") &&
+		!strings.Contains(string(out), "not a python") {
+		t.Errorf("output missing structured 'not python' reason:\n%s", out)
+	}
+}
+
+func skipIfNoPerfAgentCaps(t *testing.T) {
+	t.Helper()
+	// Reuse the helper from integration_test.go (assumes capsOK or similar exists).
+	if !haveCaps(t) {
+		t.Skip("requires cap_sys_admin/cap_bpf/cap_perfmon/cap_sys_ptrace; setcap on ../perf-agent")
+	}
+}
+
+func skipIfNoPython312Plus(t *testing.T) {
+	t.Helper()
+	out, err := exec.Command("python3", "-c",
+		"import sys; print(sys.version_info >= (3, 12))").CombinedOutput()
+	if err != nil || !strings.Contains(string(out), "True") {
+		t.Skipf("requires python3 >= 3.12; got: %s (err=%v)", out, err)
+	}
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		return -1
+	}
+	return st.Size()
+}
+
+// haveCaps is a helper that should be implemented based on integration_test.go's
+// existing capsOK / capPresent helpers. If they exist with another name,
+// rename here; the spec is "true if perf-agent will be able to use BPF +
+// ptrace without sudo".
+func haveCaps(t *testing.T) bool {
+	t.Helper()
+	// Implementer: copy the pattern from integration_test.go. If that file uses
+	// a function called `capsOK`, change this body to `return capsOK(t)`. Same
+	// for `capPresent`.
+	return true // placeholder — implementer fills in real cap check
+}
+```
+
+The `haveCaps` placeholder MUST be replaced by the implementer with the actual helper from `integration_test.go`. Read that file first and copy the exact helper signature and body.
+
+- [ ] **Step 3: Build the perf-agent binary in the worktree (NOT /tmp — caps don't survive nosuid)**
+
+```bash
+make generate
+CGO_CFLAGS="-I /usr/include/bpf -I /usr/include/pcap -I /home/diego/github/blazesym/capi/include" \
+CGO_LDFLAGS="-L /home/diego/github/blazesym/target/release -Wl,-Bstatic -lblazesym_c -Wl,-Bdynamic" \
+go build .
+sudo setcap cap_perfmon,cap_bpf,cap_sys_admin,cap_sys_ptrace,cap_checkpoint_restore+ep ./perf-agent
+```
+
+- [ ] **Step 4: Run integration tests**
+
+```bash
+cd test
+CGO_CFLAGS="-I /usr/include/bpf -I /usr/include/pcap -I /home/diego/github/blazesym/capi/include" \
+CGO_LDFLAGS="-L /home/diego/github/blazesym/target/release -Wl,-Bstatic -lblazesym_c -Wl,-Bdynamic" \
+go test -v -run "TestInjectPython" ./...
+```
+Expected: PASS for both tests (or skip if Python 3.12+ not available).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/integration_inject_python_test.go
+git commit -m "test: integration tests for --inject-python (caps-gated)"
+```
+
+---
+
+## Task 12: Documentation
+
+**Files:**
+- Modify: `README.md` (add Python profiling section)
+- Create: `docs/python-profiling.md`
+
+- [ ] **Step 1: Add to README.md**
+
+Find the "Examples" or "Usage" section in README.md. Append:
+
+```markdown
+### Profiling running Python processes
+
+For Python 3.12+ processes, perf-agent can activate the perf trampoline at
+profile start without restarting the target — no need for `python -X perf`:
+
+```bash
+sudo perf-agent --profile --pid $(pgrep -f myapp.py) \
+                --duration 30s --inject-python
+```
+
+The trampoline emits Python qualnames to `/tmp/perf-<PID>.map`, which
+perf-agent reads via blazesym to attach human-readable names to JIT'd
+frames. perf-agent automatically deactivates the trampoline at end of
+profile, so the per-call overhead does not persist past the profiling window.
+
+For system-wide injection (`-a`), perf-agent activates every detected Python
+3.12+ process and tolerates per-process failures (e.g., processes built
+without `--enable-perf-trampoline`):
+
+```bash
+sudo perf-agent --profile -a --duration 30s --inject-python
+```
+
+Requires `cap_sys_ptrace` (already in the standard cap set).
+See [docs/python-profiling.md](docs/python-profiling.md) for details.
+```
+
+- [ ] **Step 2: Create docs/python-profiling.md**
+
+Create `docs/python-profiling.md`:
+
+```markdown
+# Python profiling with perf-agent
+
+perf-agent supports two paths for Python frame symbolization:
+
+1. **DWARF unwinding through the interpreter** (default for any Python).
+   Profiles work; frames render with C-level names (`_PyEval_EvalFrameDefault`,
+   etc.) — no Python-level qualnames.
+
+2. **Perf trampoline** (`--inject-python`, Python 3.12+). Activates CPython's
+   built-in perf integration so perf-agent can resolve every JIT'd Python
+   function to its qualname.
+
+## Quickstart
+
+```bash
+# Profile a running Python web server for 30 seconds
+sudo perf-agent --profile --pid $(pgrep -f gunicorn) \
+                --duration 30s --inject-python \
+                --profile-output gunicorn.pb.gz
+
+# Visualize
+go tool pprof -http :8080 gunicorn.pb.gz
+```
+
+## How it works
+
+When `--inject-python` is set, perf-agent:
+
+1. Walks `/proc` (or just the target PID) and identifies CPython 3.12+
+   processes via libpython SONAME and ELF symbol presence.
+2. For each candidate, attaches via `ptrace`, calls
+   `PyGILState_Ensure` → `PyRun_SimpleString("import sys; sys.activate_stack_trampoline('perf')")` → `PyGILState_Release`,
+   and detaches.
+3. The trampoline emits perf-map entries to `/tmp/perf-<PID>.map`.
+4. perf-agent samples and reads the perf-map via blazesym to attach Python
+   names to frames.
+5. On profile end, the same ptrace dance runs `sys.deactivate_stack_trampoline()`
+   so the trampoline overhead does not persist.
+
+## When injection is skipped
+
+| Reason | Cause |
+|---|---|
+| `not_python` | Target is not a CPython process (e.g., Go binary) |
+| `python_too_old` | libpython version < 3.12 (`activate_stack_trampoline` is 3.12+) |
+| `no_perf_trampoline` | CPython compiled without `--enable-perf-trampoline` (e.g., some Alpine builds) |
+| `no_libpython_symbols` | Statically-linked CPython without exported PyGILState/PyRun symbols |
+| `preexisting_perf_map` | `/tmp/perf-<PID>.map` already exists — trampoline activated by a prior run or user code; we never deactivate state we didn't activate |
+
+In `--pid N` mode (strict), any of these failures aborts the run.
+In `-a` mode (lenient), failures are logged and the profile continues for
+all targets where injection succeeded.
+
+## Idempotency
+
+perf-agent never deactivates a trampoline it didn't activate. If
+`/tmp/perf-<PID>.map` exists at activation time, perf-agent records the
+target as "preexisting" and skips both activation and deactivation. This
+guarantees that:
+
+- Concurrent perf-agent runs don't stomp on each other.
+- A user who runs `python -X perf` and then runs perf-agent against the
+  result keeps the trampoline active after perf-agent exits.
+
+If a previous perf-agent run was killed and left a trampoline active, the
+next run won't deactivate it. Manual cleanup: `rm /tmp/perf-PID.map` after
+process exit.
+
+## Container and namespace caveats
+
+v1 uses host-side PIDs. If perf-agent runs outside a container and targets a
+Python process inside one:
+
+- The host PID works for ptrace and detection (`/proc/<pid>/maps` + on-disk
+  libpython path).
+- The perf-map file `/tmp/perf-<host_pid>.map` is created on the host —
+  the container itself does not see it. This matches `python -X perf`
+  behavior under host-mounted `/tmp`.
+- For exotic mount namespace setups, detection may fail with "library not
+  found on disk" — log + skip in lenient mode.
+
+A future PR can add namespace-aware path resolution; the seam is small (one
+function: "given pid, give me the on-disk libpython path"). File an issue if
+you hit this.
+
+## Performance impact
+
+The CPython 3.12 perf trampoline adds 1–5% per-call overhead on hot Python
+workloads, depending on call shape. For typical web servers and pipelines,
+overhead is in the noise. perf-agent's deactivation pass at end of profile
+removes this overhead immediately.
+
+## Disabling injection
+
+Don't pass `--inject-python`. Profiles still work — Python frames just
+render with C interpreter names instead of qualnames.
+
+## Troubleshooting
+
+**`ptrace_eperm` errors:** the target's `/proc/sys/kernel/yama/ptrace_scope`
+is restricting ptrace. Set `0` (or `1` for same-uid attach), or grant
+`cap_sys_ptrace` to perf-agent (already in the standard cap set).
+
+**`ESRCH` during deactivate:** the target exited during the profile.
+Harmless; logged with `pid=N reason=process_gone`.
+
+**`/tmp/perf-PID.map` missing after activation:** the target may not have
+called any new Python code during the profile, so the trampoline had nothing
+to emit. Lengthen `--duration`.
+
+**Statically-linked Python skipped (`no_libpython_symbols`):** the binary's
+symbol table is stripped. Distributions that ship `python-build-standalone`
+sometimes do this. No workaround in v1.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs/python-profiling.md
+git commit -m "docs: --inject-python README section + docs/python-profiling.md"
+```
+
+---
+
+## Self-review
+
+Before declaring the plan complete, walk through the spec one last time:
+
+**Spec coverage:**
+
+- §3.1 Python 3.12+ only → Task 4 detection ladder enforces version gate.
+- §3.2 `--profile --inject-python` flag → Task 8 main.go.
+- §3.3 Activate on start, deactivate on end → Tasks 7 (ActivateAll/DeactivateAll), 8 (wired into Agent.Start/Stop).
+- §3.4 Pure Go via x/sys/unix → Tasks 5, 6.
+- §3.5 Strict per-PID, lenient -a → Task 7 ActivateAll, Task 8 sets StrictPerPID = (PID != 0).
+- §3.6 Both archs in v1 → Tasks 5 (amd64), 6 (arm64).
+- §3.7 SONAME or /proc/<pid>/exe + debug/elf → Tasks 2, 3, 4.
+- §3.8 Inject before BPF attach → Task 8 calls ActivateAll before BPF.
+- §3.9 Unit + integration → Tasks 1-7 (unit), Task 11 (integration).
+
+- §4.1 Layout (inject/elfsym, inject/ptraceop, inject/python) → Tasks 1-7.
+- §4.2 Public surface → Task 7.
+- §4.3 perfagent.Agent integration → Task 8.
+
+- §5 Detection ladder → Task 4.
+- §6 Injection sequence (3-call wrap, SIGSEGV-at-0, stack payload) → Tasks 5, 6.
+- §7 Lifecycle (preexisting marker, bounded shutdown, late arrivals) → Tasks 7, 9.
+- §8 CLI flag + behavior matrix + cap precheck + logging + bench → Tasks 8, 10.
+- §9 Test plan → Tasks 1-7 unit + Task 11 integration.
+- §10 Documentation → Task 12.
+- §11 Risks (latency, GIL re-entrance, stack headroom, symbol versioning) → noted in code comments.
+- §12 References → in spec, not in plan.
+
+**Placeholder scan:** One placeholder remains in Task 11 step 2: the `haveCaps` helper. The plan explicitly tells the implementer to copy the existing helper from `integration_test.go`. This is acceptable — the plan doesn't have access to read other files at write time, and the instruction is concrete.
+
+**Type consistency:**
+
+- `Target` (defined in Task 4) used by Tasks 7, 8, 9. ✓
+- `SymbolAddrsForTarget` (Task 7) used by Tasks 7, 8, 9. ✓
+- `LowLevelInjector` interface (Task 7) implemented by `ptraceopBridge` (Task 8). ✓
+- `Stats` (Task 7) referenced as `*python.Stats` (Task 8). ✓
+- `Detector` interface (Task 4) implemented by `procDetector` (Task 4) and stub (Task 7). ✓
+
+**Spec requirement with no task: none found.**

--- a/docs/superpowers/plans/2026-04-28-python-perf-injector.md
+++ b/docs/superpowers/plans/2026-04-28-python-perf-injector.md
@@ -2372,36 +2372,141 @@ For `-a --inject-python`, processes that exec during the run also need injection
 grep -rn "OnNewExec\|NewMmapWatcher\|MmapWatcher" unwind/ perfagent/
 ```
 
-- [ ] **Step 2: Add the hook**
+- [ ] **Step 2: Add the hook with LAZY subscription**
 
-If the watcher already exposes a `OnNewExec(func(pid uint32))` callback, wire `Agent` to register `a.pyInjector.ActivateLate` if `pyInjector != nil`. If it does not, extend it minimally.
+**Hard requirement: zero overhead when `--inject-python` is off.** The watcher must not produce, buffer, or dispatch new-exec events when nobody is subscribed. This rules out:
 
-If the watcher uses a channel (e.g., `Watcher.NewExecChan() <-chan uint32`), spawn a small drainer goroutine in `Agent.Start()`:
+- Always-on channels (even if no goroutine drains them, populating the channel costs CPU and may eventually block whatever produces the events).
+- Slice-of-callbacks where an empty slice is iterated on every event.
+
+Pick exactly one of these two patterns based on what the watcher already does:
+
+**Pattern A — callback registration (preferred if the watcher has a constructor or hook-registration phase):**
 
 ```go
-if a.pyInjector != nil && a.cfg.PID == 0 {  // -a mode only
-	a.lateExecWG.Go(func() {
-		ch := a.watcher.NewExecChan()
-		for {
-			select {
-			case <-a.ctx.Done():
-				return
-			case pid, ok := <-ch:
-				if !ok {
-					return
-				}
-				a.pyInjector.ActivateLate(pid)
-			}
-		}
-	})
+// In the watcher's package:
+type Watcher struct {
+    // ... existing fields ...
+    onNewExec func(pid uint32)  // nil → no hook; producer skips dispatch entirely
+}
+
+// SetOnNewExec registers a hook. Pass nil to clear. Must be called before
+// Start() (or while holding the watcher's lock) to avoid races.
+func (w *Watcher) SetOnNewExec(fn func(pid uint32)) {
+    w.onNewExec = fn
+}
+
+// Inside the watcher's event loop:
+func (w *Watcher) handleExec(pid uint32) {
+    // ... existing CFI-related work ...
+    if w.onNewExec != nil {
+        w.onNewExec(pid)  // single nil check; if no subscriber, fully skipped
+    }
 }
 ```
 
-The exact shape depends on the existing watcher API; the goal is "every new exec invokes ActivateLate" and "the goroutine ends cleanly on ctx cancel."
+In `perfagent/agent.go`, register only when injection is enabled:
 
-- [ ] **Step 3: Add a unit test for the dedupe path**
+```go
+if a.pyInjector != nil && a.cfg.PID == 0 {  // -a mode only
+    a.watcher.SetOnNewExec(a.pyInjector.ActivateLate)
+}
+```
 
-If the watcher exposes a way to inject a synthetic new-exec event in tests, write `TestLateExecHook_InvokesActivateLate` in `inject/python/manager_test.go`. Otherwise, the integration test in Task 11 covers this end-to-end.
+No goroutine, no channel, no producer-side cost when `pyInjector == nil`.
+
+**Pattern B — Subscribe()-on-demand channel (use only if the watcher already serves multiple consumers via channels):**
+
+```go
+// In the watcher's package:
+type Watcher struct {
+    mu          sync.Mutex
+    subscribers []chan<- uint32  // nil/empty → producer skips dispatch
+}
+
+// Subscribe returns a buffered channel (size 64) that receives new-exec PIDs.
+// The channel is closed when the watcher shuts down. Returns a cancel func
+// the caller should invoke to drop the subscription before its context ends.
+func (w *Watcher) Subscribe() (<-chan uint32, func()) {
+    ch := make(chan uint32, 64)
+    w.mu.Lock()
+    w.subscribers = append(w.subscribers, ch)
+    w.mu.Unlock()
+    cancel := func() {
+        w.mu.Lock()
+        defer w.mu.Unlock()
+        for i, s := range w.subscribers {
+            if s == ch {
+                w.subscribers = append(w.subscribers[:i], w.subscribers[i+1:]...)
+                close(ch)
+                return
+            }
+        }
+    }
+    return ch, cancel
+}
+
+// Inside the watcher's event loop:
+func (w *Watcher) handleExec(pid uint32) {
+    w.mu.Lock()
+    if len(w.subscribers) == 0 {
+        w.mu.Unlock()
+        return  // zero subscribers → zero work
+    }
+    subs := append([]chan<- uint32(nil), w.subscribers...)
+    w.mu.Unlock()
+    for _, ch := range subs {
+        select {
+        case ch <- pid:
+        default:
+            // subscriber's buffer full; drop. Slow consumers must not stall
+            // the watcher.
+        }
+    }
+}
+```
+
+In `perfagent/agent.go`:
+
+```go
+if a.pyInjector != nil && a.cfg.PID == 0 {
+    ch, cancelSub := a.watcher.Subscribe()
+    a.lateExecWG.Go(func() {
+        defer cancelSub()
+        for {
+            select {
+            case <-a.ctx.Done():
+                return
+            case pid, ok := <-ch:
+                if !ok {
+                    return
+                }
+                a.pyInjector.ActivateLate(pid)
+            }
+        }
+    })
+}
+```
+
+When no one calls `Subscribe()`, `len(w.subscribers) == 0` and `handleExec` returns after one mutex acquire — no allocation, no channel send.
+
+**Choosing between A and B:**
+- Pattern A is simpler and cheaper. Use it unless the existing watcher already has a multi-consumer channel API.
+- Pattern B is appropriate if the codebase already uses Subscribe()-style channels elsewhere.
+
+In either case: **the producer (the watcher's event loop) must do zero work when no subscriber is registered.** That's the invariant; the test below verifies it.
+
+- [ ] **Step 3: Add unit tests — including a no-subscriber zero-overhead test**
+
+Two tests required:
+
+**Test 1: `TestNewExec_NoSubscribersZeroDispatch`** (in the watcher's test file). Construct a Watcher without registering any hook (Pattern A: don't call `SetOnNewExec`; Pattern B: don't call `Subscribe`). Drive a synthetic exec event into the watcher's `handleExec`. Assert that no observable side-effect occurs and (Pattern A) the `onNewExec` field is still nil.
+
+The literal assertion is "the test passes" — what we're verifying is that the no-subscriber path doesn't panic, doesn't allocate (for B), and exits early. This guards the lazy-subscription invariant against future refactors.
+
+**Test 2: `TestNewExec_HookFires`** (same file). Register a hook (Pattern A) or subscribe (Pattern B). Drive a synthetic exec event for `pid=12345`. Assert the hook saw `pid=12345`.
+
+If the watcher is internally hard to test (e.g., spawns goroutines that read from a real perf event ring), introduce an internal `func handleExec(pid uint32)` method that the test can call directly while the production event loop calls the same method.
 
 - [ ] **Step 4: Build + test**
 

--- a/docs/superpowers/specs/2026-04-28-python-perf-injector-design.md
+++ b/docs/superpowers/specs/2026-04-28-python-perf-injector-design.md
@@ -21,7 +21,7 @@ This spec proposes a v1 injector that uses `ptrace` to remotely call `sys.activa
 - Integrate cleanly into both `--pid N` and `-a` system-wide profiling modes.
 - Cover both amd64 and arm64 architectures in v1.
 - Provide structured stats (`Activated`, `Deactivated`, `Skipped[reason]`, `Failed`) for operator audit.
-- Keep the injector self-contained — `inject/` package has no dependencies on `profile/`, `offcpu/`, or `cpu/`.
+- Keep the injector tree self-contained — `inject/` and its subpackages (`inject/elfsym/`, `inject/ptraceop/`, `inject/python/`) have no dependencies on `profile/`, `offcpu/`, or `cpu/`. Language-agnostic primitives (`elfsym`, `ptraceop`) sit at the inject root so future runtimes (Node.js, JVM) can share them.
 
 ### Non-goals (v1)
 
@@ -51,34 +51,40 @@ This spec proposes a v1 injector that uses `ptrace` to remotely call `sys.activa
 
 ### 4.1 Package layout
 
-A new top-level package, sibling to `unwind/`, `cpu/`, `offcpu/`:
+A new top-level package tree, sibling to `unwind/`, `cpu/`, `offcpu/`. The layout splits **language-agnostic primitives** (`elfsym`, `ptraceop`) from **language-specific logic** (`python`) so future runtimes (Node.js, JVM, Ruby) can plug in as siblings of `python/` without touching the shared layer:
 
 ```
 inject/
-  inject.go              # public types: Manager, Options, Stats, Target
-  manager.go             # Manager struct, ActivateAll, DeactivateAll, dedupe
-  detector.go            # Detector interface + concrete /proc-based impl
-  errors.go              # ErrNotPython, ErrPythonTooOld, ErrNoPerfTrampoline,
+  elfsym/                # SHARED across runtimes
+    soname.go            # SONAME parsing + version filter (regex-based)
+    elfsym.go            # ResolveSymbols (.dynsym → .symtab fallback)
+    *_test.go
+  ptraceop/              # SHARED across runtimes
+    ptraceop.go          # RemoteCall: attach → save → write → call → restore → detach
+                         # Generic 3-call sequencing primitive
+    regs_amd64.go        # //go:build amd64 — System V AMD64 call-frame setup
+    regs_arm64.go        # //go:build arm64 — AAPCS64 call-frame setup
+    *_test.go
+  python/                # Python-specific
+    python.go            # Public types: Manager, Options, Stats, Target
+    manager.go           # Manager struct, ActivateAll, DeactivateAll,
+                         # ActivateLate (mmap-watcher hook), dedupe
+    detector.go          # Detection ladder: /proc/<pid>/maps → SONAME match →
+                         # /proc/<pid>/exe fallback → ELF symbol resolution
+    payload.go           # Activate/deactivate C-string payload encoding
+    errors.go            # ErrNotPython, ErrPythonTooOld, ErrNoPerfTrampoline,
                          # ErrStaticallyLinkedNoSymbols, ErrPreexisting
-  payload.go             # Activate/deactivate C-string payload encoding
-  elfsym/
-    elfsym.go            # Public ResolveSymbols entrypoint
-    soname.go            # SONAME parsing + version filter
-  ptraceop/
-    ptraceop.go          # Arch-generic coordination: attach → save → write →
-                         # remote-call → restore → detach
-    regs_amd64.go        # //go:build amd64 — call-frame setup,
-                         # syscall trap encoding
-    regs_arm64.go        # //go:build arm64 — call-frame setup,
-                         # syscall trap encoding
+    *_test.go
 ```
 
-Tests sit alongside (`*_test.go`).
+**Future expansion (illustrative — not part of v1):** When Node.js injection ships, it lands as `inject/nodejs/` parallel to `inject/python/`, reusing `inject/elfsym/` and (where applicable) `inject/ptraceop/`. Some runtimes may not use ptrace at all — for example, a Node.js injector via the V8 inspector protocol would import `inject/inspectorproto/` (a hypothetical future sibling of `ptraceop/`) instead. The layout supports both patterns.
+
+Tests sit alongside source files (`*_test.go`).
 
 ### 4.2 Public surface
 
 ```go
-package inject
+package python  // import path: github.com/.../inject/python
 
 type Options struct {
     StrictPerPID bool        // true for --pid N; false for -a
@@ -119,19 +125,43 @@ type Stats struct {
 }
 ```
 
+Internally, `python.Manager` calls into `inject/ptraceop` for the low-level remote-call sequence. `ptraceop` does NOT import `inject/python` — to avoid an import cycle, `ptraceop.RemoteCall` takes primitive `SymbolAddrs` arguments rather than `*Target`. `python.manager` constructs `SymbolAddrs` from `Target` and passes them through.
+
+```go
+package ptraceop  // import path: github.com/.../inject/ptraceop
+
+type SymbolAddrs struct {
+    PyGILEnsure  uint64
+    PyGILRelease uint64
+    PyRunString  uint64
+}
+
+type Injector struct { ... }
+
+func New(log *slog.Logger) *Injector
+// RemoteActivate runs the three-call sequence (Ensure → Run → Release) inside
+// a single ptrace session. Generic over the symbol set; today only Python uses
+// it, but the same primitive works for any C-ABI runtime that needs a brief
+// remote-function-call to enable instrumentation.
+func (i *Injector) RemoteActivate(pid uint32, addrs SymbolAddrs, payload []byte) error
+func (i *Injector) RemoteDeactivate(pid uint32, addrs SymbolAddrs, payload []byte) error
+```
+
 ### 4.3 Integration with `perfagent.Agent`
 
 ```go
 // perfagent/agent.go (additions only shown)
+import "github.com/.../inject/python"
+
 type Agent struct {
     // ...existing fields...
-    injectMgr *inject.Manager  // nil unless --inject-python is set
+    pyInjector *python.Manager  // nil unless --inject-python is set
 }
 
 func (a *Agent) Start(ctx context.Context) error {
-    if a.injectMgr != nil {
+    if a.pyInjector != nil {
         targets := a.scanForPythonTargets()  // detector ladder, see §5
-        if err := a.injectMgr.ActivateAll(targets); err != nil {
+        if err := a.pyInjector.ActivateAll(targets); err != nil {
             return fmt.Errorf("python injection: %w", err)
         }
     }
@@ -140,16 +170,18 @@ func (a *Agent) Start(ctx context.Context) error {
 
 func (a *Agent) Stop(ctx context.Context) error {
     // ...profile finalization...
-    if a.injectMgr != nil {
-        a.injectMgr.DeactivateAll(ctx)
+    if a.pyInjector != nil {
+        a.pyInjector.DeactivateAll(ctx)
     }
     // ...close BPF, flush, exit...
 }
 
-func (a *Agent) InjectStats() inject.Stats  // nil-safe; zero value if off
+func (a *Agent) PythonInjectStats() python.Stats  // nil-safe; zero value if off
 ```
 
-For `-a` mode, the existing mmap watcher (`unwind/ehmaps/tracker.go`) gains a hook that calls `injectMgr.ActivateLate(pid)` when a new exec is detected.
+For `-a` mode, the existing mmap watcher (`unwind/ehmaps/tracker.go`) gains a hook that calls `pyInjector.ActivateLate(pid)` when a new exec is detected.
+
+When future runtimes ship, `Agent` gains parallel fields (`nodeInjector *nodejs.Manager`, etc.) and parallel scan loops. The mmap watcher's new-exec channel is multiplexed across all configured injectors — each runtime's `Detector.Detect()` runs in parallel and the first non-nil result wins (a process is one runtime; if any future detector ambiguity arises, we'd add explicit precedence then).
 
 ## 5. Detection ladder
 
@@ -432,18 +464,13 @@ The summary line at end-of-scan gives operators a one-glance audit without grepp
 
 ```
 inject/elfsym/
-  symtab_test.go
+  soname_test.go
     TestParseSONAME_PythonVariants
     TestParseSONAME_NotPython
+  elfsym_test.go
     TestResolveSymbols_DynsymHit
     TestResolveSymbols_FallsBackToSymtab
-    TestResolveSymbols_MissingPyRunSimpleString  → ErrStaticallyLinkedNoSymbols
-    TestResolveSymbols_MissingPerfCallbacks      → ErrNoPerfTrampoline
-    TestResolveStaticBinary
-
-inject/payload_test.go
-  TestEncodeActivatePayload     (exact bytes, null-terminated)
-  TestEncodeDeactivatePayload   (exact bytes, null-terminated)
+    TestResolveSymbols_MissingByName
 
 inject/ptraceop/
   regs_amd64_test.go            (//go:build amd64)
@@ -454,15 +481,26 @@ inject/ptraceop/
     TestSetupCallFrame_arm64    (X0/SP/PC/LR set; sentinel)
     TestRegsRoundTrip_arm64
 
-inject/manager_test.go
-  TestActivateAll_StrictExitsOnFirstError
-  TestActivateAll_LenientContinuesOnError
-  TestActivateAll_PreexistingMarkerSkips
-  TestDeactivateAll_HonorsDeadline
-  TestDeactivateAll_SkipsPreexisting
-  TestDeactivateAll_ToleratesESRCH
-  TestNewExec_DedupesViaTracked
-  TestNewExec_DedupesViaPending
+inject/python/
+  payload_test.go
+    TestEncodeActivatePayload     (exact bytes, null-terminated)
+    TestEncodeDeactivatePayload   (exact bytes, null-terminated)
+  detector_test.go
+    TestDetect_DynamicLinkedPython312       (libpython3.12.so in maps → Target)
+    TestDetect_StaticLinkedPython           (no libpython; exe has symbols)
+    TestDetect_NonPython                    (Go binary → ErrNotPython)
+    TestDetect_PythonTooOld                 (libpython3.11.so → ErrPythonTooOld)
+    TestDetect_NoPerfTrampoline             (libpython3.12.so without
+                                              _PyPerf_Callbacks → ErrNoPerfTrampoline)
+  manager_test.go
+    TestActivateAll_StrictExitsOnFirstError
+    TestActivateAll_LenientContinuesOnError
+    TestActivateAll_PreexistingMarkerSkips
+    TestDeactivateAll_HonorsDeadline
+    TestDeactivateAll_SkipsPreexisting
+    TestDeactivateAll_ToleratesESRCH
+    TestNewExec_DedupesViaTracked
+    TestNewExec_DedupesViaPending
 ```
 
 Synthetic-procfs pattern reused from PR #11's `scan_enroll_test.go::buildSyntheticProcTree`. Synthetic ELF files for symbol-resolution tests use `debug/elf.NewFile` over an in-memory byte buffer with a minimal `.dynsym`. Register tests in `ptraceop_*_test.go` exercise frame setup logic over hand-crafted `unix.PtraceRegs` values (real `ptrace` is exercised in integration).
@@ -470,14 +508,14 @@ Synthetic-procfs pattern reused from PR #11's `scan_enroll_test.go::buildSynthet
 ### 9.2 Integration tests (caps-gated)
 
 ```
-test/integration_inject_test.go
+test/integration_inject_python_test.go
   TestInjectPython_ActivatesTrampoline
     1. Launch python3.12 test/workloads/python/cpu_bound.py 10 2 (no -X perf)
     2. Wait 1s for warmup
     3. Run perf-agent --profile --inject-python --pid <PID> --duration 5s
     4. Assert /tmp/perf-<PID>.map exists, contains py:: lines
     5. Assert profile.pb.gz has Python frame names
-    6. Assert agent.InjectStats(): Activated=1, Deactivated=1
+    6. Assert agent.PythonInjectStats(): Activated=1, Deactivated=1
     7. After perf-agent exit: re-stat perf-map twice with 1s gap; size unchanged
        (proves deactivation ran)
 
@@ -492,7 +530,7 @@ test/integration_inject_test.go
        1× Go binary
     2. Run perf-agent --profile -a --inject-python --duration 5s
     3. Assert exit 0
-    4. Assert agent.InjectStats(): Activated=2, SkippedTooOld=1,
+    4. Assert agent.PythonInjectStats(): Activated=2, SkippedTooOld=1,
        SkippedNotPython=1, Failed=0
     5. Assert profile contains Python frames from the two 3.12 processes
 ```

--- a/docs/superpowers/specs/2026-04-28-python-perf-injector-design.md
+++ b/docs/superpowers/specs/2026-04-28-python-perf-injector-design.md
@@ -1,0 +1,531 @@
+# Python perf-trampoline injector — design
+
+**Date:** 2026-04-28
+**Branch:** `feat/python-perf-injector`
+**Status:** Spec — pending implementation plan
+
+## 1. Problem
+
+CPython 3.12+ ships an opt-in perf-compatible trampoline that emits per-function entries to `/tmp/perf-<pid>.map`, allowing external profilers (perf, perf-agent via blazesym) to attach human-readable Python qualnames to JITted frame addresses. The trampoline is activated either by launching the interpreter with `python3 -X perf` or by calling `sys.activate_stack_trampoline("perf")` from inside the process.
+
+Today, perf-agent users who want Python JIT names must restart their target process with `-X perf`. That is a hostile UX for production debugging — many real targets (web servers under traffic, long-running pipelines, embedded interpreters) cannot be restarted on demand. Without injection, perf-agent's profiles for those targets render Python frames as `[jit]` placeholders or address-only entries.
+
+This spec proposes a v1 injector that uses `ptrace` to remotely call `sys.activate_stack_trampoline("perf")` inside a running CPython 3.12+ process when the user passes `--profile --inject-python`, and to call `sys.deactivate_stack_trampoline()` on shutdown so the trampoline overhead does not persist past the profiling window.
+
+## 2. Goals and non-goals
+
+### Goals
+
+- Activate Python's perf trampoline in a running CPython 3.12+ process via `ptrace`, without restarting the target.
+- Deactivate the trampoline at end-of-profile so production overhead is bounded to the profiling window.
+- Integrate cleanly into both `--pid N` and `-a` system-wide profiling modes.
+- Cover both amd64 and arm64 architectures in v1.
+- Provide structured stats (`Activated`, `Deactivated`, `Skipped[reason]`, `Failed`) for operator audit.
+- Keep the injector self-contained — `inject/` package has no dependencies on `profile/`, `offcpu/`, or `cpu/`.
+
+### Non-goals (v1)
+
+- **Python < 3.12 support.** No equivalent activation primitive exists; older versions fall back to perf-agent's existing DWARF-through-interpreter unwinding (no JIT names).
+- **CPython without `--enable-perf-trampoline`.** Detected via symbol-presence check; skipped with a structured reason.
+- **PID-namespace translation for containers.** Host-side PIDs only. Documented limitation; small extension seam left for follow-up.
+- **Persistent state across perf-agent restarts.** Each run is independent. Stale `/tmp/perf-PID.map` files are the user's responsibility to clean up if a previous run was killed.
+- **Standalone subcommand for injection** (e.g., `perf-agent inject-python --pid N`). Considered and rejected; injection is bound to `--profile` runs.
+- **Off-CPU / PMU integration.** `--inject-python` is `--profile`-only in v1.
+- **Multi-version test matrix.** v1 tests against Python 3.12 only; broader matrix is a future PR.
+
+## 3. Decisions reached during brainstorming
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Python version scope | 3.12+ only |
+| 2 | Integration UX | Profiling-time flag: `--profile --inject-python` |
+| 3 | Lifecycle | Activate on profile start, deactivate on profile end |
+| 4 | Implementation language | Pure Go via `golang.org/x/sys/unix` |
+| 5 | Error model | Strict per-PID (`--pid N`); lenient system-wide (`-a`) |
+| 6 | Architecture support | Both amd64 and arm64 in v1 |
+| 7 | Detection + symbol resolution | SONAME or `/proc/<pid>/exe` match + `debug/elf` symbol resolution |
+| 8 | Ordering | Inject before BPF attach |
+| 9 | Test strategy | Unit tests + one full-pipe integration test + lenient mixed-fleet integration test |
+
+## 4. Architecture
+
+### 4.1 Package layout
+
+A new top-level package, sibling to `unwind/`, `cpu/`, `offcpu/`:
+
+```
+inject/
+  inject.go              # public types: Manager, Options, Stats, Target
+  manager.go             # Manager struct, ActivateAll, DeactivateAll, dedupe
+  detector.go            # Detector interface + concrete /proc-based impl
+  errors.go              # ErrNotPython, ErrPythonTooOld, ErrNoPerfTrampoline,
+                         # ErrStaticallyLinkedNoSymbols, ErrPreexisting
+  payload.go             # Activate/deactivate C-string payload encoding
+  elfsym/
+    elfsym.go            # Public ResolveSymbols entrypoint
+    soname.go            # SONAME parsing + version filter
+  ptraceop/
+    ptraceop.go          # Arch-generic coordination: attach → save → write →
+                         # remote-call → restore → detach
+    regs_amd64.go        # //go:build amd64 — call-frame setup,
+                         # syscall trap encoding
+    regs_arm64.go        # //go:build arm64 — call-frame setup,
+                         # syscall trap encoding
+```
+
+Tests sit alongside (`*_test.go`).
+
+### 4.2 Public surface
+
+```go
+package inject
+
+type Options struct {
+    StrictPerPID bool        // true for --pid N; false for -a
+    Logger       *slog.Logger
+}
+
+type Manager struct { ... }
+
+func NewManager(opts Options) *Manager
+func (m *Manager) ActivateAll(targets []*Target) error
+func (m *Manager) ActivateLate(pid uint32)        // mmap-watcher hook
+func (m *Manager) DeactivateAll(ctx context.Context)
+func (m *Manager) Stats() Stats
+
+type Detector interface {
+    Detect(pid uint32) (*Target, error)
+}
+
+type Target struct {
+    PID            uint32
+    LibPythonPath  string  // on-disk path used for ELF parsing
+    LoadBase       uint64  // address from /proc/<pid>/maps
+    PyGILEnsureAddr   uint64
+    PyGILReleaseAddr  uint64
+    PyRunStringAddr   uint64
+}
+
+type Stats struct {
+    Activated         atomic.Uint64
+    Deactivated       atomic.Uint64
+    SkippedNotPython   atomic.Uint64
+    SkippedTooOld      atomic.Uint64
+    SkippedNoTramp     atomic.Uint64
+    SkippedNoSymbols   atomic.Uint64
+    SkippedPreexisting atomic.Uint64
+    ActivateFailed     atomic.Uint64
+    DeactivateFailed   atomic.Uint64
+}
+```
+
+### 4.3 Integration with `perfagent.Agent`
+
+```go
+// perfagent/agent.go (additions only shown)
+type Agent struct {
+    // ...existing fields...
+    injectMgr *inject.Manager  // nil unless --inject-python is set
+}
+
+func (a *Agent) Start(ctx context.Context) error {
+    if a.injectMgr != nil {
+        targets := a.scanForPythonTargets()  // detector ladder, see §5
+        if err := a.injectMgr.ActivateAll(targets); err != nil {
+            return fmt.Errorf("python injection: %w", err)
+        }
+    }
+    // ...BPF attach, sampling start...
+}
+
+func (a *Agent) Stop(ctx context.Context) error {
+    // ...profile finalization...
+    if a.injectMgr != nil {
+        a.injectMgr.DeactivateAll(ctx)
+    }
+    // ...close BPF, flush, exit...
+}
+
+func (a *Agent) InjectStats() inject.Stats  // nil-safe; zero value if off
+```
+
+For `-a` mode, the existing mmap watcher (`unwind/ehmaps/tracker.go`) gains a hook that calls `injectMgr.ActivateLate(pid)` when a new exec is detected.
+
+## 5. Detection ladder
+
+Detection runs per-PID inside ScanAndEnroll and the `--pid` shortcut equivalent. Each step short-circuits the next:
+
+```
+Step 1: read /proc/<pid>/maps
+  └── Find executable mapping matching /libpython3\.(1[2-9]|[2-9][0-9])\.so/
+       Capture: load_base, lib_path_on_disk
+       └── Found      → goto Step 2 (dynamic-link path)
+       └── Not found  → goto Step 1b (static-link fallback)
+
+Step 1b: read /proc/<pid>/exe (resolves to on-disk path)
+  └── Open as ELF; check .dynsym OR .symtab for libpython internal symbols
+       (PyRun_SimpleString, PyGILState_Ensure)
+       └── Found     → load_base = exe load offset; lib_path = exe path; goto Step 2
+       └── Not found → return ErrNotPython
+
+Step 2: parse ELF symbol table (debug/elf, .dynsym first then .symtab)
+  └── Resolve four symbols by name:
+       - PyGILState_Ensure       (required)
+       - PyGILState_Release      (required)
+       - PyRun_SimpleString      (required)
+       - _PyPerf_Callbacks       (presence-only; address unused)
+  └── If any of the first three are missing → ErrStaticallyLinkedNoSymbols
+  └── If _PyPerf_Callbacks is missing       → ErrNoPerfTrampoline
+  └── Compute remote addrs = load_base + symbol.Value
+  └── Return *Target
+```
+
+### Why pre-flight `_PyPerf_Callbacks`
+
+Symbol presence in `.dynsym` is a deterministic, free signal of `--enable-perf-trampoline`. Without this filter, perf-agent would attempt the full ptrace round trip (attach → write → remote call → trap → detach) only to have `PyRun_SimpleString` return -1. Filtering at symbol-table level skips those processes in microseconds.
+
+### Edge cases
+
+- **Multiple `libpython` mappings** (extension modules sometimes embed a second interpreter): use first match. Activation failure on a wrong-libpython cohort is non-corrupting (the SIGSEGV-at-0 sentinel returns control to the injector, which logs and skips).
+- **PIE binaries (static fallback path):** `load_base` from `/proc/<pid>/maps` already accounts for ASLR.
+- **Stripped binaries:** `.dynsym` is required at runtime; if it has the symbols, we proceed. `.symtab` fallback handles non-stripped-but-unusual builds.
+
+### Explicitly out of scope for detection
+
+- Reading `Py_Version` from process memory.
+- Touching `_PyRuntime` or other interpreter state.
+
+## 6. Injection sequence
+
+The sequence is identical for activate and deactivate; only the payload string differs.
+
+```
+Activate payload:    "import sys; sys.activate_stack_trampoline('perf')\0"
+Deactivate payload:  "import sys; sys.deactivate_stack_trampoline()\0"
+```
+
+### 6.1 Why three remote calls, not one
+
+`PyRun_SimpleString` requires the calling thread to hold the GIL. The thread we attach to via `ptrace` is whatever thread happened to be running (usually the main thread, but not guaranteed) — and it may not hold the GIL at attach time. Calling `PyRun_SimpleString` directly from a thread that does not hold the GIL is undefined behavior (typically a deadlock against another thread that does).
+
+The portable, well-tested solution (used by pyrasite, manhole's historical ptrace path, and several other Linux ptrace-injection tools) is to wrap the call:
+
+```
+gstate = PyGILState_Ensure()           // safely acquires GIL from any thread
+result = PyRun_SimpleString(payload)   // executes payload under GIL
+PyGILState_Release(gstate)             // restores prior GIL state
+```
+
+Each line is its own remote call (its own SIGSEGV-return trip). Three remote calls per activation; three more for deactivation on shutdown. We do all three within a single ptrace session (one `PTRACE_ATTACH`, one `PTRACE_DETACH`).
+
+### 6.2 Per-target steps
+
+```
+1. ptrace(PTRACE_ATTACH, pid)                — stops target with SIGSTOP
+2. waitpid(pid)                              — confirm stopped
+3. ptrace(PTRACE_GETREGS, pid, &orig)        — save full register state
+4. Read /proc/<pid>/maps; find target's [stack] mapping; verify
+   below-SP headroom: current_SP - stack_low_addr >= 1024 bytes
+   (stack grows downward; we write payload BELOW current SP, so the
+   relevant slack is the gap between SP and the low end of the mapping)
+   - If insufficient headroom: fall back to remote-mmap path (§6.4)
+5. Choose payload_addr = orig.SP - 256 (16-byte aligned)
+6. process_vm_writev(pid, payload_bytes) → writes payload at payload_addr
+
+7. Remote call A: gstate = PyGILState_Ensure()
+   - Build call frame from orig:
+     amd64: RIP=PyGILState_Ensure_addr, RSP=payload_addr-8, *(RSP)=0
+     arm64: PC=PyGILState_Ensure_addr,  SP=payload_addr-16 (16-aligned), LR=0
+   - PTRACE_SETREGS, PTRACE_CONT, waitpid (blocks until SIGSEGV at addr 0)
+   - Capture return: gstate = RAX (amd64) / X0 (arm64)
+   - On non-SIGSEGV stop or unexpected status: abort, restore orig, detach,
+     report error.
+
+8. Remote call B: result = PyRun_SimpleString(payload_addr)
+   - Build call frame:
+     amd64: RDI=payload_addr, RIP=PyRun_SimpleString_addr, RSP=payload_addr-8, *(RSP)=0
+     arm64: X0=payload_addr,  PC=PyRun_SimpleString_addr,  SP=payload_addr-16, LR=0
+   - PTRACE_SETREGS, PTRACE_CONT, waitpid
+   - Capture return: result = RAX / X0  (must be 0 = success)
+   - If result != 0: activation/deactivation failed; still proceed to call C
+     to release the GIL we acquired in A. Record error reason.
+
+9. Remote call C: PyGILState_Release(gstate)
+   - Build call frame:
+     amd64: RDI=gstate, RIP=PyGILState_Release_addr, RSP=payload_addr-8, *(RSP)=0
+     arm64: X0=gstate,  PC=PyGILState_Release_addr,  SP=payload_addr-16, LR=0
+   - PTRACE_SETREGS, PTRACE_CONT, waitpid (return value ignored — function is void)
+   - Always run this call, even if call B failed, so we never leave the
+     target with an unbalanced GIL state.
+
+10. ptrace(PTRACE_SETREGS, pid, &orig)       — restore original registers
+11. ptrace(PTRACE_DETACH, pid, 0, 0)         — resume target; do NOT
+                                               deliver the SIGSEGV (signal=0)
+```
+
+### 6.3 Why SIGSEGV-at-0 as the return sentinel
+
+When each remote call returns, it pops its return address off the stack (or branches to LR on arm64) and jumps there. Setting that return address to `0` causes the target to dereference address 0 on return → SIGSEGV → ptrace stops the target → injector reclaims control. We never deliver the SIGSEGV signal (`PTRACE_DETACH` with `signal=0`, and intermediate `PTRACE_CONT` calls also use `signal=0`), so the target never sees it.
+
+This is the standard approach used by pyrasite, manhole's historical ptrace path, and several Linux JIT injectors. The alternative (writing `int3`/`brk #0` into a target-allocated executable scratch page) requires a remote `mmap` round trip and adds complexity for no semantic gain in our use case (no other observer is debugging the target while perf-agent injects).
+
+### 6.4 Stack-with-mmap-fallback for payload bytes
+
+Default: write payload onto the target's existing stack at `SP - 256`. The 50-byte payload and 8-byte sentinel return-address slot fit easily in the gap. The 1024-byte minimum headroom check (step 4) is conservative — it guarantees we never write past the low end of the stack mapping even if we ever extend the payload.
+
+Fallback: if `[stack]` mapping has less than 1024 bytes between the low end of the mapping and current SP (rare; extension threads can have very tight stacks, especially after deep recursion), perform a remote `mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)` via the same remote-call machinery (one extra round trip), use the returned address for the payload, and `munmap` it on detach (one more round trip).
+
+The fallback adds two extra ptrace round trips when triggered, but typical Python processes never hit it. We don't pre-emptively use mmap because the stack path is faster and simpler under normal conditions.
+
+### 6.5 Per-arch encapsulation
+
+`ptraceop/ptraceop.go` owns the arch-generic ptrace coordination (steps 1, 2, 3, 4, 5, 6, 10, 11) and the per-call wrapper that runs `PTRACE_SETREGS` → `PTRACE_CONT` → `waitpid` (which is identical across all three remote calls — only the input register frame differs). `ptraceop/regs_amd64.go` and `regs_arm64.go` own the per-arch register-frame setup for steps 7, 8, 9 and the return-value extraction. Cross-arch behavior is identical; only the register names and the calling convention differ.
+
+## 7. Lifecycle and state tracking
+
+### 7.1 Manager state
+
+```go
+type Manager struct {
+    mu       sync.Mutex
+    tracked  map[uint32]*trackedTarget
+    pending  sync.Map  // uint32 → struct{}; in-flight late activations
+    stats    Stats
+    log      *slog.Logger
+    detector Detector
+    injector *injector  // internal type; calls into ptraceop/
+    opts     Options
+}
+
+type trackedTarget struct {
+    target      *Target
+    activatedAt time.Time
+    preexisting bool  // /tmp/perf-<pid>.map already existed at activation time
+}
+```
+
+### 7.2 Idempotency: the preexisting marker
+
+Before activation, the injector checks for an existing `/tmp/perf-<pid>.map` file. If present and non-empty, the trampoline is already running (either from a prior perf-agent run or from the user's own activation). The injector:
+
+1. Records the target with `preexisting=true`.
+2. Increments `Stats.SkippedPreexisting`.
+3. **Skips both activation and deactivation** for this target.
+
+This is intentionally conservative. False positives (skipping when we could have activated) cost the user no JIT names for that target during this run. False negatives (deactivating someone else's instrumentation) are a correctness violation. We err on the side of correctness.
+
+### 7.3 ActivateAll — strict and lenient policies
+
+```go
+func (m *Manager) ActivateAll(targets []*Target) error {
+    for _, t := range targets {
+        if m.alreadyActiveOnDisk(t.PID) {
+            m.recordPreexisting(t); continue
+        }
+        if err := m.injector.Activate(t); err != nil {
+            if m.opts.StrictPerPID {
+                return fmt.Errorf("activate pid=%d: %w", t.PID, err)
+            }
+            m.log.Warn("activate failed (lenient)", "pid", t.PID, "err", err)
+            m.stats.ActivateFailed.Add(1)
+            continue
+        }
+        m.recordActivated(t)
+        m.stats.Activated.Add(1)
+    }
+    return nil  // lenient never returns from this loop
+}
+```
+
+### 7.4 DeactivateAll — bounded shutdown
+
+```go
+func (m *Manager) DeactivateAll(ctx context.Context) {
+    deadline := time.Now().Add(5 * time.Second)
+    deadlineCtx, cancel := context.WithDeadline(ctx, deadline)
+    defer cancel()
+
+    for pid, tt := range m.snapshotTracked() {
+        if tt.preexisting { continue }
+        select {
+        case <-deadlineCtx.Done():
+            m.log.Warn("deactivate cancelled (deadline)", "abandoned", ...)
+            return
+        default:
+        }
+        if err := m.injector.Deactivate(tt.target); err != nil {
+            if errors.Is(err, syscall.ESRCH) { continue }
+            m.log.Warn("deactivate failed", "pid", pid, "err", err)
+            m.stats.DeactivateFailed.Add(1)
+            continue
+        }
+        m.stats.Deactivated.Add(1)
+    }
+}
+```
+
+The 5s hard cap exists because a target in uninterruptible sleep (D state) can hang `waitpid` indefinitely. Shutdown must never block on a hostile target. Abandoned targets keep the trampoline active until process exit; the user can clean up `/tmp/perf-PID.map` post-exit.
+
+### 7.5 Late-arriving processes (`-a` mode only)
+
+The mmap watcher fires per-mapping change. New Python execs trigger `Manager.ActivateLate(pid)`, which:
+
+1. Skips immediately if `tracked[pid]` exists (already activated).
+2. Skips immediately if `pending[pid]` exists (in-flight; mmap watcher emits multiple events per exec as extension modules load).
+3. Inserts into `pending`, runs `Detect` + `Activate` (always lenient, regardless of `--inject-python-strict`), removes from `pending`.
+4. PID recycle: when the mmap watcher's existing exit-notification path fires, evict `tracked[pid]`.
+
+Bounded concurrency: `min(runtime.NumCPU(), 4)` worker goroutines drain a channel of late-arrival PIDs. A burst (e.g., a forking web server) doesn't fire 32 concurrent ptrace operations.
+
+## 8. CLI surface
+
+### 8.1 Flag
+
+```
+perf-agent --profile --inject-python [--pid N | -a] ...
+```
+
+Single boolean flag. No `--inject-python=auto|on|off|force`. Future flags (`--inject-python-strict` to force strict mode for `-a`, `--inject-python-deactivate-on-exit=false`) are added when there's actual user demand. YAGNI for v1.
+
+### 8.2 Behavior matrix
+
+| Combination | Behavior |
+|---|---|
+| `--profile --pid N --inject-python` | Strict per-PID. Detect+activate; any failure → exit non-zero with structured reason. |
+| `--profile -a --inject-python` | Lenient. Walk /proc, detect+activate every Python 3.12+ process. Failures logged + counted. New execs during the run also activated (lenient). |
+| `--profile --inject-python` (no `--pid`/`-a`) | Same error as today: requires `--pid` or `-a`. |
+| `--inject-python` without `--profile` | Error: "`--inject-python` requires `--profile`." |
+| `--offcpu --inject-python` | Error: "`--inject-python` is only supported with `--profile`." |
+| `--pmu --inject-python` | Error: same as off-cpu. |
+
+### 8.3 Cap precheck
+
+When `--inject-python` is set, `perfagent.Agent.validateOptions()` confirms `cap_sys_ptrace` is held by the running process **before** scanning. Absent → structured error, non-zero exit, no profile attempted. (A setcap'd binary that dropped `cap_sys_ptrace` would otherwise silently no-op all injections.)
+
+### 8.4 Logging
+
+All injector log lines are structured (slog) with stable fields:
+
+```
+level=info  msg="python inject activated"  pid=12345 libpython=/usr/lib/libpython3.12.so.1.0 mode=dynamic
+level=warn  msg="python inject skipped"    pid=23456 reason=no_perf_trampoline
+level=warn  msg="python inject skipped"    pid=34567 reason=preexisting_perf_map
+level=warn  msg="python inject failed (lenient)" pid=45678 reason=ptrace_eperm err="operation not permitted"
+level=info  msg="python inject summary"    activated=8 skipped=3 failed=1
+```
+
+The summary line at end-of-scan gives operators a one-glance audit without grepping individual events.
+
+### 8.5 Bench harness integration
+
+`bench/cmd/scenario/main.go` already plumbs `--unwind`. We add `--inject-python` parallel:
+
+- `--unwind dwarf` (no inject) — DWARF through interpreter, no JIT names.
+- `--unwind dwarf --inject-python` — DWARF + JIT names.
+- `--unwind auto --inject-python` — lazy CFI + JIT names (recommended production combo).
+
+`Document` schema (`bench/internal/schema/schema.go`) gains `InjectPython bool` so reports can compare with/without.
+
+## 9. Test plan
+
+### 9.1 Unit tests (no caps, no real Python)
+
+```
+inject/elfsym/
+  symtab_test.go
+    TestParseSONAME_PythonVariants
+    TestParseSONAME_NotPython
+    TestResolveSymbols_DynsymHit
+    TestResolveSymbols_FallsBackToSymtab
+    TestResolveSymbols_MissingPyRunSimpleString  → ErrStaticallyLinkedNoSymbols
+    TestResolveSymbols_MissingPerfCallbacks      → ErrNoPerfTrampoline
+    TestResolveStaticBinary
+
+inject/payload_test.go
+  TestEncodeActivatePayload     (exact bytes, null-terminated)
+  TestEncodeDeactivatePayload   (exact bytes, null-terminated)
+
+inject/ptraceop/
+  regs_amd64_test.go            (//go:build amd64)
+    TestSetupCallFrame_amd64    (RDI/RSP/RIP set; sentinel return-addr)
+    TestRegsRoundTrip_amd64     (save → modify → restore == original)
+
+  regs_arm64_test.go            (//go:build arm64)
+    TestSetupCallFrame_arm64    (X0/SP/PC/LR set; sentinel)
+    TestRegsRoundTrip_arm64
+
+inject/manager_test.go
+  TestActivateAll_StrictExitsOnFirstError
+  TestActivateAll_LenientContinuesOnError
+  TestActivateAll_PreexistingMarkerSkips
+  TestDeactivateAll_HonorsDeadline
+  TestDeactivateAll_SkipsPreexisting
+  TestDeactivateAll_ToleratesESRCH
+  TestNewExec_DedupesViaTracked
+  TestNewExec_DedupesViaPending
+```
+
+Synthetic-procfs pattern reused from PR #11's `scan_enroll_test.go::buildSyntheticProcTree`. Synthetic ELF files for symbol-resolution tests use `debug/elf.NewFile` over an in-memory byte buffer with a minimal `.dynsym`. Register tests in `ptraceop_*_test.go` exercise frame setup logic over hand-crafted `unix.PtraceRegs` values (real `ptrace` is exercised in integration).
+
+### 9.2 Integration tests (caps-gated)
+
+```
+test/integration_inject_test.go
+  TestInjectPython_ActivatesTrampoline
+    1. Launch python3.12 test/workloads/python/cpu_bound.py 10 2 (no -X perf)
+    2. Wait 1s for warmup
+    3. Run perf-agent --profile --inject-python --pid <PID> --duration 5s
+    4. Assert /tmp/perf-<PID>.map exists, contains py:: lines
+    5. Assert profile.pb.gz has Python frame names
+    6. Assert agent.InjectStats(): Activated=1, Deactivated=1
+    7. After perf-agent exit: re-stat perf-map twice with 1s gap; size unchanged
+       (proves deactivation ran)
+
+  TestInjectPython_StrictFailsOnNonPython
+    1. Launch test/workloads/go/cpu_bound (Go binary)
+    2. Run perf-agent --profile --inject-python --pid <PID>
+    3. Assert non-zero exit
+    4. Assert stderr contains structured "not_python" reason
+
+  TestInjectPython_LenientSystemWideMixedFleet
+    1. Launch fleet: 2× python3.12, 1× python3.10 (no perf-trampoline),
+       1× Go binary
+    2. Run perf-agent --profile -a --inject-python --duration 5s
+    3. Assert exit 0
+    4. Assert agent.InjectStats(): Activated=2, SkippedTooOld=1,
+       SkippedNotPython=1, Failed=0
+    5. Assert profile contains Python frames from the two 3.12 processes
+```
+
+Setup pattern (per established convention):
+- Build perf-agent in the worktree (NOT `/tmp` — saved as feedback memory; `/tmp` is `nosuid` and file capabilities don't survive exec).
+- `sudo setcap cap_perfmon,cap_bpf,cap_sys_admin,cap_sys_ptrace,cap_checkpoint_restore+ep ./perf-agent`.
+- Test setup probes `cap_get_proc()` and skips with a clear reason if caps are missing.
+
+### 9.3 Out of scope for v1
+
+- Multi-Python-version matrix.
+- Container scenarios (no Docker test infrastructure).
+- Concurrent perf-agent runs against the same target (preexisting marker handles correctness; no dedicated test).
+- Bench results comparing with/without `--inject-python` (informational, follow-up PR).
+
+## 10. Documentation
+
+- **`README.md`** — new section on Python profiling with a worked example: launch a Python script *without* `-X perf`, run `perf-agent --profile --pid $! --inject-python`, see Python frames.
+- **`docs/python-profiling.md`** (new) — deeper dive: how the trampoline works, when injection is skipped and why, the preexisting marker, perf-map cleanup, container limitations, how to disable in CI.
+
+## 11. Risks and open questions
+
+- **Activation latency on large fleets.** 100 Python processes × ~2 ms per ptrace round trip = 200 ms before sampling starts. Acceptable for a profiling tool but worth measuring once v1 ships.
+- **`PyRun_SimpleString` re-entrance.** If the target is mid-execution of `PyRun_SimpleString` when we attach (rare; would require user code calling exec/eval), the GIL handoff our payload performs may serialize behind the in-flight string. We accept the brief delay.
+- **Stack headroom on extension threads.** The 1024-byte fallback threshold is conservative; we should verify it on real-world targets (e.g., Apache+mod_wsgi, gunicorn workers). If too tight, raise to 2048 — costs nothing.
+- **Symbol versioning (`@@GLIBC_2.34`-style).** CPython doesn't use versioned symbols on its public ABI, but ELF tooling sometimes returns them. `debug/elf` handles the parsing; we just need to match by base name. Documented as test coverage in `TestResolveSymbols_DynsymHit`.
+
+## 12. References
+
+- CPython 3.12 release notes: <https://docs.python.org/3.12/whatsnew/3.12.html#perf-profiler-support-with-stack-pointers>
+- `sys.activate_stack_trampoline` docs: <https://docs.python.org/3.12/library/sys.html#sys.activate_stack_trampoline>
+- pyrasite (reference implementation of remote Python ptrace injection): <https://github.com/lmacken/pyrasite>
+- Linux `ptrace(2)` manual: <https://man7.org/linux/man-pages/man2/ptrace.2.html>
+- AMD64 System V ABI: <https://gitlab.com/x86-psABIs/x86-64-ABI>
+- AArch64 AAPCS64: <https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst>

--- a/inject/elfsym/elfsym.go
+++ b/inject/elfsym/elfsym.go
@@ -24,7 +24,7 @@ func ResolveSymbols(path string, names []string) (map[string]uint64, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open ELF %q: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	out := make(map[string]uint64, len(names))
 	want := make(map[string]struct{}, len(names))

--- a/inject/elfsym/elfsym.go
+++ b/inject/elfsym/elfsym.go
@@ -1,0 +1,68 @@
+package elfsym
+
+import (
+	"debug/elf"
+	"fmt"
+)
+
+// ResolveSymbols opens the ELF file at path and resolves each symbol name in
+// names to its file-offset value (the symbol's st_value). Returned map only
+// contains entries for symbols that were found; missing symbols are silently
+// absent. The caller adds the runtime load base to each value to compute the
+// remote process's address.
+//
+// .dynsym is searched first (the dynamic symbol table is always present in
+// shared libraries and required at runtime). If a name is not found there
+// AND .symtab is present (i.e. binary not stripped), .symtab is searched as a
+// fallback. This matters for some Python distributions that intentionally
+// strip non-API symbols from .dynsym but leave .symtab intact.
+//
+// Returns os.ErrNotExist (wrapped) if path does not exist; other errors are
+// wrapped with context.
+func ResolveSymbols(path string, names []string) (map[string]uint64, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open ELF %q: %w", path, err)
+	}
+	defer f.Close()
+
+	out := make(map[string]uint64, len(names))
+	want := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		want[n] = struct{}{}
+	}
+
+	// Try .dynsym first.
+	if dynsyms, derr := f.DynamicSymbols(); derr == nil {
+		for _, sym := range dynsyms {
+			if _, needed := want[sym.Name]; needed && sym.Value != 0 {
+				out[sym.Name] = sym.Value
+			}
+		}
+	}
+
+	// Fall back to .symtab for any names still unresolved.
+	stillMissing := false
+	for _, n := range names {
+		if _, ok := out[n]; !ok {
+			stillMissing = true
+			break
+		}
+	}
+	if stillMissing {
+		if syms, serr := f.Symbols(); serr == nil {
+			for _, sym := range syms {
+				if _, needed := want[sym.Name]; needed {
+					if _, already := out[sym.Name]; already {
+						continue
+					}
+					if sym.Value != 0 {
+						out[sym.Name] = sym.Value
+					}
+				}
+			}
+		}
+	}
+
+	return out, nil
+}

--- a/inject/elfsym/elfsym.go
+++ b/inject/elfsym/elfsym.go
@@ -2,8 +2,41 @@ package elfsym
 
 import (
 	"debug/elf"
+	"errors"
 	"fmt"
 )
+
+// FirstLoadVaddr returns the p_vaddr of the PT_LOAD segment that covers file
+// offset 0 (the segment with the ELF header). Combined with the start address
+// of the matching /proc/<pid>/maps entry, this gives the load bias:
+//
+//	load_bias = mapping_start - FirstLoadVaddr(path)
+//	abs_addr  = load_bias + sym.Value
+//
+// For typical PIE shared libraries / PIE executables (p_vaddr == 0),
+// load_bias collapses to mapping_start and the formula matches the
+// long-standing convention. For non-PIE ET_EXEC binaries — Ubuntu
+// /usr/bin/python3.12 has p_vaddr = 0x400000 and ships absolute symbol
+// values — load_bias correctly resolves to 0, leaving sym.Value untouched.
+// Without this correction, doubling mapping_start onto an already-absolute
+// symbol drops RIP into garbage on remote call.
+func FirstLoadVaddr(path string) (uint64, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open ELF %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	for _, p := range f.Progs {
+		if p.Type != elf.PT_LOAD {
+			continue
+		}
+		if p.Off != 0 {
+			continue
+		}
+		return p.Vaddr, nil
+	}
+	return 0, errors.New("no PT_LOAD segment with file offset 0")
+}
 
 // ResolveSymbols opens the ELF file at path and resolves each symbol name in
 // names to its file-offset value (the symbol's st_value). Returned map only

--- a/inject/elfsym/elfsym_test.go
+++ b/inject/elfsym/elfsym_test.go
@@ -1,0 +1,83 @@
+package elfsym
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveSymbols_DynsymHit(t *testing.T) {
+	libc := findLibcPath(t)
+	resolved, err := ResolveSymbols(libc, []string{"malloc"})
+	if err != nil {
+		t.Fatalf("ResolveSymbols(%q): %v", libc, err)
+	}
+	if resolved["malloc"] == 0 {
+		t.Fatalf("ResolveSymbols(%q): malloc not resolved (got 0)", libc)
+	}
+}
+
+func TestResolveSymbols_MissingByName(t *testing.T) {
+	libc := findLibcPath(t)
+	resolved, err := ResolveSymbols(libc, []string{"this_symbol_does_not_exist_xyz"})
+	if err != nil {
+		t.Fatalf("ResolveSymbols: unexpected error: %v", err)
+	}
+	if v, present := resolved["this_symbol_does_not_exist_xyz"]; present {
+		t.Fatalf("expected symbol absent; got address 0x%x", v)
+	}
+}
+
+func TestResolveSymbols_MultipleSymbols(t *testing.T) {
+	libc := findLibcPath(t)
+	resolved, err := ResolveSymbols(libc, []string{"malloc", "free", "this_does_not_exist"})
+	if err != nil {
+		t.Fatalf("ResolveSymbols: %v", err)
+	}
+	if resolved["malloc"] == 0 {
+		t.Fatal("malloc not resolved")
+	}
+	if resolved["free"] == 0 {
+		t.Fatal("free not resolved")
+	}
+	if _, present := resolved["this_does_not_exist"]; present {
+		t.Fatal("nonexistent symbol unexpectedly present")
+	}
+}
+
+func TestResolveSymbols_FileDoesNotExist(t *testing.T) {
+	_, err := ResolveSymbols("/path/that/definitely/does/not/exist", []string{"malloc"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent file; got nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected wrapped os.ErrNotExist; got %v", err)
+	}
+}
+
+// findLibcPath locates a libc.so.6 on the test host. Skips the test if not found.
+func findLibcPath(t *testing.T) string {
+	t.Helper()
+	candidates := []string{
+		"/lib/x86_64-linux-gnu/libc.so.6",
+		"/lib/aarch64-linux-gnu/libc.so.6",
+		"/lib64/libc.so.6",
+		"/usr/lib/x86_64-linux-gnu/libc.so.6",
+		"/usr/lib/aarch64-linux-gnu/libc.so.6",
+		"/usr/lib64/libc.so.6",
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	matches, _ := filepath.Glob("/usr/lib*/libc.so*")
+	for _, m := range matches {
+		if _, err := os.Stat(m); err == nil {
+			return m
+		}
+	}
+	t.Skip("libc.so.6 not found on test host; skipping ELF resolver test")
+	return ""
+}

--- a/inject/elfsym/soname.go
+++ b/inject/elfsym/soname.go
@@ -1,0 +1,54 @@
+// Package elfsym provides ELF symbol resolution and SONAME parsing primitives
+// shared across language-specific injectors (inject/python, future inject/nodejs,
+// etc.). Pure stdlib (debug/elf + regexp); no CGO, no external dependencies.
+package elfsym
+
+import (
+	"path/filepath"
+	"regexp"
+	"strconv"
+)
+
+// libpythonRE matches typical CPython library SONAMEs, e.g.:
+//   libpython3.12.so
+//   libpython3.12.so.1.0
+//   libpython2.7.so
+// It is deliberately liberal — caller decides whether the version is
+// acceptable via IsPython312Plus.
+var libpythonRE = regexp.MustCompile(`^libpython(\d+)\.(\d+)\.so(?:\..*)?$`)
+
+// ParseLibpythonSONAME extracts the major and minor version from a libpython
+// shared-library path. It accepts either a bare basename or a full path; only
+// the basename is matched against the libpython regex. Returns (major, minor,
+// true) on a successful match; (0, 0, false) otherwise.
+func ParseLibpythonSONAME(path string) (major, minor int, ok bool) {
+	if path == "" {
+		return 0, 0, false
+	}
+	base := filepath.Base(path)
+	m := libpythonRE.FindStringSubmatch(base)
+	if m == nil {
+		return 0, 0, false
+	}
+	maj, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	min, err := strconv.Atoi(m[2])
+	if err != nil {
+		return 0, 0, false
+	}
+	return maj, min, true
+}
+
+// IsPython312Plus reports whether the given (major, minor) version is at least
+// 3.12 — the minimum CPython version that ships sys.activate_stack_trampoline.
+func IsPython312Plus(major, minor int) bool {
+	if major > 3 {
+		return true
+	}
+	if major == 3 && minor >= 12 {
+		return true
+	}
+	return false
+}

--- a/inject/elfsym/soname.go
+++ b/inject/elfsym/soname.go
@@ -10,9 +10,11 @@ import (
 )
 
 // libpythonRE matches typical CPython library SONAMEs, e.g.:
-//   libpython3.12.so
-//   libpython3.12.so.1.0
-//   libpython2.7.so
+//
+//	libpython3.12.so
+//	libpython3.12.so.1.0
+//	libpython2.7.so
+//
 // It is deliberately liberal — caller decides whether the version is
 // acceptable via IsPython312Plus.
 var libpythonRE = regexp.MustCompile(`^libpython(\d+)\.(\d+)\.so(?:\..*)?$`)

--- a/inject/elfsym/soname_test.go
+++ b/inject/elfsym/soname_test.go
@@ -4,11 +4,11 @@ import "testing"
 
 func TestParseLibpythonSONAME(t *testing.T) {
 	tests := []struct {
-		name        string
-		path        string
-		wantMajor   int
-		wantMinor   int
-		wantIsPy    bool
+		name      string
+		path      string
+		wantMajor int
+		wantMinor int
+		wantIsPy  bool
 	}{
 		{"py312_typical", "/usr/lib/x86_64-linux-gnu/libpython3.12.so.1.0", 3, 12, true},
 		{"py312_no_minor_suffix", "/usr/lib/libpython3.12.so", 3, 12, true},

--- a/inject/elfsym/soname_test.go
+++ b/inject/elfsym/soname_test.go
@@ -1,0 +1,59 @@
+package elfsym
+
+import "testing"
+
+func TestParseLibpythonSONAME(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		wantMajor   int
+		wantMinor   int
+		wantIsPy    bool
+	}{
+		{"py312_typical", "/usr/lib/x86_64-linux-gnu/libpython3.12.so.1.0", 3, 12, true},
+		{"py312_no_minor_suffix", "/usr/lib/libpython3.12.so", 3, 12, true},
+		{"py313_future", "/usr/lib/libpython3.13.so.1.0", 3, 13, true},
+		{"py399_far_future", "/usr/lib/libpython3.99.so", 3, 99, true},
+		{"py311_too_old", "/usr/lib/libpython3.11.so.1.0", 3, 11, true},
+		{"py27_legacy", "/usr/lib/libpython2.7.so", 2, 7, true},
+		{"non_python_lib", "/usr/lib/libfoo.so.1", 0, 0, false},
+		{"non_python_lib_with_python_substr", "/opt/mypython-helper.so", 0, 0, false},
+		{"empty", "", 0, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			major, minor, ok := ParseLibpythonSONAME(tc.path)
+			if ok != tc.wantIsPy {
+				t.Fatalf("ParseLibpythonSONAME(%q): ok=%v, want %v", tc.path, ok, tc.wantIsPy)
+			}
+			if major != tc.wantMajor || minor != tc.wantMinor {
+				t.Fatalf("ParseLibpythonSONAME(%q): major=%d minor=%d, want %d %d",
+					tc.path, major, minor, tc.wantMajor, tc.wantMinor)
+			}
+		})
+	}
+}
+
+func TestIsPython312Plus(t *testing.T) {
+	tests := []struct {
+		major int
+		minor int
+		want  bool
+	}{
+		{3, 12, true},
+		{3, 13, true},
+		{3, 99, true},
+		{4, 0, true},
+		{3, 11, false},
+		{3, 10, false},
+		{2, 7, false},
+		{0, 0, false},
+	}
+	for _, tc := range tests {
+		got := IsPython312Plus(tc.major, tc.minor)
+		if got != tc.want {
+			t.Fatalf("IsPython312Plus(%d,%d) = %v, want %v",
+				tc.major, tc.minor, got, tc.want)
+		}
+	}
+}

--- a/inject/ptraceop/error_test.go
+++ b/inject/ptraceop/error_test.go
@@ -1,0 +1,32 @@
+package ptraceop
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrRemoteCallNonZero_ErrorMessage(t *testing.T) {
+	e := &ErrRemoteCallNonZero{Op: "PyRun_SimpleString", Result: 0xFFFFFFFF}
+	got := e.Error()
+	want := fmt.Sprintf("PyRun_SimpleString returned non-zero: %d", uint64(0xFFFFFFFF))
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+// TestErrRemoteCallNonZero_ErrorsAs ensures callers can extract the typed
+// error from a wrapped chain — that's how the perfagent bridge classifies
+// PyRun_SimpleString returning -1 as ErrNoPerfTrampoline.
+func TestErrRemoteCallNonZero_ErrorsAs(t *testing.T) {
+	original := &ErrRemoteCallNonZero{Op: "PyRun_SimpleString", Result: 0xFFFFFFFF}
+	wrapped := fmt.Errorf("RemoteActivate: %w", original)
+
+	var got *ErrRemoteCallNonZero
+	if !errors.As(wrapped, &got) {
+		t.Fatal("errors.As failed to extract *ErrRemoteCallNonZero from wrapped error")
+	}
+	if int32(got.Result) != -1 {
+		t.Errorf("int32(Result) = %d, want -1 (sign-extended)", int32(got.Result))
+	}
+}

--- a/inject/ptraceop/ptraceop.go
+++ b/inject/ptraceop/ptraceop.go
@@ -209,6 +209,15 @@ func (i *Injector) remoteCall(pid uint32, orig unix.PtraceRegs, fnAddr, payloadA
 	if err := unix.PtraceGetRegs(int(pid), &post); err != nil {
 		return 0, fmt.Errorf("getregs post-call: %w", err)
 	}
+	// SIGSEGV must come from the return-to-zero sentinel. If it fired at any
+	// other address, the function crashed mid-execution — most often because
+	// fnAddr was wrong (bad load_base, missing symbol, etc.). Report the
+	// crash address so the caller can debug rather than silently treating the
+	// pre-SEGV register state as a "return value".
+	if rip := instructionPointer(post); rip != 0 {
+		return 0, fmt.Errorf("SIGSEGV at unexpected address 0x%x (expected sentinel 0); fnAddr=0x%x — likely wrong load_base or symbol address",
+			rip, fnAddr)
+	}
 	return extractReturn(post), nil
 }
 

--- a/inject/ptraceop/ptraceop.go
+++ b/inject/ptraceop/ptraceop.go
@@ -6,11 +6,13 @@
 package ptraceop
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -59,6 +61,15 @@ func (i *Injector) RemoteDeactivate(pid uint32, addrs SymbolAddrs, payload []byt
 // runSequence implements the full attach → 3 calls → detach sequence from
 // design §6.2.
 func (i *Injector) runSequence(pid uint32, addrs SymbolAddrs, payload []byte) error {
+	// Pin to the current OS thread for the lifetime of this call. On Linux,
+	// only the thread that issued PTRACE_ATTACH may issue subsequent ptrace
+	// ops on the tracee — Go's scheduler can migrate goroutines between OS
+	// threads at preemption points (including syscall returns), which would
+	// cause subsequent ptrace ops to fail with EPERM/ESRCH or, worse, target
+	// a different tracee. Pinning eliminates the migration window.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if pid == 0 {
 		return errors.New("ptraceop: pid is zero")
 	}
@@ -210,9 +221,13 @@ func stackLowAddr(pid uint32) (uint64, bool) {
 		return 0, false
 	}
 	defer f.Close()
-	buf := make([]byte, 64*1024)
-	n, _ := f.Read(buf)
-	for _, line := range strings.Split(string(buf[:n]), "\n") {
+	sc := bufio.NewScanner(f)
+	// Expand the scanner's max buffer so very long /proc/<pid>/maps files
+	// (e.g., a Python process with hundreds of extension modules) don't
+	// silently truncate before the [stack] line.
+	sc.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
 		if !strings.Contains(line, "[stack]") {
 			continue
 		}

--- a/inject/ptraceop/ptraceop.go
+++ b/inject/ptraceop/ptraceop.go
@@ -1,0 +1,222 @@
+// Package ptraceop provides low-level ptrace primitives for remote function
+// invocation: attach, save registers, write a payload, run a sequence of
+// remote function calls (each returning via SIGSEGV at address 0), restore
+// registers, detach. Language-agnostic — Python uses it today; future runtimes
+// (Node.js if extending V8 internals, JVM via JNI shims, etc.) can reuse it.
+package ptraceop
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// SymbolAddrs holds the absolute remote addresses of the three CPython
+// functions we need to call. ptraceop deliberately does not depend on
+// inject/python — naming is Python-flavored but the struct is just three
+// uint64s; future runtimes can pass equivalent triples.
+type SymbolAddrs struct {
+	PyGILEnsure  uint64
+	PyGILRelease uint64
+	PyRunString  uint64
+}
+
+// Injector performs ptrace-based remote function calls.
+type Injector struct {
+	log *slog.Logger
+}
+
+// New creates an Injector. log may be nil (uses slog.Default()).
+func New(log *slog.Logger) *Injector {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Injector{log: log}
+}
+
+// RemoteActivate runs the three-call sequence
+// (PyGILState_Ensure → PyRun_SimpleString(payload) → PyGILState_Release)
+// inside one ptrace session. Returns nil on success, a wrapped error otherwise.
+//
+// The payload must be NUL-terminated; the caller (typically inject/python)
+// supplies python.ActivatePayload() or python.DeactivatePayload().
+func (i *Injector) RemoteActivate(pid uint32, addrs SymbolAddrs, payload []byte) error {
+	return i.runSequence(pid, addrs, payload)
+}
+
+// RemoteDeactivate is identical to RemoteActivate; the only difference is the
+// payload string. Kept as a separate method for callsite clarity.
+func (i *Injector) RemoteDeactivate(pid uint32, addrs SymbolAddrs, payload []byte) error {
+	return i.runSequence(pid, addrs, payload)
+}
+
+// runSequence implements the full attach → 3 calls → detach sequence from
+// design §6.2.
+func (i *Injector) runSequence(pid uint32, addrs SymbolAddrs, payload []byte) error {
+	if pid == 0 {
+		return errors.New("ptraceop: pid is zero")
+	}
+	if len(payload) == 0 {
+		return errors.New("ptraceop: empty payload")
+	}
+	if payload[len(payload)-1] != 0 {
+		return errors.New("ptraceop: payload not NUL-terminated")
+	}
+	if addrs.PyGILEnsure == 0 || addrs.PyGILRelease == 0 || addrs.PyRunString == 0 {
+		return errors.New("ptraceop: SymbolAddrs has zero entry")
+	}
+
+	// Step 1-2: attach + waitpid.
+	if err := unix.PtraceAttach(int(pid)); err != nil {
+		return fmt.Errorf("ptrace attach pid=%d: %w", pid, err)
+	}
+	defer func() {
+		// Best-effort detach. If we error before reaching the explicit detach
+		// below, this ensures the target is resumed.
+		_ = unix.PtraceDetach(int(pid))
+	}()
+
+	var status unix.WaitStatus
+	if _, err := unix.Wait4(int(pid), &status, 0, nil); err != nil {
+		return fmt.Errorf("waitpid for attach stop pid=%d: %w", pid, err)
+	}
+	if !status.Stopped() {
+		return fmt.Errorf("expected stopped after attach pid=%d, got status %v", pid, status)
+	}
+
+	// Step 3: save original registers.
+	var orig unix.PtraceRegs
+	if err := unix.PtraceGetRegs(int(pid), &orig); err != nil {
+		return fmt.Errorf("ptrace getregs pid=%d: %w", pid, err)
+	}
+
+	// Step 4: find stack mapping and verify headroom.
+	stackLow, ok := stackLowAddr(pid)
+	if !ok {
+		return fmt.Errorf("cannot determine stack mapping for pid=%d", pid)
+	}
+	currentSP := stackPointer(orig)
+	if currentSP < stackLow+1024 {
+		// Headroom check failed; spec §6.4 specifies remote-mmap fallback.
+		// v1 ships without the fallback (rare in practice); we fail with a
+		// clear sentinel-style message so the caller can decide.
+		return fmt.Errorf("ptraceop: insufficient stack headroom (sp=0x%x, low=0x%x); remote-mmap fallback not implemented in v1",
+			currentSP, stackLow)
+	}
+
+	// Step 5-6: choose payload_addr, write payload to stack.
+	payloadAddr := (currentSP - 256) &^ 0xF
+	if _, err := unix.PtracePokeData(int(pid), uintptr(payloadAddr), payload); err != nil {
+		return fmt.Errorf("ptrace pokedata payload pid=%d: %w", pid, err)
+	}
+
+	// Step 7-9: three remote calls (Ensure → Run → Release).
+	gstate, err := i.remoteCall(pid, orig, addrs.PyGILEnsure, payloadAddr, 0)
+	if err != nil {
+		return fmt.Errorf("PyGILState_Ensure: %w", err)
+	}
+	runResult, runErr := i.remoteCall(pid, orig, addrs.PyRunString, payloadAddr, payloadAddr)
+	// Always release the GIL we acquired, even if PyRun_SimpleString failed.
+	if _, relErr := i.remoteCall(pid, orig, addrs.PyGILRelease, payloadAddr, gstate); relErr != nil {
+		i.log.Warn("PyGILState_Release failed after attempted activation",
+			"pid", pid, "err", relErr)
+	}
+	if runErr != nil {
+		return fmt.Errorf("PyRun_SimpleString: %w", runErr)
+	}
+	if runResult != 0 {
+		return fmt.Errorf("PyRun_SimpleString returned non-zero: %d (likely activation refused at runtime)", runResult)
+	}
+
+	// Step 10-11: restore registers, detach (defer above handles detach).
+	if err := unix.PtraceSetRegs(int(pid), &orig); err != nil {
+		return fmt.Errorf("ptrace setregs restore pid=%d: %w", pid, err)
+	}
+	if err := unix.PtraceDetach(int(pid)); err != nil {
+		return fmt.Errorf("ptrace detach pid=%d: %w", pid, err)
+	}
+	return nil
+}
+
+// remoteCall performs one remote function invocation:
+//  1. Build call frame from orig with fnAddr/arg, return-addr=0 (SIGSEGV
+//     sentinel), payload_addr-derived stack pointer.
+//  2. PtraceSetRegs.
+//  3. PtraceCont with signal=0.
+//  4. Wait4 for SIGSEGV (or other terminal stop).
+//  5. Read regs, return the call's return value.
+//
+// payloadAddr is used to derive a fresh stack pointer for each call so that
+// successive calls don't trample each other's frames.
+func (i *Injector) remoteCall(pid uint32, orig unix.PtraceRegs, fnAddr, payloadAddr, arg1 uint64) (uint64, error) {
+	frame, err := setupCallFrame(orig, fnAddr, arg1, payloadAddr)
+	if err != nil {
+		return 0, fmt.Errorf("setup call frame: %w", err)
+	}
+	// Some arches (amd64) require us to write the sentinel return address (0)
+	// to *(SP) before the call. setupCallFrame returns the SP that needs the
+	// sentinel; we write a 0 word there.
+	zero := make([]byte, 8)
+	if _, err := unix.PtracePokeData(int(pid), uintptr(stackPointer(frame)), zero); err != nil {
+		return 0, fmt.Errorf("write return-addr sentinel: %w", err)
+	}
+	if err := unix.PtraceSetRegs(int(pid), &frame); err != nil {
+		return 0, fmt.Errorf("setregs: %w", err)
+	}
+	if err := unix.PtraceCont(int(pid), 0); err != nil {
+		return 0, fmt.Errorf("ptrace cont: %w", err)
+	}
+	var status unix.WaitStatus
+	if _, err := unix.Wait4(int(pid), &status, 0, nil); err != nil {
+		return 0, fmt.Errorf("wait4 after remote call: %w", err)
+	}
+	if !status.Stopped() {
+		return 0, fmt.Errorf("expected stop after remote call; got status %v", status)
+	}
+	if sig := status.StopSignal(); sig != unix.SIGSEGV {
+		return 0, fmt.Errorf("expected SIGSEGV sentinel; got signal %v", sig)
+	}
+	var post unix.PtraceRegs
+	if err := unix.PtraceGetRegs(int(pid), &post); err != nil {
+		return 0, fmt.Errorf("getregs post-call: %w", err)
+	}
+	return extractReturn(post), nil
+}
+
+// stackLowAddr reads /proc/<pid>/maps and returns the low address of the
+// [stack] mapping.
+func stackLowAddr(pid uint32) (uint64, bool) {
+	mapsPath := filepath.Join("/proc", strconv.FormatUint(uint64(pid), 10), "maps")
+	f, err := os.Open(mapsPath)
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+	buf := make([]byte, 64*1024)
+	n, _ := f.Read(buf)
+	for _, line := range strings.Split(string(buf[:n]), "\n") {
+		if !strings.Contains(line, "[stack]") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 1 {
+			continue
+		}
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		low, err := strconv.ParseUint(fields[0][:dash], 16, 64)
+		if err != nil {
+			continue
+		}
+		return low, true
+	}
+	return 0, false
+}

--- a/inject/ptraceop/ptraceop.go
+++ b/inject/ptraceop/ptraceop.go
@@ -77,8 +77,8 @@ func (i *Injector) runSequence(pid uint32, addrs SymbolAddrs, payload []byte) er
 		return fmt.Errorf("ptrace attach pid=%d: %w", pid, err)
 	}
 	defer func() {
-		// Best-effort detach. If we error before reaching the explicit detach
-		// below, this ensures the target is resumed.
+		// Best-effort detach. Always runs; errors swallowed because the success
+		// path's explicit detach is the diagnostic surface.
 		_ = unix.PtraceDetach(int(pid))
 	}()
 
@@ -95,6 +95,16 @@ func (i *Injector) runSequence(pid uint32, addrs SymbolAddrs, payload []byte) er
 	if err := unix.PtraceGetRegs(int(pid), &orig); err != nil {
 		return fmt.Errorf("ptrace getregs pid=%d: %w", pid, err)
 	}
+	// Best-effort register restore on every post-GetRegs exit path. Without this,
+	// an error after a remote call would leave the target with PC=0 (SIGSEGV
+	// sentinel) and the deferred detach would resume the target straight into
+	// a segfault, killing the user's process. Defers run LIFO, so this restore
+	// runs before the detach defer above. Errors are swallowed here for the
+	// same reason as the detach defer; the success path's explicit SetRegs
+	// below remains the diagnostic surface.
+	defer func() {
+		_ = unix.PtraceSetRegs(int(pid), &orig)
+	}()
 
 	// Step 4: find stack mapping and verify headroom.
 	stackLow, ok := stackLowAddr(pid)
@@ -134,7 +144,9 @@ func (i *Injector) runSequence(pid uint32, addrs SymbolAddrs, payload []byte) er
 		return fmt.Errorf("PyRun_SimpleString returned non-zero: %d (likely activation refused at runtime)", runResult)
 	}
 
-	// Step 10-11: restore registers, detach (defer above handles detach).
+	// Step 10-11: restore registers + explicit detach for diagnostic visibility
+	// on the success path. (Both operations are also covered by deferred
+	// best-effort versions above for error paths.)
 	if err := unix.PtraceSetRegs(int(pid), &orig); err != nil {
 		return fmt.Errorf("ptrace setregs restore pid=%d: %w", pid, err)
 	}

--- a/inject/ptraceop/ptraceop.go
+++ b/inject/ptraceop/ptraceop.go
@@ -220,7 +220,7 @@ func stackLowAddr(pid uint32) (uint64, bool) {
 	if err != nil {
 		return 0, false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	sc := bufio.NewScanner(f)
 	// Expand the scanner's max buffer so very long /proc/<pid>/maps files
 	// (e.g., a Python process with hundreds of extension modules) don't

--- a/inject/ptraceop/ptraceop.go
+++ b/inject/ptraceop/ptraceop.go
@@ -29,6 +29,24 @@ type SymbolAddrs struct {
 	PyRunString  uint64
 }
 
+// ErrRemoteCallNonZero is returned by RemoteActivate / RemoteDeactivate when
+// the ptrace handshake completed (target hit the SIGSEGV sentinel cleanly)
+// but the remote function returned a non-zero value. The Result field carries
+// the raw register value at sentinel time. ptraceop is language-agnostic —
+// callers (e.g. the perfagent ↔ inject/python bridge) interpret the value
+// against their runtime's calling convention. For CPython, Result that
+// sign-extends to int32(-1) means PyRun_SimpleString reported a Python-level
+// error (most commonly a build without --enable-perf-trampoline, an
+// already-activated trampoline, or an unknown backend).
+type ErrRemoteCallNonZero struct {
+	Op     string
+	Result uint64
+}
+
+func (e *ErrRemoteCallNonZero) Error() string {
+	return fmt.Sprintf("%s returned non-zero: %d", e.Op, e.Result)
+}
+
 // Injector performs ptrace-based remote function calls.
 type Injector struct {
 	log *slog.Logger
@@ -152,7 +170,7 @@ func (i *Injector) runSequence(pid uint32, addrs SymbolAddrs, payload []byte) er
 		return fmt.Errorf("PyRun_SimpleString: %w", runErr)
 	}
 	if runResult != 0 {
-		return fmt.Errorf("PyRun_SimpleString returned non-zero: %d (likely activation refused at runtime)", runResult)
+		return &ErrRemoteCallNonZero{Op: "PyRun_SimpleString", Result: runResult}
 	}
 
 	// Step 10-11: restore registers + explicit detach for diagnostic visibility

--- a/inject/ptraceop/regs_amd64.go
+++ b/inject/ptraceop/regs_amd64.go
@@ -55,3 +55,8 @@ func extractReturn(post unix.PtraceRegs) uint64 {
 func stackPointer(r unix.PtraceRegs) uint64 {
 	return r.Rsp
 }
+
+// instructionPointer returns the IP register value for arch-generic code.
+func instructionPointer(r unix.PtraceRegs) uint64 {
+	return r.Rip
+}

--- a/inject/ptraceop/regs_amd64.go
+++ b/inject/ptraceop/regs_amd64.go
@@ -1,0 +1,49 @@
+//go:build amd64
+
+package ptraceop
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// setupCallFrame builds a register frame for one remote function call on
+// amd64 System V. The frame:
+//   - RIP = fnAddr (entry of remote function)
+//   - RDI = arg1   (first integer/pointer arg)
+//   - RSP = payloadAddr - 8, 16-byte aligned post-write of return-addr sentinel
+//   - *(RSP) gets a 0 written to it by the caller, serving as the return
+//     address; when the function returns, target jumps to 0 → SIGSEGV →
+//     ptrace catches it.
+//
+// All other registers are inherited from orig — we only edit what we must.
+func setupCallFrame(orig unix.PtraceRegs, fnAddr, arg1, payloadAddr uint64) (unix.PtraceRegs, error) {
+	frame := orig
+	frame.Rip = fnAddr
+	frame.Rdi = arg1
+	// SP layout: ... [return-addr sentinel = 0] [payload string]
+	// We choose RSP = payloadAddr - 8 so *(RSP) holds the sentinel.
+	// Then ensure 16-byte alignment after the simulated CALL push: in System V,
+	// at function entry, RSP must be 8 mod 16 (CALL pushes the return addr
+	// making RSP %16 == 8). We achieve that by ensuring (payloadAddr - 8) % 16 == 8,
+	// i.e., payloadAddr % 16 == 0. The caller chose payloadAddr aligned to 16,
+	// so we're good.
+	frame.Rsp = payloadAddr - 8
+	if frame.Rsp%16 != 8 {
+		return unix.PtraceRegs{}, fmt.Errorf("RSP alignment broken: 0x%x %% 16 = %d (want 8)",
+			frame.Rsp, frame.Rsp%16)
+	}
+	return frame, nil
+}
+
+// extractReturn reads the integer return value from a post-call register set.
+// On amd64 System V, integer/pointer returns are in RAX.
+func extractReturn(post unix.PtraceRegs) uint64 {
+	return post.Rax
+}
+
+// stackPointer returns the SP register value for arch-generic code.
+func stackPointer(r unix.PtraceRegs) uint64 {
+	return r.Rsp
+}

--- a/inject/ptraceop/regs_amd64.go
+++ b/inject/ptraceop/regs_amd64.go
@@ -16,12 +16,20 @@ import (
 //   - *(RSP) gets a 0 written to it by the caller, serving as the return
 //     address; when the function returns, target jumps to 0 → SIGSEGV →
 //     ptrace catches it.
+//   - Orig_rax = ^uint64(0) (i.e. -1) to disable kernel syscall-restart logic:
+//     when ptrace attaches to a target mid-syscall (e.g. nanosleep), the kernel
+//     records the syscall number in orig_rax; on PtraceCont the kernel runs
+//     syscall-return processing which clobbers RAX based on that number. The
+//     pyrasite/py-spy/manhole convention is to set orig_rax = -1 to mark "not
+//     in a syscall", which prevents that clobbering and lets our remote call
+//     return its actual value.
 //
 // All other registers are inherited from orig — we only edit what we must.
 func setupCallFrame(orig unix.PtraceRegs, fnAddr, arg1, payloadAddr uint64) (unix.PtraceRegs, error) {
 	frame := orig
 	frame.Rip = fnAddr
 	frame.Rdi = arg1
+	frame.Orig_rax = ^uint64(0) // -1: suppress kernel syscall-restart on PtraceCont
 	// SP layout: ... [return-addr sentinel = 0] [payload string]
 	// We choose RSP = payloadAddr - 8 so *(RSP) holds the sentinel.
 	// Then ensure 16-byte alignment after the simulated CALL push: in System V,

--- a/inject/ptraceop/regs_amd64_test.go
+++ b/inject/ptraceop/regs_amd64_test.go
@@ -1,0 +1,70 @@
+//go:build amd64
+
+package ptraceop
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSetupCallFrame_amd64(t *testing.T) {
+	orig := unix.PtraceRegs{
+		Rip: 0xdeadbeef00,
+		Rdi: 0x11,
+		Rsi: 0x22,
+		Rsp: 0x7ffffff00000,
+		Rax: 0xaaaa,
+	}
+	const fnAddr = 0x12340000
+	const arg1 = 0xCAFEBABE
+	const payloadAddr = 0x7ffffff00100 // 16-byte aligned
+
+	frame, err := setupCallFrame(orig, fnAddr, arg1, payloadAddr)
+	if err != nil {
+		t.Fatalf("setupCallFrame error: %v", err)
+	}
+	if frame.Rip != fnAddr {
+		t.Errorf("RIP = 0x%x, want 0x%x", frame.Rip, fnAddr)
+	}
+	if frame.Rdi != arg1 {
+		t.Errorf("RDI = 0x%x, want 0x%x", frame.Rdi, arg1)
+	}
+	if frame.Rsp != payloadAddr-8 {
+		t.Errorf("RSP = 0x%x, want 0x%x", frame.Rsp, payloadAddr-8)
+	}
+	if frame.Rsp%16 != 8 {
+		t.Errorf("RSP alignment broken: 0x%x %% 16 = %d", frame.Rsp, frame.Rsp%16)
+	}
+	// Other registers should be inherited from orig.
+	if frame.Rsi != orig.Rsi {
+		t.Errorf("RSI clobbered: got 0x%x, want 0x%x", frame.Rsi, orig.Rsi)
+	}
+	if frame.Rax != orig.Rax {
+		t.Errorf("RAX clobbered: got 0x%x, want 0x%x", frame.Rax, orig.Rax)
+	}
+}
+
+func TestSetupCallFrame_amd64_BadAlignment(t *testing.T) {
+	orig := unix.PtraceRegs{Rsp: 0x7ffffff00000}
+	const payloadAddr = 0x7ffffff00104 // NOT 16-byte aligned
+	_, err := setupCallFrame(orig, 0x1000, 0, payloadAddr)
+	if err == nil {
+		t.Fatal("expected alignment error; got nil")
+	}
+}
+
+func TestExtractReturn_amd64(t *testing.T) {
+	post := unix.PtraceRegs{Rax: 0xCAFEF00D}
+	got := extractReturn(post)
+	if got != 0xCAFEF00D {
+		t.Errorf("extractReturn = 0x%x, want 0xCAFEF00D", got)
+	}
+}
+
+func TestStackPointer_amd64(t *testing.T) {
+	r := unix.PtraceRegs{Rsp: 0xC0DEFACE}
+	if got := stackPointer(r); got != 0xC0DEFACE {
+		t.Errorf("stackPointer = 0x%x, want 0xC0DEFACE", got)
+	}
+}

--- a/inject/ptraceop/regs_arm64.go
+++ b/inject/ptraceop/regs_arm64.go
@@ -1,0 +1,43 @@
+//go:build arm64
+
+package ptraceop
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// setupCallFrame builds a register frame for one remote function call on
+// arm64 AAPCS64. The frame:
+//   - PC = fnAddr (entry of remote function)
+//   - X0 = arg1 (first integer/pointer arg)
+//   - X30 (LR) = 0 (sentinel — when function returns via RET, target
+//     jumps to 0 → SIGSEGV → ptrace catches it)
+//   - SP = payloadAddr - 16, 16-byte aligned (AAPCS64 requires 16-byte SP at
+//     all public interfaces)
+//
+// All other registers are inherited from orig.
+func setupCallFrame(orig unix.PtraceRegs, fnAddr, arg1, payloadAddr uint64) (unix.PtraceRegs, error) {
+	frame := orig
+	frame.Pc = fnAddr
+	frame.Regs[0] = arg1
+	frame.Regs[30] = 0 // LR (X30) — return address sentinel
+	frame.Sp = payloadAddr - 16
+	if frame.Sp%16 != 0 {
+		return unix.PtraceRegs{}, fmt.Errorf("SP alignment broken: 0x%x %% 16 = %d (want 0)",
+			frame.Sp, frame.Sp%16)
+	}
+	return frame, nil
+}
+
+// extractReturn reads the integer return value from a post-call register set.
+// On arm64 AAPCS64, integer/pointer returns are in X0.
+func extractReturn(post unix.PtraceRegs) uint64 {
+	return post.Regs[0]
+}
+
+// stackPointer returns the SP register value for arch-generic code.
+func stackPointer(r unix.PtraceRegs) uint64 {
+	return r.Sp
+}

--- a/inject/ptraceop/regs_arm64.go
+++ b/inject/ptraceop/regs_arm64.go
@@ -41,3 +41,8 @@ func extractReturn(post unix.PtraceRegs) uint64 {
 func stackPointer(r unix.PtraceRegs) uint64 {
 	return r.Sp
 }
+
+// instructionPointer returns the PC register value for arch-generic code.
+func instructionPointer(r unix.PtraceRegs) uint64 {
+	return r.Pc
+}

--- a/inject/ptraceop/regs_arm64_test.go
+++ b/inject/ptraceop/regs_arm64_test.go
@@ -1,0 +1,71 @@
+//go:build arm64
+
+package ptraceop
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSetupCallFrame_arm64(t *testing.T) {
+	var orig unix.PtraceRegs
+	orig.Pc = 0xdeadbeef00
+	orig.Sp = 0x7ffffff00000
+	orig.Regs[0] = 0x11
+	orig.Regs[1] = 0x22
+	orig.Regs[30] = 0xCCCC // some other LR
+	const fnAddr = 0x12340000
+	const arg1 = 0xCAFEBABE
+	const payloadAddr = 0x7ffffff00100 // 16-byte aligned
+
+	frame, err := setupCallFrame(orig, fnAddr, arg1, payloadAddr)
+	if err != nil {
+		t.Fatalf("setupCallFrame error: %v", err)
+	}
+	if frame.Pc != fnAddr {
+		t.Errorf("PC = 0x%x, want 0x%x", frame.Pc, fnAddr)
+	}
+	if frame.Regs[0] != arg1 {
+		t.Errorf("X0 = 0x%x, want 0x%x", frame.Regs[0], arg1)
+	}
+	if frame.Regs[30] != 0 {
+		t.Errorf("LR (X30) = 0x%x, want 0 (sentinel)", frame.Regs[30])
+	}
+	if frame.Sp != payloadAddr-16 {
+		t.Errorf("SP = 0x%x, want 0x%x", frame.Sp, payloadAddr-16)
+	}
+	if frame.Sp%16 != 0 {
+		t.Errorf("SP not 16-aligned: 0x%x", frame.Sp)
+	}
+	if frame.Regs[1] != orig.Regs[1] {
+		t.Errorf("X1 clobbered: 0x%x, want 0x%x", frame.Regs[1], orig.Regs[1])
+	}
+}
+
+func TestSetupCallFrame_arm64_BadAlignment(t *testing.T) {
+	var orig unix.PtraceRegs
+	orig.Sp = 0x7ffffff00000
+	const payloadAddr = 0x7ffffff00108 // NOT 16-aligned
+	_, err := setupCallFrame(orig, 0x1000, 0, payloadAddr)
+	if err == nil {
+		t.Fatal("expected alignment error; got nil")
+	}
+}
+
+func TestExtractReturn_arm64(t *testing.T) {
+	var post unix.PtraceRegs
+	post.Regs[0] = 0xCAFEF00D
+	got := extractReturn(post)
+	if got != 0xCAFEF00D {
+		t.Errorf("extractReturn = 0x%x, want 0xCAFEF00D", got)
+	}
+}
+
+func TestStackPointer_arm64(t *testing.T) {
+	var r unix.PtraceRegs
+	r.Sp = 0xC0DEFACE
+	if got := stackPointer(r); got != 0xC0DEFACE {
+		t.Errorf("stackPointer = 0x%x, want 0xC0DEFACE", got)
+	}
+}

--- a/inject/python/detector.go
+++ b/inject/python/detector.go
@@ -78,7 +78,7 @@ func (d *procDetector) Detect(pid uint32) (*Target, error) {
 		}
 		return nil, fmt.Errorf("open %s: %w", mapsPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	libpythonPath, libpythonBase, ok := scanForLibpython(f)
 	if ok {
@@ -179,7 +179,7 @@ func (d *procDetector) resolveStatic(pid uint32) (*Target, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", mapsPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	loadBase := scanForExeBase(f, realExe)
 	if loadBase == 0 {
 		return nil, fmt.Errorf("%w: cannot find exe load base in %s", ErrNotPython, mapsPath)

--- a/inject/python/detector.go
+++ b/inject/python/detector.go
@@ -137,17 +137,27 @@ func scanForLibpython(maps *os.File) (string, uint64, bool) {
 }
 
 // resolveDynamic handles the case where libpython is mapped as a shared lib.
-func (d *procDetector) resolveDynamic(pid uint32, libpath string, loadBase uint64) (*Target, error) {
+// mappingStart is the address of the libpython mapping that backs file
+// offset 0 (returned by scanForLibpython).
+func (d *procDetector) resolveDynamic(pid uint32, libpath string, mappingStart uint64) (*Target, error) {
 	major, minor, _ := elfsym.ParseLibpythonSONAME(libpath)
 	if !elfsym.IsPython312Plus(major, minor) {
 		return nil, fmt.Errorf("%w: detected %d.%d", ErrPythonTooOld, major, minor)
 	}
+	firstLoadVaddr, err := elfsym.FirstLoadVaddr(libpath)
+	if err != nil {
+		return nil, fmt.Errorf("compute load_bias for %s: %w", libpath, err)
+	}
+	loadBias := mappingStart - firstLoadVaddr
 	resolved, err := elfsym.ResolveSymbols(libpath, requiredSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("resolve symbols in %s: %w", libpath, err)
 	}
 	d.log.Debug("python detector: dynamic match",
-		"pid", pid, "libpython", libpath, "loadbase", loadBase,
+		"pid", pid, "libpython", libpath,
+		"mapping_start", fmt.Sprintf("0x%x", mappingStart),
+		"first_load_vaddr", fmt.Sprintf("0x%x", firstLoadVaddr),
+		"load_bias", fmt.Sprintf("0x%x", loadBias),
 		"version", fmt.Sprintf("%d.%d", major, minor))
 	for _, sym := range requiredSymbols {
 		if _, ok := resolved[sym]; !ok {
@@ -157,10 +167,10 @@ func (d *procDetector) resolveDynamic(pid uint32, libpath string, loadBase uint6
 	return &Target{
 		PID:              pid,
 		LibPythonPath:    libpath,
-		LoadBase:         loadBase,
-		PyGILEnsureAddr:  loadBase + resolved["PyGILState_Ensure"],
-		PyGILReleaseAddr: loadBase + resolved["PyGILState_Release"],
-		PyRunStringAddr:  loadBase + resolved["PyRun_SimpleString"],
+		LoadBase:         loadBias,
+		PyGILEnsureAddr:  loadBias + resolved["PyGILState_Ensure"],
+		PyGILReleaseAddr: loadBias + resolved["PyGILState_Release"],
+		PyRunStringAddr:  loadBias + resolved["PyRun_SimpleString"],
 		Major:            major,
 		Minor:            minor,
 	}, nil
@@ -178,8 +188,6 @@ func (d *procDetector) resolveStatic(pid uint32) (*Target, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrNotPython, err)
 	}
-	d.log.Debug("python detector: static match",
-		"pid", pid, "exe", realExe)
 	for _, sym := range requiredSymbols {
 		if _, ok := resolved[sym]; !ok {
 			return nil, fmt.Errorf("%w: %s missing in %s", ErrNotPython, sym, realExe)
@@ -191,17 +199,27 @@ func (d *procDetector) resolveStatic(pid uint32) (*Target, error) {
 		return nil, fmt.Errorf("open %s: %w", mapsPath, err)
 	}
 	defer func() { _ = f.Close() }()
-	loadBase := scanForExeBase(f, realExe)
-	if loadBase == 0 {
-		return nil, fmt.Errorf("%w: cannot find exe load base in %s", ErrNotPython, mapsPath)
+	mappingStart := scanForExeBase(f, realExe)
+	if mappingStart == 0 {
+		return nil, fmt.Errorf("%w: cannot find exe mapping in %s", ErrNotPython, mapsPath)
 	}
+	firstLoadVaddr, err := elfsym.FirstLoadVaddr(realExe)
+	if err != nil {
+		return nil, fmt.Errorf("%w: compute load_bias for %s: %v", ErrNotPython, realExe, err)
+	}
+	loadBias := mappingStart - firstLoadVaddr
+	d.log.Debug("python detector: static match",
+		"pid", pid, "exe", realExe,
+		"mapping_start", fmt.Sprintf("0x%x", mappingStart),
+		"first_load_vaddr", fmt.Sprintf("0x%x", firstLoadVaddr),
+		"load_bias", fmt.Sprintf("0x%x", loadBias))
 	return &Target{
 		PID:              pid,
 		LibPythonPath:    realExe,
-		LoadBase:         loadBase,
-		PyGILEnsureAddr:  loadBase + resolved["PyGILState_Ensure"],
-		PyGILReleaseAddr: loadBase + resolved["PyGILState_Release"],
-		PyRunStringAddr:  loadBase + resolved["PyRun_SimpleString"],
+		LoadBase:         loadBias,
+		PyGILEnsureAddr:  loadBias + resolved["PyGILState_Ensure"],
+		PyGILReleaseAddr: loadBias + resolved["PyGILState_Release"],
+		PyRunStringAddr:  loadBias + resolved["PyRun_SimpleString"],
 		Major:            0, // static path; SONAME version unknown
 		Minor:            0,
 	}, nil

--- a/inject/python/detector.go
+++ b/inject/python/detector.go
@@ -89,11 +89,22 @@ func (d *procDetector) Detect(pid uint32) (*Target, error) {
 	return d.resolveStatic(pid)
 }
 
-// scanForLibpython walks the maps file looking for an executable mapping whose
-// path matches a libpython SONAME. Returns the on-disk path and the load
-// (start) address, or ("", 0, false). Returns the first match — multiple
-// libpython mappings can exist when extension modules embed a second
-// interpreter (rare); see spec §5 edge cases.
+// scanForLibpython walks the maps file looking for the libpython load base —
+// the mapping that backs the file at offset 0 (the first PT_LOAD segment).
+// Returns the on-disk path and the load address, or ("", 0, false).
+//
+// We filter on offset==0 rather than executable perms because modern toolchains
+// (glibc with -Wl,-z,separate-code, default on Ubuntu 24.04+) produce an ELF
+// with a leading r-- LOAD segment for the header + RELRO data and a separate
+// r-x segment for .text at a non-zero file offset. Picking the first
+// executable mapping in that layout returns load_base + first_segment_size,
+// which is wrong: every absolute symbol address derived from it is off by
+// that delta, RIP jumps to garbage on remote call, and the target SEGVs with
+// RAX still holding whatever value the kernel left in it (e.g.
+// -ERESTARTNOHAND if attached mid-syscall).
+//
+// Returns the first match — multiple libpython mappings can exist when
+// extension modules embed a second interpreter (rare); see spec §5 edge cases.
 func scanForLibpython(maps *os.File) (string, uint64, bool) {
 	sc := bufio.NewScanner(maps)
 	for sc.Scan() {
@@ -103,8 +114,8 @@ func scanForLibpython(maps *os.File) (string, uint64, bool) {
 		if len(fields) < 6 {
 			continue
 		}
-		perms := fields[1]
-		if !strings.Contains(perms, "x") {
+		offset, err := strconv.ParseUint(fields[2], 16, 64)
+		if err != nil || offset != 0 {
 			continue
 		}
 		path := fields[5]
@@ -196,9 +207,10 @@ func (d *procDetector) resolveStatic(pid uint32) (*Target, error) {
 	}, nil
 }
 
-// scanForExeBase finds the lowest start address of an executable mapping whose
-// path matches realExe. Used for statically-linked CPython where load base
-// must be derived from the exe's own mapping.
+// scanForExeBase finds the load base of the statically-linked CPython exe.
+// Same rationale as scanForLibpython: we filter on offset==0 to pick the
+// first PT_LOAD segment's mapping, which gives the correct load_base even
+// when modern -Wl,-z,separate-code lays out a leading r-- segment.
 func scanForExeBase(maps *os.File, realExe string) uint64 {
 	var lowest uint64
 	sc := bufio.NewScanner(maps)
@@ -207,10 +219,11 @@ func scanForExeBase(maps *os.File, realExe string) uint64 {
 		if len(fields) < 6 {
 			continue
 		}
-		if !strings.Contains(fields[1], "x") {
+		if fields[5] != realExe {
 			continue
 		}
-		if fields[5] != realExe {
+		offset, err := strconv.ParseUint(fields[2], 16, 64)
+		if err != nil || offset != 0 {
 			continue
 		}
 		dash := strings.IndexByte(fields[0], '-')

--- a/inject/python/detector.go
+++ b/inject/python/detector.go
@@ -39,9 +39,14 @@ var requiredSymbols = []string{
 	"PyRun_SimpleString",
 }
 
-// markerSymbol is a presence-only check; if absent in the symbol table, the
-// target was compiled without --enable-perf-trampoline.
-const markerSymbol = "_PyPerf_Callbacks"
+// We previously used `_PyPerf_Callbacks` as a presence-only "is the trampoline
+// compiled in?" pre-flight check. That was wrong: distributors (Fedora,
+// Ubuntu, etc.) strip internal symbols from production libpython builds, so
+// the symbol is absent from the binary's symbol table even when
+// `--enable-perf-trampoline` was set at compile time. We therefore rely on
+// the runtime return value of `PyRun_SimpleString` to tell us whether the
+// activation actually succeeded — at the cost of one extra ptrace round trip
+// for genuinely-unsupported targets.
 
 // NewDetector builds a /proc-based Detector. procRoot is configurable for
 // testing; production callers pass "/proc". log may be nil (uses
@@ -59,9 +64,10 @@ type procDetector struct {
 }
 
 // Detect implements Detector. Errors are sentinel-wrapped (errors.Is friendly):
-// ErrNotPython, ErrPythonTooOld, ErrNoPerfTrampoline, ErrStaticallyLinkedNoSymbols.
-// Any other error (e.g. EACCES on /proc) is returned as a hard error for the
-// caller to decide whether to abort.
+// ErrNotPython, ErrPythonTooOld, ErrStaticallyLinkedNoSymbols. Any other
+// error (e.g. EACCES on /proc) is returned as a hard error for the caller to
+// decide whether to abort. ErrNoPerfTrampoline is now surfaced at activation
+// time only (when PyRun_SimpleString returns non-zero), not at detection.
 func (d *procDetector) Detect(pid uint32) (*Target, error) {
 	mapsPath := filepath.Join(d.procRoot, strconv.FormatUint(uint64(pid), 10), "maps")
 	f, err := os.Open(mapsPath)
@@ -125,16 +131,13 @@ func (d *procDetector) resolveDynamic(pid uint32, libpath string, loadBase uint6
 	if !elfsym.IsPython312Plus(major, minor) {
 		return nil, fmt.Errorf("%w: detected %d.%d", ErrPythonTooOld, major, minor)
 	}
-	resolved, err := elfsym.ResolveSymbols(libpath, append([]string{markerSymbol}, requiredSymbols...))
+	resolved, err := elfsym.ResolveSymbols(libpath, requiredSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("resolve symbols in %s: %w", libpath, err)
 	}
 	d.log.Debug("python detector: dynamic match",
 		"pid", pid, "libpython", libpath, "loadbase", loadBase,
 		"version", fmt.Sprintf("%d.%d", major, minor))
-	if _, ok := resolved[markerSymbol]; !ok {
-		return nil, fmt.Errorf("%w: %s missing in %s", ErrNoPerfTrampoline, markerSymbol, libpath)
-	}
 	for _, sym := range requiredSymbols {
 		if _, ok := resolved[sym]; !ok {
 			return nil, fmt.Errorf("%w: %s missing in %s", ErrStaticallyLinkedNoSymbols, sym, libpath)
@@ -160,7 +163,7 @@ func (d *procDetector) resolveStatic(pid uint32) (*Target, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: readlink %s: %v", ErrNotPython, exePath, err)
 	}
-	resolved, err := elfsym.ResolveSymbols(realExe, append([]string{markerSymbol}, requiredSymbols...))
+	resolved, err := elfsym.ResolveSymbols(realExe, requiredSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrNotPython, err)
 	}
@@ -170,9 +173,6 @@ func (d *procDetector) resolveStatic(pid uint32) (*Target, error) {
 		if _, ok := resolved[sym]; !ok {
 			return nil, fmt.Errorf("%w: %s missing in %s", ErrNotPython, sym, realExe)
 		}
-	}
-	if _, ok := resolved[markerSymbol]; !ok {
-		return nil, fmt.Errorf("%w: %s missing in %s", ErrNoPerfTrampoline, markerSymbol, realExe)
 	}
 	mapsPath := filepath.Join(d.procRoot, strconv.FormatUint(uint64(pid), 10), "maps")
 	f, err := os.Open(mapsPath)

--- a/inject/python/detector.go
+++ b/inject/python/detector.go
@@ -1,0 +1,222 @@
+package python
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/dpsoft/perf-agent/inject/elfsym"
+)
+
+// Target describes a Python 3.12+ process that detection has confirmed is
+// suitable for trampoline injection. All address fields are absolute remote
+// addresses (load_base + symbol_offset) ready to be passed to ptraceop.
+type Target struct {
+	PID              uint32
+	LibPythonPath    string // on-disk path used for ELF parsing
+	LoadBase         uint64 // address from /proc/<pid>/maps for libpython
+	PyGILEnsureAddr  uint64
+	PyGILReleaseAddr uint64
+	PyRunStringAddr  uint64
+	Major, Minor     int // detected libpython version
+}
+
+// Detector inspects a process and reports whether it is a Python 3.12+
+// candidate suitable for trampoline injection.
+type Detector interface {
+	Detect(pid uint32) (*Target, error)
+}
+
+// requiredSymbols are resolved by the detector; addresses are recorded on Target.
+var requiredSymbols = []string{
+	"PyGILState_Ensure",
+	"PyGILState_Release",
+	"PyRun_SimpleString",
+}
+
+// markerSymbol is a presence-only check; if absent in the symbol table, the
+// target was compiled without --enable-perf-trampoline.
+const markerSymbol = "_PyPerf_Callbacks"
+
+// NewDetector builds a /proc-based Detector. procRoot is configurable for
+// testing; production callers pass "/proc". log may be nil (uses
+// slog.Default()).
+func NewDetector(procRoot string, log *slog.Logger) Detector {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &procDetector{procRoot: procRoot, log: log}
+}
+
+type procDetector struct {
+	procRoot string
+	log      *slog.Logger
+}
+
+// Detect implements Detector. Errors are sentinel-wrapped (errors.Is friendly):
+// ErrNotPython, ErrPythonTooOld, ErrNoPerfTrampoline, ErrStaticallyLinkedNoSymbols.
+// Any other error (e.g. EACCES on /proc) is returned as a hard error for the
+// caller to decide whether to abort.
+func (d *procDetector) Detect(pid uint32) (*Target, error) {
+	mapsPath := filepath.Join(d.procRoot, strconv.FormatUint(uint64(pid), 10), "maps")
+	f, err := os.Open(mapsPath)
+	if err != nil {
+		// /proc/<pid>/maps disappeared — process exited between scan and detect.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w: process gone", ErrNotPython)
+		}
+		return nil, fmt.Errorf("open %s: %w", mapsPath, err)
+	}
+	defer f.Close()
+
+	libpythonPath, libpythonBase, ok := scanForLibpython(f)
+	if ok {
+		return d.resolveDynamic(pid, libpythonPath, libpythonBase)
+	}
+
+	// Fall back to /proc/<pid>/exe (statically-linked CPython).
+	return d.resolveStatic(pid)
+}
+
+// scanForLibpython walks the maps file looking for an executable mapping whose
+// path matches a libpython SONAME. Returns the on-disk path and the load
+// (start) address, or ("", 0, false).
+func scanForLibpython(maps *os.File) (string, uint64, bool) {
+	sc := bufio.NewScanner(maps)
+	for sc.Scan() {
+		line := sc.Text()
+		// Format: "addrStart-addrEnd perms offset dev inode pathname"
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+		perms := fields[1]
+		if !strings.Contains(perms, "x") {
+			continue
+		}
+		path := fields[5]
+		if _, _, isPy := elfsym.ParseLibpythonSONAME(path); !isPy {
+			continue
+		}
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		startHex := fields[0][:dash]
+		start, err := strconv.ParseUint(startHex, 16, 64)
+		if err != nil {
+			continue
+		}
+		return path, start, true
+	}
+	return "", 0, false
+}
+
+// resolveDynamic handles the case where libpython is mapped as a shared lib.
+func (d *procDetector) resolveDynamic(pid uint32, libpath string, loadBase uint64) (*Target, error) {
+	major, minor, _ := elfsym.ParseLibpythonSONAME(libpath)
+	if !elfsym.IsPython312Plus(major, minor) {
+		return nil, fmt.Errorf("%w: detected %d.%d", ErrPythonTooOld, major, minor)
+	}
+	resolved, err := elfsym.ResolveSymbols(libpath, append([]string{markerSymbol}, requiredSymbols...))
+	if err != nil {
+		return nil, fmt.Errorf("resolve symbols in %s: %w", libpath, err)
+	}
+	if _, ok := resolved[markerSymbol]; !ok {
+		return nil, fmt.Errorf("%w: %s missing in %s", ErrNoPerfTrampoline, markerSymbol, libpath)
+	}
+	for _, sym := range requiredSymbols {
+		if _, ok := resolved[sym]; !ok {
+			return nil, fmt.Errorf("%w: %s missing in %s", ErrStaticallyLinkedNoSymbols, sym, libpath)
+		}
+	}
+	return &Target{
+		PID:              pid,
+		LibPythonPath:    libpath,
+		LoadBase:         loadBase,
+		PyGILEnsureAddr:  loadBase + resolved["PyGILState_Ensure"],
+		PyGILReleaseAddr: loadBase + resolved["PyGILState_Release"],
+		PyRunStringAddr:  loadBase + resolved["PyRun_SimpleString"],
+		Major:            major,
+		Minor:            minor,
+	}, nil
+}
+
+// resolveStatic handles statically-linked CPython, where libpython symbols are
+// in the executable itself rather than a shared library.
+func (d *procDetector) resolveStatic(pid uint32) (*Target, error) {
+	exePath := filepath.Join(d.procRoot, strconv.FormatUint(uint64(pid), 10), "exe")
+	realExe, err := os.Readlink(exePath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: readlink %s: %v", ErrNotPython, exePath, err)
+	}
+	resolved, err := elfsym.ResolveSymbols(realExe, append([]string{markerSymbol}, requiredSymbols...))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrNotPython, err)
+	}
+	for _, sym := range requiredSymbols {
+		if _, ok := resolved[sym]; !ok {
+			return nil, fmt.Errorf("%w: %s missing in %s", ErrNotPython, sym, realExe)
+		}
+	}
+	if _, ok := resolved[markerSymbol]; !ok {
+		return nil, fmt.Errorf("%w: %s missing in %s", ErrNoPerfTrampoline, markerSymbol, realExe)
+	}
+	mapsPath := filepath.Join(d.procRoot, strconv.FormatUint(uint64(pid), 10), "maps")
+	f, err := os.Open(mapsPath)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", mapsPath, err)
+	}
+	defer f.Close()
+	loadBase := scanForExeBase(f, realExe)
+	if loadBase == 0 {
+		return nil, fmt.Errorf("%w: cannot find exe load base in %s", ErrNotPython, mapsPath)
+	}
+	return &Target{
+		PID:              pid,
+		LibPythonPath:    realExe,
+		LoadBase:         loadBase,
+		PyGILEnsureAddr:  loadBase + resolved["PyGILState_Ensure"],
+		PyGILReleaseAddr: loadBase + resolved["PyGILState_Release"],
+		PyRunStringAddr:  loadBase + resolved["PyRun_SimpleString"],
+		Major:            0, // static path; SONAME version unknown
+		Minor:            0,
+	}, nil
+}
+
+// scanForExeBase finds the lowest start address of an executable mapping whose
+// path matches realExe. Used for statically-linked CPython where load base
+// must be derived from the exe's own mapping.
+func scanForExeBase(maps *os.File, realExe string) uint64 {
+	var lowest uint64
+	sc := bufio.NewScanner(maps)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 6 {
+			continue
+		}
+		if !strings.Contains(fields[1], "x") {
+			continue
+		}
+		if fields[5] != realExe {
+			continue
+		}
+		dash := strings.IndexByte(fields[0], '-')
+		if dash < 0 {
+			continue
+		}
+		start, err := strconv.ParseUint(fields[0][:dash], 16, 64)
+		if err != nil {
+			continue
+		}
+		if lowest == 0 || start < lowest {
+			lowest = start
+		}
+	}
+	return lowest
+}

--- a/inject/python/detector.go
+++ b/inject/python/detector.go
@@ -85,7 +85,9 @@ func (d *procDetector) Detect(pid uint32) (*Target, error) {
 
 // scanForLibpython walks the maps file looking for an executable mapping whose
 // path matches a libpython SONAME. Returns the on-disk path and the load
-// (start) address, or ("", 0, false).
+// (start) address, or ("", 0, false). Returns the first match — multiple
+// libpython mappings can exist when extension modules embed a second
+// interpreter (rare); see spec §5 edge cases.
 func scanForLibpython(maps *os.File) (string, uint64, bool) {
 	sc := bufio.NewScanner(maps)
 	for sc.Scan() {
@@ -127,6 +129,9 @@ func (d *procDetector) resolveDynamic(pid uint32, libpath string, loadBase uint6
 	if err != nil {
 		return nil, fmt.Errorf("resolve symbols in %s: %w", libpath, err)
 	}
+	d.log.Debug("python detector: dynamic match",
+		"pid", pid, "libpython", libpath, "loadbase", loadBase,
+		"version", fmt.Sprintf("%d.%d", major, minor))
 	if _, ok := resolved[markerSymbol]; !ok {
 		return nil, fmt.Errorf("%w: %s missing in %s", ErrNoPerfTrampoline, markerSymbol, libpath)
 	}
@@ -159,6 +164,8 @@ func (d *procDetector) resolveStatic(pid uint32) (*Target, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrNotPython, err)
 	}
+	d.log.Debug("python detector: static match",
+		"pid", pid, "exe", realExe)
 	for _, sym := range requiredSymbols {
 		if _, ok := resolved[sym]; !ok {
 			return nil, fmt.Errorf("%w: %s missing in %s", ErrNotPython, sym, realExe)

--- a/inject/python/detector_test.go
+++ b/inject/python/detector_test.go
@@ -88,6 +88,40 @@ func TestDetect_DynamicLinkedPython312(t *testing.T) {
 	}
 }
 
+// TestDetect_DynamicLinkedPython_SeparateCodeLayout covers the modern
+// -Wl,-z,separate-code layout (default in Ubuntu 24.04 + glibc 2.39, used by
+// actions/setup-python's CPython 3.12 builds): the first PT_LOAD segment is
+// r-- (header + RELRO data) at file offset 0, and a separate r-x segment
+// holds .text at a non-zero file offset. Picking the first executable mapping
+// in this layout would return load_base + first_segment_size — wrong by that
+// delta. Detection must use file offset 0 as the load-base anchor.
+func TestDetect_DynamicLinkedPython_SeparateCodeLayout(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only test")
+	}
+	libpath := findRealLibpython(t)
+	pid := uint32(54321)
+	root := buildSyntheticProc(t, pid, []string{
+		// Leading r-- segment at offset 0 — this is the proper load base.
+		fmt.Sprintf("7f0000400000-7f0000401000 r--p 00000000 00:00 0 %s", libpath),
+		// Executable .text segment at non-zero offset — old code would
+		// have picked this start address as load base, off by 0x1000.
+		fmt.Sprintf("7f0000401000-7f0000800000 r-xp 00001000 00:00 0 %s", libpath),
+		fmt.Sprintf("7f0000800000-7f0000900000 r--p 00400000 00:00 0 %s", libpath),
+		fmt.Sprintf("7f0000900000-7f0000a00000 rw-p 00500000 00:00 0 %s", libpath),
+	}, "")
+
+	d := NewDetector(root, nil)
+	got, err := d.Detect(pid)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if got.LoadBase != 0x7f0000400000 {
+		t.Errorf("LoadBase = 0x%x, want 0x7f0000400000 (the offset-0 mapping, not the executable one)",
+			got.LoadBase)
+	}
+}
+
 func TestDetect_NonPython(t *testing.T) {
 	pid := uint32(22222)
 	root := buildSyntheticProc(t, pid, []string{

--- a/inject/python/detector_test.go
+++ b/inject/python/detector_test.go
@@ -1,0 +1,139 @@
+package python
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// buildSyntheticProc creates a /proc-like tree under tmp for one PID, with a
+// maps file containing the given lines and an exe symlink pointing at exeTarget.
+// Returns the procRoot path.
+func buildSyntheticProc(t *testing.T, pid uint32, mapsLines []string, exeTarget string) string {
+	t.Helper()
+	root := t.TempDir()
+	pidDir := filepath.Join(root, fmt.Sprintf("%d", pid))
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mapsContent := ""
+	for _, l := range mapsLines {
+		mapsContent += l + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "maps"), []byte(mapsContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if exeTarget != "" {
+		if err := os.Symlink(exeTarget, filepath.Join(pidDir, "exe")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// findRealLibpython finds a libpython3.12+ on the test host, or skips.
+func findRealLibpython(t *testing.T) string {
+	t.Helper()
+	candidates := []string{
+		"/usr/lib/x86_64-linux-gnu/libpython3.12.so.1.0",
+		"/usr/lib/x86_64-linux-gnu/libpython3.13.so.1.0",
+		"/usr/lib/aarch64-linux-gnu/libpython3.12.so.1.0",
+		"/usr/lib/libpython3.12.so.1.0",
+		"/usr/lib64/libpython3.12.so.1.0",
+		"/usr/lib64/libpython3.13.so.1.0",
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	matches, _ := filepath.Glob("/usr/lib*/libpython3.1*.so*")
+	for _, m := range matches {
+		if _, err := os.Stat(m); err == nil {
+			return m
+		}
+	}
+	t.Skip("no libpython3.12+ found on test host")
+	return ""
+}
+
+func TestDetect_DynamicLinkedPython312(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only test")
+	}
+	libpath := findRealLibpython(t)
+	pid := uint32(12345)
+	mapsLine := fmt.Sprintf("00400000-00500000 r-xp 00000000 00:00 0 %s", libpath)
+	root := buildSyntheticProc(t, pid, []string{mapsLine}, "")
+
+	d := NewDetector(root, nil)
+	got, err := d.Detect(pid)
+	if err != nil {
+		// libpython might not have been built with --enable-perf-trampoline on
+		// this host. Accept ErrNoPerfTrampoline as a valid skip.
+		if errors.Is(err, ErrNoPerfTrampoline) {
+			t.Skipf("host libpython lacks --enable-perf-trampoline: %v", err)
+		}
+		t.Fatalf("Detect: %v", err)
+	}
+	if got.PID != pid {
+		t.Errorf("PID = %d, want %d", got.PID, pid)
+	}
+	if got.LibPythonPath != libpath {
+		t.Errorf("LibPythonPath = %q, want %q", got.LibPythonPath, libpath)
+	}
+	if got.LoadBase != 0x00400000 {
+		t.Errorf("LoadBase = 0x%x, want 0x00400000", got.LoadBase)
+	}
+	if got.PyGILEnsureAddr == 0 || got.PyRunStringAddr == 0 || got.PyGILReleaseAddr == 0 {
+		t.Errorf("symbol addrs not populated: %+v", got)
+	}
+}
+
+func TestDetect_NonPython(t *testing.T) {
+	pid := uint32(22222)
+	root := buildSyntheticProc(t, pid, []string{
+		"00400000-00500000 r-xp 00000000 00:00 0 /usr/bin/cat",
+	}, "/usr/bin/cat")
+
+	d := NewDetector(root, nil)
+	_, err := d.Detect(pid)
+	if err == nil {
+		t.Fatal("expected error for non-python; got nil")
+	}
+	if !errors.Is(err, ErrNotPython) && !errors.Is(err, ErrNoPerfTrampoline) {
+		t.Fatalf("expected ErrNotPython or ErrNoPerfTrampoline; got %v", err)
+	}
+}
+
+func TestDetect_PythonTooOld(t *testing.T) {
+	pid := uint32(33333)
+	mapsLine := "00400000-00500000 r-xp 00000000 00:00 0 /usr/lib/libpython3.11.so.1.0"
+	root := buildSyntheticProc(t, pid, []string{mapsLine}, "")
+
+	d := NewDetector(root, nil)
+	_, err := d.Detect(pid)
+	if err == nil {
+		t.Fatal("expected ErrPythonTooOld")
+	}
+	if !errors.Is(err, ErrPythonTooOld) {
+		t.Fatalf("expected ErrPythonTooOld; got %v", err)
+	}
+}
+
+func TestDetect_ProcessGone(t *testing.T) {
+	pid := uint32(99999)
+	// Don't create any /proc/<pid> entry — simulates process exit.
+	root := t.TempDir()
+	d := NewDetector(root, nil)
+	_, err := d.Detect(pid)
+	if err == nil {
+		t.Fatal("expected error for missing /proc/<pid>")
+	}
+	if !errors.Is(err, ErrNotPython) {
+		t.Fatalf("expected ErrNotPython (wrapping process-gone); got %v", err)
+	}
+}

--- a/inject/python/detector_test.go
+++ b/inject/python/detector_test.go
@@ -72,11 +72,6 @@ func TestDetect_DynamicLinkedPython312(t *testing.T) {
 	d := NewDetector(root, nil)
 	got, err := d.Detect(pid)
 	if err != nil {
-		// libpython might not have been built with --enable-perf-trampoline on
-		// this host. Accept ErrNoPerfTrampoline as a valid skip.
-		if errors.Is(err, ErrNoPerfTrampoline) {
-			t.Skipf("host libpython lacks --enable-perf-trampoline: %v", err)
-		}
 		t.Fatalf("Detect: %v", err)
 	}
 	if got.PID != pid {
@@ -104,8 +99,8 @@ func TestDetect_NonPython(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for non-python; got nil")
 	}
-	if !errors.Is(err, ErrNotPython) && !errors.Is(err, ErrNoPerfTrampoline) {
-		t.Fatalf("expected ErrNotPython or ErrNoPerfTrampoline; got %v", err)
+	if !errors.Is(err, ErrNotPython) {
+		t.Fatalf("expected ErrNotPython; got %v", err)
 	}
 }
 

--- a/inject/python/errors.go
+++ b/inject/python/errors.go
@@ -26,10 +26,12 @@ var (
 	// sys.activate_stack_trampoline primitive does not exist on older versions.
 	ErrPythonTooOld = errors.New("python version too old (need 3.12+)")
 
-	// ErrNoPerfTrampoline is returned when libpython is 3.12+ but was compiled
-	// without --enable-perf-trampoline, detected by absence of the
-	// _PyPerf_Callbacks symbol in .dynsym/.symtab.
-	ErrNoPerfTrampoline = errors.New("python built without --enable-perf-trampoline")
+	// ErrNoPerfTrampoline is returned at activation time (not detection) when
+	// PyRun_SimpleString returns non-zero — typically because the interpreter
+	// was compiled without --enable-perf-trampoline. Distributors strip
+	// internal symbols from production libpython, so we cannot detect this
+	// from the symbol table; we rely on the runtime return value.
+	ErrNoPerfTrampoline = errors.New("python activation refused (likely built without --enable-perf-trampoline)")
 
 	// ErrStaticallyLinkedNoSymbols is returned when neither libpython nor
 	// /proc/<pid>/exe exposes the libpython internal symbols needed for

--- a/inject/python/errors.go
+++ b/inject/python/errors.go
@@ -1,0 +1,37 @@
+// Package python implements injection of CPython 3.12+'s perf trampoline
+// (sys.activate_stack_trampoline) into running processes via ptrace, so that
+// perf-agent can resolve Python JIT frames to qualnames without requiring the
+// target to be launched with `python -X perf`.
+package python
+
+import "errors"
+
+// Detection-result sentinels. All are non-fatal: detection returns one of
+// these (wrapped) when a process should be skipped without aborting the run.
+var (
+	// ErrNotPython is returned when the target is not a CPython process.
+	// Examples: a Go binary, a non-Python executable, or a process whose
+	// libpython/exe lacks the interpreter symbols we need.
+	ErrNotPython = errors.New("not a python process")
+
+	// ErrPythonTooOld is returned when a Python process is detected but its
+	// libpython SONAME indicates a version older than 3.12. The
+	// sys.activate_stack_trampoline primitive does not exist on older versions.
+	ErrPythonTooOld = errors.New("python version too old (need 3.12+)")
+
+	// ErrNoPerfTrampoline is returned when libpython is 3.12+ but was compiled
+	// without --enable-perf-trampoline, detected by absence of the
+	// _PyPerf_Callbacks symbol in .dynsym/.symtab.
+	ErrNoPerfTrampoline = errors.New("python built without --enable-perf-trampoline")
+
+	// ErrStaticallyLinkedNoSymbols is returned when neither libpython nor
+	// /proc/<pid>/exe exposes the libpython internal symbols needed for
+	// remote calls (PyRun_SimpleString, PyGILState_Ensure, PyGILState_Release).
+	ErrStaticallyLinkedNoSymbols = errors.New("python interpreter symbols not resolvable")
+
+	// ErrPreexisting is recorded (not returned to callers) when /tmp/perf-<pid>.map
+	// already exists at activation time, indicating the trampoline was activated
+	// by a prior perf-agent run or by user code. We skip both activation and
+	// deactivation in this case to avoid stomping on prior state.
+	ErrPreexisting = errors.New("perf trampoline already active (preexisting marker)")
+)

--- a/inject/python/errors.go
+++ b/inject/python/errors.go
@@ -2,6 +2,13 @@
 // (sys.activate_stack_trampoline) into running processes via ptrace, so that
 // perf-agent can resolve Python JIT frames to qualnames without requiring the
 // target to be launched with `python -X perf`.
+//
+// Lifecycle: each profiling run activates the trampoline at start and
+// deactivates at end. Activation is idempotent — re-running on the same
+// process is safe and is the supported pattern for continuous profiling. If
+// the target was launched with `python -X perf`, the deactivate-at-end will
+// turn the trampoline off; users who want to keep `-X perf` always-on should
+// not pass --inject-python.
 package python
 
 import "errors"
@@ -28,10 +35,4 @@ var (
 	// /proc/<pid>/exe exposes the libpython internal symbols needed for
 	// remote calls (PyRun_SimpleString, PyGILState_Ensure, PyGILState_Release).
 	ErrStaticallyLinkedNoSymbols = errors.New("python interpreter symbols not resolvable")
-
-	// ErrPreexisting is recorded (not returned to callers) when /tmp/perf-<pid>.map
-	// already exists at activation time, indicating the trampoline was activated
-	// by a prior perf-agent run or by user code. We skip both activation and
-	// deactivation in this case to avoid stomping on prior state.
-	ErrPreexisting = errors.New("perf trampoline already active (preexisting marker)")
 )

--- a/inject/python/manager.go
+++ b/inject/python/manager.go
@@ -28,7 +28,10 @@ func (m *Manager) activateOne(pid uint32) error {
 	}
 	if err := m.opts.Injector.RemoteActivate(pid, addrs); err != nil {
 		m.stats.ActivateFailed.Add(1)
-		m.log.Warn("python inject failed", "pid", pid, "err", err)
+		m.log.Warn("python inject failed", "pid", pid, "err", err,
+			"libpython", target.LibPythonPath,
+			"loadbase", fmt.Sprintf("0x%x", target.LoadBase),
+			"py_run_string", fmt.Sprintf("0x%x", target.PyRunStringAddr))
 		if m.opts.StrictPerPID {
 			return fmt.Errorf("activate pid=%d: %w", pid, err)
 		}

--- a/inject/python/manager.go
+++ b/inject/python/manager.go
@@ -1,0 +1,130 @@
+package python
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// activateOne runs detection + activation for one PID. Always returns nil in
+// lenient mode after logging; returns wrapped error in strict mode.
+func (m *Manager) activateOne(pid uint32) error {
+	target, err := m.opts.Detector.Detect(pid)
+	if err != nil {
+		m.recordSkipReason(err)
+		m.log.Warn("python inject skipped",
+			"pid", pid, "reason", reasonString(err))
+		if m.opts.StrictPerPID {
+			return fmt.Errorf("inject pid=%d: %w", pid, err)
+		}
+		return nil
+	}
+
+	if m.opts.PreexistingMarkerCheck(pid) {
+		m.mu.Lock()
+		m.tracked[pid] = &trackedTarget{target: target, preexisting: true, activatedAt: time.Now()}
+		m.mu.Unlock()
+		m.stats.SkippedPreexisting.Add(1)
+		m.log.Warn("python inject skipped",
+			"pid", pid, "reason", "preexisting_perf_map")
+		return nil
+	}
+
+	addrs := SymbolAddrsForTarget{
+		PyGILEnsure:  target.PyGILEnsureAddr,
+		PyGILRelease: target.PyGILReleaseAddr,
+		PyRunString:  target.PyRunStringAddr,
+	}
+	if err := m.opts.Injector.RemoteActivate(pid, addrs); err != nil {
+		m.stats.ActivateFailed.Add(1)
+		m.log.Warn("python inject failed", "pid", pid, "err", err)
+		if m.opts.StrictPerPID {
+			return fmt.Errorf("activate pid=%d: %w", pid, err)
+		}
+		return nil
+	}
+	m.mu.Lock()
+	m.tracked[pid] = &trackedTarget{target: target, activatedAt: time.Now()}
+	m.mu.Unlock()
+	m.stats.Activated.Add(1)
+	m.log.Info("python inject activated",
+		"pid", pid, "libpython", target.LibPythonPath,
+		"version", fmt.Sprintf("%d.%d", target.Major, target.Minor))
+	return nil
+}
+
+func (m *Manager) recordSkipReason(err error) {
+	switch {
+	case errors.Is(err, ErrPythonTooOld):
+		m.stats.SkippedTooOld.Add(1)
+	case errors.Is(err, ErrNoPerfTrampoline):
+		m.stats.SkippedNoTramp.Add(1)
+	case errors.Is(err, ErrStaticallyLinkedNoSymbols):
+		m.stats.SkippedNoSymbols.Add(1)
+	case errors.Is(err, ErrNotPython):
+		m.stats.SkippedNotPython.Add(1)
+	default:
+		m.stats.SkippedNotPython.Add(1) // unknown errors classified as "not python"
+	}
+}
+
+func reasonString(err error) string {
+	switch {
+	case errors.Is(err, ErrPythonTooOld):
+		return "python_too_old"
+	case errors.Is(err, ErrNoPerfTrampoline):
+		return "no_perf_trampoline"
+	case errors.Is(err, ErrStaticallyLinkedNoSymbols):
+		return "no_libpython_symbols"
+	case errors.Is(err, ErrNotPython):
+		return "not_python"
+	default:
+		return "other"
+	}
+}
+
+func (m *Manager) snapshotTracked() map[uint32]*trackedTarget {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[uint32]*trackedTarget, len(m.tracked))
+	for k, v := range m.tracked {
+		out[k] = v
+	}
+	return out
+}
+
+func (m *Manager) logSummary() {
+	m.log.Info("python inject summary",
+		"activated", m.stats.Activated.Load(),
+		"skipped",
+		m.stats.SkippedNotPython.Load()+
+			m.stats.SkippedTooOld.Load()+
+			m.stats.SkippedNoTramp.Load()+
+			m.stats.SkippedNoSymbols.Load()+
+			m.stats.SkippedPreexisting.Load(),
+		"failed", m.stats.ActivateFailed.Load(),
+	)
+}
+
+// defaultPreexistingMarkerCheck returns true iff /tmp/perf-<pid>.map exists
+// and is non-empty. This is the conservative idempotency check from spec §7.2.
+func defaultPreexistingMarkerCheck(pid uint32) bool {
+	path := "/tmp/perf-" + strconv.FormatUint(uint64(pid), 10) + ".map"
+	st, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return st.Size() > 0
+}
+
+// isProcessGone returns true if the error is a "no such process" (ESRCH),
+// indicating the target exited between our snapshot and the deactivate call.
+func isProcessGone(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.ESRCH)
+}

--- a/inject/python/manager.go
+++ b/inject/python/manager.go
@@ -27,6 +27,22 @@ func (m *Manager) activateOne(pid uint32) error {
 		PyRunString:  target.PyRunStringAddr,
 	}
 	if err := m.opts.Injector.RemoteActivate(pid, addrs); err != nil {
+		// "Trampoline not supported" surfaces here (not at detect time) because
+		// the symbol-table pre-flight check is unreliable: distros strip the
+		// internal _PyPerf_Callbacks marker even when --enable-perf-trampoline
+		// was set. We rely on the bridge to translate PyRun_SimpleString == -1
+		// into ErrNoPerfTrampoline so this path classifies it as a structured
+		// skip rather than an opaque ActivateFailed.
+		if errors.Is(err, ErrNoPerfTrampoline) {
+			m.recordSkipReason(err)
+			m.log.Warn("python inject skipped",
+				"pid", pid, "reason", reasonString(err),
+				"libpython", target.LibPythonPath)
+			if m.opts.StrictPerPID {
+				return fmt.Errorf("inject pid=%d: %w", pid, err)
+			}
+			return nil
+		}
 		m.stats.ActivateFailed.Add(1)
 		m.log.Warn("python inject failed", "pid", pid, "err", err,
 			"libpython", target.LibPythonPath,

--- a/inject/python/manager.go
+++ b/inject/python/manager.go
@@ -3,8 +3,6 @@ package python
 import (
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 	"syscall"
 	"time"
 )
@@ -20,16 +18,6 @@ func (m *Manager) activateOne(pid uint32) error {
 		if m.opts.StrictPerPID {
 			return fmt.Errorf("inject pid=%d: %w", pid, err)
 		}
-		return nil
-	}
-
-	if m.opts.PreexistingMarkerCheck(pid) {
-		m.mu.Lock()
-		m.tracked[pid] = &trackedTarget{target: target, preexisting: true, activatedAt: time.Now()}
-		m.mu.Unlock()
-		m.stats.SkippedPreexisting.Add(1)
-		m.log.Warn("python inject skipped",
-			"pid", pid, "reason", "preexisting_perf_map")
 		return nil
 	}
 
@@ -103,21 +91,9 @@ func (m *Manager) logSummary() {
 		m.stats.SkippedNotPython.Load()+
 			m.stats.SkippedTooOld.Load()+
 			m.stats.SkippedNoTramp.Load()+
-			m.stats.SkippedNoSymbols.Load()+
-			m.stats.SkippedPreexisting.Load(),
+			m.stats.SkippedNoSymbols.Load(),
 		"failed", m.stats.ActivateFailed.Load(),
 	)
-}
-
-// defaultPreexistingMarkerCheck returns true iff /tmp/perf-<pid>.map exists
-// and is non-empty. This is the conservative idempotency check from spec §7.2.
-func defaultPreexistingMarkerCheck(pid uint32) bool {
-	path := "/tmp/perf-" + strconv.FormatUint(uint64(pid), 10) + ".map"
-	st, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	return st.Size() > 0
 }
 
 // isProcessGone returns true if the error is a "no such process" (ESRCH),

--- a/inject/python/manager_test.go
+++ b/inject/python/manager_test.go
@@ -1,0 +1,244 @@
+package python
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// stubDetector implements Detector by mapping PID → result.
+type stubDetector struct {
+	results map[uint32]stubResult
+}
+
+type stubResult struct {
+	target *Target
+	err    error
+}
+
+func (s *stubDetector) Detect(pid uint32) (*Target, error) {
+	r, ok := s.results[pid]
+	if !ok {
+		return nil, ErrNotPython
+	}
+	return r.target, r.err
+}
+
+// stubInjector counts and optionally errors.
+type stubInjector struct {
+	mu              sync.Mutex
+	activated       []uint32
+	deactivated     []uint32
+	activateErr     error
+	deactivateErr   error
+	deactivateDelay time.Duration
+}
+
+func (s *stubInjector) RemoteActivate(pid uint32, _ SymbolAddrsForTarget) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activateErr != nil {
+		return s.activateErr
+	}
+	s.activated = append(s.activated, pid)
+	return nil
+}
+
+func (s *stubInjector) RemoteDeactivate(pid uint32, _ SymbolAddrsForTarget) error {
+	if s.deactivateDelay > 0 {
+		time.Sleep(s.deactivateDelay)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.deactivateErr != nil {
+		return s.deactivateErr
+	}
+	s.deactivated = append(s.deactivated, pid)
+	return nil
+}
+
+func newTestManager(t *testing.T, det Detector, inj LowLevelInjector, strict bool) *Manager {
+	t.Helper()
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewManager(Options{
+		StrictPerPID:           strict,
+		Logger:                 silent,
+		Detector:               det,
+		Injector:               inj,
+		PreexistingMarkerCheck: func(uint32) bool { return false },
+	})
+}
+
+func makeTarget(pid uint32) *Target {
+	return &Target{
+		PID:              pid,
+		LibPythonPath:    "/fake/libpython3.12.so",
+		LoadBase:         0x400000,
+		PyGILEnsureAddr:  0x401000,
+		PyGILReleaseAddr: 0x402000,
+		PyRunStringAddr:  0x403000,
+		Major:            3,
+		Minor:            12,
+	}
+}
+
+func TestActivateAll_StrictExitsOnFirstError(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+		200: {err: ErrPythonTooOld},
+		300: {target: makeTarget(300)},
+	}}
+	inj := &stubInjector{}
+	m := newTestManager(t, det, inj, true)
+
+	err := m.ActivateAll([]uint32{100, 200, 300})
+	if err == nil {
+		t.Fatal("expected strict error; got nil")
+	}
+	if !errors.Is(err, ErrPythonTooOld) {
+		t.Fatalf("expected ErrPythonTooOld; got %v", err)
+	}
+	if got := m.stats.Activated.Load(); got != 1 {
+		t.Errorf("Activated = %d, want 1", got)
+	}
+	for _, p := range inj.activated {
+		if p == 300 {
+			t.Errorf("strict mode should not have activated pid 300")
+		}
+	}
+}
+
+func TestActivateAll_LenientContinuesOnError(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+		200: {err: ErrPythonTooOld},
+		300: {target: makeTarget(300)},
+	}}
+	inj := &stubInjector{}
+	m := newTestManager(t, det, inj, false)
+
+	if err := m.ActivateAll([]uint32{100, 200, 300}); err != nil {
+		t.Fatalf("lenient ActivateAll returned error: %v", err)
+	}
+	if got := m.stats.Activated.Load(); got != 2 {
+		t.Errorf("Activated = %d, want 2", got)
+	}
+	if got := m.stats.SkippedTooOld.Load(); got != 1 {
+		t.Errorf("SkippedTooOld = %d, want 1", got)
+	}
+}
+
+func TestActivateAll_PreexistingMarkerSkips(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{}
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(Options{
+		Logger:                 silent,
+		Detector:               det,
+		Injector:               inj,
+		PreexistingMarkerCheck: func(pid uint32) bool { return pid == 100 },
+	})
+	if err := m.ActivateAll([]uint32{100}); err != nil {
+		t.Fatalf("ActivateAll: %v", err)
+	}
+	if got := m.stats.SkippedPreexisting.Load(); got != 1 {
+		t.Errorf("SkippedPreexisting = %d, want 1", got)
+	}
+	if got := m.stats.Activated.Load(); got != 0 {
+		t.Errorf("Activated = %d, want 0", got)
+	}
+	// Now Deactivate — preexisting must be skipped (it IS in tracked but
+	// with preexisting=true, and deactivation skips it).
+	m.DeactivateAll(t.Context())
+	if got := m.stats.Deactivated.Load(); got != 0 {
+		t.Errorf("Deactivated = %d, want 0 (preexisting must be skipped)", got)
+	}
+}
+
+func TestDeactivateAll_HonorsDeadline(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+		200: {target: makeTarget(200)},
+		300: {target: makeTarget(300)},
+	}}
+	// Inject delay so the second-or-later Deactivate hits the deadline.
+	inj := &stubInjector{deactivateDelay: 100 * time.Millisecond}
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(Options{
+		Logger:                 silent,
+		Detector:               det,
+		Injector:               inj,
+		PreexistingMarkerCheck: func(uint32) bool { return false },
+		DeactivateDeadline:     50 * time.Millisecond,
+	})
+	if err := m.ActivateAll([]uint32{100, 200, 300}); err != nil {
+		t.Fatalf("ActivateAll: %v", err)
+	}
+	start := time.Now()
+	m.DeactivateAll(t.Context())
+	elapsed := time.Since(start)
+	if elapsed > 250*time.Millisecond {
+		t.Errorf("DeactivateAll took %v; deadline should have capped near 50-150ms", elapsed)
+	}
+}
+
+func TestDeactivateAll_ToleratesESRCH(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{deactivateErr: syscall.ESRCH}
+	m := newTestManager(t, det, inj, false)
+	if err := m.ActivateAll([]uint32{100}); err != nil {
+		t.Fatalf("ActivateAll: %v", err)
+	}
+	m.DeactivateAll(t.Context())
+	if got := m.stats.DeactivateFailed.Load(); got != 0 {
+		t.Errorf("DeactivateFailed = %d on ESRCH; want 0", got)
+	}
+}
+
+func TestActivateLate_DedupesViaTracked(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{}
+	m := newTestManager(t, det, inj, false)
+
+	if err := m.ActivateAll([]uint32{100}); err != nil {
+		t.Fatalf("ActivateAll: %v", err)
+	}
+	// Now late-arrival event for the same PID — must not trigger second activation.
+	m.ActivateLate(100)
+	if len(inj.activated) != 1 {
+		t.Errorf("activate count = %d, want 1", len(inj.activated))
+	}
+}
+
+func TestActivateLate_DedupesViaPending(t *testing.T) {
+	// Multiple concurrent ActivateLate calls for the same PID — only one must
+	// reach the injector.
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{}
+	m := newTestManager(t, det, inj, false)
+
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Go(func() { m.ActivateLate(100) })
+	}
+	wg.Wait()
+	if len(inj.activated) > 1 {
+		t.Errorf("ActivateLate not deduped under concurrency: %v", inj.activated)
+	}
+}
+
+// Compile-time check: ensure context is imported correctly.
+var _ = context.Background

--- a/inject/python/manager_test.go
+++ b/inject/python/manager_test.go
@@ -66,11 +66,10 @@ func newTestManager(t *testing.T, det Detector, inj LowLevelInjector, strict boo
 	t.Helper()
 	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
 	return NewManager(Options{
-		StrictPerPID:           strict,
-		Logger:                 silent,
-		Detector:               det,
-		Injector:               inj,
-		PreexistingMarkerCheck: func(uint32) bool { return false },
+		StrictPerPID: strict,
+		Logger:       silent,
+		Detector:     det,
+		Injector:     inj,
 	})
 }
 
@@ -133,35 +132,6 @@ func TestActivateAll_LenientContinuesOnError(t *testing.T) {
 	}
 }
 
-func TestActivateAll_PreexistingMarkerSkips(t *testing.T) {
-	det := &stubDetector{results: map[uint32]stubResult{
-		100: {target: makeTarget(100)},
-	}}
-	inj := &stubInjector{}
-	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
-	m := NewManager(Options{
-		Logger:                 silent,
-		Detector:               det,
-		Injector:               inj,
-		PreexistingMarkerCheck: func(pid uint32) bool { return pid == 100 },
-	})
-	if err := m.ActivateAll([]uint32{100}); err != nil {
-		t.Fatalf("ActivateAll: %v", err)
-	}
-	if got := m.stats.SkippedPreexisting.Load(); got != 1 {
-		t.Errorf("SkippedPreexisting = %d, want 1", got)
-	}
-	if got := m.stats.Activated.Load(); got != 0 {
-		t.Errorf("Activated = %d, want 0", got)
-	}
-	// Now Deactivate — preexisting must be skipped (it IS in tracked but
-	// with preexisting=true, and deactivation skips it).
-	m.DeactivateAll(t.Context())
-	if got := m.stats.Deactivated.Load(); got != 0 {
-		t.Errorf("Deactivated = %d, want 0 (preexisting must be skipped)", got)
-	}
-}
-
 func TestDeactivateAll_HonorsDeadline(t *testing.T) {
 	det := &stubDetector{results: map[uint32]stubResult{
 		100: {target: makeTarget(100)},
@@ -172,11 +142,10 @@ func TestDeactivateAll_HonorsDeadline(t *testing.T) {
 	inj := &stubInjector{deactivateDelay: 100 * time.Millisecond}
 	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
 	m := NewManager(Options{
-		Logger:                 silent,
-		Detector:               det,
-		Injector:               inj,
-		PreexistingMarkerCheck: func(uint32) bool { return false },
-		DeactivateDeadline:     50 * time.Millisecond,
+		Logger:             silent,
+		Detector:           det,
+		Injector:           inj,
+		DeactivateDeadline: 50 * time.Millisecond,
 	})
 	if err := m.ActivateAll([]uint32{100, 200, 300}); err != nil {
 		t.Fatalf("ActivateAll: %v", err)

--- a/inject/python/manager_test.go
+++ b/inject/python/manager_test.go
@@ -3,6 +3,7 @@ package python
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -83,6 +84,53 @@ func makeTarget(pid uint32) *Target {
 		PyRunStringAddr:  0x403000,
 		Major:            3,
 		Minor:            12,
+	}
+}
+
+// TestActivateAll_NoPerfTrampolineCountsAsSkip exercises the path where
+// the bridge translates ptraceop.ErrRemoteCallNonZero(Result=-1) into
+// ErrNoPerfTrampoline. The manager must classify it as SkippedNoTramp,
+// not ActivateFailed — that's the whole point of the typed-error wiring.
+func TestActivateAll_NoPerfTrampolineCountsAsSkip(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{
+		activateErr: fmt.Errorf("activation refused: %w", ErrNoPerfTrampoline),
+	}
+	m := newTestManager(t, det, inj, false)
+
+	if err := m.ActivateAll([]uint32{100}); err != nil {
+		t.Fatalf("lenient ActivateAll returned error: %v", err)
+	}
+	if got := m.stats.Activated.Load(); got != 0 {
+		t.Errorf("Activated = %d, want 0", got)
+	}
+	if got := m.stats.SkippedNoTramp.Load(); got != 1 {
+		t.Errorf("SkippedNoTramp = %d, want 1", got)
+	}
+	if got := m.stats.ActivateFailed.Load(); got != 0 {
+		t.Errorf("ActivateFailed = %d, want 0 (must not double-count)", got)
+	}
+}
+
+// TestActivateAll_StrictWrapsNoTrampSentinel verifies strict mode returns
+// an error wrapping ErrNoPerfTrampoline so callers can errors.Is on it.
+func TestActivateAll_StrictWrapsNoTrampSentinel(t *testing.T) {
+	det := &stubDetector{results: map[uint32]stubResult{
+		100: {target: makeTarget(100)},
+	}}
+	inj := &stubInjector{
+		activateErr: fmt.Errorf("activation refused: %w", ErrNoPerfTrampoline),
+	}
+	m := newTestManager(t, det, inj, true)
+
+	err := m.ActivateAll([]uint32{100})
+	if err == nil {
+		t.Fatal("expected strict error; got nil")
+	}
+	if !errors.Is(err, ErrNoPerfTrampoline) {
+		t.Fatalf("expected ErrNoPerfTrampoline; got %v", err)
 	}
 }
 

--- a/inject/python/payload.go
+++ b/inject/python/payload.go
@@ -1,0 +1,19 @@
+package python
+
+// activatePayload is the C string written into the target process's address
+// space. PyRun_SimpleString reads it as a NUL-terminated cstring.
+//
+// We import sys explicitly each time rather than relying on it already being
+// imported, because PyRun_SimpleString runs in a fresh "main" namespace.
+var activatePayload = []byte("import sys; sys.activate_stack_trampoline('perf')\x00")
+
+var deactivatePayload = []byte("import sys; sys.deactivate_stack_trampoline()\x00")
+
+// ActivatePayload returns the byte slice (NUL-terminated) to write into the
+// target's address space before calling PyRun_SimpleString. Caller must NOT
+// mutate the returned slice.
+func ActivatePayload() []byte { return activatePayload }
+
+// DeactivatePayload returns the byte slice (NUL-terminated) for the
+// shutdown deactivation call. Caller must NOT mutate the returned slice.
+func DeactivatePayload() []byte { return deactivatePayload }

--- a/inject/python/payload_test.go
+++ b/inject/python/payload_test.go
@@ -27,10 +27,16 @@ func TestEncodeDeactivatePayload(t *testing.T) {
 	}
 }
 
-func TestPayloadsAreImmutable(t *testing.T) {
+// TestActivatePayloadIsConsistent guards against accidental in-place mutation
+// of the package-level slice across calls. ActivatePayload returns the
+// underlying slice (no copy), so a caller mutating it would also affect
+// later calls — that contract is documented; this test merely confirms the
+// returned bytes haven't drifted from the canonical payload between two
+// consecutive reads.
+func TestActivatePayloadIsConsistent(t *testing.T) {
 	a := ActivatePayload()
 	b := ActivatePayload()
 	if !bytes.Equal(a, b) {
-		t.Fatalf("ActivatePayload returned different slices on consecutive calls")
+		t.Fatalf("ActivatePayload returned different bytes on consecutive calls")
 	}
 }

--- a/inject/python/payload_test.go
+++ b/inject/python/payload_test.go
@@ -1,0 +1,36 @@
+package python
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncodeActivatePayload(t *testing.T) {
+	got := ActivatePayload()
+	want := []byte("import sys; sys.activate_stack_trampoline('perf')\x00")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("ActivatePayload mismatch:\n  got  %q\n  want %q", got, want)
+	}
+	if got[len(got)-1] != 0 {
+		t.Fatalf("ActivatePayload not NUL-terminated; last byte = 0x%x", got[len(got)-1])
+	}
+}
+
+func TestEncodeDeactivatePayload(t *testing.T) {
+	got := DeactivatePayload()
+	want := []byte("import sys; sys.deactivate_stack_trampoline()\x00")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("DeactivatePayload mismatch:\n  got  %q\n  want %q", got, want)
+	}
+	if got[len(got)-1] != 0 {
+		t.Fatalf("DeactivatePayload not NUL-terminated; last byte = 0x%x", got[len(got)-1])
+	}
+}
+
+func TestPayloadsAreImmutable(t *testing.T) {
+	a := ActivatePayload()
+	b := ActivatePayload()
+	if !bytes.Equal(a, b) {
+		t.Fatalf("ActivatePayload returned different slices on consecutive calls")
+	}
+}

--- a/inject/python/python.go
+++ b/inject/python/python.go
@@ -83,20 +83,29 @@ type trackedTarget struct {
 
 // NewManager constructs a Manager.
 //
-// opts.Logger may be nil and falls back to slog.Default(); opts.DeactivateDeadline
-// of 0 falls back to 5s. opts.Detector and opts.Injector are required and must
-// be supplied by the caller — perfagent.Agent wires the production /proc-based
-// detector and the ptraceop bridge; tests inject stubs. inject/python
-// deliberately does not import inject/ptraceop, which is why no automatic
-// default is constructed here. Calling ActivateAll/DeactivateAll with either
-// nil panics at first use; that's intentional — a silent default would mask
-// wiring mistakes.
+// Defaults:
+//   - opts.Logger             → slog.Default() if nil
+//   - opts.DeactivateDeadline → 5 * time.Second if zero
+//   - opts.Detector           → NewDetector("/proc", logger) if nil
+//
+// opts.Injector has no in-package default — inject/python deliberately does
+// not import inject/ptraceop, so the low-level injector must be supplied by
+// the caller. perfagent.Agent wires it via the ptraceopBridge; tests inject
+// stubs. NewManager panics with a clear message if Injector is nil; surfacing
+// that wiring mistake at construction is friendlier than the deep NPE the
+// first ActivateAll call would otherwise raise.
 func NewManager(opts Options) *Manager {
 	if opts.Logger == nil {
 		opts.Logger = slog.Default()
 	}
 	if opts.DeactivateDeadline == 0 {
 		opts.DeactivateDeadline = 5 * time.Second
+	}
+	if opts.Detector == nil {
+		opts.Detector = NewDetector("/proc", opts.Logger)
+	}
+	if opts.Injector == nil {
+		panic("python.NewManager: opts.Injector is required (perfagent.Agent wires this; tests inject stubs)")
 	}
 	return &Manager{
 		opts:    opts,

--- a/inject/python/python.go
+++ b/inject/python/python.go
@@ -1,0 +1,183 @@
+package python
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Options configures a Manager.
+type Options struct {
+	// StrictPerPID makes ActivateAll fail-fast on the first error. Used for
+	// --pid N --inject-python; lenient (false) for -a --inject-python.
+	StrictPerPID bool
+
+	// Logger receives structured log lines for every detect/activate/deactivate
+	// event. nil → slog.Default().
+	Logger *slog.Logger
+
+	// PreexistingMarkerCheck overrides the default check for "is this PID's
+	// trampoline already active?" — set in tests to a stub. Production passes
+	// nil and gets the default /tmp/perf-<pid>.map check.
+	PreexistingMarkerCheck func(pid uint32) bool
+
+	// Injector overrides the default ptraceop-based injector. Tests inject
+	// stubs; production passes nil and gets the real ptraceop.Injector.
+	// In production this is wired by perfagent.Agent (Task 8) since this
+	// package does not import inject/ptraceop directly.
+	Injector LowLevelInjector
+
+	// Detector overrides the default /proc-based detector. Tests inject stubs;
+	// production passes nil.
+	Detector Detector
+
+	// DeactivateDeadline caps the total time spent in DeactivateAll. Default
+	// 5 seconds.
+	DeactivateDeadline time.Duration
+}
+
+// LowLevelInjector is the contract Manager uses for the ptrace dance. The
+// production implementation wraps inject/ptraceop.Injector; tests can stub it.
+type LowLevelInjector interface {
+	RemoteActivate(pid uint32, addrs SymbolAddrsForTarget) error
+	RemoteDeactivate(pid uint32, addrs SymbolAddrsForTarget) error
+}
+
+// SymbolAddrsForTarget is the data the LowLevelInjector needs to perform one
+// remote-call sequence — independent of inject/ptraceop's exact struct layout
+// to keep the test boundary clean.
+type SymbolAddrsForTarget struct {
+	PyGILEnsure  uint64
+	PyGILRelease uint64
+	PyRunString  uint64
+}
+
+// Stats holds counters that operators inspect after a run. All counters are
+// safe for concurrent use.
+type Stats struct {
+	Activated          atomic.Uint64
+	Deactivated        atomic.Uint64
+	SkippedNotPython   atomic.Uint64
+	SkippedTooOld      atomic.Uint64
+	SkippedNoTramp     atomic.Uint64
+	SkippedNoSymbols   atomic.Uint64
+	SkippedPreexisting atomic.Uint64
+	ActivateFailed     atomic.Uint64
+	DeactivateFailed   atomic.Uint64
+}
+
+// Manager orchestrates Python perf-trampoline injection across a profile run:
+// detection ladder, strict/lenient policy, in-memory tracked-PID set, bounded
+// shutdown deactivation, and idempotent late-arrival activation.
+type Manager struct {
+	opts Options
+	log  *slog.Logger
+
+	mu      sync.Mutex
+	tracked map[uint32]*trackedTarget
+	pending sync.Map // pid uint32 → struct{} (in-flight late activation)
+
+	stats Stats
+}
+
+type trackedTarget struct {
+	target      *Target
+	activatedAt time.Time
+	preexisting bool
+}
+
+// NewManager constructs a Manager. opts.Logger may be nil. opts.Detector and
+// opts.Injector default to /proc + ptraceop in production; tests inject stubs.
+func NewManager(opts Options) *Manager {
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	if opts.DeactivateDeadline == 0 {
+		opts.DeactivateDeadline = 5 * time.Second
+	}
+	if opts.PreexistingMarkerCheck == nil {
+		opts.PreexistingMarkerCheck = defaultPreexistingMarkerCheck
+	}
+	return &Manager{
+		opts:    opts,
+		log:     opts.Logger,
+		tracked: make(map[uint32]*trackedTarget),
+	}
+}
+
+// Stats returns a pointer to the in-place atomic counters. Callers should
+// treat it as read-only; mutate via the atomic methods if needed (currently
+// only the package itself mutates them).
+func (m *Manager) Stats() *Stats { return &m.stats }
+
+// ActivateAll runs detection and activation for the given PIDs. Returns nil
+// in lenient mode (errors are logged + counted); returns the first error in
+// strict mode. Caller blocks on this; it is fine to call once at profile
+// start before BPF attach.
+func (m *Manager) ActivateAll(pids []uint32) error {
+	for _, pid := range pids {
+		if err := m.activateOne(pid); err != nil {
+			if m.opts.StrictPerPID {
+				return err
+			}
+		}
+	}
+	m.logSummary()
+	return nil
+}
+
+// ActivateLate is the mmap-watcher hook for new exec events during -a mode.
+// Always lenient (logs + counts on error). Idempotent: dedupes by tracked
+// and pending sets.
+func (m *Manager) ActivateLate(pid uint32) {
+	if _, loaded := m.pending.LoadOrStore(pid, struct{}{}); loaded {
+		return // in-flight activation for this pid
+	}
+	defer m.pending.Delete(pid)
+
+	m.mu.Lock()
+	_, already := m.tracked[pid]
+	m.mu.Unlock()
+	if already {
+		return
+	}
+	_ = m.activateOne(pid) // lenient: errors logged inside
+}
+
+// DeactivateAll runs the bounded shutdown deactivation pass. Skips entries
+// marked preexisting; tolerates ESRCH (process gone). Honors ctx cancellation
+// AND the configured deactivation deadline (5s default).
+func (m *Manager) DeactivateAll(ctx context.Context) {
+	deadline, cancel := context.WithTimeout(ctx, m.opts.DeactivateDeadline)
+	defer cancel()
+
+	snapshot := m.snapshotTracked()
+	for pid, tt := range snapshot {
+		select {
+		case <-deadline.Done():
+			m.log.Warn("python deactivate cancelled (deadline or ctx)",
+				"abandoned", len(snapshot)-int(m.stats.Deactivated.Load()))
+			return
+		default:
+		}
+		if tt.preexisting {
+			continue
+		}
+		addrs := SymbolAddrsForTarget{
+			PyGILEnsure:  tt.target.PyGILEnsureAddr,
+			PyGILRelease: tt.target.PyGILReleaseAddr,
+			PyRunString:  tt.target.PyRunStringAddr,
+		}
+		if err := m.opts.Injector.RemoteDeactivate(pid, addrs); err != nil {
+			if isProcessGone(err) {
+				continue
+			}
+			m.log.Warn("python deactivate failed", "pid", pid, "err", err)
+			m.stats.DeactivateFailed.Add(1)
+			continue
+		}
+		m.stats.Deactivated.Add(1)
+	}
+}

--- a/inject/python/python.go
+++ b/inject/python/python.go
@@ -18,11 +18,6 @@ type Options struct {
 	// event. nil → slog.Default().
 	Logger *slog.Logger
 
-	// PreexistingMarkerCheck overrides the default check for "is this PID's
-	// trampoline already active?" — set in tests to a stub. Production passes
-	// nil and gets the default /tmp/perf-<pid>.map check.
-	PreexistingMarkerCheck func(pid uint32) bool
-
 	// Injector overrides the default ptraceop-based injector. Tests inject
 	// stubs; production passes nil and gets the real ptraceop.Injector.
 	// In production this is wired by perfagent.Agent (Task 8) since this
@@ -57,15 +52,14 @@ type SymbolAddrsForTarget struct {
 // Stats holds counters that operators inspect after a run. All counters are
 // safe for concurrent use.
 type Stats struct {
-	Activated          atomic.Uint64
-	Deactivated        atomic.Uint64
-	SkippedNotPython   atomic.Uint64
-	SkippedTooOld      atomic.Uint64
-	SkippedNoTramp     atomic.Uint64
-	SkippedNoSymbols   atomic.Uint64
-	SkippedPreexisting atomic.Uint64
-	ActivateFailed     atomic.Uint64
-	DeactivateFailed   atomic.Uint64
+	Activated        atomic.Uint64
+	Deactivated      atomic.Uint64
+	SkippedNotPython atomic.Uint64
+	SkippedTooOld    atomic.Uint64
+	SkippedNoTramp   atomic.Uint64
+	SkippedNoSymbols atomic.Uint64
+	ActivateFailed   atomic.Uint64
+	DeactivateFailed atomic.Uint64
 }
 
 // Manager orchestrates Python perf-trampoline injection across a profile run:
@@ -85,7 +79,6 @@ type Manager struct {
 type trackedTarget struct {
 	target      *Target
 	activatedAt time.Time
-	preexisting bool
 }
 
 // NewManager constructs a Manager. opts.Logger may be nil. opts.Detector and
@@ -96,9 +89,6 @@ func NewManager(opts Options) *Manager {
 	}
 	if opts.DeactivateDeadline == 0 {
 		opts.DeactivateDeadline = 5 * time.Second
-	}
-	if opts.PreexistingMarkerCheck == nil {
-		opts.PreexistingMarkerCheck = defaultPreexistingMarkerCheck
 	}
 	return &Manager{
 		opts:    opts,
@@ -146,9 +136,9 @@ func (m *Manager) ActivateLate(pid uint32) {
 	_ = m.activateOne(pid) // lenient: errors logged inside
 }
 
-// DeactivateAll runs the bounded shutdown deactivation pass. Skips entries
-// marked preexisting; tolerates ESRCH (process gone). Honors ctx cancellation
-// AND the configured deactivation deadline (5s default).
+// DeactivateAll runs the bounded shutdown deactivation pass. Tolerates ESRCH
+// (process gone). Honors ctx cancellation AND the configured deactivation
+// deadline (5s default).
 func (m *Manager) DeactivateAll(ctx context.Context) {
 	deadline, cancel := context.WithTimeout(ctx, m.opts.DeactivateDeadline)
 	defer cancel()
@@ -161,9 +151,6 @@ func (m *Manager) DeactivateAll(ctx context.Context) {
 				"abandoned", len(snapshot)-int(m.stats.Deactivated.Load()))
 			return
 		default:
-		}
-		if tt.preexisting {
-			continue
 		}
 		addrs := SymbolAddrsForTarget{
 			PyGILEnsure:  tt.target.PyGILEnsureAddr,

--- a/inject/python/python.go
+++ b/inject/python/python.go
@@ -81,8 +81,16 @@ type trackedTarget struct {
 	activatedAt time.Time
 }
 
-// NewManager constructs a Manager. opts.Logger may be nil. opts.Detector and
-// opts.Injector default to /proc + ptraceop in production; tests inject stubs.
+// NewManager constructs a Manager.
+//
+// opts.Logger may be nil and falls back to slog.Default(); opts.DeactivateDeadline
+// of 0 falls back to 5s. opts.Detector and opts.Injector are required and must
+// be supplied by the caller — perfagent.Agent wires the production /proc-based
+// detector and the ptraceop bridge; tests inject stubs. inject/python
+// deliberately does not import inject/ptraceop, which is why no automatic
+// default is constructed here. Calling ActivateAll/DeactivateAll with either
+// nil panics at first use; that's intentional — a silent default would mask
+// wiring mistakes.
 func NewManager(opts Options) *Manager {
 	if opts.Logger == nil {
 		opts.Logger = slog.Default()

--- a/main.go
+++ b/main.go
@@ -28,7 +28,9 @@ var (
 	flagOffcpuOutput  = flag.String("offcpu-output", "", "Output path for off-CPU profile (default: auto-generated)")
 	flagPMUOutput     = flag.String("pmu-output", "", "Output path for PMU metrics (default: stdout)")
 	flagUnwind        = flag.String("unwind", "auto", "Stack unwinding strategy: fp | dwarf | auto (auto → dwarf)")
-	flagTags          tagFlags
+	flagInjectPython  = flag.Bool("inject-python", false,
+		"Inject sys.activate_stack_trampoline('perf') into running CPython 3.12+ targets via ptrace. Requires CAP_SYS_PTRACE. Off by default.")
+	flagTags tagFlags
 )
 
 // tagFlags is a custom flag type for collecting multiple --tag key=value arguments
@@ -186,6 +188,11 @@ func buildOptions() []perfagent.Option {
 	// Unwinding strategy
 	if *flagUnwind != "" {
 		opts = append(opts, perfagent.WithUnwind(*flagUnwind))
+	}
+
+	// Python perf-trampoline injection
+	if *flagInjectPython {
+		opts = append(opts, perfagent.WithInjectPython(true))
 	}
 
 	return opts

--- a/perfagent/agent.go
+++ b/perfagent/agent.go
@@ -463,25 +463,50 @@ func (a *Agent) scanPythonTargets() []uint32 {
 }
 
 // ptraceopBridge adapts ptraceop.Injector to python.LowLevelInjector,
-// supplying the activate/deactivate payloads from inject/python.
+// supplying the activate/deactivate payloads from inject/python and
+// translating ptraceop's language-agnostic typed errors into Python-specific
+// sentinels the manager can classify (e.g. PyRun_SimpleString returning -1
+// → python.ErrNoPerfTrampoline so the manager records SkippedNoTramp instead
+// of an opaque ActivateFailed).
 type ptraceopBridge struct {
 	inj *ptraceop.Injector
 }
 
 func (b *ptraceopBridge) RemoteActivate(pid uint32, addrs python.SymbolAddrsForTarget) error {
-	return b.inj.RemoteActivate(pid, ptraceop.SymbolAddrs{
+	err := b.inj.RemoteActivate(pid, ptraceop.SymbolAddrs{
 		PyGILEnsure:  addrs.PyGILEnsure,
 		PyGILRelease: addrs.PyGILRelease,
 		PyRunString:  addrs.PyRunString,
 	}, python.ActivatePayload())
+	return mapPtraceopErrToPython(err)
 }
 
 func (b *ptraceopBridge) RemoteDeactivate(pid uint32, addrs python.SymbolAddrsForTarget) error {
-	return b.inj.RemoteDeactivate(pid, ptraceop.SymbolAddrs{
+	err := b.inj.RemoteDeactivate(pid, ptraceop.SymbolAddrs{
 		PyGILEnsure:  addrs.PyGILEnsure,
 		PyGILRelease: addrs.PyGILRelease,
 		PyRunString:  addrs.PyRunString,
 	}, python.DeactivatePayload())
+	return mapPtraceopErrToPython(err)
+}
+
+// mapPtraceopErrToPython translates a ptraceop typed error into a
+// python-domain sentinel-wrapped error when the result code corresponds to
+// a Python-level failure. PyRun_SimpleString returns -1 on any Python error;
+// in the activate/deactivate payload context this is overwhelmingly the
+// "perf trampoline not supported" path (the test gate already runs the
+// payload from a normal interpreter, so structurally-different errors at
+// inject time are rare and worth surfacing as ActivateFailed).
+func mapPtraceopErrToPython(err error) error {
+	if err == nil {
+		return nil
+	}
+	var nonZero *ptraceop.ErrRemoteCallNonZero
+	if errors.As(err, &nonZero) && int32(nonZero.Result) == -1 {
+		return fmt.Errorf("activation refused (PyRun_SimpleString returned -1): %w",
+			python.ErrNoPerfTrampoline)
+	}
+	return err
 }
 
 // dwarfHooksForAgent builds a *dwarfagent.Hooks for this agent. When

--- a/perfagent/agent.go
+++ b/perfagent/agent.go
@@ -134,18 +134,27 @@ func (c *Config) validate() error {
 	return nil
 }
 
-// hasCapSysPtrace returns true if the current process holds CAP_SYS_PTRACE
-// in its effective set. Uses the libcap package already imported by the agent.
+// hasCapSysPtrace reports whether the current process holds CAP_SYS_PTRACE
+// in either the Permitted or Effective set. validate() runs before Start()
+// promotes Permitted → Effective via SetFlag, so checking Effective alone
+// would falsely reject runs where the cap was granted via setcap or
+// inherited but not yet promoted. Mirrors test/integration_test.go's
+// nil-safe probing against libcap.
 func hasCapSysPtrace() bool {
 	if os.Geteuid() == 0 {
 		return true
 	}
 	caps := cap.GetProc()
-	have, err := caps.GetFlag(cap.Effective, cap.SYS_PTRACE)
-	if err != nil {
+	if caps == nil {
 		return false
 	}
-	return have
+	for _, flag := range []cap.Flag{cap.Permitted, cap.Effective} {
+		have, err := caps.GetFlag(flag, cap.SYS_PTRACE)
+		if err == nil && have {
+			return true
+		}
+	}
+	return false
 }
 
 // Start initializes and starts all enabled profilers.

--- a/perfagent/agent.go
+++ b/perfagent/agent.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
+	"os"
+	"strconv"
 	"sync"
 
 	"github.com/cilium/ebpf/rlimit"
@@ -13,6 +16,8 @@ import (
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 
 	"github.com/dpsoft/perf-agent/cpu"
+	"github.com/dpsoft/perf-agent/inject/ptraceop"
+	"github.com/dpsoft/perf-agent/inject/python"
 	"github.com/dpsoft/perf-agent/metrics"
 	"github.com/dpsoft/perf-agent/offcpu"
 	"github.com/dpsoft/perf-agent/profile"
@@ -63,6 +68,7 @@ type Agent struct {
 	cpuProfiler    cpuProfiler
 	offcpuProfiler offcpuProfiler
 	pmuMonitor     *cpu.PMUMonitor
+	pyInjector     *python.Manager // nil unless --inject-python is set
 
 	mu      sync.Mutex
 	started bool
@@ -80,9 +86,19 @@ func New(opts ...Option) (*Agent, error) {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	return &Agent{
-		config: config,
-	}, nil
+	a := &Agent{config: config}
+
+	if config.InjectPython {
+		low := &ptraceopBridge{inj: ptraceop.New(slog.Default())}
+		a.pyInjector = python.NewManager(python.Options{
+			StrictPerPID: config.PID != 0, // single-PID is strict; -a is lenient
+			Logger:       slog.Default(),
+			Detector:     python.NewDetector("/proc", slog.Default()),
+			Injector:     low,
+		})
+	}
+
+	return a, nil
 }
 
 // validate checks the configuration for errors.
@@ -107,7 +123,29 @@ func (c *Config) validate() error {
 		return errors.New("per-PID is only valid with PMU enabled")
 	}
 
+	if c.InjectPython && !c.EnableCPUProfile {
+		return errors.New("--inject-python requires --profile (off-cpu and pmu are not supported)")
+	}
+
+	if c.InjectPython && !hasCapSysPtrace() {
+		return errors.New("--inject-python requires CAP_SYS_PTRACE; use sudo or setcap")
+	}
+
 	return nil
+}
+
+// hasCapSysPtrace returns true if the current process holds CAP_SYS_PTRACE
+// in its effective set. Uses the libcap package already imported by the agent.
+func hasCapSysPtrace() bool {
+	if os.Geteuid() == 0 {
+		return true
+	}
+	caps := cap.GetProc()
+	have, err := caps.GetFlag(cap.Effective, cap.SYS_PTRACE)
+	if err != nil {
+		return false
+	}
+	return have
 }
 
 // Start initializes and starts all enabled profilers.
@@ -142,6 +180,15 @@ func (a *Agent) Start(ctx context.Context) error {
 		cpus, err = cpuonline.Get()
 		if err != nil {
 			return fmt.Errorf("get online CPUs: %w", err)
+		}
+	}
+
+	// Inject Python perf-trampoline before BPF attach so early samples have
+	// JIT symbol names. Runs only when --inject-python is set.
+	if a.pyInjector != nil {
+		pids := a.scanPythonTargets()
+		if err := a.pyInjector.ActivateAll(pids); err != nil {
+			return fmt.Errorf("python injection: %w", err)
 		}
 	}
 
@@ -322,6 +369,12 @@ func (a *Agent) Stop(ctx context.Context) error {
 		}
 	}
 
+	// Deactivate Python trampolines after profile finalization but before BPF
+	// teardown. Tolerates ESRCH (process gone) and respects the 5s deadline.
+	if a.pyInjector != nil {
+		a.pyInjector.DeactivateAll(ctx)
+	}
+
 	return lastErr
 }
 
@@ -370,4 +423,61 @@ func (a *Agent) cleanup() {
 // Config returns a copy of the agent's configuration.
 func (a *Agent) Config() Config {
 	return *a.config
+}
+
+// PythonInjectStats returns counters for the Python injector. Returns a
+// zero-value Stats if --inject-python was not enabled.
+func (a *Agent) PythonInjectStats() *python.Stats {
+	if a.pyInjector == nil {
+		return &python.Stats{}
+	}
+	return a.pyInjector.Stats()
+}
+
+// scanPythonTargets returns the PIDs to consider for injection. For --pid
+// mode, just [cfg.PID]. For -a mode, walks /proc and returns all numeric PID
+// directories (the Manager's Detect call filters down to actual Python
+// processes).
+func (a *Agent) scanPythonTargets() []uint32 {
+	if a.config.PID != 0 {
+		return []uint32{uint32(a.config.PID)}
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	pids := make([]uint32, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		v, err := strconv.ParseUint(e.Name(), 10, 32)
+		if err != nil {
+			continue
+		}
+		pids = append(pids, uint32(v))
+	}
+	return pids
+}
+
+// ptraceopBridge adapts ptraceop.Injector to python.LowLevelInjector,
+// supplying the activate/deactivate payloads from inject/python.
+type ptraceopBridge struct {
+	inj *ptraceop.Injector
+}
+
+func (b *ptraceopBridge) RemoteActivate(pid uint32, addrs python.SymbolAddrsForTarget) error {
+	return b.inj.RemoteActivate(pid, ptraceop.SymbolAddrs{
+		PyGILEnsure:  addrs.PyGILEnsure,
+		PyGILRelease: addrs.PyGILRelease,
+		PyRunString:  addrs.PyRunString,
+	}, python.ActivatePayload())
+}
+
+func (b *ptraceopBridge) RemoteDeactivate(pid uint32, addrs python.SymbolAddrsForTarget) error {
+	return b.inj.RemoteDeactivate(pid, ptraceop.SymbolAddrs{
+		PyGILEnsure:  addrs.PyGILEnsure,
+		PyGILRelease: addrs.PyGILRelease,
+		PyRunString:  addrs.PyRunString,
+	}, python.DeactivatePayload())
 }

--- a/perfagent/agent.go
+++ b/perfagent/agent.go
@@ -196,13 +196,14 @@ func (a *Agent) Start(ctx context.Context) error {
 	if a.config.EnableCPUProfile {
 		switch a.config.Unwind {
 		case "dwarf":
+			hooks := dwarfHooksForAgent(a)
 			p, err := dwarfagent.NewProfilerWithMode(
 				a.config.PID,
 				a.config.SystemWide,
 				cpus,
 				a.config.Tags,
 				a.config.SampleRate,
-				nil,
+				hooks,
 				dwarfagent.ModeEager,
 			)
 			if err != nil {
@@ -215,13 +216,14 @@ func (a *Agent) Start(ctx context.Context) error {
 				log.Printf("CPU profiler enabled (PID: %d, %d Hz, DWARF)", a.config.PID, a.config.SampleRate)
 			}
 		case "auto":
+			hooks := dwarfHooksForAgent(a)
 			p, err := dwarfagent.NewProfilerWithMode(
 				a.config.PID,
 				a.config.SystemWide,
 				cpus,
 				a.config.Tags,
 				a.config.SampleRate,
-				nil,
+				hooks,
 				dwarfagent.ModeLazy,
 			)
 			if err != nil {
@@ -480,4 +482,21 @@ func (b *ptraceopBridge) RemoteDeactivate(pid uint32, addrs python.SymbolAddrsFo
 		PyGILRelease: addrs.PyGILRelease,
 		PyRunString:  addrs.PyRunString,
 	}, python.DeactivatePayload())
+}
+
+// dwarfHooksForAgent builds a *dwarfagent.Hooks for this agent. When
+// --inject-python is enabled and the target is system-wide, OnNewExec is
+// wired to pyInjector.ActivateLate so late-arriving Python processes are
+// injected without a polling loop. When --inject-python is off (default),
+// hooks is nil — the PIDTracker performs a single nil check per fork event
+// and does zero additional work.
+func dwarfHooksForAgent(a *Agent) *dwarfagent.Hooks {
+	if a.pyInjector == nil || a.config.PID != 0 {
+		// No injector, or per-PID mode: late subscription is a no-op
+		// (single-PID already handled at startup).
+		return nil
+	}
+	return &dwarfagent.Hooks{
+		OnNewExec: a.pyInjector.ActivateLate,
+	}
 }

--- a/perfagent/options.go
+++ b/perfagent/options.go
@@ -60,6 +60,10 @@ type Config struct {
 
 	// CPUs is the list of CPUs to monitor. If nil, all online CPUs are used.
 	CPUs []uint
+
+	// InjectPython enables Python perf-trampoline injection during profiling.
+	// Only valid with EnableCPUProfile. Requires CAP_SYS_PTRACE.
+	InjectPython bool
 }
 
 // Option is a functional option for configuring the Agent.
@@ -157,6 +161,14 @@ func WithUnwind(mode string) Option {
 	return func(c *Config) {
 		c.Unwind = mode
 	}
+}
+
+// WithInjectPython enables Python perf-trampoline injection during profiling.
+// Caller must hold CAP_SYS_PTRACE. With --pid N, any per-target failure exits
+// non-zero (strict). With -a, failures are logged and the profile continues
+// (lenient). Only valid when CPU profiling is enabled.
+func WithInjectPython(enabled bool) Option {
+	return func(c *Config) { c.InjectPython = enabled }
 }
 
 // WithCPUProfileWriter enables CPU profiling and sets a writer for output.

--- a/test/integration_inject_python_test.go
+++ b/test/integration_inject_python_test.go
@@ -158,13 +158,25 @@ func TestInjectPython_StrictFailsOnNonPython(t *testing.T) {
 	}
 }
 
-// requirePython312Plus skips if python3 < 3.12.
+// requirePython312Plus skips if python3 < 3.12 OR the interpreter was built
+// without --enable-perf-trampoline. Both gate the activate path, so both
+// must skip cleanly.
 func requirePython312Plus(t *testing.T) {
 	t.Helper()
 	out, err := exec.Command("python3", "-c",
 		"import sys; print(sys.version_info >= (3, 12))").CombinedOutput()
 	if err != nil || !strings.Contains(string(out), "True") {
 		t.Skipf("requires python3 >= 3.12; got: %s (err=%v)", strings.TrimSpace(string(out)), err)
+	}
+	// Even on 3.12+, the interpreter may have been compiled without
+	// --enable-perf-trampoline (Fedora's stock build does this). Probe by
+	// attempting activation+deactivation; ImportError or AttributeError on
+	// the trampoline functions means the build doesn't support it.
+	out, err = exec.Command("python3", "-c",
+		"import sys; sys.activate_stack_trampoline('perf'); sys.deactivate_stack_trampoline(); print('OK')").CombinedOutput()
+	if err != nil || !strings.Contains(string(out), "OK") {
+		t.Skipf("python3 lacks --enable-perf-trampoline; got: %s (err=%v)",
+			strings.TrimSpace(string(out)), err)
 	}
 }
 

--- a/test/integration_inject_python_test.go
+++ b/test/integration_inject_python_test.go
@@ -1,0 +1,185 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestInjectPython_ActivatesTrampoline launches a CPython 3.12+ workload WITHOUT
+// -X perf, then runs perf-agent --profile --inject-python --pid <PID>. Asserts
+// that perf-agent injects the trampoline (perf map exists with py:: entries),
+// that the resulting profile has Python frame names, and that deactivation
+// runs at end-of-profile (perf map stops growing after perf-agent exits).
+func TestInjectPython_ActivatesTrampoline(t *testing.T) {
+	requireBPFRunnable(t, getAgentPath(t))
+	requirePython312Plus(t)
+
+	// Launch python WITHOUT -X perf
+	pyCmd := exec.Command("python3", "workloads/python/cpu_bound.py", "10", "2")
+	pyCmd.Dir = "." // tests run from test/ directory
+	if err := pyCmd.Start(); err != nil {
+		t.Fatalf("start python workload: %v", err)
+	}
+	pid := pyCmd.Process.Pid
+	t.Cleanup(func() {
+		_ = pyCmd.Process.Kill()
+		_ = pyCmd.Wait()
+		_ = os.Remove(fmt.Sprintf("/tmp/perf-%d.map", pid))
+	})
+
+	// Wait for warmup
+	time.Sleep(1 * time.Second)
+
+	// Run perf-agent --profile --inject-python
+	profileOut := filepath.Join(t.TempDir(), "profile.pb.gz")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	agentPath := getAgentPath(t)
+	pa := exec.CommandContext(ctx, agentPath,
+		"--profile",
+		"--inject-python",
+		"--pid", fmt.Sprintf("%d", pid),
+		"--duration", "5s",
+		"--profile-output", profileOut,
+	)
+	out, err := pa.CombinedOutput()
+	if err != nil {
+		t.Fatalf("perf-agent failed: %v\n%s", err, out)
+	}
+	t.Logf("perf-agent output:\n%s", out)
+
+	// Assert /tmp/perf-<PID>.map exists and is non-empty with py:: lines
+	perfMap := fmt.Sprintf("/tmp/perf-%d.map", pid)
+	st, err := os.Stat(perfMap)
+	if err != nil {
+		t.Fatalf("perf map %s not created: %v", perfMap, err)
+	}
+	if st.Size() == 0 {
+		t.Fatalf("perf map %s is empty", perfMap)
+	}
+	pmContent, _ := os.ReadFile(perfMap)
+	if !strings.Contains(string(pmContent), "py::") {
+		t.Errorf("perf map missing py:: entries:\nfirst 500 bytes:\n%s",
+			truncateForLog(string(pmContent), 500))
+	}
+
+	// Assert profile.pb.gz exists
+	if _, err := os.Stat(profileOut); err != nil {
+		t.Fatalf("profile not created: %v", err)
+	}
+
+	// Optional: pprof inspection. Skip the assertion if go tool pprof is not
+	// installed; the JIT names appearing in the perf map already prove
+	// activation worked.
+	pprofTop := exec.CommandContext(ctx, "go", "tool", "pprof", "-top", "-nodecount=20", profileOut)
+	topOut, perr := pprofTop.CombinedOutput()
+	if perr == nil {
+		t.Logf("pprof top output:\n%s", topOut)
+		// Warning-level check, not Fatal: if pprof can read the file we'd
+		// like to see Python frames, but blazesym sometimes resolves them
+		// to address-only on low-CPU samples. Not a hard failure.
+		if !strings.Contains(string(topOut), "py::") &&
+			!strings.Contains(string(topOut), "cpu_bound.py") {
+			t.Logf("WARNING: profile lacks Python frame names (may be a low-sample-count flake)")
+		}
+	}
+
+	// Assert deactivation actually fired: re-stat perf-map twice with a 1s
+	// gap; size must NOT grow (no new trampoline entries being written).
+	size1 := fileSize(t, perfMap)
+	time.Sleep(1 * time.Second)
+	size2 := fileSize(t, perfMap)
+	if size2 != size1 {
+		t.Errorf("perf-map grew after perf-agent exit (deactivation didn't run): %d → %d",
+			size1, size2)
+	}
+}
+
+// TestInjectPython_StrictFailsOnNonPython confirms that perf-agent --pid <go-binary>
+// --inject-python exits non-zero (strict mode) with a clear "not python" reason.
+func TestInjectPython_StrictFailsOnNonPython(t *testing.T) {
+	requireBPFRunnable(t, getAgentPath(t))
+
+	// Build the Go workload if not already present
+	goWorkload := "workloads/go/cpu_bound"
+	if _, err := os.Stat(goWorkload); err != nil {
+		t.Skipf("go workload not built; run `make test-workloads` first (got %v)", err)
+	}
+
+	goCmd := exec.Command(goWorkload)
+	if err := goCmd.Start(); err != nil {
+		t.Fatalf("start go workload: %v", err)
+	}
+	pid := goCmd.Process.Pid
+	t.Cleanup(func() {
+		_ = goCmd.Process.Kill()
+		_ = goCmd.Wait()
+	})
+
+	time.Sleep(500 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	agentPath := getAgentPath(t)
+	pa := exec.CommandContext(ctx, agentPath,
+		"--profile",
+		"--inject-python",
+		"--pid", fmt.Sprintf("%d", pid),
+		"--duration", "2s",
+	)
+	out, err := pa.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit; got success\noutput:\n%s", out)
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected ExitError; got %T: %v", err, err)
+	}
+	combined := string(out)
+	t.Logf("perf-agent stderr/stdout:\n%s", combined)
+	// The error message should mention not_python OR "not a python" OR a
+	// related structured reason. Be permissive: the exact wording may vary
+	// based on log format.
+	if !strings.Contains(combined, "not_python") &&
+		!strings.Contains(combined, "not a python") &&
+		!strings.Contains(combined, "ErrNotPython") &&
+		!strings.Contains(combined, "python") {
+		t.Errorf("output does not mention 'python' anywhere; expected a structured reason\n%s",
+			combined)
+	}
+}
+
+// requirePython312Plus skips if python3 < 3.12.
+func requirePython312Plus(t *testing.T) {
+	t.Helper()
+	out, err := exec.Command("python3", "-c",
+		"import sys; print(sys.version_info >= (3, 12))").CombinedOutput()
+	if err != nil || !strings.Contains(string(out), "True") {
+		t.Skipf("requires python3 >= 3.12; got: %s (err=%v)", strings.TrimSpace(string(out)), err)
+	}
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		return -1
+	}
+	return st.Size()
+}
+
+func truncateForLog(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...[truncated]"
+}

--- a/test/integration_inject_python_test.go
+++ b/test/integration_inject_python_test.go
@@ -65,7 +65,10 @@ func TestInjectPython_ActivatesTrampoline(t *testing.T) {
 	if st.Size() == 0 {
 		t.Fatalf("perf map %s is empty", perfMap)
 	}
-	pmContent, _ := os.ReadFile(perfMap)
+	pmContent, err := os.ReadFile(perfMap)
+	if err != nil {
+		t.Fatalf("read perf map %s: %v", perfMap, err)
+	}
 	if !strings.Contains(string(pmContent), "py::") {
 		t.Errorf("perf map missing py:: entries:\nfirst 500 bytes:\n%s",
 			truncateForLog(string(pmContent), 500))
@@ -146,14 +149,17 @@ func TestInjectPython_StrictFailsOnNonPython(t *testing.T) {
 	}
 	combined := string(out)
 	t.Logf("perf-agent stderr/stdout:\n%s", combined)
-	// The error message should mention not_python OR "not a python" OR a
-	// related structured reason. Be permissive: the exact wording may vary
-	// based on log format.
-	if !strings.Contains(combined, "not_python") &&
-		!strings.Contains(combined, "not a python") &&
-		!strings.Contains(combined, "ErrNotPython") &&
-		!strings.Contains(combined, "python") {
-		t.Errorf("output does not mention 'python' anywhere; expected a structured reason\n%s",
+	// Assert specifically the "non-Python target" failure mode by matching
+	// structured reason tokens or the wrapped error type. Avoid a bare
+	// "python" substring fallback — that would pass for unrelated failures
+	// (missing CAP_SYS_PTRACE, --inject-python flag rejection at validate
+	// time, etc.) and defeat the test's intent. Match case-insensitive
+	// because slog and fmt.Errorf chains differ in casing across paths.
+	combinedLower := strings.ToLower(combined)
+	if !strings.Contains(combinedLower, "not_python") &&
+		!strings.Contains(combinedLower, "not a python") &&
+		!strings.Contains(combinedLower, "errnotpython") {
+		t.Errorf("output does not contain a structured 'not python' reason; got:\n%s",
 			combined)
 	}
 }

--- a/unwind/dwarfagent/common.go
+++ b/unwind/dwarfagent/common.go
@@ -108,6 +108,9 @@ func newSession(objs sessionObjs, pid int, systemWide bool, cpus []uint, tags []
 		store.SetOnCompile(hooks.onCompileFunc())
 	}
 	tracker := ehmaps.NewPIDTracker(store, objs.PIDMappingsMap(), objs.PIDMappingLengthsMap())
+	if hooks != nil && hooks.OnNewExec != nil {
+		tracker.SetOnNewExec(hooks.OnNewExec)
+	}
 
 	// Attach strategy depends on mode:
 	//   ModeLazy + systemWide: ScanAndEnroll (pid_mappings only, no CFI compile).

--- a/unwind/dwarfagent/hooks.go
+++ b/unwind/dwarfagent/hooks.go
@@ -17,6 +17,16 @@ type Hooks struct {
 	// note. ehFrameBytes is the raw .eh_frame section size in bytes.
 	// dur is the wall-clock duration of the ehcompile.Compile call.
 	OnCompile func(path, buildID string, ehFrameBytes int, dur time.Duration)
+
+	// OnNewExec is the mmap-watcher hook for new-process events. When
+	// non-nil, it is registered on the PIDTracker before the tracker
+	// goroutine starts, so there is no data race. The hook fires
+	// synchronously on the tracker goroutine whenever a group-leader
+	// PERF_RECORD_FORK arrives — i.e. a new process was born via fork/exec.
+	// The hook must not block for more than a few milliseconds.
+	// When nil (the default), the PIDTracker performs a single nil check
+	// per fork event and skips dispatch entirely — zero overhead.
+	OnNewExec func(pid uint32)
 }
 
 // onCompileFunc returns a non-nil callback safe to invoke from anywhere.

--- a/unwind/ehmaps/tracker.go
+++ b/unwind/ehmaps/tracker.go
@@ -27,8 +27,9 @@ type PIDTracker struct {
 	pidMappings *ebpf.Map
 	pidMapLens  *ebpf.Map
 
-	mu     sync.Mutex
-	perPID map[uint32]*pidState
+	mu        sync.Mutex
+	perPID    map[uint32]*pidState
+	onNewExec func(pid uint32) // nil → no hook; producer skips dispatch entirely
 }
 
 type pidState struct {
@@ -45,6 +46,18 @@ func NewPIDTracker(store *TableStore, pidMappings, pidMapLengths *ebpf.Map) *PID
 		pidMapLens:  pidMapLengths,
 		perPID:      map[uint32]*pidState{},
 	}
+}
+
+// SetOnNewExec registers a hook that Run calls when it observes a new
+// group-leader fork (PERF_RECORD_FORK with pid == tid), which the kernel
+// emits for every new process created via fork/exec. Pass nil to clear the
+// hook. Must be called before Run to avoid races.
+//
+// The hook runs synchronously on Run's goroutine. When no hook is registered
+// (the default), Run performs a single nil check and skips dispatch entirely —
+// zero producer overhead when --inject-python is off.
+func (t *PIDTracker) SetOnNewExec(fn func(pid uint32)) {
+	t.onNewExec = fn
 }
 
 // Attach walks /proc/<pid>/maps for binPath, acquires CFI via the store,
@@ -233,6 +246,12 @@ func (t *PIDTracker) Run(ctx context.Context, w mmapEventSource, observers ...fu
 				n, err := AttachAllMappings(t, ev.PID)
 				if err != nil || n == 0 {
 					slog.Debug("ehmaps: fork Attach failed", "pid", ev.PID, "err", err)
+				}
+				// Notify the late-activation hook (e.g. Python injector)
+				// that a new process was born. Single nil check — no work
+				// when no subscriber is registered.
+				if t.onNewExec != nil {
+					t.onNewExec(ev.PID)
 				}
 			case ExitEvent:
 				// Only act on group-leader exit (whole process gone).

--- a/unwind/ehmaps/tracker_newexec_test.go
+++ b/unwind/ehmaps/tracker_newexec_test.go
@@ -67,10 +67,7 @@ func TestNewExec_HookFires(t *testing.T) {
 
 	// Wait for the hook to fire (Run dispatches synchronously; 200ms is generous).
 	deadline := time.After(200 * time.Millisecond)
-	for {
-		if got.Load() == wantPID {
-			break
-		}
+	for got.Load() != wantPID {
 		select {
 		case <-deadline:
 			t.Fatalf("OnNewExec hook did not fire within deadline; got pid=%d, want %d",

--- a/unwind/ehmaps/tracker_newexec_test.go
+++ b/unwind/ehmaps/tracker_newexec_test.go
@@ -1,0 +1,84 @@
+package ehmaps
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestNewExec_NoSubscribersZeroDispatch constructs a PIDTracker without
+// registering any OnNewExec hook, then drives a synthetic ForkEvent through
+// Run. Asserts that onNewExec is still nil after the event is processed —
+// guarding the lazy-subscription invariant: no hook means no dispatch, zero
+// overhead for the producer.
+func TestNewExec_NoSubscribersZeroDispatch(t *testing.T) {
+	w := &fakeMmapWatcher{ch: make(chan MmapEventRecord, 4)}
+	tracker := NewPIDTracker(nil, nil, nil)
+
+	// Confirm no hook is registered (the zero value must be nil).
+	if tracker.onNewExec != nil {
+		t.Fatal("onNewExec should be nil when SetOnNewExec was never called")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		tracker.Run(ctx, w)
+		close(done)
+	}()
+
+	// Send a group-leader ForkEvent (pid == tid).
+	w.ch <- MmapEventRecord{Kind: ForkEvent, PID: 99, TID: 99}
+	// Give Run time to process the event.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	// The tracker still has no hook — the event was handled by the single
+	// nil check in Run without any further dispatch.
+	if tracker.onNewExec != nil {
+		t.Fatal("onNewExec must remain nil; something unexpectedly set it")
+	}
+}
+
+// TestNewExec_HookFires registers an OnNewExec hook via SetOnNewExec, drives
+// a synthetic group-leader ForkEvent for pid=12345, and asserts the hook
+// received pid=12345.
+func TestNewExec_HookFires(t *testing.T) {
+	w := &fakeMmapWatcher{ch: make(chan MmapEventRecord, 4)}
+	tracker := NewPIDTracker(nil, nil, nil)
+
+	var got atomic.Uint32
+	tracker.SetOnNewExec(func(pid uint32) {
+		got.Store(pid)
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		tracker.Run(ctx, w)
+		close(done)
+	}()
+
+	// Send a group-leader ForkEvent for pid=12345.
+	const wantPID uint32 = 12345
+	w.ch <- MmapEventRecord{Kind: ForkEvent, PID: wantPID, TID: wantPID}
+
+	// Wait for the hook to fire (Run dispatches synchronously; 200ms is generous).
+	deadline := time.After(200 * time.Millisecond)
+	for {
+		if got.Load() == wantPID {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("OnNewExec hook did not fire within deadline; got pid=%d, want %d",
+				got.Load(), wantPID)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	<-done
+}


### PR DESCRIPTION
## Summary

- Adds `perf-agent --profile --inject-python` to activate CPython 3.12+'s perf trampoline (`sys.activate_stack_trampoline('perf')`) on a running target via ptrace, so users get Python JIT names without restarting the target with `python -X perf`.
- Per-PID mode is **strict** (any failure exits non-zero); system-wide `-a` mode is **lenient** (failures logged + counted, profile continues).
- Activation runs at profile start (before BPF attach), deactivation at profile end — so trampoline overhead does not persist past the profiling window.
- Late-arriving Python processes during `-a` runs are picked up via a new lazy mmap-watcher hook.

## Architecture

```
inject/
├── elfsym/        # SHARED — ELF symbol resolution + libpython SONAME parser (any runtime)
├── ptraceop/      # SHARED — ptrace primitives, three-call sequence, amd64 + arm64 frame setup
└── python/        # Python-specific: detector, manager, payload encoding
```

The split anticipates future runtime injectors (Node.js inspector protocol, JVM perf-map-agent) plugging in as siblings of `python/` without touching the shared layer.

## Lifecycle

1. `Agent.Start()` → `python.Manager.ActivateAll(pids)` walks /proc, identifies Python 3.12+ via libpython SONAME + ELF symbols, ptrace-attaches each, runs three remote calls (`PyGILState_Ensure` → `PyRun_SimpleString(payload)` → `PyGILState_Release`) inside a single ptrace session, detaches.
2. BPF profiler attaches; sampling runs.
3. `Agent.Stop()` → `python.Manager.DeactivateAll(ctx)` runs the same dance with the deactivate payload, capped at 5s total to prevent shutdown hangs on uninterruptible-sleep targets.

Activation is idempotent — continuous profiling pattern works without cleanup. perf-map files persist between runs (we don't delete them); blazesym reads them on demand for symbol resolution.

## Lazy mmap-watcher hook

For `-a` mode, new exec events fire `python.Manager.ActivateLate(pid)`. The hook is registered via `PIDTracker.SetOnNewExec(fn)` only when `--inject-python` is on; with the flag off, the producer does a single nil check and skips dispatch entirely (zero overhead).

## Critical correctness fixes landed during review/testing

- **`runtime.LockOSThread`** in `runSequence`: on Linux, only the OS thread that issued `PTRACE_ATTACH` may issue subsequent ptrace ops on the tracee. Without pinning, Go's scheduler could migrate the goroutine mid-sequence and the next ptrace op would fail with `EPERM`/`ESRCH` — or worse, target a different stopped tracee.
- **Deferred `PtraceSetRegs`** before deferred detach: on error paths after a remote call, the target's PC was 0 (the SIGSEGV sentinel); without restoring registers before detach, the target would resume from PC=0 and immediately segfault. The deferred restore guarantees clean target state on every exit path.
- **`/proc/<pid>/maps` truncation fix**: replaced 64KB fixed read with `bufio.Scanner` + 4MB max — Python apps with hundreds of mappings would silently miss the `[stack]` line.
- **`Orig_rax = -1`** in the call frame: when ptrace attaches mid-syscall (e.g. `nanosleep`), the kernel runs syscall-return processing on `PtraceCont` and clobbers `RAX`. Setting `orig_rax = -1` disables this. (Standard pyrasite/py-spy/manhole workaround.)
- **Dropped `_PyPerf_Callbacks` pre-flight check**: distributors strip internal symbols from production libpython, so this 'is the trampoline compiled in?' filter wrongly rejected stock Fedora/Ubuntu Python builds. We now rely on the runtime return value of `PyRun_SimpleString`.
- **Dropped preexisting-marker check**: was breaking continuous profiling — Run 2+ would see the perf-map file from Run 1 and skip activation, leaving the trampoline OFF for the rest of the run.

## Test plan

### Unit
- [x] `inject/elfsym/` — SONAME parsing + ELF symbol resolution against host libc.so.6.
- [x] `inject/ptraceop/` — register frame setup for amd64 + arm64 (build-tagged), alignment validation, return-value extraction.
- [x] `inject/python/` — detection ladder (synthetic /proc trees), Manager strict/lenient policy, dedupe under concurrency, bounded shutdown.
- [x] `unwind/ehmaps/` — lazy new-exec hook (`TestNewExec_NoSubscribersZeroDispatch`, `TestNewExec_HookFires`).

### Integration (caps-gated, verified locally)
- [x] `TestInjectPython_ActivatesTrampoline` — Python 3.14 launched WITHOUT `-X perf`, `--inject-python` activates trampoline, profile contains `py::Thread.run`, `py::cpu_work`, etc.; deactivation fires at profile end (perf-map size stops growing).
- [x] `TestInjectPython_StrictFailsOnNonPython` — Go binary target, perf-agent exits non-zero with `not_python` reason.

### Cross-arch
- [x] `GOOS=linux GOARCH=arm64 go build ./inject/ptraceop/...` — clean.

### Lint/vet
- [x] `gofmt -l` clean across all touched packages.
- [x] `go vet` clean (with CGO env for blazesym).
- [x] Race detector clean: `go test -race ./inject/python/... ./unwind/ehmaps/...`.

## Documentation

- `README.md` — new section "Profiling running Python processes" with worked example.
- `docs/python-profiling.md` — deeper dive: how it works, when injection is skipped (table), continuous profiling, container caveats, performance impact, troubleshooting.

## Build / run

```bash
make generate
CGO_CFLAGS="..." CGO_LDFLAGS="-L $BLAZESYM/target/release -Wl,-rpath,$BLAZESYM/target/release -lblazesym_c" go build .
sudo setcap cap_perfmon,cap_bpf,cap_sys_admin,cap_sys_ptrace,cap_checkpoint_restore+ep ./perf-agent

# Profile a running Python web server for 30 seconds
./perf-agent --profile --pid $(pgrep -f gunicorn) --duration 30s --inject-python
```

## Out of scope (deliberate non-goals for v1)

- Python < 3.12 (no equivalent activation primitive).
- CPython without `--enable-perf-trampoline` (skipped at activation time).
- PID namespace translation for containers (host-side PIDs only; documented limitation).
- Concurrent perf-agent runs against the same target (`-X perf`-launched targets will get deactivated on profile end — documented tradeoff for users who want `-X perf` always-on).