### PR TITLE
refactor(internal/perfevent): extract per-CPU perf_event_open helper

### DIFF
--- a/internal/perfevent/perfevent.go
+++ b/internal/perfevent/perfevent.go
@@ -1,0 +1,133 @@
+// Package perfevent opens per-CPU software perf_event_open events and
+// attaches a BPF program to each. It exists to deduplicate the boilerplate
+// that profile.NewProfiler and dwarfagent.NewProfilerWithMode each used to
+// spell out independently — same PerfEventAttr, same per-CPU loop, same
+// "tolerate ESRCH on offline CPU" rule, same cleanup-on-error.
+package perfevent
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
+)
+
+// Set is a bundle of per-CPU perf events with their attached BPF links.
+// Close releases everything in the right order; safe to call once.
+type Set struct {
+	fds   []int
+	links []link.Link
+}
+
+// FDs returns the underlying perf_event file descriptors. Callers should
+// treat the returned slice as read-only — the Set still owns these fds and
+// will close them via Close. Used by collectors that need to read counter
+// values directly (currently none, but PMU-side collectors might).
+func (s *Set) FDs() []int { return s.fds }
+
+// Close closes every attached link and then every fd. Errors are
+// best-effort — the first non-nil error is returned, but cleanup proceeds
+// regardless.
+func (s *Set) Close() error {
+	if s == nil {
+		return nil
+	}
+	var firstErr error
+	for _, l := range s.links {
+		if err := l.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	for _, fd := range s.fds {
+		if err := unix.Close(fd); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	s.links = nil
+	s.fds = nil
+	return firstErr
+}
+
+// Option configures OpenAll.
+type Option func(*config)
+
+type config struct {
+	// deferEnable causes OpenAll to set PerfBitDisabled at perf_event_open
+	// time and call PERF_EVENT_IOC_ENABLE after the BPF link is attached.
+	// Eliminates the (tiny) race window where the event fires between
+	// open and attach. dwarfagent uses this; profile historically did not.
+	deferEnable bool
+}
+
+// WithDeferredEnable opens each event disabled and enables it after the
+// BPF program is attached. Recommended for new call sites.
+func WithDeferredEnable() Option { return func(c *config) { c.deferEnable = true } }
+
+// OpenAll opens one PERF_TYPE_SOFTWARE / PERF_COUNT_SW_CPU_CLOCK event per
+// CPU at the given sample rate (treated as Hz via PerfBitFreq), attaches
+// prog to each via link.AttachRawLink, and returns the resulting Set.
+//
+// Offline CPUs (ESRCH from perf_event_open) are skipped silently — they
+// come back online or stay offline, neither is an error here. If every CPU
+// is offline / no event was attached, OpenAll returns an error.
+//
+// On any failure mid-loop, every fd and link opened so far is released
+// before returning. Caller never has to clean up after a non-nil error.
+func OpenAll(prog *ebpf.Program, cpus []uint, sampleRate int, opts ...Option) (*Set, error) {
+	cfg := config{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	bits := uint64(unix.PerfBitFreq)
+	if cfg.deferEnable {
+		bits |= unix.PerfBitDisabled
+	}
+	attr := &unix.PerfEventAttr{
+		Type:   unix.PERF_TYPE_SOFTWARE,
+		Config: unix.PERF_COUNT_SW_CPU_CLOCK,
+		Size:   uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
+		Sample: uint64(sampleRate),
+		Bits:   bits,
+	}
+
+	s := &Set{}
+	for _, cpu := range cpus {
+		fd, err := unix.PerfEventOpen(attr, -1, int(cpu), -1, unix.PERF_FLAG_FD_CLOEXEC)
+		if err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				continue
+			}
+			_ = s.Close()
+			return nil, fmt.Errorf("perf_event_open cpu=%d: %w", cpu, err)
+		}
+		s.fds = append(s.fds, fd)
+
+		rl, err := link.AttachRawLink(link.RawLinkOptions{
+			Target:  fd,
+			Program: prog,
+			Attach:  ebpf.AttachPerfEvent,
+		})
+		if err != nil {
+			_ = s.Close()
+			return nil, fmt.Errorf("attach perf event cpu=%d: %w", cpu, err)
+		}
+		s.links = append(s.links, rl)
+
+		if cfg.deferEnable {
+			if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
+				_ = s.Close()
+				return nil, fmt.Errorf("enable perf event cpu=%d: %w", cpu, err)
+			}
+		}
+	}
+
+	if len(s.fds) == 0 {
+		return nil, fmt.Errorf("no perf events attached (cpus=%d, all offline?)", len(cpus))
+	}
+	return s, nil
+}

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -6,15 +6,13 @@ import (
 	"io"
 	"log"
 	"os"
-	"unsafe"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/link"
-	"golang.org/x/sys/unix"
 
 	blazesym "github.com/libbpf/blazesym/go"
 
 	"github.com/dpsoft/perf-agent/internal/bpfstack"
+	"github.com/dpsoft/perf-agent/internal/perfevent"
 	"github.com/dpsoft/perf-agent/pprof"
 	"github.com/dpsoft/perf-agent/unwind/procmap"
 )
@@ -24,15 +22,9 @@ type Profiler struct {
 	objs       *perfObjects
 	symbolizer *blazesym.Symbolizer
 	resolver   *procmap.Resolver
-	perfEvents []*perfEvent
+	perfSet    *perfevent.Set
 	tags       []string
 	sampleRate int
-}
-
-// perfEvent wraps a Linux perf event for CPU sampling
-type perfEvent struct {
-	fd   int
-	link *link.RawLink
 }
 
 // stackBuilder accumulates symbolized stack frames
@@ -103,27 +95,10 @@ func NewProfiler(pid int, systemWide bool, cpus []uint, tags []string, sampleRat
 		}
 	}
 
-	var perfEvents []*perfEvent
-	for _, id := range cpus {
-		pe, err := newPerfEvent(int(id), sampleRate)
-		if err != nil {
-			for _, pe := range perfEvents {
-				_ = pe.Close()
-			}
-			_ = objs.Close()
-			return nil, fmt.Errorf("create perf event on CPU %d: %w", id, err)
-		}
-
-		if err := pe.attachPerfEvent(objs.Profile); err != nil {
-			_ = pe.Close()
-			for _, pe := range perfEvents {
-				_ = pe.Close()
-			}
-			_ = objs.Close()
-			return nil, fmt.Errorf("attach eBPF to perf event on CPU %d: %w", id, err)
-		}
-
-		perfEvents = append(perfEvents, pe)
+	perfSet, err := perfevent.OpenAll(objs.Profile, cpus, sampleRate)
+	if err != nil {
+		_ = objs.Close()
+		return nil, err
 	}
 
 	symbolizer, err := blazesym.NewSymbolizer(
@@ -131,9 +106,7 @@ func NewProfiler(pid int, systemWide bool, cpus []uint, tags []string, sampleRat
 		blazesym.SymbolizerWithInlinedFns(true),
 	)
 	if err != nil {
-		for _, pe := range perfEvents {
-			_ = pe.Close()
-		}
+		_ = perfSet.Close()
 		_ = objs.Close()
 		return nil, fmt.Errorf("create symbolizer: %w", err)
 	}
@@ -142,7 +115,7 @@ func NewProfiler(pid int, systemWide bool, cpus []uint, tags []string, sampleRat
 		objs:       objs,
 		symbolizer: symbolizer,
 		resolver:   procmap.NewResolver(),
-		perfEvents: perfEvents,
+		perfSet:    perfSet,
 		tags:       tags,
 		sampleRate: sampleRate,
 	}, nil
@@ -152,9 +125,7 @@ func NewProfiler(pid int, systemWide bool, cpus []uint, tags []string, sampleRat
 func (pr *Profiler) Close() {
 	pr.symbolizer.Close()
 	pr.resolver.Close()
-	for _, pe := range pr.perfEvents {
-		_ = pe.Close()
-	}
+	_ = pr.perfSet.Close()
 	_ = pr.objs.Close()
 }
 
@@ -286,44 +257,3 @@ func (pr *Profiler) createSample(sb *stackBuilder, value uint64, pid int) pprof.
 	}
 }
 
-// perfEvent helpers
-
-func newPerfEvent(cpu int, sampleRate int) (*perfEvent, error) {
-	attr := unix.PerfEventAttr{
-		Type:   unix.PERF_TYPE_SOFTWARE,
-		Size:   uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
-		Config: unix.PERF_COUNT_SW_CPU_CLOCK,
-		Sample: uint64(sampleRate),
-		Bits:   unix.PerfBitFreq, // Enable frequency mode
-	}
-
-	fd, err := unix.PerfEventOpen(&attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
-	if err != nil {
-		return nil, os.NewSyscallError("perf_event_open", err)
-	}
-
-	return &perfEvent{fd: fd}, nil
-}
-
-func (pe *perfEvent) Close() error {
-	if pe.link != nil {
-		_ = pe.link.Close()
-	}
-	if pe.fd >= 0 {
-		return unix.Close(pe.fd)
-	}
-	return nil
-}
-
-func (pe *perfEvent) attachPerfEvent(prog *ebpf.Program) error {
-	rawLink, err := link.AttachRawLink(link.RawLinkOptions{
-		Target:  pe.fd,
-		Program: prog,
-		Attach:  ebpf.AttachPerfEvent,
-	})
-	if err != nil {
-		return fmt.Errorf("attach raw link: %w", err)
-	}
-	pe.link = rawLink
-	return nil
-}

--- a/unwind/dwarfagent/agent.go
+++ b/unwind/dwarfagent/agent.go
@@ -1,17 +1,11 @@
 package dwarfagent
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"syscall"
-	"unsafe"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/link"
-	"golang.org/x/sys/unix"
-
+	"github.com/dpsoft/perf-agent/internal/perfevent"
 	"github.com/dpsoft/perf-agent/pprof"
 	"github.com/dpsoft/perf-agent/profile"
 	"github.com/dpsoft/perf-agent/unwind/ehmaps"
@@ -45,13 +39,11 @@ const (
 // Profiler is the DWARF-capable CPU profiler. Same public shape as
 // profile.Profiler (Collect / CollectAndWrite / Close) so
 // perfagent.Agent can swap on --unwind. Most heavy lifting lives in
-// the embedded *session — Profiler only adds per-CPU perf_event +
-// RawLink slices.
+// the embedded *session — Profiler only adds the per-CPU perf-event Set.
 type Profiler struct {
 	*session
 	sampleRate int
-	perfFDs    []int
-	perfLinks  []link.Link
+	perfSet    *perfevent.Set
 }
 
 // NewProfilerWithMode is the variant of NewProfiler that accepts both
@@ -82,11 +74,12 @@ func NewProfilerWithMode(pid int, systemWide bool, cpus []uint, tags []string, s
 		return nil, err
 	}
 
-	p := &Profiler{session: sess, sampleRate: sampleRate}
-	if err := p.attachPerfEvents(objs.Program(), cpus, sampleRate); err != nil {
-		_ = p.close()
+	perfSet, err := perfevent.OpenAll(objs.Program(), cpus, sampleRate, perfevent.WithDeferredEnable())
+	if err != nil {
+		_ = sess.close()
 		return nil, err
 	}
+	p := &Profiler{session: sess, sampleRate: sampleRate, perfSet: perfSet}
 
 	sess.runTracker()
 	sess.readerWG.Add(1)
@@ -116,58 +109,6 @@ func NewProfiler(pid int, systemWide bool, cpus []uint, tags []string, sampleRat
 	return NewProfilerWithHooks(pid, systemWide, cpus, tags, sampleRate, nil)
 }
 
-// attachPerfEvents opens one perf_event_open per CPU (pid=-1, cpu=N,
-// BPF pids-map filter) and link.AttachRawLinks the BPF program to each.
-// Populates p.perfFDs + p.perfLinks for Close to tear down.
-func (p *Profiler) attachPerfEvents(prog *ebpf.Program, cpus []uint, sampleRate int) error {
-	attr := &unix.PerfEventAttr{
-		Type:   unix.PERF_TYPE_SOFTWARE,
-		Config: unix.PERF_COUNT_SW_CPU_CLOCK,
-		Size:   uint32(unsafe.Sizeof(unix.PerfEventAttr{})),
-		Sample: uint64(sampleRate),
-		Bits:   unix.PerfBitFreq | unix.PerfBitDisabled,
-	}
-	cleanup := func() {
-		for _, l := range p.perfLinks {
-			_ = l.Close()
-		}
-		for _, fd := range p.perfFDs {
-			_ = unix.Close(fd)
-		}
-		p.perfLinks = nil
-		p.perfFDs = nil
-	}
-	for _, cpu := range cpus {
-		fd, err := unix.PerfEventOpen(attr, -1, int(cpu), -1, unix.PERF_FLAG_FD_CLOEXEC)
-		if err != nil {
-			if errors.Is(err, syscall.ESRCH) {
-				continue
-			}
-			cleanup()
-			return fmt.Errorf("perf_event_open cpu=%d: %w", cpu, err)
-		}
-		p.perfFDs = append(p.perfFDs, fd)
-		rl, err := link.AttachRawLink(link.RawLinkOptions{
-			Target:  fd,
-			Program: prog,
-			Attach:  ebpf.AttachPerfEvent,
-		})
-		if err != nil {
-			cleanup()
-			return fmt.Errorf("attach perf event cpu=%d: %w", cpu, err)
-		}
-		p.perfLinks = append(p.perfLinks, rl)
-		if err := unix.IoctlSetInt(fd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
-			cleanup()
-			return fmt.Errorf("enable perf event cpu=%d: %w", cpu, err)
-		}
-	}
-	if len(p.perfFDs) == 0 {
-		return fmt.Errorf("no perf events attached (pid=%d, cpus=%d)", p.pid, len(cpus))
-	}
-	return nil
-}
-
 // aggregateCPUSample is the CPU-specific ringbuf aggregator: each
 // sample counts once; blocking-ns isn't meaningful here. Wrapped as a
 // free function so consumeRingbuf can pass it generically.
@@ -195,18 +136,11 @@ func (p *Profiler) CollectAndWrite(outputPath string) error {
 	return p.Collect(f)
 }
 
-// Close closes perf-event links + fds, then delegates the rest to
+// Close closes the per-CPU perf-event Set, then delegates the rest to
 // session.close (ringbuf reader, watcher, symbolizer, BPF handle).
 // Idempotent at the stop-channel level.
 func (p *Profiler) Close() error {
-	for _, l := range p.perfLinks {
-		_ = l.Close()
-	}
-	for _, fd := range p.perfFDs {
-		_ = unix.Close(fd)
-	}
-	p.perfLinks = nil
-	p.perfFDs = nil
+	_ = p.perfSet.Close()
 	return p.close()
 }
 


### PR DESCRIPTION
## Summary

Both `profile.NewProfiler` (FP CPU profiler) and `dwarfagent.NewProfilerWithMode` (DWARF CPU profiler) spelled out an identical per-CPU \"PerfEventOpen → AttachRawLink → cleanup-on-error\" loop with a near-identical `PerfEventAttr` literal. Two small drift points between them:

- **dwarfagent** opened events with `PerfBitDisabled` and explicitly `IOC_ENABLE`'d after attach (closes the open→attach race window); **profile** opened events already-enabled.
- **dwarfagent** silently skipped offline CPUs (`ESRCH` from `perf_event_open`); **profile** treated `ESRCH` as a hard error, which would fail any run that included a hot-unplugged CPU.

## What this PR does

Centralises both behaviours in `internal/perfevent`:

- `perfevent.Set` — bundle of per-CPU fds + links, single `Close()`.
- `OpenAll(prog, cpus, sampleRate, opts...)` — the per-CPU loop.
- `WithDeferredEnable()` — opt-in for the disabled-then-`IOC_ENABLE` pattern.
- `ESRCH`-on-open is silently skipped (offline CPU is not an error either path should reject).

`profile/` migrates **without** `WithDeferredEnable` (preserves immediate-enable behaviour) but now also tolerates offline CPUs — a strict improvement. `dwarfagent/` migrates **with** `WithDeferredEnable` (preserves the race-free attach behaviour).

`PerfEventAttr` is now defined in exactly one place; future tweaks (precise sampling, hardware counter switch, etc.) only need to touch one helper.

## Diff shape

\`\`\`
 internal/perfevent/perfevent.go | +133  (new)
 profile/profiler.go             | +14 / -74
 unwind/dwarfagent/agent.go      | +4  / -62
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` all green
- [ ] CI: lint, build amd64+arm64, unit tests amd64+arm64
- [ ] CI: integration tests amd64+arm64 — exercises both \`profile.NewProfiler\` and \`dwarfagent.NewProfilerWithMode\` end-to-end through real perf_event_open

## Behaviour notes

- **profile path**: previously errored on offline CPUs in the \`cpus\` slice; now skips them silently. If callers were relying on the error, they will see it as a non-event. \`OpenAll\` still errors when **every** CPU is offline (\"no perf events attached\").
- **dwarfagent path**: byte-for-byte equivalent (same disabled-then-IOC_ENABLE).