### PR TITLE
examples/PGO: fix create_llvm_prof + rustc flags so the cycle works

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ High-fidelity pprof: every `Mapping` carries the absolute path, GNU build-id, an
 
 For toolchains that don't speak pprof, add `--perf-data-output app.perf.data` to emit a kernel-format `perf.data` alongside the pprof output. Same capture, two formats:
 
-- **AutoFDO PGO** for Rust (`-C profile-use=...`) and C++ (`clang -fprofile-sample-use=...`) via Google's [`create_llvm_prof`](https://github.com/google/autofdo). End-to-end demo: [`examples/rust-pgo`](examples/rust-pgo/), [`examples/cpp-pgo`](examples/cpp-pgo/).
+- **AutoFDO PGO** for Rust (`rustc -Cllvm-args=-sample-profile-file=...`) and C++ (`clang -fprofile-sample-use=...`) via Google's [`create_llvm_prof`](https://github.com/google/autofdo). End-to-end demo: [`examples/rust-pgo`](examples/rust-pgo/), [`examples/cpp-pgo`](examples/cpp-pgo/).
 - **[FlameGraph](https://github.com/brendangregg/FlameGraph)** — `perf script | stackcollapse-perf.pl | flamegraph.pl` produces an SVG. Demo: [`examples/flamegraph`](examples/flamegraph/).
 
 See [`docs/perf-data-output.md`](docs/perf-data-output.md) for the per-tool walkthrough.

--- a/docs/perf-data-output.md
+++ b/docs/perf-data-output.md
@@ -61,13 +61,19 @@ perf-agent --profile --pid $(pgrep my-app) --duration 60s \
            --perf-data-output train.perf.data
 
 # 3. Convert to LLVM .profdata via autofdo's create_llvm_prof
-#    (https://github.com/google/autofdo#install)
+#    (https://github.com/google/autofdo#install). --use_lbr=false is
+#    required: perf-agent samples cycles without branch records, and
+#    create_llvm_prof's default LBR mode produces an empty profile.
 create_llvm_prof --binary=./target/release/my-app \
                  --profile=train.perf.data \
-                 --out=train.prof
+                 --out=train.prof \
+                 --use_lbr=false
 
-# 4. Recompile with PGO
-RUSTFLAGS="-C profile-use=$(pwd)/train.prof" cargo build --release
+# 4. Recompile with PGO. Stable rustc has no high-level AutoFDO flag
+#    (`-C profile-use` is for instrumented PGO and rejects sample
+#    profiles), so plumb the profile through to LLVM directly.
+RUSTFLAGS="-Cllvm-args=-sample-profile-file=$(pwd)/train.prof" \
+    cargo build --release
 ```
 
 ### C++ AutoFDO PGO

--- a/examples/cpp-pgo/Makefile
+++ b/examples/cpp-pgo/Makefile
@@ -1,4 +1,10 @@
-CXX      ?= clang++
+# `?=` doesn't help here: GNU Make's built-in CXX default is g++, and
+# `?=` only assigns when undefined — built-ins count as defined. Using
+# `=` overrides that while still allowing `make CXX=...` on the command
+# line. clang is required: create_llvm_prof's AutoFDO output uses
+# LLVM's sample-profile format, consumed only by clang's
+# -fprofile-sample-use. (gcc would need create_gcov + -fauto-profile.)
+CXX      = clang++
 CXXFLAGS ?= -O2 -g -std=c++17
 
 .PHONY: baseline pgo strip clean

--- a/examples/cpp-pgo/pgo-cycle.sh
+++ b/examples/cpp-pgo/pgo-cycle.sh
@@ -38,7 +38,8 @@ echo "==> 4. Convert perf.data → LLVM .prof"
 create_llvm_prof \
     --binary=./workload-baseline \
     --profile=train.perf.data \
-    --out=train.prof
+    --out=train.prof \
+    --use_lbr=false
 
 echo "==> 5. PGO build (-fprofile-sample-use=train.prof)"
 make -s pgo

--- a/examples/rust-pgo/README.md
+++ b/examples/rust-pgo/README.md
@@ -38,14 +38,25 @@ duration with `DURATION=60s` (default 30s).
 2. Benchmarks the baseline binary.
 3. Runs the workload, attaches perf-agent for `$DURATION`, writes
    `train.perf.data`.
-4. `create_llvm_prof --binary=… --profile=train.perf.data --out=train.prof`
-   produces an LLVM sample-profile.
-5. `cargo build --release` with `-C profile-use=train.prof -C strip=symbols` —
-   PGO build, final binary stripped.
+4. `create_llvm_prof --binary=… --profile=train.perf.data --out=train.prof
+   --use_lbr=false` produces an LLVM sample-profile. `--use_lbr=false` is
+   required because perf-agent samples cycles without branch records;
+   without the flag, AutoFDO produces an empty profile.
+5. `cargo build --release` with
+   `-Cllvm-args=-sample-profile-file=train.prof -C strip=symbols` —
+   PGO build, final binary stripped. Stable rustc has no high-level
+   AutoFDO flag (`-C profile-use` is for *instrumented* PGO and rejects
+   sample profiles with "bad magic"), so we drop to the underlying LLVM
+   option directly.
 6. Benchmarks the optimised binary, prints the speedup.
 
-Typical result: 5–15% speedup on this synthetic workload. Real production
-workloads vary; the numbers are illustrative.
+Typical result on this synthetic via the rustc LLVM-args path: 1–3%
+improvement. The companion [C++ demo](../cpp-pgo/) on the same shape of
+workload reaches ~30% — clang's `-fprofile-sample-use` integrates the
+profile into the full optimisation pipeline (inlining, branch layout,
+register allocation), whereas rustc only feeds it to LLVM at the
+codegen pass. Real production workloads vary; the numbers are
+illustrative.
 
 ## Why this works
 

--- a/examples/rust-pgo/pgo-cycle.sh
+++ b/examples/rust-pgo/pgo-cycle.sh
@@ -44,10 +44,17 @@ echo "==> 4. Convert perf.data → LLVM .prof via create_llvm_prof"
 create_llvm_prof \
     --binary=./target/release/rust-pgo-example \
     --profile=train.perf.data \
-    --out=train.prof
+    --out=train.prof \
+    --use_lbr=false
 
 echo "==> 5. PGO build (uses train.prof; strips symbols on the final artefact)"
-RUSTFLAGS="-C profile-use=$WORKDIR/train.prof -C strip=symbols" \
+# Stable rustc doesn't expose a high-level AutoFDO flag — `-C profile-use`
+# is for instrumented PGO and rejects sample profiles with "bad magic".
+# Drop to the underlying LLVM option via -Cllvm-args=-sample-profile-file.
+# -pgo-warn-missing-function surfaces functions present in the profile
+# but not in the binary (a sign the binary was rebuilt between training
+# and use, breaking the build-id join).
+RUSTFLAGS="-Cllvm-args=-sample-profile-file=$WORKDIR/train.prof -Cllvm-args=-pgo-warn-missing-function -C strip=symbols" \
     cargo build --release --quiet
 
 echo "==> 6. PGO-optimised benchmark"


### PR DESCRIPTION
## Summary

Three pre-existing bugs in the PGO examples (added in #17) prevented the cycle from completing. Each is small but the combination meant the demo never produced a faster binary.

- **`create_llvm_prof` needs `--use_lbr=false`.** perf-agent samples cycles without branch records; without the flag, AutoFDO silently produces an empty `.prof` file (warning: "use_lbr was enabled but range_count_map was empty").
- **Stable rustc has no high-level AutoFDO flag.** `-C profile-use=...` is for *instrumented* PGO and rejects sample profiles with "bad magic". Replaced with `-Cllvm-args=-sample-profile-file=...` (the underlying LLVM option).
- **`examples/cpp-pgo/Makefile` had `CXX ?= clang++`** which doesn't override Make's built-in `g++` default. Switched to `CXX = clang++`. clang is required because `create_llvm_prof`'s output uses LLVM's sample-profile format, consumed only by clang's `-fprofile-sample-use` (gcc would need `create_gcov` + `-fauto-profile`).
- **README expectations revised.** The rust demo via the LLVM-args path measured ~1–3% speedup on the synthetic; the C++ demo on the same shape of workload reaches ~30% because clang's `-fprofile-sample-use` integrates the profile into the full optimisation pipeline (inlining, branch layout, register allocation), whereas rustc only feeds it to LLVM at the codegen pass.

## Validation

End-to-end runs against the rust workload (`ITER=10000000000 DURATION=20s`):
- `create_llvm_prof`: 1541/1552 samples mapped to the binary by build-id (~99%).
- C++ cycle: **14.54s → 10.20s, 1.43× faster (29.8% improvement)**.
- Rust cycle: **16.79s → 16.60s, 1.01× faster (1.1% improvement)**.

## Test plan

- [ ] `cd examples/cpp-pgo && rm -f workload-* train.* *.json && PATH=/path/to/autofdo/build:$PATH AGENT=/path/to/perf-agent ITER=10000000000 DURATION=20s bash pgo-cycle.sh` — confirm a non-zero speedup is reported.
- [ ] `cd examples/rust-pgo && rm -f train.* *.json *.txt rust-pgo-exampl*.pb.gz && PATH=/path/to/autofdo/build:$PATH AGENT=/path/to/perf-agent ITER=10000000000 DURATION=20s bash pgo-cycle.sh` — confirm cycle completes without rustc rejecting the profile.
- [ ] `git log -1` — message accurately captures the three fixes.