### PR TITLE
feat(pprof): per-sample labels, folded into the dedup hash

### DIFF
--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -1,8 +1,10 @@
 package pprof
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -89,6 +91,10 @@ type ProfileSample struct {
 	Stack       []Frame
 	Value       uint64
 	Value2      uint64
+	// Labels are per-sample pprof labels, merged over BuildersOptions.Labels.
+	// Keys present in both win here. Use for context that must not fragment
+	// stack identity (GPU stall reason, PC, queue, device, correlation ID).
+	Labels map[string]string
 }
 
 type BuildersOptions struct {
@@ -269,6 +275,9 @@ func (p *ProfileBuilder) CreateSampleOrAddValue(inputSample *ProfileSample) {
 		p.tmpLocationIDs = append(p.tmpLocationIDs, loc.ID)
 	}
 	h := xxhash.Sum64(uint64Bytes(p.tmpLocationIDs))
+	if len(inputSample.Labels) > 0 {
+		h = hashLabels(h, inputSample.Labels)
+	}
 	sample := p.sampleHashToSample[h]
 	if sample != nil {
 		p.addValue(inputSample, sample)
@@ -279,6 +288,30 @@ func (p *ProfileBuilder) CreateSampleOrAddValue(inputSample *ProfileSample) {
 	copy(sample.Location, p.tmpLocations)
 	p.sampleHashToSample[h] = sample
 	p.Profile.Sample = append(p.Profile.Sample, sample)
+}
+
+// hashLabels folds per-sample labels into the sample dedup hash so that two
+// samples sharing a stack but carrying different labels are kept apart rather
+// than silently merged. Keys are sorted, so the result does not depend on Go's
+// randomized map iteration order.
+func hashLabels(seed uint64, labels map[string]string) uint64 {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	d := xxhash.New()
+	var seedBuf [8]byte
+	binary.LittleEndian.PutUint64(seedBuf[:], seed)
+	_, _ = d.Write(seedBuf[:])
+	for _, k := range keys {
+		_, _ = d.WriteString(k)
+		_, _ = d.WriteString("\x00")
+		_, _ = d.WriteString(labels[k])
+		_, _ = d.WriteString("\x00")
+	}
+	return d.Sum64()
 }
 
 func (p *ProfileBuilder) addLocation(frame Frame, pid uint32) *profile.Location {
@@ -446,9 +479,12 @@ func (p *ProfileBuilder) newSample(inputSample *ProfileSample) *profile.Sample {
 		sample.Value = []int64{0, 0}
 	}
 	sample.Location = make([]*profile.Location, len(inputSample.Stack))
-	if len(p.opt.Labels) > 0 {
-		sample.Label = make(map[string][]string, len(p.opt.Labels))
+	if len(p.opt.Labels) > 0 || len(inputSample.Labels) > 0 {
+		sample.Label = make(map[string][]string, len(p.opt.Labels)+len(inputSample.Labels))
 		for k, v := range p.opt.Labels {
+			sample.Label[k] = []string{v}
+		}
+		for k, v := range inputSample.Labels {
 			sample.Label[k] = []string{v}
 		}
 	}

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -624,3 +624,95 @@ func TestNewProfileBuilders_StaticLabelsOnSample(t *testing.T) {
 		}
 	}
 }
+
+func TestProfileSampleLabels(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames([]string{"main"}),
+		Value:      100,
+		Labels:     map[string]string{"gpu_kernel": "flash_attn_fwd"},
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 1)
+		assert.Equal(t, []string{"flash_attn_fwd"}, b.Profile.Sample[0].Label["gpu_kernel"])
+	}
+}
+
+func TestProfileSampleLabelsMergeWithBuilderLabels(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{
+		SampleRate: 99,
+		Labels:     map[string]string{"pod_uid": "pod-a", "gpu_kernel": "from_builder"},
+	})
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames([]string{"main"}),
+		Value:      100,
+		Labels:     map[string]string{"gpu_kernel": "from_sample"},
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 1)
+		labels := b.Profile.Sample[0].Label
+		assert.Equal(t, []string{"pod-a"}, labels["pod_uid"],
+			"builder-level labels with no per-sample override must survive")
+		assert.Equal(t, []string{"from_sample"}, labels["gpu_kernel"],
+			"per-sample labels must win over builder-level labels of the same key")
+	}
+}
+
+func TestSameStackDifferentLabelsNotMerged(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	stack := []string{"main", "compute"}
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      10,
+		Labels:     map[string]string{"gpu_stall": "long_scoreboard"},
+	})
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      20,
+		Labels:     map[string]string{"gpu_stall": "barrier"},
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 2,
+			"samples with identical stacks but different labels must not be merged")
+	}
+}
+
+func TestSameStackSameLabelsStillMerged(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	stack := []string{"main", "compute"}
+	labels := map[string]string{"gpu_stall": "barrier"}
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      10,
+		Labels:     labels,
+	})
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      20,
+		Labels:     labels,
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 1,
+			"identical stack and identical labels must still aggregate")
+	}
+}
+
+func TestLabelHashIsOrderIndependent(t *testing.T) {
+	a := hashLabels(1234, map[string]string{"x": "1", "y": "2"})
+	b := hashLabels(1234, map[string]string{"y": "2", "x": "1"})
+	assert.Equal(t, a, b, "label hash must not depend on map iteration order")
+}


### PR DESCRIPTION
Adds `ProfileSample.Labels` so an individual sample can carry its own pprof labels.

`BuildersOptions.Labels` already existed, but it is builder-level and constant — every sample in a profile receives the same map. Context that varies per sample had nowhere to go except synthetic stack frames, and frames are stack identity: encoding varying context there makes every distinct value a distinct flame-graph leaf.

## The non-obvious part

`CreateSampleOrAddValue` hashed only the stack’s location IDs:

```go
h := xxhash.Sum64(uint64Bytes(p.tmpLocationIDs))
```

So two samples with an identical stack but *different* labels would have merged, and one label set would silently win. Labels are now folded into that hash, with keys sorted so the result does not depend on Go’s randomized map iteration order.

## Behaviour

- Per-sample keys override builder-level keys of the same name; builder-level keys with no override survive.
- The no-labels path is byte-identical to before. All three existing callers (`offcpu/profiler.go`, `profile/profiler.go`, `unwind/dwarfagent/common.go`) leave `Labels` nil, so existing profiles are unaffected — this is guarded by `len(...) > 0` in both `newSample` and `CreateSampleOrAddValue`.
- `CreateSample` (the `SampleAggregated` path) needs no hash treatment: it never dedups.

## Tests

Five, written before the implementation:

- per-sample labels land on the sample
- per-sample labels merge over builder-level labels, per-sample winning
- identical stacks with **different** labels stay separate
- identical stacks with **identical** labels still aggregate
- the label hash is order-independent

`go test ./pprof/ ./perfagent/ ./unwind/... ./profile/ ./cpu/` passes; `go build ./...` clean.

## Why now

This is the first of two enablers for GPU profiling work (spec on the `gpu-v2` branch), but it stands on its own — per-sample labels are generally useful for pprof output. No GPU code is involved.