### PR TITLE
docs(caps): explain the capability set and when CAP_SYS_ADMIN is redundant

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,42 @@ See [`docs/perf-data-output.md`](docs/perf-data-output.md) for the per-tool walk
 - Linux kernel 5.8+ (BTF + CO-RE).
 - Root, OR `setcap cap_sys_admin,cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep ./perf-agent`.
 
+<details>
+<summary>What each capability is for, and when <code>cap_sys_admin</code> can be dropped</summary>
+
+| Capability | Why it is needed |
+|---|---|
+| `cap_bpf` | Load eBPF programs and create maps |
+| `cap_perfmon` | `perf_event_open`, stack traces, tracing attachment |
+| `cap_sys_ptrace` | Read `/proc/<pid>/maps` and `/proc/<pid>/mem` of the target |
+| `cap_checkpoint_restore` | Follow `/proc/<pid>/map_files/` symlinks during symbolization |
+| `cap_sys_admin` | Only on kernels older than 5.8/5.9 — see below |
+
+`cap_sys_admin` is kept for backward compatibility. Two capabilities were added
+to the kernel to carve out the roles perf-agent used it for — but they did not
+arrive in the same release:
+
+- **`CAP_PERFMON` (kernel 5.8)** covers `perf_event_open`, including `pid=-1`
+  for system-wide profiling.
+- **`CAP_CHECKPOINT_RESTORE` (kernel 5.9)** covers `/proc/<pid>/map_files`.
+
+perf-agent's documented floor is kernel 5.8, and on exactly 5.8
+`cap_checkpoint_restore` does not exist — so dropping `cap_sys_admin` there would
+break symbolization. That single kernel minor version is why the full set is
+still the default.
+
+On **kernel 5.9 or newer** the minimal set is:
+
+```bash
+sudo setcap cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep ./perf-agent
+```
+
+If you run 6.x — as most deployments now do — this is the set to use. It matters
+most for per-pod and sidecar deployments, where `cap_sys_admin` is the near-root
+capability that gets a workload rejected by admission policy.
+
+</details>
+
 ---
 
 ## Usage

--- a/perfagent/agent.go
+++ b/perfagent/agent.go
@@ -292,12 +292,37 @@ func (a *Agent) Start(ctx context.Context) error {
 		return errors.New("agent already started")
 	}
 
-	// Set capabilities:
-	//   CAP_SYS_ADMIN          - perf_event_open with pid=-1 (system-wide perf events)
+	// Capabilities raised to Effective. The set is deliberately the historical
+	// superset so that pre-5.8 kernels keep working:
+	//
 	//   CAP_BPF                - load eBPF programs and create maps
 	//   CAP_PERFMON            - perf_event_open, stack traces, tracing attachment
 	//   CAP_SYS_PTRACE         - read /proc/<pid>/maps and /proc/<pid>/mem of other processes
 	//   CAP_CHECKPOINT_RESTORE - follow /proc/<pid>/map_files/ symlinks (blazesym symbolization)
+	//   CAP_SYS_ADMIN          - only needed on kernels older than 5.8/5.9; see below
+	//
+	// CAP_SYS_ADMIN is retained for backward compatibility, not because current
+	// kernels need it. Two capabilities were introduced to carve out its roles,
+	// but they did not arrive together:
+	//
+	//   - CAP_PERFMON (5.8) covers perf_event_open, including pid=-1 for
+	//     system-wide profiling.
+	//   - CAP_CHECKPOINT_RESTORE (5.9) covers /proc/<pid>/map_files.
+	//
+	// That one-version gap is the whole reason this is still here. The project
+	// documents a floor of kernel 5.8, and on exactly 5.8 CAP_CHECKPOINT_RESTORE
+	// does not exist, so dropping CAP_SYS_ADMIN would break symbolization there.
+	//
+	// On kernel >= 5.9 the minimal working set is:
+	//
+	//   cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep
+	//
+	// Dropping CAP_SYS_ADMIN matters for per-pod and sidecar deployments, where
+	// it is the near-root capability that gets a workload rejected. The condition
+	// is not "wait for newer kernels" - deployments already target 6.x. It is:
+	// raise the documented floor from 5.8 to 5.9+, then verify the minimal set
+	// for both --pid and -a runs (-a is the one that exercises
+	// perf_event_open(pid=-1)), then drop it here.
 	caps := cap.GetProc()
 	if err := caps.SetFlag(cap.Effective, true, cap.SYS_ADMIN, cap.BPF, cap.PERFMON, cap.SYS_PTRACE, cap.CHECKPOINT_RESTORE); err != nil {
 		return fmt.Errorf("set capabilities: %w", err)

--- a/unwind/ehmaps/openable.go
+++ b/unwind/ehmaps/openable.go
@@ -12,8 +12,9 @@ import (
 // unlinked-but-mapped binaries), then falls back to the symbolic path.
 // Returns "" when neither resolves.
 //
-// Requires CAP_SYS_ADMIN to read /proc/<pid>/map_files. perf-agent's
-// standard cap set covers this.
+// Reading /proc/<pid>/map_files required CAP_SYS_ADMIN before kernel 5.9, and
+// CAP_CHECKPOINT_RESTORE from 5.9 onward. perf-agent's standard cap set holds
+// both, so this works either way.
 //
 // Note: the probe (open + close) and the caller's subsequent use of the
 // returned path are not atomic. Callers must still handle errors from


### PR DESCRIPTION
Documentation only. **No behaviour change** — the requested capability set is unchanged, and no `setcap` line in any README was edited.

## What was wrong

`unwind/ehmaps/openable.go` claimed:

> Requires CAP_SYS_ADMIN to read /proc/<pid>/map_files.

while `perfagent/agent.go` already attributed the same thing correctly to `CAP_CHECKPOINT_RESTORE`. Beyond that contradiction, nothing anywhere explained what any of the five capabilities were actually for.

## What this records

The two capabilities that replace `CAP_SYS_ADMIN` did not arrive together:

| Capability | Kernel | Covers |
|---|---|---|
| `CAP_PERFMON` | 5.8 | `perf_event_open`, including `pid=-1` for system-wide |
| `CAP_CHECKPOINT_RESTORE` | 5.9 | `/proc/<pid>/map_files` |

perf-agent documents a floor of **kernel 5.8**, and on exactly 5.8 `CAP_CHECKPOINT_RESTORE` does not exist — so dropping `CAP_SYS_ADMIN` there would break symbolization. That single kernel minor version is the entire reason the full set is still requested.

## Why not just drop it

Because it would break anyone on 5.8. The condition for dropping it is not "wait for newer kernels" — deployments already run 6.x — it is **raise the documented floor from 5.8 to 5.9+**, then verify the minimal set for both `--pid` and `-a` runs (`-a` is the one that exercises `perf_event_open(pid=-1)`). Raising the floor is a project decision and is deliberately not part of this PR.

This matters because `CAP_SYS_ADMIN` is near-root and is what gets a per-pod or sidecar agent rejected by admission policy. On kernel ≥ 5.9 the minimal set is:

```
cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep
```

which is now documented in the README behind a `<details>` block, alongside a table of what each capability is for.

## Verification

Every changed line in `perfagent/agent.go` and `unwind/ehmaps/openable.go` is a comment; `caps.SetFlag(...)` is byte-identical. `go build ./...` clean, `go test ./perfagent/ ./unwind/ehmaps/` passes.