### PR TITLE
GPU V2 Phase 2: the continuous core

### DIFF
--- a/docs/superpowers/plans/2026-08-16-gpu-v2-phase1-enablers.md
+++ b/docs/superpowers/plans/2026-08-16-gpu-v2-phase1-enablers.md
@@ -73,12 +73,35 @@ func TestProfileSampleLabels(t *testing.T) {
 		assert.Equal(t, []string{"flash_attn_fwd"}, b.Profile.Sample[0].Label["gpu_kernel"])
 	}
 }
+
+func TestProfileSampleLabelsMergeWithBuilderLabels(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{
+		SampleRate: 99,
+		Labels:     map[string]string{"pod_uid": "pod-a", "gpu_kernel": "from_builder"},
+	})
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames([]string{"main"}),
+		Value:      100,
+		Labels:     map[string]string{"gpu_kernel": "from_sample"},
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 1)
+		labels := b.Profile.Sample[0].Label
+		assert.Equal(t, []string{"pod-a"}, labels["pod_uid"],
+			"builder-level labels with no per-sample override must survive")
+		assert.Equal(t, []string{"from_sample"}, labels["gpu_kernel"],
+			"per-sample labels must win over builder-level labels of the same key")
+	}
+}
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-go test ./pprof/ -run TestProfileSampleLabels -v
+go test ./pprof/ -run "TestProfileSampleLabels" -v
 ```
 
 Expected: compile failure — `unknown field Labels in struct literal of type ProfileSample`.
@@ -119,7 +142,7 @@ Replace the label block in `newSample`:
 - [ ] **Step 4: Run the test to verify it passes**
 
 ```bash
-go test ./pprof/ -run TestProfileSampleLabels -v
+go test ./pprof/ -run "TestProfileSampleLabels" -v
 ```
 
 Expected: PASS.

--- a/docs/superpowers/plans/2026-08-16-gpu-v2-phase1-enablers.md
+++ b/docs/superpowers/plans/2026-08-16-gpu-v2-phase1-enablers.md
@@ -6,13 +6,13 @@
 
 **Architecture:** Both changes are to existing, shipping code and carry no GPU dependency. Task 1 adds a `Labels` field to `ProfileSample` and folds it into the sample dedup hash, so GPU metadata can live in labels rather than synthetic stack frames. Task 2 extracts the capability set into a testable function and drops `CAP_SYS_ADMIN`, which `CAP_PERFMON` and `CAP_CHECKPOINT_RESTORE` have superseded since kernels 5.8 and 5.9.
 
-**Tech Stack:** Go 1.25, `github.com/google/pprof/profile`, `github.com/cespare/xxhash/v2`, `kernel.org/pub/linux/libs/security/libcap/cap`, testify (`assert` + `require`).
+**Tech Stack:** Go 1.26, `github.com/google/pprof/profile`, `github.com/cespare/xxhash/v2`, `kernel.org/pub/linux/libs/security/libcap/cap`, testify (`assert` + `require`).
 
 **Spec:** `docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md` (§8 Output representation, §11 Deployment, §14 Phase 1)
 
 ## Global Constraints
 
-- Go 1.25.0+.
+- Go 1.26.0+ (go.mod declares `go 1.26.0`; CI pins `1.26`).
 - CGO is required to build or test this repo. Every `go test` / `go build` invocation must be prefixed with the environment block in "Build environment" below, or it fails to link blazesym.
 - Output format stays pprof. No new wire format, no OTLP emitter.
 - Capability claims assume kernel ≥ 5.9. The dev host runs 6.19.

--- a/docs/superpowers/plans/2026-08-16-gpu-v2-phase1-enablers.md
+++ b/docs/superpowers/plans/2026-08-16-gpu-v2-phase1-enablers.md
@@ -1,0 +1,466 @@
+# GPU V2 Phase 1 — Enablers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the two small, independent changes on `main` that unblock every later GPU V2 phase — per-sample pprof labels, and removal of the redundant `CAP_SYS_ADMIN` requirement.
+
+**Architecture:** Both changes are to existing, shipping code and carry no GPU dependency. Task 1 adds a `Labels` field to `ProfileSample` and folds it into the sample dedup hash, so GPU metadata can live in labels rather than synthetic stack frames. Task 2 extracts the capability set into a testable function and drops `CAP_SYS_ADMIN`, which `CAP_PERFMON` and `CAP_CHECKPOINT_RESTORE` have superseded since kernels 5.8 and 5.9.
+
+**Tech Stack:** Go 1.25, `github.com/google/pprof/profile`, `github.com/cespare/xxhash/v2`, `kernel.org/pub/linux/libs/security/libcap/cap`, testify (`assert` + `require`).
+
+**Spec:** `docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md` (§8 Output representation, §11 Deployment, §14 Phase 1)
+
+## Global Constraints
+
+- Go 1.25.0+.
+- CGO is required to build or test this repo. Every `go test` / `go build` invocation must be prefixed with the environment block in "Build environment" below, or it fails to link blazesym.
+- Output format stays pprof. No new wire format, no OTLP emitter.
+- Capability claims assume kernel ≥ 5.9. The dev host runs 6.19.
+- Do not commit `CLAUDE.md`.
+- No `Co-Authored-By` lines in commit messages.
+
+## Build environment
+
+Every test and build command in this plan assumes this has been exported in the shell first:
+
+```bash
+export CGO_CFLAGS="-I /usr/include/bpf -I /usr/include/pcap -I /home/diego/github/blazesym/capi/include"
+export CGO_LDFLAGS="-L/home/diego/github/blazesym/target/release -lblazesym_c"
+export LD_LIBRARY_PATH=/home/diego/github/blazesym/target/release
+```
+
+`make test-unit` will not work: it runs `go generate` first, which needs `llvm-strip`. The eBPF bytecode is committed, so run `go test` directly as shown in each step.
+
+## Scope note
+
+The spec's §14 said the first plan would cover Phases 1 and 2. On review, Phase 2 (the continuous core) is a separate subsystem with a different deliverable — it creates the `gpu/` package on this branch, while Phase 1 modifies existing shipping code destined for `main`. Splitting them keeps each plan independently shippable and testable. Phase 2 gets its own plan once Phase 1's gate passes.
+
+---
+
+### Task 1: Per-sample pprof labels
+
+GPU context currently has nowhere to go except synthetic stack frames, which makes it part of stack identity. With PC sampling that produces one flame-graph leaf per sampled instruction. `BuildersOptions.Labels` already exists but is builder-level and constant — every sample in a profile gets the same map. This task gives an individual sample its own labels.
+
+The subtle part is step 6: `CreateSampleOrAddValue` currently hashes only the stack's location IDs, so two samples with the same stack but different labels would silently merge and one label set would win.
+
+**Files:**
+- Modify: `pprof/pprof.go` — `ProfileSample` struct (line ~85), `newSample` (line ~441), `CreateSampleOrAddValue` (line ~263), imports (line ~3)
+- Test: `pprof/pprof_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `ProfileSample.Labels map[string]string` — optional per-sample labels. Per-sample keys override `BuildersOptions.Labels` keys of the same name.
+  - `hashLabels(seed uint64, labels map[string]string) uint64` — package-private, order-independent fold of labels into a dedup hash.
+
+- [ ] **Step 1: Write the failing test for per-sample labels**
+
+Append to `pprof/pprof_test.go`:
+
+```go
+func TestProfileSampleLabels(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames([]string{"main"}),
+		Value:      100,
+		Labels:     map[string]string{"gpu_kernel": "flash_attn_fwd"},
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 1)
+		assert.Equal(t, []string{"flash_attn_fwd"}, b.Profile.Sample[0].Label["gpu_kernel"])
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+go test ./pprof/ -run TestProfileSampleLabels -v
+```
+
+Expected: compile failure — `unknown field Labels in struct literal of type ProfileSample`.
+
+- [ ] **Step 3: Add the field and merge it in `newSample`**
+
+In `pprof/pprof.go`, add the field to `ProfileSample`:
+
+```go
+type ProfileSample struct {
+	Pid         uint32
+	SampleType  SampleType
+	Aggregation SampleAggregation
+	Stack       []Frame
+	Value       uint64
+	Value2      uint64
+	// Labels are per-sample pprof labels, merged over BuildersOptions.Labels.
+	// Keys present in both win here. Use for context that must not fragment
+	// stack identity (GPU stall reason, PC, queue, device, correlation ID).
+	Labels map[string]string
+}
+```
+
+Replace the label block in `newSample`:
+
+```go
+	if len(p.opt.Labels) > 0 || len(inputSample.Labels) > 0 {
+		sample.Label = make(map[string][]string, len(p.opt.Labels)+len(inputSample.Labels))
+		for k, v := range p.opt.Labels {
+			sample.Label[k] = []string{v}
+		}
+		for k, v := range inputSample.Labels {
+			sample.Label[k] = []string{v}
+		}
+	}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+go test ./pprof/ -run TestProfileSampleLabels -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test for label-aware dedup**
+
+This is the correctness case. Omitting `Aggregation` selects the zero value (`false`), which routes through `CreateSampleOrAddValue` — the deduplicating path. Append to `pprof/pprof_test.go`:
+
+```go
+func TestSameStackDifferentLabelsNotMerged(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	stack := []string{"main", "compute"}
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      10,
+		Labels:     map[string]string{"gpu_stall": "long_scoreboard"},
+	})
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      20,
+		Labels:     map[string]string{"gpu_stall": "barrier"},
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 2,
+			"samples with identical stacks but different labels must not be merged")
+	}
+}
+
+func TestSameStackSameLabelsStillMerged(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	stack := []string{"main", "compute"}
+	labels := map[string]string{"gpu_stall": "barrier"}
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      10,
+		Labels:     labels,
+	})
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      20,
+		Labels:     labels,
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 1,
+			"identical stack and identical labels must still aggregate")
+	}
+}
+
+func TestLabelHashIsOrderIndependent(t *testing.T) {
+	a := hashLabels(1234, map[string]string{"x": "1", "y": "2"})
+	b := hashLabels(1234, map[string]string{"y": "2", "x": "1"})
+	assert.Equal(t, a, b, "label hash must not depend on map iteration order")
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+```bash
+go test ./pprof/ -run 'TestSameStack|TestLabelHash' -v
+```
+
+Expected: `TestSameStackDifferentLabelsNotMerged` FAILS with `expected 2, got 1` (labels are not in the hash, so the samples merge). `TestLabelHashIsOrderIndependent` fails to compile — `undefined: hashLabels`.
+
+- [ ] **Step 7: Fold labels into the dedup hash**
+
+In `pprof/pprof.go`, add `encoding/binary` and `slices` to the import block:
+
+```go
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/google/pprof/profile"
+
+	"github.com/klauspost/compress/gzip"
+
+	"github.com/dpsoft/perf-agent/unwind/procmap"
+)
+```
+
+In `CreateSampleOrAddValue`, replace the single hash line:
+
+```go
+	h := xxhash.Sum64(uint64Bytes(p.tmpLocationIDs))
+	if len(inputSample.Labels) > 0 {
+		h = hashLabels(h, inputSample.Labels)
+	}
+```
+
+Add the helper next to `CreateSampleOrAddValue`:
+
+```go
+// hashLabels folds per-sample labels into the sample dedup hash so that two
+// samples sharing a stack but carrying different labels are kept apart rather
+// than silently merged. Keys are sorted, so the result does not depend on Go's
+// randomized map iteration order.
+func hashLabels(seed uint64, labels map[string]string) uint64 {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	d := xxhash.New()
+	var seedBuf [8]byte
+	binary.LittleEndian.PutUint64(seedBuf[:], seed)
+	_, _ = d.Write(seedBuf[:])
+	for _, k := range keys {
+		_, _ = d.WriteString(k)
+		_, _ = d.WriteString("\x00")
+		_, _ = d.WriteString(labels[k])
+		_, _ = d.WriteString("\x00")
+	}
+	return d.Sum64()
+}
+```
+
+- [ ] **Step 8: Run the full pprof test suite**
+
+```bash
+go test ./pprof/ -count=1 -v
+```
+
+Expected: PASS, including the pre-existing tests. If `TestSampleAggregation` or `TestProfileComments` now fail, the label merge changed behaviour for samples with no labels — check that the `len(...) > 0` guards in both `newSample` and `CreateSampleOrAddValue` are present.
+
+- [ ] **Step 9: Verify no other caller is disturbed**
+
+```bash
+go build ./... && go test ./profile/ ./offcpu/ ./cpu/ -count=1
+```
+
+Expected: builds clean; those suites behave exactly as before (`ProfileSample.Labels` is optional and nil for every existing caller).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add pprof/pprof.go pprof/pprof_test.go
+git commit -m "feat(pprof): per-sample labels, folded into the dedup hash
+
+BuildersOptions.Labels is builder-level and constant, so every sample in a
+profile receives the same map. GPU context varies per sample and had nowhere
+to go but synthetic stack frames, which makes it part of stack identity — with
+PC sampling that yields one flame-graph leaf per sampled instruction.
+
+ProfileSample.Labels adds per-sample labels, merged over the builder-level map
+with per-sample keys winning. CreateSampleOrAddValue hashed only the stack's
+location IDs, so samples sharing a stack but carrying different labels would
+have merged silently; labels are now folded into that hash with sorted keys so
+the result is independent of map iteration order."
+```
+
+---
+
+### Task 2: Drop the redundant `CAP_SYS_ADMIN` requirement
+
+perf-agent requests `CAP_SYS_ADMIN` and every documented `setcap` line includes it. On kernel ≥ 5.9 it is redundant: `CAP_PERFMON` (5.8) covers `perf_event_open` including `pid=-1`, and `CAP_CHECKPOINT_RESTORE` (5.9) covers `/proc/<pid>/map_files`. `CAP_SYS_ADMIN` is near-root and is what gets a per-pod agent rejected, so removing it is a prerequisite for the §11 deployment model.
+
+The capability set is currently an inline call inside `Start()`, which is untestable. This task extracts it first.
+
+**Files:**
+- Modify: `perfagent/agent.go` — capability comment block (line ~296) and `SetFlag` call (line ~302)
+- Modify: `unwind/ehmaps/openable.go:15` — stale comment
+- Modify: `README.md` (lines 40, 116, 366), `bench/README.md:28`, `examples/README.md:15`, `examples/rust-pgo/README.md:12`, `examples/flamegraph/README.md:11`
+- Test: `perfagent/agent_test.go`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `requiredCapabilities() []cap.Value` — package-private in `perfagent`, returns the capability set the agent raises to Effective.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `perfagent/agent_test.go`:
+
+```go
+func TestRequiredCapabilitiesExcludesSysAdmin(t *testing.T) {
+	caps := requiredCapabilities()
+
+	assert.NotContains(t, caps, cap.SYS_ADMIN,
+		"CAP_SYS_ADMIN is redundant on kernel >= 5.9: CAP_PERFMON covers "+
+			"perf_event_open including pid=-1, CAP_CHECKPOINT_RESTORE covers "+
+			"/proc/<pid>/map_files")
+
+	assert.Contains(t, caps, cap.BPF)
+	assert.Contains(t, caps, cap.PERFMON)
+	assert.Contains(t, caps, cap.SYS_PTRACE)
+	assert.Contains(t, caps, cap.CHECKPOINT_RESTORE)
+}
+```
+
+Ensure `perfagent/agent_test.go` imports `kernel.org/pub/linux/libs/security/libcap/cap` and `github.com/stretchr/testify/assert`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+go test ./perfagent/ -run TestRequiredCapabilitiesExcludesSysAdmin -v
+```
+
+Expected: compile failure — `undefined: requiredCapabilities`.
+
+- [ ] **Step 3: Extract the capability set and drop `SYS_ADMIN`**
+
+In `perfagent/agent.go`, add above the function containing the `SetFlag` call:
+
+```go
+// requiredCapabilities is the capability set the agent raises to Effective.
+//
+//	CAP_BPF                - load eBPF programs and create maps
+//	CAP_PERFMON            - perf_event_open (including pid=-1 for system-wide),
+//	                         stack traces, tracing attachment. Since kernel 5.8
+//	                         this covers what CAP_SYS_ADMIN used to be needed for.
+//	CAP_SYS_PTRACE         - read /proc/<pid>/maps and /proc/<pid>/mem of other processes
+//	CAP_CHECKPOINT_RESTORE - follow /proc/<pid>/map_files/ symlinks for blazesym
+//	                         symbolization. Added in kernel 5.9 precisely so this
+//	                         does not require CAP_SYS_ADMIN.
+func requiredCapabilities() []cap.Value {
+	return []cap.Value{cap.BPF, cap.PERFMON, cap.SYS_PTRACE, cap.CHECKPOINT_RESTORE}
+}
+```
+
+Replace the existing comment block and `SetFlag` call with:
+
+```go
+	caps := cap.GetProc()
+	if err := caps.SetFlag(cap.Effective, true, requiredCapabilities()...); err != nil {
+		return fmt.Errorf("set capabilities: %w", err)
+	}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+go test ./perfagent/ -run TestRequiredCapabilitiesExcludesSysAdmin -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Fix the stale comment in `unwind/ehmaps/openable.go`**
+
+Replace lines 15–16:
+
+```go
+// Requires CAP_CHECKPOINT_RESTORE to read /proc/<pid>/map_files (kernel 5.9+;
+// before that it needed CAP_SYS_ADMIN). perf-agent's standard cap set covers this.
+```
+
+- [ ] **Step 6: Update every documented `setcap` invocation**
+
+Remove `cap_sys_admin,` from each of these, leaving `cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep`:
+
+- `README.md:40`, `README.md:116`, `README.md:366`
+- `bench/README.md:28` (note this one orders them `cap_perfmon,cap_bpf,cap_sys_admin,...`)
+- `examples/README.md:15`
+- `examples/rust-pgo/README.md:12`
+- `examples/flamegraph/README.md:11`
+
+Verify none remain:
+
+```bash
+grep -rn "cap_sys_admin" --include="*.md" . | grep -v docs/superpowers
+```
+
+Expected: no output.
+
+- [ ] **Step 7: Run the unit suites**
+
+```bash
+go build ./... && go test ./perfagent/ ./unwind/... -count=1
+```
+
+Expected: builds clean. Pre-existing failures unrelated to capabilities may appear in packages that need root — note them, do not fix them here.
+
+- [ ] **Step 8: Verify on hardware — this is the phase gate**
+
+Build and grant the reduced set. Do **not** put the binary in `/tmp`: it is mounted `nosuid` and file capabilities do not survive exec there.
+
+```bash
+go build -o ./perf-agent .
+sudo setcap cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep ./perf-agent
+getcap ./perf-agent
+```
+
+Expected from `getcap`: `cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore=ep` with no `cap_sys_admin`.
+
+Then run both modes as a non-root user, with no `sudo`:
+
+```bash
+./perf-agent --pid $$ --profile --duration 5s
+./perf-agent -a --profile --duration 5s
+```
+
+Expected: both complete and write a `.pb.gz`. The system-wide run is the one that actually exercises `perf_event_open(pid=-1)` — the capability `CAP_SYS_ADMIN` was believed to be required for. If it fails with `EACCES` or `EPERM`, stop: check `cat /proc/sys/kernel/perf_event_paranoid` and report the value rather than restoring `CAP_SYS_ADMIN`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add perfagent/agent.go perfagent/agent_test.go unwind/ehmaps/openable.go \
+        README.md bench/README.md examples/README.md \
+        examples/rust-pgo/README.md examples/flamegraph/README.md
+git commit -m "feat(caps): drop redundant CAP_SYS_ADMIN
+
+CAP_PERFMON (kernel 5.8) covers perf_event_open including pid=-1 for
+system-wide profiling, and CAP_CHECKPOINT_RESTORE (kernel 5.9) was added
+specifically so /proc/<pid>/map_files could be read without CAP_SYS_ADMIN.
+The agent has been requesting a near-root capability it has not needed for
+years, and every documented setcap line propagated it.
+
+Extracts the set into requiredCapabilities() so it can be asserted in a test,
+and corrects the comment in unwind/ehmaps/openable.go, which still attributed
+map_files access to CAP_SYS_ADMIN while perfagent/agent.go already documented
+it correctly.
+
+Verified on kernel 6.19: a binary with only cap_bpf, cap_perfmon,
+cap_sys_ptrace and cap_checkpoint_restore completes both --pid and -a runs."
+```
+
+---
+
+## Phase gate
+
+Phase 1 is complete when:
+
+1. `go test ./pprof/ ./perfagent/ -count=1` passes.
+2. A setcap'd binary carrying no `cap_sys_admin` completes both a `--pid` and an `-a` profile run as a non-root user (Task 2, Step 8).
+3. `grep -rn "cap_sys_admin" --include="*.md" .` returns nothing outside `docs/superpowers/`.
+
+Both tasks are independent of each other and of the `gpu/` package. They are intended to land on `main` as two separate PRs, not as part of the GPU branch — nothing in them references GPU code.
+
+Once the gate passes, write the Phase 2 plan (the continuous core: bounded ring, correlation-ID index, sink backpressure, conformance suite, and the ported canonical model).

--- a/docs/superpowers/plans/2026-08-16-gpu-v2-phase1-enablers.md
+++ b/docs/superpowers/plans/2026-08-16-gpu-v2-phase1-enablers.md
@@ -289,166 +289,161 @@ the result is independent of map iteration order."
 
 ---
 
-### Task 2: Drop the redundant `CAP_SYS_ADMIN` requirement
+### Task 2: Document the capability set — why each cap, and when `CAP_SYS_ADMIN` stops being needed
 
-perf-agent requests `CAP_SYS_ADMIN` and every documented `setcap` line includes it. On kernel ≥ 5.9 it is redundant: `CAP_PERFMON` (5.8) covers `perf_event_open` including `pid=-1`, and `CAP_CHECKPOINT_RESTORE` (5.9) covers `/proc/<pid>/map_files`. `CAP_SYS_ADMIN` is near-root and is what gets a per-pod agent rejected, so removing it is a prerequisite for the §11 deployment model.
+**No behaviour change.** The requested capability set stays exactly as it is. What is wrong today is the *documentation*: `unwind/ehmaps/openable.go` attributes `/proc/<pid>/map_files` access to `CAP_SYS_ADMIN` while `perfagent/agent.go` already attributes it correctly to `CAP_CHECKPOINT_RESTORE`, and nothing anywhere explains what each capability is actually for.
 
-The capability set is currently an inline call inside `Start()`, which is untestable. This task extracts it first.
+The reason to document rather than drop is precise, and worth stating in the code so nobody has to rediscover it. The two capabilities that replace `CAP_SYS_ADMIN` did **not** arrive together:
+
+- `CAP_PERFMON` — kernel **5.8** — `perf_event_open`, including `pid=-1`
+- `CAP_CHECKPOINT_RESTORE` — kernel **5.9** — `/proc/<pid>/map_files`
+
+The project currently documents a floor of **kernel 5.8+** (`README.md:115`, `test/README.md:162`, `TESTING.md:230`). On exactly 5.8, `CAP_CHECKPOINT_RESTORE` does not exist, so dropping `CAP_SYS_ADMIN` would break symbolization there. A single kernel minor version is the entire obstacle.
+
+Current deployments target 6.x, where both capabilities are long available and `CAP_SYS_ADMIN` is unambiguously redundant. So the condition for dropping it is not "wait for kernels to catch up" — it is "raise the documented floor from 5.8 to 5.9+". This task records that, so the drop later is a deliberate decision against a stated condition rather than a rediscovery. Raising the floor is a project decision and is explicitly **not** part of this task.
+
+Do not edit the `setcap` lines in `README.md`, `bench/README.md`, or the `examples/` READMEs. They stay as-is because the code still requests the full set.
 
 **Files:**
-- Modify: `perfagent/agent.go` — capability comment block (line ~296) and `SetFlag` call (line ~302)
-- Modify: `unwind/ehmaps/openable.go:15` — stale comment
-- Modify: `README.md` (lines 40, 116, 366), `bench/README.md:28`, `examples/README.md:15`, `examples/rust-pgo/README.md:12`, `examples/flamegraph/README.md:11`
-- Test: `perfagent/agent_test.go`
+- Modify: `perfagent/agent.go` — the capability comment block above the `SetFlag` call (line ~296)
+- Modify: `unwind/ehmaps/openable.go:15-16` — the stale comment
+- Modify: `README.md` — add a subsection under the existing capability guidance
 
 **Interfaces:**
 - Consumes: nothing from Task 1.
-- Produces: `requiredCapabilities() []cap.Value` — package-private in `perfagent`, returns the capability set the agent raises to Effective.
+- Produces: nothing. Documentation only; no exported or package-private identifiers are added or changed.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Correct the stale comment in `unwind/ehmaps/openable.go`**
 
-Append to `perfagent/agent_test.go`:
-
-```go
-func TestRequiredCapabilitiesExcludesSysAdmin(t *testing.T) {
-	caps := requiredCapabilities()
-
-	assert.NotContains(t, caps, cap.SYS_ADMIN,
-		"CAP_SYS_ADMIN is redundant on kernel >= 5.9: CAP_PERFMON covers "+
-			"perf_event_open including pid=-1, CAP_CHECKPOINT_RESTORE covers "+
-			"/proc/<pid>/map_files")
-
-	assert.Contains(t, caps, cap.BPF)
-	assert.Contains(t, caps, cap.PERFMON)
-	assert.Contains(t, caps, cap.SYS_PTRACE)
-	assert.Contains(t, caps, cap.CHECKPOINT_RESTORE)
-}
-```
-
-Ensure `perfagent/agent_test.go` imports `kernel.org/pub/linux/libs/security/libcap/cap` and `github.com/stretchr/testify/assert`.
-
-- [ ] **Step 2: Run the test to verify it fails**
-
-```bash
-go test ./perfagent/ -run TestRequiredCapabilitiesExcludesSysAdmin -v
-```
-
-Expected: compile failure — `undefined: requiredCapabilities`.
-
-- [ ] **Step 3: Extract the capability set and drop `SYS_ADMIN`**
-
-In `perfagent/agent.go`, add above the function containing the `SetFlag` call:
+Replace lines 15–16, which currently read:
 
 ```go
-// requiredCapabilities is the capability set the agent raises to Effective.
-//
-//	CAP_BPF                - load eBPF programs and create maps
-//	CAP_PERFMON            - perf_event_open (including pid=-1 for system-wide),
-//	                         stack traces, tracing attachment. Since kernel 5.8
-//	                         this covers what CAP_SYS_ADMIN used to be needed for.
-//	CAP_SYS_PTRACE         - read /proc/<pid>/maps and /proc/<pid>/mem of other processes
-//	CAP_CHECKPOINT_RESTORE - follow /proc/<pid>/map_files/ symlinks for blazesym
-//	                         symbolization. Added in kernel 5.9 precisely so this
-//	                         does not require CAP_SYS_ADMIN.
-func requiredCapabilities() []cap.Value {
-	return []cap.Value{cap.BPF, cap.PERFMON, cap.SYS_PTRACE, cap.CHECKPOINT_RESTORE}
-}
+// Requires CAP_SYS_ADMIN to read /proc/<pid>/map_files. perf-agent's
+// standard cap set covers this.
 ```
 
-Replace the existing comment block and `SetFlag` call with:
+with:
 
 ```go
-	caps := cap.GetProc()
-	if err := caps.SetFlag(cap.Effective, true, requiredCapabilities()...); err != nil {
-		return fmt.Errorf("set capabilities: %w", err)
-	}
+// Reading /proc/<pid>/map_files required CAP_SYS_ADMIN before kernel 5.9, and
+// CAP_CHECKPOINT_RESTORE from 5.9 onward. perf-agent's standard cap set holds
+// both, so this works either way.
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [ ] **Step 2: Expand the capability comment block in `perfagent/agent.go`**
 
-```bash
-go test ./perfagent/ -run TestRequiredCapabilitiesExcludesSysAdmin -v
-```
-
-Expected: PASS.
-
-- [ ] **Step 5: Fix the stale comment in `unwind/ehmaps/openable.go`**
-
-Replace lines 15–16:
+Replace the existing comment block above the `caps.SetFlag(...)` call. Leave the `SetFlag` call itself untouched:
 
 ```go
-// Requires CAP_CHECKPOINT_RESTORE to read /proc/<pid>/map_files (kernel 5.9+;
-// before that it needed CAP_SYS_ADMIN). perf-agent's standard cap set covers this.
+	// Capabilities raised to Effective. The set is deliberately the historical
+	// superset so that pre-5.8 kernels keep working:
+	//
+	//   CAP_BPF                - load eBPF programs and create maps
+	//   CAP_PERFMON            - perf_event_open, stack traces, tracing attachment
+	//   CAP_SYS_PTRACE         - read /proc/<pid>/maps and /proc/<pid>/mem of other processes
+	//   CAP_CHECKPOINT_RESTORE - follow /proc/<pid>/map_files/ symlinks (blazesym symbolization)
+	//   CAP_SYS_ADMIN          - only needed on kernels older than 5.8/5.9; see below
+	//
+	// CAP_SYS_ADMIN is retained for backward compatibility, not because current
+	// kernels need it. Two capabilities were introduced to carve out its roles,
+	// but they did not arrive together:
+	//
+	//   - CAP_PERFMON (5.8) covers perf_event_open, including pid=-1 for
+	//     system-wide profiling.
+	//   - CAP_CHECKPOINT_RESTORE (5.9) covers /proc/<pid>/map_files.
+	//
+	// That one-version gap is the whole reason this is still here. The project
+	// documents a floor of kernel 5.8, and on exactly 5.8 CAP_CHECKPOINT_RESTORE
+	// does not exist, so dropping CAP_SYS_ADMIN would break symbolization there.
+	//
+	// On kernel >= 5.9 the minimal working set is:
+	//
+	//   cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep
+	//
+	// Dropping CAP_SYS_ADMIN matters for per-pod and sidecar deployments, where
+	// it is the near-root capability that gets a workload rejected. The condition
+	// is not "wait for newer kernels" - deployments already target 6.x. It is:
+	// raise the documented floor from 5.8 to 5.9+, then verify the minimal set
+	// for both --pid and -a runs (-a is the one that exercises
+	// perf_event_open(pid=-1)), then drop it here.
 ```
 
-- [ ] **Step 6: Update every documented `setcap` invocation**
-
-Remove `cap_sys_admin,` from each of these, leaving `cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep`:
-
-- `README.md:40`, `README.md:116`, `README.md:366`
-- `bench/README.md:28` (note this one orders them `cap_perfmon,cap_bpf,cap_sys_admin,...`)
-- `examples/README.md:15`
-- `examples/rust-pgo/README.md:12`
-- `examples/flamegraph/README.md:11`
-
-Verify none remain:
-
-```bash
-grep -rn "cap_sys_admin" --include="*.md" . | grep -v docs/superpowers
-```
-
-Expected: no output.
-
-- [ ] **Step 7: Run the unit suites**
+- [ ] **Step 3: Verify it still builds and the existing tests pass**
 
 ```bash
 go build ./... && go test ./perfagent/ ./unwind/... -count=1
 ```
 
-Expected: builds clean. Pre-existing failures unrelated to capabilities may appear in packages that need root — note them, do not fix them here.
+Expected: builds clean, and behaviour is identical because only comments changed. Packages requiring root may fail as they did before — note them, do not fix them here.
 
-- [ ] **Step 8: Verify on hardware — this is the phase gate**
+- [ ] **Step 4: Document the capability set in `README.md`**
 
-Build and grant the reduced set. Do **not** put the binary in `/tmp`: it is mounted `nosuid` and file capabilities do not survive exec there.
+Find the existing capability guidance near `README.md:116` (`- Root, OR \`setcap ...\``). Immediately after that line, add:
+
+```markdown
+<details>
+<summary>What each capability is for, and when <code>cap_sys_admin</code> can be dropped</summary>
+
+| Capability | Why it is needed |
+|---|---|
+| `cap_bpf` | Load eBPF programs and create maps |
+| `cap_perfmon` | `perf_event_open`, stack traces, tracing attachment |
+| `cap_sys_ptrace` | Read `/proc/<pid>/maps` and `/proc/<pid>/mem` of the target |
+| `cap_checkpoint_restore` | Follow `/proc/<pid>/map_files/` symlinks during symbolization |
+| `cap_sys_admin` | Only on kernels older than 5.8/5.9 — see below |
+
+`cap_sys_admin` is kept for backward compatibility. Two capabilities were added
+to the kernel to carve out the roles perf-agent used it for — but they did not
+arrive in the same release:
+
+- **`CAP_PERFMON` (kernel 5.8)** covers `perf_event_open`, including `pid=-1`
+  for system-wide profiling.
+- **`CAP_CHECKPOINT_RESTORE` (kernel 5.9)** covers `/proc/<pid>/map_files`.
+
+perf-agent's documented floor is kernel 5.8, and on exactly 5.8
+`cap_checkpoint_restore` does not exist — so dropping `cap_sys_admin` there would
+break symbolization. That single kernel minor version is why the full set is
+still the default.
+
+On **kernel 5.9 or newer** the minimal set is:
 
 ```bash
-go build -o ./perf-agent .
 sudo setcap cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep ./perf-agent
-getcap ./perf-agent
 ```
 
-Expected from `getcap`: `cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore=ep` with no `cap_sys_admin`.
+If you run 6.x — as most deployments now do — this is the set to use. It matters
+most for per-pod and sidecar deployments, where `cap_sys_admin` is the near-root
+capability that gets a workload rejected by admission policy.
 
-Then run both modes as a non-root user, with no `sudo`:
-
-```bash
-./perf-agent --pid $$ --profile --duration 5s
-./perf-agent -a --profile --duration 5s
+</details>
 ```
 
-Expected: both complete and write a `.pb.gz`. The system-wide run is the one that actually exercises `perf_event_open(pid=-1)` — the capability `CAP_SYS_ADMIN` was believed to be required for. If it fails with `EACCES` or `EPERM`, stop: check `cat /proc/sys/kernel/perf_event_paranoid` and report the value rather than restoring `CAP_SYS_ADMIN`.
-
-- [ ] **Step 9: Commit**
+- [ ] **Step 5: Confirm no `setcap` line was changed**
 
 ```bash
-git add perfagent/agent.go perfagent/agent_test.go unwind/ehmaps/openable.go \
-        README.md bench/README.md examples/README.md \
-        examples/rust-pgo/README.md examples/flamegraph/README.md
-git commit -m "feat(caps): drop redundant CAP_SYS_ADMIN
+grep -rn "cap_sys_admin" --include="*.md" . | grep -v docs/superpowers
+```
 
-CAP_PERFMON (kernel 5.8) covers perf_event_open including pid=-1 for
-system-wide profiling, and CAP_CHECKPOINT_RESTORE (kernel 5.9) was added
-specifically so /proc/<pid>/map_files could be read without CAP_SYS_ADMIN.
-The agent has been requesting a near-root capability it has not needed for
-years, and every documented setcap line propagated it.
+Expected: the pre-existing lines in `README.md` (3), `bench/README.md` (1), `examples/README.md` (1), `examples/rust-pgo/README.md` (1) and `examples/flamegraph/README.md` (1) are all still present and unmodified, plus the new occurrences inside the block added in Step 4. Nothing was removed.
 
-Extracts the set into requiredCapabilities() so it can be asserted in a test,
-and corrects the comment in unwind/ehmaps/openable.go, which still attributed
-map_files access to CAP_SYS_ADMIN while perfagent/agent.go already documented
-it correctly.
+- [ ] **Step 6: Commit**
 
-Verified on kernel 6.19: a binary with only cap_bpf, cap_perfmon,
-cap_sys_ptrace and cap_checkpoint_restore completes both --pid and -a runs."
+```bash
+git add perfagent/agent.go unwind/ehmaps/openable.go README.md
+git commit -m "docs(caps): explain the capability set and when CAP_SYS_ADMIN is redundant
+
+No behaviour change - the requested capability set is unchanged, because
+dropping CAP_SYS_ADMIN would break kernels older than 5.8/5.9.
+
+What was wrong was the documentation. unwind/ehmaps/openable.go attributed
+/proc/<pid>/map_files access to CAP_SYS_ADMIN while perfagent/agent.go already
+attributed it correctly to CAP_CHECKPOINT_RESTORE, and nothing explained what
+any of the capabilities were for.
+
+Records the two kernel versions that made CAP_SYS_ADMIN redundant - CAP_PERFMON
+in 5.8 for perf_event_open including pid=-1, CAP_CHECKPOINT_RESTORE in 5.9 for
+map_files - and the minimal set for kernel >= 5.9, so dropping it later is a
+deliberate decision against stated conditions."
 ```
 
 ---
@@ -458,9 +453,11 @@ cap_sys_ptrace and cap_checkpoint_restore completes both --pid and -a runs."
 Phase 1 is complete when:
 
 1. `go test ./pprof/ ./perfagent/ -count=1` passes.
-2. A setcap'd binary carrying no `cap_sys_admin` completes both a `--pid` and an `-a` profile run as a non-root user (Task 2, Step 8).
-3. `grep -rn "cap_sys_admin" --include="*.md" .` returns nothing outside `docs/superpowers/`.
+2. `go build ./...` succeeds.
+3. Task 2 changed no `setcap` invocation and no capability code — `git diff` for Task 2 touches comments and `README.md` only.
 
-Both tasks are independent of each other and of the `gpu/` package. They are intended to land on `main` as two separate PRs, not as part of the GPU branch — nothing in them references GPU code.
+The original spec gate for Task 2 (a setcap'd binary without `cap_sys_admin` completing `--pid` and `-a` runs) no longer applies, because the capability set is unchanged. That verification becomes the entry condition for a future task that actually drops `CAP_SYS_ADMIN`, once the minimum supported kernel is ≥ 5.9.
+
+Both tasks are independent of each other and of the `gpu/` package. Task 1 is a behaviour change and should land on `main` as its own PR; Task 2 is documentation and can land separately.
 
 Once the gate passes, write the Phase 2 plan (the continuous core: bounded ring, correlation-ID index, sink backpressure, conformance suite, and the ported canonical model).

--- a/docs/superpowers/plans/2026-08-17-gpu-v2-phase2-continuous-core.md
+++ b/docs/superpowers/plans/2026-08-17-gpu-v2-phase2-continuous-core.md
@@ -1,0 +1,1206 @@
+# GPU V2 Phase 2 — Continuous Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `gpu/` core so it survives a fast producer — bounded memory, indexed joins, accounted losses — before any vendor shim exists to stress it.
+
+**Architecture:** A clean-slate `gpu/` package on `gpu-v2`. The canonical event model and the join ladder are ported from PR #10 (branch `gpu-profiling-spec`, `54502dd9`) with revisions; the storage beneath them is new. PR #10's `Timeline` appends to five unbounded slices and joins them with linear scans at `Snapshot()` — invisible at fixture scale, fatal at CUPTI rates. This replaces that with a bounded FIFO cache with time-based eviction, a correlation-ID index, and a sink that can report loss.
+
+**Tech Stack:** Go 1.26, `github.com/google/pprof/profile` via the repo's `pprof` package, testify (`assert` + `require`). No eBPF, no CGO-dependent GPU code in this phase.
+
+**Spec:** `docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md` (§7 Canonical event model, §8 Output representation, §9 Overhead control, §10 Correlation and joins, §13 Testing, §14 Phase 2)
+
+## Global Constraints
+
+- Go 1.26.0+ (go.mod declares `go 1.26.0`; CI pins `1.26`).
+- CGO is required to build or test this repo. Export the block in "Build environment" before any `go` command.
+- Output format stays pprof. No new wire format, no OTLP emitter.
+- All `*_ns` fields in the normalized model are CPU-monotonic. Producers convert before emitting; the core never converts.
+- A heuristic join is never reported as exact. Heuristic and ambiguous joins are always marked.
+- No event is ever dropped silently. Every loss path increments a counter that reaches the snapshot.
+- Do not commit `CLAUDE.md`.
+- No `Co-Authored-By` lines in commit messages.
+- Use `git -c user.name="diego" -c user.email="diegolparra@gmail.com" commit`.
+
+## Build environment
+
+```bash
+export CGO_CFLAGS="-I /usr/include/bpf -I /usr/include/pcap -I /home/diego/github/blazesym/capi/include"
+export CGO_LDFLAGS="-L/home/diego/github/blazesym/target/release -lblazesym_c"
+export LD_LIBRARY_PATH=/home/diego/github/blazesym/target/release
+```
+
+Do not run `make test-unit` — it runs `go generate`, which needs `llvm-strip` (not installed). Run `go test` directly.
+
+## Prerequisite — read before Task 1
+
+**Task 5 cannot start until `ProfileSample.Labels` is available on this branch.** That field is Phase 1's Task 1, currently on the unmerged branch `feat/pprof-sample-labels` (commit `aca4df91`). `gpu-v2` was branched from `main` before it existed.
+
+Resolve it in one of two ways before reaching Task 5, and record which:
+
+- **Preferred:** `feat/pprof-sample-labels` merges to `main`, then rebase `gpu-v2` onto `main`.
+- **If that PR is still open:** merge `feat/pprof-sample-labels` into `gpu-v2` directly. Note this in the ledger so the eventual rebase is expected to be a no-op.
+
+Verify before starting Task 5:
+
+```bash
+grep -n "Labels map\[string\]string" pprof/pprof.go
+```
+
+Expected: the field exists on `ProfileSample`. If it does not, stop and resolve the prerequisite.
+
+Tasks 1–4 and 6 have no dependency on it.
+
+## Source material
+
+Port from worktree `/home/diego/github/perf-agent/.worktrees/gpu-profiling-spec` at `54502dd9`:
+
+- `gpu/types.go` — canonical model. Port with the §7 revisions in Task 1.
+- `gpu/timeline.go` — the join ladder (`findLaunchByCorrelation`, `findLaunchHeuristic`, `launchKernelNamesCompatible`, `findLaunchForEvent`, `isJoinCandidateEvent`, `samplesForExec`). Port the *decision logic* in Task 4; do **not** port its storage.
+
+Read those files. Do not copy the whole package.
+
+---
+
+### Task 1: Canonical event model
+
+Port the model, applying the §7 changes: split the fat `GPUSample`, add `GPUModule`, and give the sink error returns.
+
+**Files:**
+- Create: `gpu/types.go`
+- Test: `gpu/types_test.go`
+
+**Interfaces:**
+- Produces (later tasks depend on these exact names):
+  - `GPUBackendID string`; constants `BackendLinuxDRM`, `BackendHIP`, `BackendCUPTI`, `BackendReplay`
+  - `CorrelationID struct { Backend GPUBackendID; Value string }` — comparable, usable as a map key
+  - `ClockDomain uint8`; `ClockDomainCPUMonotonic`; `NormalizeClockDomain(ClockDomain) ClockDomain`; `ValidateSupportedClockDomain(ClockDomain) error`
+  - `LaunchContext struct { PID, TID uint32; TimeNs uint64; CPUStack []pp.Frame; Tags map[string]string }`
+  - `GPUKernelLaunch struct { Correlation CorrelationID; Queue GPUQueueRef; KernelName string; ClockDomain ClockDomain; TimeNs uint64; Launch LaunchContext }`
+  - `GPUKernelExec struct { Execution GPUExecutionRef; Correlation CorrelationID; Queue GPUQueueRef; KernelName string; ClockDomain ClockDomain; StartNs, EndNs uint64 }`
+  - `GPUPCSample struct { Correlation CorrelationID; Module ModuleRef; ClockDomain ClockDomain; TimeNs uint64; PCOffset uint64; StallReason string; Count uint64 }`
+  - `ModuleRef struct { Backend GPUBackendID; CRC uint64 }`
+  - `GPUModule struct { Ref ModuleRef; SizeBytes uint64; LoadedNs uint64 }`
+  - `GPUCapability uint8`; `CapabilityLaunchTrace`, `CapabilityExecTimeline`, `CapabilityPCSampling`
+  - `EventSink interface` — every method returns `error`
+  - `Backend interface { ID() GPUBackendID; Capabilities() []GPUCapability; Start(context.Context, EventSink) error; Stop(context.Context) error; Close() error }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `gpu/types_test.go`:
+
+```go
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCorrelationIDUsableAsMapKey(t *testing.T) {
+	m := map[CorrelationID]int{}
+	a := CorrelationID{Backend: BackendCUPTI, Value: "1234"}
+	b := CorrelationID{Backend: BackendCUPTI, Value: "1234"}
+	c := CorrelationID{Backend: BackendHIP, Value: "1234"}
+
+	m[a] = 1
+	m[c] = 2
+
+	assert.Equal(t, 1, m[b], "equal correlation IDs must hash to the same bucket")
+	assert.Len(t, m, 2, "same value under a different backend is a different key")
+}
+
+func TestNormalizeClockDomainDefaultsToCPUMonotonic(t *testing.T) {
+	assert.Equal(t, ClockDomainCPUMonotonic, NormalizeClockDomain(ClockDomain(0)))
+	assert.Equal(t, ClockDomainCPUMonotonic, NormalizeClockDomain(ClockDomainCPUMonotonic))
+}
+
+func TestValidateSupportedClockDomainRejectsDeviceClocks(t *testing.T) {
+	require.NoError(t, ValidateSupportedClockDomain(ClockDomainCPUMonotonic))
+	require.NoError(t, ValidateSupportedClockDomain(ClockDomain(0)),
+		"zero value normalizes to cpu-monotonic and must be accepted")
+	assert.Error(t, ValidateSupportedClockDomain(ClockDomainGPUDevice),
+		"producers must convert device clocks before emitting")
+	assert.Error(t, ValidateSupportedClockDomain(ClockDomainSynced))
+}
+
+func TestPCSamplesAreSeparateFromExecutions(t *testing.T) {
+	// GPUPCSample must not be reachable by widening GPUKernelExec: PC data is
+	// capability-gated and only CUPTI-class backends emit it.
+	s := GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "7"},
+		Module:      ModuleRef{Backend: BackendCUPTI, CRC: 0xdeadbeef},
+		PCOffset:    0x1a40,
+		StallReason: "long_scoreboard",
+		Count:       3,
+	}
+	assert.Equal(t, uint64(0x1a40), s.PCOffset)
+	assert.Equal(t, uint64(3), s.Count)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+go test ./gpu/ -count=1 -v
+```
+
+Expected: build failure — the `gpu` package does not exist.
+
+- [ ] **Step 3: Write `gpu/types.go`**
+
+Port from `.worktrees/gpu-profiling-spec/gpu/types.go`, keeping its `GPUBackendID`, `GPUDeviceRef`, `GPUQueueRef`, `GPUExecutionRef`, `CorrelationID`, `ClockDomain` (with its JSON marshalling, `NormalizeClockDomain`, `ValidateSupportedClockDomain`), `LaunchContext`, `GPUKernelLaunch`, `GPUKernelExec`, `GPUTimelineEvent`, `WorkloadAttribution`, `JoinStats`, and the capability model.
+
+Apply these changes:
+
+1. Backend constants: keep `BackendLinuxDRM`, `BackendHIP`, `BackendReplay`. Drop `BackendLinuxKFD`, `BackendAMDSample`, `BackendStream`, `BackendHostReplay` — those backends are not in V2. Add `BackendCUPTI GPUBackendID = "cupti"`.
+2. Strip PC/source fields from the sample type. `GPUSample` in PR #10 carries `PC`, `Function`, `File`, `Line`, `StallReason` for a model that never produced them. Delete `GPUSample` entirely and add:
+
+```go
+// ModuleRef identifies a GPU binary (a cubin for CUPTI) by content hash. It is
+// symbolization metadata, not an event: the bytes travel out of band and are
+// resolved centrally.
+type ModuleRef struct {
+	Backend GPUBackendID `json:"backend"`
+	CRC     uint64       `json:"crc"`
+}
+
+// GPUModule records that a GPU binary was loaded. Emitted on its own lifecycle,
+// replayed to consumers that attach late.
+type GPUModule struct {
+	Ref       ModuleRef `json:"ref"`
+	SizeBytes uint64    `json:"size_bytes"`
+	LoadedNs  uint64    `json:"loaded_ns"`
+}
+
+// GPUPCSample is one program-counter sample with its stall reason, attributed to
+// a kernel launch by correlation ID. Capability-gated: only backends advertising
+// CapabilityPCSampling emit these, so no backend pays for CUPTI's richness.
+//
+// PCOffset is an offset within Module, not an absolute address — it means
+// nothing without the module, which is why the two are separate types.
+type GPUPCSample struct {
+	Correlation CorrelationID `json:"correlation"`
+	Module      ModuleRef     `json:"module"`
+	ClockDomain ClockDomain   `json:"clock_domain,omitempty"`
+	TimeNs      uint64        `json:"time_ns"`
+	PCOffset    uint64        `json:"pc_offset"`
+	StallReason string        `json:"stall_reason,omitempty"`
+	Count       uint64        `json:"count"`
+}
+```
+
+3. Capabilities: keep `CapabilityLaunchTrace`, `CapabilityExecTimeline`, `CapabilityPCSampling`, `CapabilityLifecycleTimeline`, and their name maps. Drop `CapabilityDeviceCounters`, `CapabilityStallReasons`, `CapabilitySourceMap` — stall reasons now ride on `GPUPCSample`, and source mapping is Phase 6.
+4. `EventSink` methods all return `error`, so a producer can be told to stop:
+
+```go
+// EventSink receives normalized events from a backend. Every method returns an
+// error so a backend can be pushed back on: a sink at capacity returns
+// ErrSinkFull, and the backend is expected to drop and count rather than block.
+type EventSink interface {
+	EmitLaunch(GPUKernelLaunch) error
+	EmitExec(GPUKernelExec) error
+	EmitPCSample(GPUPCSample) error
+	EmitModule(GPUModule) error
+	EmitEvent(GPUTimelineEvent) error
+}
+```
+
+5. `Backend` drops `EventBackends()` — that existed to support the multiplexed stdin paths V2 removes.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+go test ./gpu/ -count=1 -v
+```
+
+Expected: PASS, 4/4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gpu/types.go gpu/types_test.go
+git commit -m "feat(gpu): canonical event model
+
+Ports the vendor-neutral model from the gpu-profiling-spec exploration with the
+revisions in spec section 7.
+
+GPUSample carried PC, function, file, line and stall reason for a model that
+never produced any of them. It is replaced by GPUPCSample, gated behind
+CapabilityPCSampling, plus GPUModule/ModuleRef for the binary a PC offset is
+meaningless without. Backends that cannot sample PCs no longer carry the fields,
+and CUPTI's richness is not truncated at the boundary.
+
+EventSink methods now return error so a backend can be pushed back on instead of
+a sink silently absorbing everything."
+```
+
+---
+
+### Task 2: Bounded launch cache
+
+The structure that decides how late a PC sample can arrive and still be attributable. PR #10 keeps every launch forever in a slice; this keeps a bounded, time-evicted FIFO with an index, and counts what it drops.
+
+**Files:**
+- Create: `gpu/launchcache.go`
+- Test: `gpu/launchcache_test.go`
+
+**Interfaces:**
+- Consumes: `CorrelationID`, `GPUKernelLaunch` (Task 1)
+- Produces:
+  - `LaunchCacheConfig struct { Capacity int; HorizonNs uint64 }`
+  - `NewLaunchCache(LaunchCacheConfig) *LaunchCache`
+  - `(*LaunchCache) Put(GPUKernelLaunch)`
+  - `(*LaunchCache) Get(CorrelationID) (GPUKernelLaunch, bool)`
+  - `(*LaunchCache) Len() int`
+  - `(*LaunchCache) Stats() LaunchCacheStats`
+  - `LaunchCacheStats struct { Live int; EvictedCapacity, EvictedHorizon, Replaced uint64 }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `gpu/launchcache_test.go`:
+
+```go
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func launch(value string, timeNs uint64) GPUKernelLaunch {
+	return GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: value},
+		KernelName:  "k_" + value,
+		TimeNs:      timeNs,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: timeNs},
+	}
+}
+
+func TestLaunchCacheGetsWhatItPut(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 4})
+	c.Put(launch("a", 10))
+
+	got, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "a"})
+	require.True(t, ok)
+	assert.Equal(t, "k_a", got.KernelName)
+}
+
+func TestLaunchCacheMissIsNotAnError(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 4})
+	_, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "nope"})
+	assert.False(t, ok, "a miss must be reported, not fabricated")
+}
+
+func TestLaunchCacheEvictsOldestOverCapacity(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 2})
+	c.Put(launch("a", 10))
+	c.Put(launch("b", 20))
+	c.Put(launch("c", 30))
+
+	_, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "a"})
+	assert.False(t, ok, "oldest entry must be evicted first")
+	_, ok = c.Get(CorrelationID{Backend: BackendCUPTI, Value: "c"})
+	assert.True(t, ok)
+
+	assert.Equal(t, uint64(1), c.Stats().EvictedCapacity)
+	assert.Equal(t, 2, c.Stats().Live)
+}
+
+func TestLaunchCacheEvictsBeyondHorizon(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 100, HorizonNs: 50})
+	c.Put(launch("old", 10))
+	c.Put(launch("new", 100)) // 100-10 = 90 > horizon 50
+
+	_, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "old"})
+	assert.False(t, ok, "entries older than the horizon must be evicted")
+	assert.Equal(t, uint64(1), c.Stats().EvictedHorizon)
+}
+
+func TestLaunchCacheMemoryIsBounded(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 16})
+	for i := 0; i < 100000; i++ {
+		c.Put(launch(string(rune('a'+i%26))+string(rune('a'+i/26%26))+string(rune(i)), uint64(i)))
+	}
+	assert.LessOrEqual(t, c.Len(), 16, "cache must stay bounded under sustained load")
+	assert.Greater(t, c.Stats().EvictedCapacity, uint64(0), "evictions must be counted, not silent")
+}
+
+func TestLaunchCacheReplacesDuplicateCorrelation(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 4})
+	c.Put(launch("a", 10))
+	c.Put(launch("a", 20))
+
+	got, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "a"})
+	require.True(t, ok)
+	assert.Equal(t, uint64(20), got.TimeNs, "a repeated correlation ID must take the newer launch")
+	assert.Equal(t, 1, c.Stats().Live, "a replacement must not grow the cache")
+	assert.Equal(t, uint64(1), c.Stats().Replaced)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+go test ./gpu/ -count=1 -run TestLaunchCache -v
+```
+
+Expected: build failure — `undefined: NewLaunchCache`.
+
+- [ ] **Step 3: Write `gpu/launchcache.go`**
+
+```go
+package gpu
+
+import "sync"
+
+// LaunchCacheConfig bounds the cache two ways. Capacity caps memory; HorizonNs
+// caps how far back an attribution can reach.
+//
+// HorizonNs is the load-bearing tunable for PC sampling: samples arrive
+// asynchronously, sometimes seconds after the launch that produced them, and a
+// launch evicted before its samples land makes those samples unattributable.
+// Too small silently loses attribution; too large costs memory. Zero disables
+// horizon eviction and leaves only the capacity bound.
+type LaunchCacheConfig struct {
+	Capacity  int
+	HorizonNs uint64
+}
+
+// LaunchCacheStats reports what the cache holds and what it dropped. Every
+// eviction path is counted: a cache that loses attributions silently is
+// indistinguishable from a correlation bug.
+type LaunchCacheStats struct {
+	Live            int    `json:"live"`
+	EvictedCapacity uint64 `json:"evicted_capacity,omitempty"`
+	EvictedHorizon  uint64 `json:"evicted_horizon,omitempty"`
+	Replaced        uint64 `json:"replaced,omitempty"`
+}
+
+const defaultLaunchCacheCapacity = 65536
+
+// LaunchCache is a bounded FIFO of recent launches indexed by correlation ID.
+// Put and Get are O(1) amortized. It replaces the unbounded slice plus linear
+// scan the earlier prototype used, which was quadratic at snapshot time.
+type LaunchCache struct {
+	mu       sync.Mutex
+	cfg      LaunchCacheConfig
+	byCorr   map[CorrelationID]GPUKernelLaunch
+	order    []CorrelationID // insertion order; entries before head are dead
+	head     int
+	newestNs uint64
+	stats    LaunchCacheStats
+}
+
+func NewLaunchCache(cfg LaunchCacheConfig) *LaunchCache {
+	if cfg.Capacity <= 0 {
+		cfg.Capacity = defaultLaunchCacheCapacity
+	}
+	return &LaunchCache{
+		cfg:    cfg,
+		byCorr: make(map[CorrelationID]GPUKernelLaunch, cfg.Capacity),
+		order:  make([]CorrelationID, 0, cfg.Capacity),
+	}
+}
+
+func (c *LaunchCache) Put(l GPUKernelLaunch) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if l.TimeNs > c.newestNs {
+		c.newestNs = l.TimeNs
+	}
+	if _, exists := c.byCorr[l.Correlation]; exists {
+		// Same correlation seen again: take the newer launch without growing
+		// the FIFO. The stale order entry is skipped when it reaches the head.
+		c.byCorr[l.Correlation] = l
+		c.stats.Replaced++
+		c.evictLocked()
+		return
+	}
+	c.byCorr[l.Correlation] = l
+	c.order = append(c.order, l.Correlation)
+	c.evictLocked()
+}
+
+func (c *LaunchCache) Get(id CorrelationID) (GPUKernelLaunch, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	l, ok := c.byCorr[id]
+	return l, ok
+}
+
+func (c *LaunchCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.byCorr)
+}
+
+func (c *LaunchCache) Stats() LaunchCacheStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := c.stats
+	s.Live = len(c.byCorr)
+	return s
+}
+
+// evictLocked drops entries past the horizon first, then past capacity. The
+// caller must hold c.mu.
+func (c *LaunchCache) evictLocked() {
+	if c.cfg.HorizonNs > 0 {
+		for c.head < len(c.order) {
+			id := c.order[c.head]
+			l, live := c.byCorr[id]
+			if !live {
+				c.head++ // stale order entry from a replacement
+				continue
+			}
+			if c.newestNs <= l.TimeNs || c.newestNs-l.TimeNs <= c.cfg.HorizonNs {
+				break
+			}
+			delete(c.byCorr, id)
+			c.head++
+			c.stats.EvictedHorizon++
+		}
+	}
+	for len(c.byCorr) > c.cfg.Capacity && c.head < len(c.order) {
+		id := c.order[c.head]
+		c.head++
+		if _, live := c.byCorr[id]; !live {
+			continue
+		}
+		delete(c.byCorr, id)
+		c.stats.EvictedCapacity++
+	}
+	c.compactLocked()
+}
+
+// compactLocked reclaims the dead prefix of order once it dominates the slice,
+// so a long-running agent does not grow order without bound.
+func (c *LaunchCache) compactLocked() {
+	if c.head < 1024 || c.head*2 < len(c.order) {
+		return
+	}
+	rest := c.order[c.head:]
+	c.order = append(c.order[:0], rest...)
+	c.head = 0
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+go test ./gpu/ -count=1 -run TestLaunchCache -v
+```
+
+Expected: PASS, 6/6.
+
+- [ ] **Step 5: Add the race check**
+
+```bash
+go test ./gpu/ -count=1 -race -run TestLaunchCache
+```
+
+Expected: PASS, no race reported. The cache is written by producer goroutines and read at snapshot time, so it must be safe without external locking.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gpu/launchcache.go gpu/launchcache_test.go
+git commit -m "feat(gpu): bounded launch cache with time-based eviction
+
+The structure that decides how late a PC sample can arrive and still be
+attributable. The earlier prototype kept every launch in an unbounded slice and
+searched it linearly for every execution and every event - invisible against
+fixtures, quadratic and unbounded at real rates.
+
+Bounded FIFO indexed by correlation ID: O(1) put and get, capacity and horizon
+eviction, and a counter on every drop path. A cache that loses attributions
+silently is indistinguishable from a correlation bug, so nothing is dropped
+without being counted."
+```
+
+---
+
+### Task 3: Accounting sink
+
+`EventSink` gained error returns in Task 1. This is the implementation that turns them into backpressure and a loss record.
+
+**Files:**
+- Create: `gpu/sink.go`
+- Test: `gpu/sink_test.go`
+
+**Interfaces:**
+- Consumes: `EventSink` and all event types (Task 1). Also the test helper
+  `launch(value string, timeNs uint64) GPUKernelLaunch` defined in Task 2's
+  `gpu/launchcache_test.go` — same package, so it is already in scope. Do not
+  redefine it; Task 2 must be complete first.
+- Produces:
+  - `ErrSinkFull` — sentinel error
+  - `SinkStats struct { Launches, Execs, PCSamples, Modules, Events uint64; DroppedFull, DroppedInvalid uint64 }`
+  - `NewCountingSink(inner EventSink, capacity int) *CountingSink`
+  - `(*CountingSink) Stats() SinkStats`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `gpu/sink_test.go`:
+
+```go
+package gpu
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingSink struct {
+	launches int
+	execs    int
+}
+
+func (r *recordingSink) EmitLaunch(GPUKernelLaunch) error   { r.launches++; return nil }
+func (r *recordingSink) EmitExec(GPUKernelExec) error       { r.execs++; return nil }
+func (r *recordingSink) EmitPCSample(GPUPCSample) error     { return nil }
+func (r *recordingSink) EmitModule(GPUModule) error         { return nil }
+func (r *recordingSink) EmitEvent(GPUTimelineEvent) error   { return nil }
+
+func TestCountingSinkForwardsAndCounts(t *testing.T) {
+	inner := &recordingSink{}
+	s := NewCountingSink(inner, 10)
+
+	require.NoError(t, s.EmitLaunch(launch("a", 10)))
+	require.NoError(t, s.EmitExec(GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+		StartNs:     20, EndNs: 30,
+	}))
+
+	assert.Equal(t, 1, inner.launches)
+	assert.Equal(t, 1, inner.execs)
+	assert.Equal(t, uint64(1), s.Stats().Launches)
+	assert.Equal(t, uint64(1), s.Stats().Execs)
+}
+
+func TestCountingSinkReturnsErrSinkFullAtCapacity(t *testing.T) {
+	s := NewCountingSink(&recordingSink{}, 2)
+
+	require.NoError(t, s.EmitLaunch(launch("a", 10)))
+	require.NoError(t, s.EmitLaunch(launch("b", 20)))
+	err := s.EmitLaunch(launch("c", 30))
+
+	require.Error(t, err, "a sink at capacity must push back, not absorb silently")
+	assert.True(t, errors.Is(err, ErrSinkFull))
+	assert.Equal(t, uint64(1), s.Stats().DroppedFull, "the drop must be counted")
+}
+
+func TestCountingSinkRejectsUnsupportedClockDomain(t *testing.T) {
+	s := NewCountingSink(&recordingSink{}, 10)
+
+	l := launch("a", 10)
+	l.ClockDomain = ClockDomainGPUDevice
+	err := s.EmitLaunch(l)
+
+	require.Error(t, err, "producers must convert device clocks before emitting")
+	assert.Equal(t, uint64(1), s.Stats().DroppedInvalid)
+	assert.Equal(t, uint64(0), s.Stats().Launches, "a rejected event is not counted as accepted")
+}
+
+func TestCountingSinkZeroCapacityIsUnbounded(t *testing.T) {
+	s := NewCountingSink(&recordingSink{}, 0)
+	for i := 0; i < 1000; i++ {
+		require.NoError(t, s.EmitLaunch(launch("x", uint64(i))))
+	}
+	assert.Equal(t, uint64(0), s.Stats().DroppedFull)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+go test ./gpu/ -count=1 -run TestCountingSink -v
+```
+
+Expected: build failure — `undefined: NewCountingSink`.
+
+- [ ] **Step 3: Write `gpu/sink.go`**
+
+```go
+package gpu
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// ErrSinkFull is returned when the sink has reached capacity. A backend
+// receiving it should drop the event and count it locally rather than block:
+// blocking a producer inside a profiled application is worse than losing a
+// sample, and the loss is visible in SinkStats either way.
+var ErrSinkFull = errors.New("gpu: sink full")
+
+// SinkStats is the ingestion-side loss record. JoinStats reports what could not
+// be correlated; this reports what never arrived.
+type SinkStats struct {
+	Launches  uint64 `json:"launches,omitempty"`
+	Execs     uint64 `json:"execs,omitempty"`
+	PCSamples uint64 `json:"pc_samples,omitempty"`
+	Modules   uint64 `json:"modules,omitempty"`
+	Events    uint64 `json:"events,omitempty"`
+
+	DroppedFull    uint64 `json:"dropped_full,omitempty"`
+	DroppedInvalid uint64 `json:"dropped_invalid,omitempty"`
+}
+
+// CountingSink wraps a sink with admission control and accounting. capacity is
+// the total accepted-event budget; zero means unbounded.
+type CountingSink struct {
+	mu       sync.Mutex
+	inner    EventSink
+	capacity int
+	accepted int
+	stats    SinkStats
+}
+
+func NewCountingSink(inner EventSink, capacity int) *CountingSink {
+	return &CountingSink{inner: inner, capacity: capacity}
+}
+
+func (s *CountingSink) Stats() SinkStats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stats
+}
+
+// admit applies the clock-domain contract and the capacity bound. It returns
+// nil when the event may proceed, and has already counted the drop otherwise.
+func (s *CountingSink) admit(domain ClockDomain) error {
+	if err := ValidateSupportedClockDomain(domain); err != nil {
+		s.stats.DroppedInvalid++
+		return fmt.Errorf("gpu: rejected event: %w", err)
+	}
+	if s.capacity > 0 && s.accepted >= s.capacity {
+		s.stats.DroppedFull++
+		return ErrSinkFull
+	}
+	s.accepted++
+	return nil
+}
+
+func (s *CountingSink) EmitLaunch(l GPUKernelLaunch) error {
+	s.mu.Lock()
+	if err := s.admit(l.ClockDomain); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.stats.Launches++
+	s.mu.Unlock()
+	return s.inner.EmitLaunch(l)
+}
+
+func (s *CountingSink) EmitExec(e GPUKernelExec) error {
+	s.mu.Lock()
+	if err := s.admit(e.ClockDomain); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.stats.Execs++
+	s.mu.Unlock()
+	return s.inner.EmitExec(e)
+}
+
+func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
+	s.mu.Lock()
+	if err := s.admit(p.ClockDomain); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.stats.PCSamples++
+	s.mu.Unlock()
+	return s.inner.EmitPCSample(p)
+}
+
+func (s *CountingSink) EmitModule(m GPUModule) error {
+	s.mu.Lock()
+	if s.capacity > 0 && s.accepted >= s.capacity {
+		s.stats.DroppedFull++
+		s.mu.Unlock()
+		return ErrSinkFull
+	}
+	s.accepted++
+	s.stats.Modules++
+	s.mu.Unlock()
+	return s.inner.EmitModule(m)
+}
+
+func (s *CountingSink) EmitEvent(e GPUTimelineEvent) error {
+	s.mu.Lock()
+	if err := s.admit(e.ClockDomain); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.stats.Events++
+	s.mu.Unlock()
+	return s.inner.EmitEvent(e)
+}
+```
+
+Note `EmitModule` deliberately skips the clock check: `GPUModule` carries a load timestamp but is symbolization metadata rather than a timeline event, and has no `ClockDomain` field.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+go test ./gpu/ -count=1 -run TestCountingSink -v
+```
+
+Expected: PASS, 4/4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gpu/sink.go gpu/sink_test.go
+git commit -m "feat(gpu): accounting sink with backpressure
+
+EventSink methods return error as of the model change; this is what makes that
+mean something. CountingSink applies the clock-domain contract at the boundary,
+enforces a capacity budget, and counts every rejection.
+
+A backend receiving ErrSinkFull drops and counts rather than blocking - blocking
+a producer inside a profiled application is worse than losing a sample, and
+either way the loss is visible. JoinStats reports what could not be correlated;
+SinkStats reports what never arrived."
+```
+
+---
+
+### Task 4: Indexed timeline and join ladder
+
+Port the join *decisions* from PR #10; replace the linear scans with `LaunchCache` lookups.
+
+**Files:**
+- Create: `gpu/timeline.go`
+- Test: `gpu/timeline_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 types, `LaunchCache` (Task 2), `SinkStats` (Task 3). Also the
+  test helper `launch(...)` from Task 2's `gpu/launchcache_test.go` — in scope
+  already, do not redefine. This task defines `execFor(...)`, which Task 5 reuses.
+- Produces:
+  - `TimelineConfig struct { LaunchCache LaunchCacheConfig; LaunchEventJoinWindowNs uint64 }`
+  - `NewTimeline(TimelineConfig) *Timeline` — implements `EventSink`
+  - `(*Timeline) Snapshot() Snapshot`
+  - `ExecutionView struct { Launch *GPUKernelLaunch; Exec GPUKernelExec; PCSamples []GPUPCSample; Join JoinKind; Heuristic, Ambiguous bool }`
+  - `JoinKind string`; `JoinExact`, `JoinHeuristic`
+  - `Snapshot struct { Executions []ExecutionView; Events []GPUTimelineEvent; Modules []GPUModule; JoinStats JoinStats; LaunchCache LaunchCacheStats }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `gpu/timeline_test.go`:
+
+```go
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func execFor(value string, startNs, endNs uint64) GPUKernelExec {
+	return GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: value},
+		KernelName:  "k_" + value,
+		StartNs:     startNs,
+		EndNs:       endNs,
+	}
+}
+
+func TestTimelineJoinsExactByCorrelationID(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.NotNil(t, snap.Executions[0].Launch)
+	assert.Equal(t, JoinExact, snap.Executions[0].Join)
+	assert.False(t, snap.Executions[0].Heuristic, "an exact join must never be marked heuristic")
+	assert.Equal(t, uint64(1), snap.JoinStats.ExactExecutionJoinCount)
+}
+
+func TestTimelineReportsUnmatchedExecution(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitExec(execFor("ghost", 20, 30)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Nil(t, snap.Executions[0].Launch, "an unmatched execution must not invent a launch")
+	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+}
+
+func TestTimelineAttachesPCSamplesByCorrelation(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+		PCOffset:    0x1a40, StallReason: "long_scoreboard", Count: 5, TimeNs: 25,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.Len(t, snap.Executions[0].PCSamples, 1)
+	assert.Equal(t, uint64(0x1a40), snap.Executions[0].PCSamples[0].PCOffset)
+}
+
+func TestTimelineDegradesWhenLaunchEvicted(t *testing.T) {
+	// A PC sample whose launch has aged out must become unattributed, never
+	// mis-attributed to a different launch.
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 1}})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitLaunch(launch("b", 20))) // evicts "a"
+	require.NoError(t, tl.EmitExec(execFor("a", 30, 40)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Nil(t, snap.Executions[0].Launch, "an evicted launch must not be replaced by another")
+	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+	assert.Equal(t, uint64(1), snap.LaunchCache.EvictedCapacity,
+		"the eviction that caused the miss must be visible in the snapshot")
+}
+
+func TestTimelineSnapshotIsBoundedUnderLoad(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 64}})
+	for i := 0; i < 50000; i++ {
+		require.NoError(t, tl.EmitLaunch(launch("x", uint64(i))))
+	}
+	assert.LessOrEqual(t, tl.Snapshot().LaunchCache.Live, 64)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+go test ./gpu/ -count=1 -run TestTimeline -v
+```
+
+Expected: build failure — `undefined: NewTimeline`.
+
+- [ ] **Step 3: Write `gpu/timeline.go`**
+
+Read `.worktrees/gpu-profiling-spec/gpu/timeline.go` first and port the decision logic — the exact-then-heuristic ordering, `JoinStats` accounting, and the `Heuristic`/`Ambiguous` marking. Do not port `findLaunchByCorrelation` (replaced by `LaunchCache.Get`), the unbounded slices, or `samplesForExec`'s linear scan.
+
+Structure:
+
+- `Timeline` holds a `*LaunchCache`, a bounded `[]GPUKernelExec`, a `map[CorrelationID][]GPUPCSample` of pending samples, a bounded `[]GPUTimelineEvent`, a `[]GPUModule`, a `SinkStats`-style eviction counter, and a `sync.Mutex`. Every `Emit*` takes the lock — Task 3's `CountingSink` is a separate concern and does not serialize this.
+- `EmitLaunch` → `cache.Put`.
+- `EmitExec` → append to the bounded exec slice, evicting oldest and counting when over capacity.
+- `EmitPCSample` → append into the pending-samples map keyed by correlation.
+- `EmitModule` → append.
+- `Snapshot` → for each exec: `cache.Get(exec.Correlation)`; hit is `JoinExact`; miss falls through to the ported heuristic (queue + kernel-name compatible + `launch.TimeNs <= exec.StartNs`) over the cache's live entries, marking `Heuristic` and `Ambiguous` when more than one candidate matched. Attach `pendingSamples[exec.Correlation]`. Fill `JoinStats` and `LaunchCache` stats.
+
+Requirements the tests pin:
+
+- an exact join must set `Join = JoinExact` and leave `Heuristic` false
+- a miss must leave `Launch` nil rather than attaching a different launch
+- eviction counts must reach `Snapshot().LaunchCache`
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+go test ./gpu/ -count=1 -run TestTimeline -v
+```
+
+Expected: PASS, 5/5.
+
+- [ ] **Step 5: Race check**
+
+```bash
+go test ./gpu/ -count=1 -race
+```
+
+Expected: PASS. Unlike the earlier prototype — which had no synchronization and was safe only by the accident that its emitters touched different slices — `Timeline` is explicitly guarded.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gpu/timeline.go gpu/timeline_test.go
+git commit -m "feat(gpu): indexed timeline with the ported join ladder
+
+Keeps the join decisions from the earlier prototype - exact correlation ID
+first, then a bounded queue/kernel-name heuristic, with heuristic and ambiguous
+joins always marked so a guess is never presented as vendor truth. Replaces the
+storage underneath: correlation lookups go through the bounded LaunchCache
+instead of scanning every launch for every execution and every event.
+
+A PC sample whose launch has aged out degrades to unattributed rather than
+attaching to a neighbouring launch, and the eviction that caused it is visible
+in the snapshot.
+
+Ingestion is mutex-guarded. The prototype had no synchronization at all and was
+safe only because its emitters happened to touch different slices."
+```
+
+---
+
+### Task 5: pprof projection — frames and labels
+
+**Blocked on the prerequisite above.** Verify `ProfileSample.Labels` exists before starting.
+
+**Files:**
+- Create: `gpu/projection.go`
+- Test: `gpu/projection_test.go`
+
+**Interfaces:**
+- Consumes: `Snapshot`, `ExecutionView` (Task 4); `pp.ProfileSample`, `pp.Frame`, `pp.FrameFromName`, `pp.FramesFromNames`, `pp.SampleTypeCpu`, `pp.SampleAggregated` from `github.com/dpsoft/perf-agent/pprof`; and `ProfileSample.Labels`, which is the prerequisite at the top of this plan. Also the test helpers `launch(...)` (Task 2) and `execFor(...)` (Task 4) — in scope already, do not redefine.
+- Produces: `ProjectExecutions(Snapshot) []pp.ProfileSample`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `gpu/projection_test.go`:
+
+```go
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pp "github.com/dpsoft/perf-agent/pprof"
+)
+
+func frameNames(frames []pp.Frame) []string {
+	out := make([]string, 0, len(frames))
+	for _, f := range frames {
+		out = append(out, f.Name)
+	}
+	return out
+}
+
+func TestProjectionPutsStackInFramesAndDetailInLabels(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	l := launch("a", 10)
+	l.Launch.CPUStack = pp.FramesFromNames([]string{"train_step", "cudaLaunchKernel"})
+	l.Launch.Tags = map[string]string{"pod_uid": "pod-a"}
+	require.NoError(t, tl.EmitLaunch(l))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+		PCOffset:    0x1a40, StallReason: "long_scoreboard", Count: 5, TimeNs: 25,
+	}))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+
+	assert.Equal(t,
+		[]string{"train_step", "cudaLaunchKernel", "[gpu:launch]", "[gpu:kernel:k_a]"},
+		frameNames(samples[0].Stack),
+		"frames carry the CPU stack, the boundary marker and the kernel - nothing else")
+
+	assert.Equal(t, "long_scoreboard", samples[0].Labels["gpu_stall"])
+	assert.Equal(t, "0x1a40", samples[0].Labels["gpu_pc"])
+	assert.Equal(t, "pod-a", samples[0].Labels["pod_uid"])
+}
+
+func TestProjectionKeepsPCOutOfStackIdentity(t *testing.T) {
+	// Two PC samples from one kernel must share a stack and differ only by
+	// label. Putting the PC in a frame would make every sampled instruction a
+	// distinct flame-graph leaf.
+	tl := NewTimeline(TimelineConfig{})
+	l := launch("a", 10)
+	l.Launch.CPUStack = pp.FramesFromNames([]string{"train_step"})
+	require.NoError(t, tl.EmitLaunch(l))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+	for _, pc := range []uint64{0x100, 0x200} {
+		require.NoError(t, tl.EmitPCSample(GPUPCSample{
+			Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+			PCOffset:    pc, StallReason: "barrier", Count: 1, TimeNs: 25,
+		}))
+	}
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 2)
+	assert.Equal(t, frameNames(samples[0].Stack), frameNames(samples[1].Stack),
+		"PC must not appear in frames")
+	assert.NotEqual(t, samples[0].Labels["gpu_pc"], samples[1].Labels["gpu_pc"])
+}
+
+func TestProjectionFallsBackToExecutionDuration(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 90)))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+	assert.Equal(t, uint64(70), samples[0].Value,
+		"with no PC samples the execution interval is the weight")
+}
+
+func TestProjectionHandlesUnmatchedExecution(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitExec(execFor("ghost", 20, 30)))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+	assert.Equal(t, []string{"[gpu:launch]", "[gpu:kernel:k_ghost]"}, frameNames(samples[0].Stack),
+		"an execution with no launch still projects, without a fabricated CPU stack")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+go test ./gpu/ -count=1 -run TestProjection -v
+```
+
+Expected: build failure — `undefined: ProjectExecutions`.
+
+- [ ] **Step 3: Write `gpu/projection.go`**
+
+Rules, from spec §8:
+
+- **Frames**, in order: the launch's `CPUStack` (omitted when there is no launch), then `[gpu:launch]`, then `[gpu:kernel:<name>]` when the kernel name is non-empty. Nothing else goes in frames.
+- **Labels**: `gpu_stall`, `gpu_pc` (formatted `%#x`), `gpu_queue`, `gpu_device`, `gpu_correlation`, plus every key from the launch's `Tags`.
+- One `pp.ProfileSample` per PC sample; when an execution has none, one sample weighted by `max(1, EndNs-StartNs)`.
+- PC-sample weight is `max(1, Count)`.
+- Set `Pid` from the launch's `LaunchContext.PID`, `SampleType: pp.SampleTypeCpu`, `Aggregation: pp.SampleAggregated`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+go test ./gpu/ -count=1 -run TestProjection -v
+```
+
+Expected: PASS, 4/4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gpu/projection.go gpu/projection_test.go
+git commit -m "feat(gpu): project executions into pprof frames and labels
+
+The earlier prototype encoded every piece of GPU context as a synthetic stack
+frame, including the PC. Frames are stack identity, so one flame-graph leaf per
+sampled instruction - which destroys aggregation exactly when PC sampling makes
+the profile interesting.
+
+Frames now carry only what should nest: the CPU stack, the [gpu:launch]
+boundary, and the kernel. Stall reason, PC, queue, device, correlation and the
+pod/container tags move to per-sample labels, so two samples from one kernel
+share a stack and differ only by label."
+```
+
+---
+
+### Task 6: Conformance suite and the phase gate
+
+Replaces PR #10's 53 checked-in goldens with invariants any producer must satisfy.
+
+**Files:**
+- Create: `gpu/conformance_test.go`
+- Test: itself
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `runConformance(t *testing.T, name string, drive func(EventSink) error)` — a helper later vendor backends call.
+
+- [ ] **Step 1: Write the suite**
+
+Create `gpu/conformance_test.go` with a table of producer scenarios (`drive` functions emitting into a sink) and, for each, assert:
+
+1. **Exact joins are never reported heuristic** — every `ExecutionView` with `Join == JoinExact` has `Heuristic == false`.
+2. **Heuristic joins are always marked** — `Join == JoinHeuristic` implies `Heuristic == true`.
+3. **No launch is fabricated** — every non-nil `view.Launch` has a `Correlation` that some emitted launch actually carried.
+4. **Timestamps are monotonic within the declared domain** — every emitted `*_ns` is non-decreasing per correlation, and every accepted event has `ClockDomainCPUMonotonic` after normalization.
+5. **Losses are accounted** — `SinkStats.DroppedFull + DroppedInvalid` plus `LaunchCacheStats.EvictedCapacity + EvictedHorizon` equals emitted minus retained.
+6. **Bounded memory** — after driving 100k events through a cache of capacity 64, `Snapshot().LaunchCache.Live <= 64`.
+
+Include at least three scenarios: an all-exact producer, a producer with deliberate correlation gaps, and a high-rate producer that overflows both the sink and the cache.
+
+- [ ] **Step 2: Run the suite**
+
+```bash
+go test ./gpu/ -count=1 -run TestConformance -v
+```
+
+Expected: PASS for every scenario.
+
+- [ ] **Step 3: Write the phase-gate benchmark**
+
+Add to `gpu/conformance_test.go`:
+
+```go
+func BenchmarkSnapshotAtScale(b *testing.B) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 65536}})
+	for i := 0; i < 1_000_000; i++ {
+		_ = tl.EmitLaunch(launch("x", uint64(i)))
+		if i%4 == 0 {
+			_ = tl.EmitExec(execFor("x", uint64(i), uint64(i+10)))
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tl.Snapshot()
+	}
+}
+```
+
+- [ ] **Step 4: Run the gate**
+
+```bash
+go test ./gpu/ -count=1 -run XXX -bench BenchmarkSnapshotAtScale -benchmem -benchtime 3x
+```
+
+Expected: snapshot completes in well under a second, and `B/op` reflects the bounded cache rather than a million retained launches. **Record the numbers in the report** — this is the Phase 2 gate and the evidence has to exist, not be asserted.
+
+- [ ] **Step 5: Full suite and race**
+
+```bash
+go test ./gpu/ -count=1 && go test ./gpu/ -count=1 -race && go build ./...
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gpu/conformance_test.go
+git commit -m "test(gpu): backend-agnostic conformance suite and scale gate
+
+Replaces the 53 checked-in replay goldens the earlier prototype relied on. Each
+golden encoded the JSON shape of the normalized model, so adding a field
+rewrote all of them and produced an unreviewable diff - pressure on the model to
+stop evolving, which is exactly what this work needs it to do. Two of them also
+failed host-dependently by resolving a cgroup ID against the real machine,
+capturing environment as contract.
+
+The suite asserts invariants instead: exact joins are never reported heuristic,
+no launch is fabricated, timestamps are monotonic in the declared domain, every
+loss is accounted, and memory stays bounded. Replay, HIP and CUPTI producers
+will all run the same suite.
+
+BenchmarkSnapshotAtScale is the phase gate: a million launches through a bounded
+cache must snapshot in well under a second with flat memory."
+```
+
+---
+
+## Phase gate
+
+Phase 2 is complete when:
+
+1. `go test ./gpu/ -count=1` passes and `go test ./gpu/ -count=1 -race` is clean.
+2. `BenchmarkSnapshotAtScale` snapshots 1M emitted launches in well under a second, with allocation reflecting the bounded cache. Numbers recorded, not asserted.
+3. The conformance suite passes for all three producer scenarios.
+4. `go build ./...` succeeds.
+
+Nothing in this phase touches eBPF, CGO-linked GPU code, or the CLI. The `gpu/` package is reachable only from tests until Phase 3 wires a consumer to it — deliberately, so the core is proven before a fast producer exists to stress it.

--- a/docs/superpowers/plans/2026-08-17-gpu-v2-phase2-continuous-core.md
+++ b/docs/superpowers/plans/2026-08-17-gpu-v2-phase2-continuous-core.md
@@ -266,6 +266,7 @@ Create `gpu/launchcache_test.go`:
 package gpu
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -324,7 +325,9 @@ func TestLaunchCacheEvictsBeyondHorizon(t *testing.T) {
 func TestLaunchCacheMemoryIsBounded(t *testing.T) {
 	c := NewLaunchCache(LaunchCacheConfig{Capacity: 16})
 	for i := 0; i < 100000; i++ {
-		c.Put(launch(string(rune('a'+i%26))+string(rune('a'+i/26%26))+string(rune(i)), uint64(i)))
+		// Unique correlation per launch: a repeated ID would exercise
+		// replacement rather than the capacity bound this test exists for.
+		c.Put(launch(strconv.Itoa(i), uint64(i)))
 	}
 	assert.LessOrEqual(t, c.Len(), 16, "cache must stay bounded under sustained load")
 	assert.Greater(t, c.Stats().EvictedCapacity, uint64(0), "evictions must be counted, not silent")
@@ -807,6 +810,7 @@ Create `gpu/timeline_test.go`:
 package gpu
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -879,9 +883,13 @@ func TestTimelineDegradesWhenLaunchEvicted(t *testing.T) {
 func TestTimelineSnapshotIsBoundedUnderLoad(t *testing.T) {
 	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 64}})
 	for i := 0; i < 50000; i++ {
-		require.NoError(t, tl.EmitLaunch(launch("x", uint64(i))))
+		// Unique correlation per launch. Reusing one ID would make every Put a
+		// replacement, leaving Live at 1 and passing this assertion vacuously.
+		require.NoError(t, tl.EmitLaunch(launch(strconv.Itoa(i), uint64(i))))
 	}
-	assert.LessOrEqual(t, tl.Snapshot().LaunchCache.Live, 64)
+	snap := tl.Snapshot()
+	assert.Equal(t, 64, snap.LaunchCache.Live, "cache must fill to capacity and hold there")
+	assert.Greater(t, snap.LaunchCache.EvictedCapacity, uint64(0), "evictions must be counted")
 }
 ```
 
@@ -1142,9 +1150,14 @@ Add to `gpu/conformance_test.go`:
 func BenchmarkSnapshotAtScale(b *testing.B) {
 	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 65536}})
 	for i := 0; i < 1_000_000; i++ {
-		_ = tl.EmitLaunch(launch("x", uint64(i)))
+		// Every launch gets its own correlation ID. Reusing one would mean the
+		// cache holds a single entry for the whole run, and this benchmark
+		// would report a fast snapshot precisely because the structure under
+		// test was empty - the phase gate would pass while measuring nothing.
+		id := strconv.Itoa(i)
+		_ = tl.EmitLaunch(launch(id, uint64(i)))
 		if i%4 == 0 {
-			_ = tl.EmitExec(execFor("x", uint64(i), uint64(i+10)))
+			_ = tl.EmitExec(execFor(id, uint64(i), uint64(i+10)))
 		}
 	}
 	b.ResetTimer()

--- a/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
+++ b/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
@@ -40,7 +40,7 @@ projection, the input paths, and the test strategy are not.
   losslessly with pprof, and Collector v0.148.0+ ships a pprof receiver, so the
   ecosystem on-ramp already exists without a format change. Revisit at beta.
 - **Not** a general off-box symbolization redesign. Off-box symbolization enters
-  in Phase 5 scoped to cubin disassembly, where it has a concrete driver.
+  in Phase 6 scoped to cubin disassembly, where it has a concrete driver.
 - **Not** a replacement for vendor tracing tools. Nsight and rocprof remain the
   right tools for one-shot deep analysis.
 - **Not** multi-vendor at launch. NVIDIA first; AMD converges onto the same ABI
@@ -112,6 +112,38 @@ ABI (the consumer reads a perf-agent-defined record, not a CUPTI one).
 | `gpu_stall_reason_map_v1` | one-shot stall index → name table |
 | `gpu_config_v1` | sampling factor, SM count, clock frequency |
 | `gpu_dropped_v1` | producer-side drop counts by class |
+
+### 6.1 Shared runtime, thin adapters
+
+Every vendor needs its own shim — CUPTI, rocprofiler-sdk and Level Zero are
+different APIs and nothing below the process boundary can paper over that. The
+cost is bounded by factoring aggressively:
+
+```
+shim/
+  core/     shared: USDT ABI, batching, token bucket, sequence numbers,
+            semaphore watch + late-attach replay, clock-fit scaffolding
+  nvidia/   CUPTI adapter            → libperfagent-gpu-nvidia.so
+  amd/      rocprofiler-sdk adapter  → libperfagent-gpu-amd.so
+```
+
+Only five things are genuinely per-vendor: the injection mechanism
+(`CUDA_INJECTION64_PATH` vs `LD_PRELOAD`/`HSA_TOOLS_LIB`), SDK registration,
+event-kind mapping onto our record types, which timestamp call feeds the clock
+fit, and the PC-sampling enable/disable API. Everything else lives in `core/`.
+
+This is the one place the design deliberately diverges from ParcaGPU rather than
+following it. Their probes are CUPTI-shaped (`cuda_correlation`, `cubin_loaded`),
+so a second vendor means a second ABI and a second consumer. Vendor-neutrality
+only pays for itself if `core/` is real; otherwise it is a tax with no benefit.
+
+**NVIDIA ships first.** The risk that carries is that the ABI ossifies
+CUPTI-shaped before a second consumer exists. The mitigation is a design-time
+cross-check, not implementation work: the rocprofiler bridge on the
+`gpu-profiling-spec` branch already shows what ROCm produces — its buffer-tracing
+kinds and its `CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER` callback map onto the
+same four record types — so the ABI is reviewed against that known taxonomy
+before it is frozen.
 
 Requirements:
 
@@ -250,16 +282,34 @@ Carried from PR #10 as **contracts, revised — not ported verbatim**:
   duplicates of each other, and `internal/k8slabels/cgroup_parse.go` predates both
   and handles cgroupfs and systemd driver conventions better.
 
+Carried as the **template for the vendor adapter**, not as shipping code:
+
+- `examples/rocprofiler_sdk_preload_bridge.cpp` (837 lines) is already the shim
+  architecture this design calls for. It registers via `rocprofiler_configure`,
+  uses buffer tracing for execution records, and hooks
+  `CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER` — the AMD analogue of cubin module
+  load. The only part that does not survive is its emit path: four
+  `write_line_locked` call sites that become USDT probe fires. It informs the ABI
+  review in §6.1 and becomes the second adapter in Phase 5.
+
 Dropped:
 
-- demo scripts (14 files), `cmd/amd-sample-collector` (1,584 lines), examples
-- the stdin input paths — `--gpu-stream-stdin`, `--gpu-amd-sample-stdin` — and
-  with them the `stream` and `amdsample` backends. This removes the only ROCm
-  execution-data path; AMD degrades to lifecycle plus HIP host launches until a
-  ROCm shim emits the ABI. Accepted deliberately.
+- demo scripts (14 files), `cmd/amd-sample-collector` (1,584 lines), examples.
+  The collector exists only because there was no in-process transport; the USDT
+  ABI removes its reason to exist.
 - the 53 checked-in replay goldens (§13)
 - the experimental CLI flag surface, collapsed to a source selector and an output
   selector
+
+Dropped on a delay:
+
+- the stdin input paths — `--gpu-stream-stdin`, `--gpu-amd-sample-stdin` — and the
+  `stream` and `amdsample` backends. These are the only ROCm execution-data path,
+  and with NVIDIA shipping first their removal would leave AMD degraded to
+  lifecycle plus HIP host launches for a full cycle. They are therefore kept alive
+  but **deprecated and undocumented** through Phases 3–4, and deleted in Phase 5
+  once the ROCm adapter replaces them. Deletion is cleanup, not a prerequisite, so
+  this costs nothing and removes the regression window entirely.
 
 `gpu/backend/replay` and `gpu/host/replay` are kept but demoted from CLI flags to
 test-only, to drive the conformance suite deterministically.
@@ -307,16 +357,26 @@ backpressure and drop counters, guarded ingestion. Port types and join ladder;
 rewrite storage and projection. Conformance suite replaces goldens.
 *Gate:* a synthetic high-rate replay holds flat memory and sub-second snapshot.
 
-**Phase 3 — USDT ABI and eBPF consumer.** Frozen ABI, consumer driven by a stub
-emitter.
-*Gate:* the stub drives the full pipeline to pprof on a machine with no GPU.
+**Phase 3 — USDT ABI, shared shim core, eBPF consumer.** The `core/` runtime of
+§6.1 and the consumer, driven by a stub emitter. Before the ABI is frozen it is
+reviewed against the rocprofiler bridge's known event taxonomy (§6.1), on paper.
+*Gate:* the stub drives the full pipeline to pprof on a machine with no GPU, and
+the ABI review has been done.
 
-**Phase 4 — CUPTI shim, callback and activity only.** Launch correlation anchor,
-activity records for real GPU intervals, clock correlation, token bucket.
+**Phase 4 — CUPTI adapter: callback and activity only. NVIDIA ships.** Launch
+correlation anchor, activity records for real GPU intervals, clock correlation,
+token bucket. This is the milestone the program exists for.
 *Gate:* on the RTX 3090, a CUDA workload yields exact-join kernels carrying real
 CPU stacks.
 
-**Phase 5 — PC sampling and cubin.** Adaptive windows, bounded launch cache for
+**Phase 5 — ROCm adapter.** Port the existing bridge's emit path onto the ABI.
+Small, because the bridge is written and validated. Its real function is to prove
+`core/` is not secretly CUPTI-shaped — a split with one consumer cannot be
+trusted. Deletes the deprecated stdin paths and the `stream`/`amdsample` backends.
+*Gate:* AMD produces exact-join kernel executions through the same consumer and
+the same canonical events as NVIDIA, with no NVIDIA-specific code in `core/`.
+
+**Phase 6 — PC sampling and cubin.** Adaptive windows, bounded launch cache for
 late batches, stall-reason and config replay on late attach, cubin capture by CRC,
 and cubin disassembly to address→source. Off-box symbolization enters here. Ships
 disabled by default.
@@ -342,7 +402,7 @@ Setup steps, none of them obstacles:
   production it is a **node prerequisite in the same class as installing the
   driver**, and it matters because the shim runs as the application's user, which
   in a container is usually not root.
-- Phase 5 source mapping requires workloads compiled with `nvcc -lineinfo`;
+- Phase 6 source mapping requires workloads compiled with `nvcc -lineinfo`;
   without it, degrade to PC-offset frames.
 
 ## 16. Risks
@@ -357,15 +417,24 @@ Setup steps, none of them obstacles:
 - **Late attach.** Cubin loads, stall maps and device config occur before the
   consumer attaches. Mitigated by semaphore-count detection and replay; incomplete
   replay produces unsymbolizable PC samples rather than wrong ones.
-- **AMD regression window.** Between dropping the stdin paths and shipping a ROCm
-  shim, AMD has no kernel-execution data. Accepted.
+- **The ABI ossifies CUPTI-shaped.** NVIDIA ships first and is the only consumer
+  until Phase 5, which is exactly how ParcaGPU's probe surface ended up
+  vendor-specific. Mitigated by the paper review in §6.1 against the rocprofiler
+  bridge's known taxonomy, and by Phase 5's gate being explicitly "no
+  NVIDIA-specific code in `core/`" rather than merely "AMD works". If Phase 5
+  requires ABI changes, that is the design working as intended, not a failure —
+  which is why the version suffixes exist.
 
 ## 17. Open questions
 
 1. Does a narrow CUPTI spike precede Phase 3, to inform the ABI before it freezes?
    The trade is ABI quality against the risk that a spike on unbounded buffers
-   hides the failure mode Phase 2 exists to fix.
-2. Does the ROCm shim adopt the ABI in this cycle, or does AMD stay degraded until
-   a later one?
-3. Sidecar or same-container as the shipping default. Sidecar plus shared volume
+   hides the failure mode Phase 2 exists to fix. Partly answered by §6.1: the
+   rocprofiler bridge already supplies a second real taxonomy to design against,
+   which is most of what a spike would have bought.
+2. Sidecar or same-container as the shipping default. Sidecar plus shared volume
    is the design target; same-container is simpler but couples lifecycles.
+3. Does `core/` ship as a static archive linked into each adapter, or as a shared
+   object the adapters load? Static is simpler to inject and avoids a second
+   `.so` in the application's address space; shared allows fixing transport bugs
+   without rebuilding every adapter.

--- a/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
+++ b/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
@@ -169,9 +169,27 @@ Requirements:
   USDT semaphore count to detect attachment.
 - Field names avoid CUDA vocabulary where a neutral term exists (`queue` not
   `stream`) so ROCm can emit the same ABI.
+- **Every launch and execution carries a correlation ID, without exception.** A
+  producer whose vendor API does not supply one must synthesise a unique value
+  per launch; emitting the zero value is not permitted.
 
-Authoring the probes requires `systemtap-sdt-devel` (`sys/sdt.h`), which is not
-currently installed on the lab box.
+  This last requirement was discovered by building Phase 2 rather than by
+  design, and it is the kind of constraint the phase existed to surface. The
+  core indexes launches by `CorrelationID`, so every correlation-less launch
+  collapses onto the single zero-value key: the cache retains one of them, the
+  rest are counted as replacements, and the heuristic join — which after Phase 2
+  serves correlation-less executions exclusively — sees at most one candidate.
+  A DRM/lifecycle backend emitting correlation-less events would therefore
+  attribute almost nothing, and `MatchedLaunchCount` would read 1 regardless of
+  volume.
+
+  A synthetic ID costs the producer a counter. Making the core key on something
+  else would cost it the O(1) exact-join path that Phase 2's gate depends on.
+
+Authoring the probes requires `systemtap-sdt-devel` (`sys/sdt.h`), or emitting
+`.note.stapsdt` notes via inline asm to avoid the build dependency entirely.
+Neither is installed on the lab box; the choice belongs in Phase 3 on its
+merits.
 
 ## 7. Canonical event model
 
@@ -447,5 +465,15 @@ Setup steps, none of them obstacles:
    hides the failure mode Phase 2 exists to fix. Partly answered by §6.1: the
    rocprofiler bridge already supplies a second real taxonomy to design against,
    which is most of what a spike would have bought.
+
+   **Phase 2 shifted this toward yes.** Twelve defects in that phase came from
+   specifying behaviour against a document rather than against something real,
+   and the ABI is the most expensive artifact in the program to get wrong —
+   version suffixes make it survivable, not free. The mitigation for the
+   original objection is that a spike's output should be *knowledge about CUPTI
+   record shapes*, with the code discarded; it does not need to run against the
+   Phase 2 core at all, so it cannot be misled by buffer behaviour.
+
+   Open, with a deadline: it must be settled before Phase 3 freezes the ABI.
 2. Sidecar or same-container as the shipping default. Sidecar plus shared volume
    is the design target; same-container is simpler but couples lifecycles.

--- a/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
+++ b/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
@@ -1,0 +1,370 @@
+# GPU Profiling V2 — Design Spec
+
+Status: draft for review
+Date: 2026-08-16
+Supersedes: the GPU design work on branch `gpu-profiling-spec` (PR #10), which becomes reference material
+
+## 1. Context
+
+perf-agent is an eBPF CPU/off-CPU/PMU profiler. It owns what we will call the
+**host semantic plane**: PID/TID, cgroup, pod and container identity, CPU stacks
+at a launch site, scheduling and submission timing.
+
+It has no **vendor semantic plane**. DRM/ioctl tracing can observe that a process
+submits work to a GPU driver, but it cannot recover a kernel name, a stream, a
+stall reason, or a source line. Those facts exist only inside vendor profiling
+APIs — CUPTI for NVIDIA, ROCProfiler for AMD.
+
+Neither plane substitutes for the other, and neither can be reconstructed from
+the other. V2 exists to add the vendor plane and join it to the host plane that
+already works.
+
+PR #10 explored this and produced a vendor-neutral event model, a join ladder,
+cgroup attribution, and a pprof projection — validated entirely against replay
+fixtures. The model and the join logic are worth keeping. The storage layer, the
+projection, the input paths, and the test strategy are not.
+
+## 2. Goals
+
+- Attribute GPU work to the CPU stack, process, container and pod that caused it.
+- Support NVIDIA via CUPTI as the first vendor backend, with a transport that AMD
+  can adopt unchanged.
+- Stay viable as an always-on profiler: bounded memory, bounded overhead,
+  accounted losses.
+- Emit standard pprof. No new wire format.
+
+## 3. Non-goals
+
+- **Not** an OTLP-profiles emitter. OTLP profiles entered public alpha in March
+  2026 and the Profiling SIG advises against relying on it. It round-trips
+  losslessly with pprof, and Collector v0.148.0+ ships a pprof receiver, so the
+  ecosystem on-ramp already exists without a format change. Revisit at beta.
+- **Not** a general off-box symbolization redesign. Off-box symbolization enters
+  in Phase 5 scoped to cubin disassembly, where it has a concrete driver.
+- **Not** a replacement for vendor tracing tools. Nsight and rocprof remain the
+  right tools for one-shot deep analysis.
+- **Not** multi-vendor at launch. NVIDIA first; AMD converges onto the same ABI
+  afterward.
+
+## 4. Invariants
+
+Three from the architecture discussion, held as constraints on every decision
+below:
+
+1. **The vendor SDK is the semantic source of truth.** Kernel identity, execution
+   intervals, correlation IDs, stall reasons and source mapping come from CUPTI.
+   We do not attempt to infer them from DRM or eBPF.
+2. **USDT is transport, never the canonical model.** The probe ABI is
+   perf-agent's, not CUPTI-shaped. Raw vendor structs never cross the boundary.
+3. **perf-agent owns correlation, host attribution and representation.** The shim
+   never unwinds a stack, never symbolizes, and never learns about pods.
+
+Three amendments established during review:
+
+4. **Batch every event class, not only PC samples.** A USDT probe with an eBPF
+   consumer attached traps into the kernel on every fire. ParcaGPU's default
+   token-bucket of 100 events/sec/thread exists because of probe cost, not data
+   volume. Rate-limiting launches would discard correlation anchors that later PC
+   sample batches need, so launches must be batched rather than dropped.
+5. **GPU detail belongs in sample labels, not stack frames.** See §8.
+6. **Clock correlation happens once in the shim, as a fit.** Not per-record.
+
+## 5. Architecture
+
+```
+CUDA application
+      │  CUDA_INJECTION64_PATH
+      ▼
+libperfagent-gpu.so
+      │  CUPTI callback + activity APIs
+      │  clock correlation, batching, token-bucket, cubin capture
+      │
+      │  vendor-neutral USDT ABI
+      ▼
+eBPF programs (uprobe/USDT attach)
+      │  kernel-side filter; task identity free at probe time
+      ▼
+ring buffer → canonical GPU events
+      │  bounded ring, correlation-ID index
+      ▼
+join with host plane  ── CPU stack, cgroup/pod/container (existing)
+      ▼
+pprof
+   frames: CPU stack → [gpu:launch] → kernel name
+   labels: stall, pc, queue, device, correlation, cgroup, pod, container
+```
+
+The shim is the only NVIDIA-aware component. Everything below the USDT boundary
+is vendor-neutral.
+
+## 6. The USDT ABI
+
+Versioned, batch-oriented, and stable across CUPTI releases. Large payloads are
+passed by pointer + length so that CUPTI struct layout changes do not break the
+ABI (the consumer reads a perf-agent-defined record, not a CUPTI one).
+
+| Probe | Carries |
+|---|---|
+| `gpu_launch_v1` | batch of launches: correlation ID, kernel name ref, queue/stream, context, host timestamp |
+| `gpu_exec_v1` | batch of executions: correlation ID, device, queue, start/end in CPU-monotonic |
+| `gpu_pc_sample_batch_v1` | batch of PC samples: correlation ID, module ref, PC offset, stall index, count |
+| `gpu_module_load_v1` | cubin identity (CRC), size, and bytes ref |
+| `gpu_stall_reason_map_v1` | one-shot stall index → name table |
+| `gpu_config_v1` | sampling factor, SM count, clock frequency |
+| `gpu_dropped_v1` | producer-side drop counts by class |
+
+Requirements:
+
+- Every batch record carries a monotonically increasing sequence number per
+  probe, so the consumer can detect gaps it did not observe.
+- `gpu_stall_reason_map_v1`, `gpu_config_v1` and outstanding `gpu_module_load_v1`
+  records must be **replayed when a consumer attaches late**. The shim tracks the
+  USDT semaphore count to detect attachment.
+- Field names avoid CUDA vocabulary where a neutral term exists (`queue` not
+  `stream`) so ROCm can emit the same ABI.
+
+Authoring the probes requires `systemtap-sdt-devel` (`sys/sdt.h`), which is not
+currently installed on the lab box.
+
+## 7. Canonical event model
+
+Carried from PR #10 `gpu/types.go`, with changes:
+
+- `Backend` / `EventSink` / capability advertisement: kept as-is. This contract is
+  the most valuable artifact of PR #10 and a CUPTI producer fits it unchanged.
+- `GPUSample` is **split**. A lean shared type stays; a new capability-gated
+  `GPUPCSample` carries PC offset, module identity, stall index and count. This
+  prevents CUPTI's richness from either taxing every backend or being truncated at
+  the boundary — the failure mode the architecture discussion identified as
+  "the canonical model becomes the limiting factor once you normalize."
+- `GPUModule` is added as symbolization metadata on its own lifecycle. It is not
+  an event in the profile.
+- `EventSink` methods gain an error return, so a producer can be told to slow
+  down and losses can be accounted. Today they return nothing.
+
+Clock domain: the existing `ClockDomain` type models cpu-monotonic, synced and
+gpu-device, but `ValidateSupportedClockDomain` rejects the latter two. That stays.
+Producers convert before emitting. The shim establishes the conversion by sampling
+`cuptiGetTimestamp` against `CLOCK_MONOTONIC` at start and periodically re-fitting
+for drift. It must not anchor each record's end to "now" — the approach currently
+prototyped in `examples/rocprofiler_sdk_preload_bridge.cpp` — which drifts under
+queueing.
+
+## 8. Output representation
+
+PR #10 encodes all GPU context as synthetic stack frames. Frames are stack
+identity, so `[gpu:pc:0x1a40]` as a frame produces one flame-graph leaf per
+sampled instruction. With PC sampling at ~100 samples/sec this destroys
+aggregation.
+
+The split:
+
+- **Frames** — what should nest in the flame graph: real CPU stack, then
+  `[gpu:launch]`, then the kernel name.
+- **Labels** — what must not fragment aggregation: stall reason, PC, queue,
+  device, correlation ID, cgroup, pod UID, container ID.
+
+This needs a small change in the existing pprof builder. `pprof/pprof.go` exposes
+`BuildersOptions.Labels`, which is builder-level and constant — every sample in a
+profile receives the same map. `ProfileSample`, which callers emit, has no
+`Labels` field. Adding one and merging it with the builder map where labels are
+applied is the whole change. `google/pprof`'s `Sample.Label` is already wired up.
+
+## 9. Overhead control
+
+- **Token-bucket rate limit** on callback-path probes, configurable, defaulting
+  conservatively.
+- **Batching** on every probe class (§4.4).
+- **Adaptive PC sampling**: enable in short windows (~50 ms), then disable, with
+  the gap tuned by a controller to hold a target samples/sec. Continuous PC
+  sampling in kernel-serialized mode is not production-viable.
+- **Drop accounting** end to end: producer drops via `gpu_dropped_v1`, ring-buffer
+  drops at the eBPF boundary, and eviction counts from the bounded ring. All
+  surfaced; none silent.
+
+## 10. Correlation and joins
+
+The join ladder from PR #10 `gpu/timeline.go` is kept: exact correlation ID first,
+then queue + kernel-name + bounded-time heuristic, with `Heuristic` and
+`Ambiguous` marked per view and rolled into `JoinStats`. A guessed join is never
+presented as a vendor-provided one. NVIDIA will mostly take the exact path, but
+PC sample batches arrive late and need the honesty machinery.
+
+The storage under it is rewritten:
+
+- Unbounded slices become a **bounded ring with time-based eviction**. The
+  eviction horizon is what determines how late a PC sample batch can arrive and
+  still be attributable, so it is a first-class tunable, not an implementation
+  detail.
+- Linear scans become a **correlation-ID index**. Today `Snapshot()` scans all
+  launches for every execution and every event, and all samples for every
+  execution — quadratic, and invisible at fixture scale.
+- Ingestion is single-owner or mutex-guarded. Today `Timeline` and `Manager` have
+  no synchronization and are safe only by the accident that emitters touch
+  different slices and `Snapshot()` runs after both `Stop()` calls join.
+
+## 11. Deployment
+
+perf-agent runs per-pod rather than as a DaemonSet, which changes the transport
+question materially. Parca does not solve the sidecar problem; it avoids it by
+running as a node DaemonSet with `hostPID` and `privileged`.
+
+Target model: **sidecar plus a shared volume.**
+
+- The shim ships on an `emptyDir` mounted into both the application container and
+  the perf-agent container at the same path. The app sets
+  `CUDA_INJECTION64_PATH` to it; the agent opens the identical file in its own
+  mount namespace. Same inode — which is what uprobe attachment actually keys on
+  — with no `/proc/<pid>/root` traversal and no overlay-inode instability.
+- PID visibility is still required, but for perf-agent's **existing** function,
+  not the GPU path: `unwind/procmap` reads `/proc/<pid>/maps`,
+  `/proc/<pid>/map_files/...` and `/proc/<pid>/comm` to unwind and symbolize.
+  `internal/nspid` already translates namespace-local PIDs to host PIDs, and
+  `internal/k8slabels` already derives identity from `/proc` and downward-API env
+  with no Kubernetes API, kubelet, or CRI socket.
+
+**Capability reduction is a prerequisite, not a nicety.** perf-agent currently
+requests `CAP_SYS_ADMIN` in `perfagent/agent.go` and every documented `setcap`
+line includes it. On any kernel ≥ 5.9 it is redundant:
+
+- `CAP_PERFMON` (5.8) covers `perf_event_open`, including `pid=-1` system-wide.
+- `CAP_CHECKPOINT_RESTORE` (5.9) covers `/proc/<pid>/map_files`, which is what
+  `perfagent/agent.go` already documents while `unwind/ehmaps/openable.go` still
+  attributes to `CAP_SYS_ADMIN`.
+
+`CAP_SYS_ADMIN` is near-root and is what gets a per-pod agent rejected. Dropping
+it is the difference between "needs a privileged pod" and "needs four narrow
+capabilities."
+
+## 12. What we carry, what we drop
+
+Carried from PR #10 as **contracts, revised — not ported verbatim**:
+
+- `gpu/types.go` — the backend/sink contract and capability model, with §7 changes
+- the join ladder logic from `gpu/timeline.go`
+- `gpu/backend/linuxdrm` and `linuxkfd` lifecycle observation, as a complement to
+  the vendor plane rather than a substitute
+- cgroup attribution, **folded into the existing `internal/k8slabels`** rather
+  than carried. There are currently three cgroup parsers in the tree:
+  `gpu/cgroupmeta/cgroupmeta.go` and `gpu/backend/linuxdrm/cgroup.go` are verbatim
+  duplicates of each other, and `internal/k8slabels/cgroup_parse.go` predates both
+  and handles cgroupfs and systemd driver conventions better.
+
+Dropped:
+
+- demo scripts (14 files), `cmd/amd-sample-collector` (1,584 lines), examples
+- the stdin input paths — `--gpu-stream-stdin`, `--gpu-amd-sample-stdin` — and
+  with them the `stream` and `amdsample` backends. This removes the only ROCm
+  execution-data path; AMD degrades to lifecycle plus HIP host launches until a
+  ROCm shim emits the ABI. Accepted deliberately.
+- the 53 checked-in replay goldens (§13)
+- the experimental CLI flag surface, collapsed to a source selector and an output
+  selector
+
+`gpu/backend/replay` and `gpu/host/replay` are kept but demoted from CLI flags to
+test-only, to drive the conformance suite deterministically.
+
+## 13. Testing
+
+Replace goldens with a **backend-agnostic conformance suite**. The 53 checked-in
+goldens each encode the current JSON shape of the normalized model; adding a field
+regenerates all of them and produces an unreviewable diff, which pressures the
+model to stop evolving — exactly what this work requires it to do. Two of them
+already fail host-dependently by resolving cgroup ID 1000 against the real host,
+which is proof they capture environment as contract.
+
+The suite asserts invariants that any producer must satisfy:
+
+- an exact join is never reported as heuristic, and heuristic joins are always
+  marked
+- emitted timestamps are monotonic within the declared clock domain
+- dropped events are counted at every stage, never silently lost
+- eviction from the bounded ring is accounted and bounded
+- a sample whose launch has been evicted degrades to unattributed rather than
+  mis-attributed
+
+Replay, HIP and CUPTI producers all run the same suite. Five existing test files
+read `gpu/testdata` and are rewritten as part of this work.
+
+## 14. Phasing
+
+Each phase has an exit gate. No phase begins before its predecessor's gate passes.
+
+This spec describes a program, not a single unit of work. **The first
+implementation plan covers Phases 1 and 2 only** — the enablers and the
+continuous core. Phases 3–5 are specified here to establish direction and to
+constrain Phase 2's interfaces, but each gets its own plan once its predecessor's
+gate has passed and its open questions (§17) are resolved.
+
+**Phase 1 — Enablers on `main`.** `ProfileSample.Labels`; drop `cap.SYS_ADMIN`
+from the capability set and fix the two stale comments and the documented `setcap`
+lines. Two small independent PRs.
+*Gate:* a setcap'd binary without `cap_sys_admin` completes both a `--pid` and an
+`-a` profile run.
+
+**Phase 2 — Core made continuous.** Bounded ring, correlation-ID index, sink
+backpressure and drop counters, guarded ingestion. Port types and join ladder;
+rewrite storage and projection. Conformance suite replaces goldens.
+*Gate:* a synthetic high-rate replay holds flat memory and sub-second snapshot.
+
+**Phase 3 — USDT ABI and eBPF consumer.** Frozen ABI, consumer driven by a stub
+emitter.
+*Gate:* the stub drives the full pipeline to pprof on a machine with no GPU.
+
+**Phase 4 — CUPTI shim, callback and activity only.** Launch correlation anchor,
+activity records for real GPU intervals, clock correlation, token bucket.
+*Gate:* on the RTX 3090, a CUDA workload yields exact-join kernels carrying real
+CPU stacks.
+
+**Phase 5 — PC sampling and cubin.** Adaptive windows, bounded launch cache for
+late batches, stall-reason and config replay on late attach, cubin capture by CRC,
+and cubin disassembly to address→source. Off-box symbolization enters here. Ships
+disabled by default.
+*Gate:* measured overhead on a real workload, not a microbenchmark; and a flame
+graph that reaches a CUDA source line from a CPU stack.
+
+## 15. Lab readiness
+
+Verified on the development host:
+
+- RTX 3090 (GA102, sm_86) — Ampere, so CUPTI PC sampling is supported (Volta+)
+- CUDA 13.3 with CUPTI including `cupti_pcsampling.h`, plus `nvcc` and `nsys`
+- the card is deliberately idle/unbound; `gpu-lab on|off|status` manages it
+
+Gaps:
+
+- `sys/sdt.h` is missing — `systemtap-sdt-devel` is required to author USDT probes
+  and therefore blocks Phase 3
+- NVIDIA gates GPU performance counters to admin users by default
+  (`NVreg_RestrictProfilingToAdminUsers`). Whether PC sampling is reachable
+  without a modprobe option and reboot is **unverified** and should be checked
+  before Phase 5 is scheduled.
+- Phase 5 requires workloads compiled with `nvcc -lineinfo` for source mapping;
+  without it, degrade to PC-offset frames.
+
+## 16. Risks
+
+- **ABI churn.** Freezing the USDT ABI in Phase 3 before CUPTI experience in
+  Phase 4 risks a bad shape. Mitigated by pointer-passed records and version
+  suffixes; a narrow throwaway spike against CUPTI before Phase 3 freezes the ABI
+  would reduce this further and is worth considering.
+- **Probe overhead at high launch rates.** Batching is the mitigation; if it is
+  insufficient, the fallback is sampling launches while preserving correlation
+  anchors for sampled kernels only.
+- **Late attach.** Cubin loads, stall maps and device config occur before the
+  consumer attaches. Mitigated by semaphore-count detection and replay; incomplete
+  replay produces unsymbolizable PC samples rather than wrong ones.
+- **AMD regression window.** Between dropping the stdin paths and shipping a ROCm
+  shim, AMD has no kernel-execution data. Accepted.
+- **NVIDIA profiling restriction** could block Phase 5 entirely on some hosts.
+  Unverified.
+
+## 17. Open questions
+
+1. Does a narrow CUPTI spike precede Phase 3, to inform the ABI before it freezes?
+   The trade is ABI quality against the risk that a spike on unbounded buffers
+   hides the failure mode Phase 2 exists to fix.
+2. Does the ROCm shim adopt the ABI in this cycle, or does AMD stay degraded until
+   a later one?
+3. Sidecar or same-container as the shipping default. Sidecar plus shared volume
+   is the design target; same-container is simpler but couples lifecycles.

--- a/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
+++ b/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
@@ -331,15 +331,18 @@ Verified on the development host:
 - CUDA 13.3 with CUPTI including `cupti_pcsampling.h`, plus `nvcc` and `nsys`
 - the card is deliberately idle/unbound; `gpu-lab on|off|status` manages it
 
-Gaps:
+Setup steps, none of them obstacles:
 
-- `sys/sdt.h` is missing — `systemtap-sdt-devel` is required to author USDT probes
-  and therefore blocks Phase 3
-- NVIDIA gates GPU performance counters to admin users by default
-  (`NVreg_RestrictProfilingToAdminUsers`). Whether PC sampling is reachable
-  without a modprobe option and reboot is **unverified** and should be checked
-  before Phase 5 is scheduled.
-- Phase 5 requires workloads compiled with `nvcc -lineinfo` for source mapping;
+- `sys/sdt.h` is not installed (`systemtap-sdt-devel`). Alternatively the shim can
+  emit `.note.stapsdt` notes via inline asm and carry no systemtap build
+  dependency at all — worth deciding in Phase 3 on its merits, not because of
+  what happens to be installed.
+- `NVreg_RestrictProfilingToAdminUsers=0` is needed for non-root access to the
+  CUPTI profiling APIs. On the lab box this is a modprobe option and a reboot. In
+  production it is a **node prerequisite in the same class as installing the
+  driver**, and it matters because the shim runs as the application's user, which
+  in a container is usually not root.
+- Phase 5 source mapping requires workloads compiled with `nvcc -lineinfo`;
   without it, degrade to PC-offset frames.
 
 ## 16. Risks
@@ -356,8 +359,6 @@ Gaps:
   replay produces unsymbolizable PC samples rather than wrong ones.
 - **AMD regression window.** Between dropping the stdin paths and shipping a ROCm
   shim, AMD has no kernel-execution data. Accepted.
-- **NVIDIA profiling restriction** could block Phase 5 entirely on some hosts.
-  Unverified.
 
 ## 17. Open questions
 

--- a/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
+++ b/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
@@ -188,8 +188,31 @@ Requirements:
 
 Authoring the probes requires `systemtap-sdt-devel` (`sys/sdt.h`), or emitting
 `.note.stapsdt` notes via inline asm to avoid the build dependency entirely.
-Neither is installed on the lab box; the choice belongs in Phase 3 on its
-merits.
+
+**Both routes are verified working on the lab box.** `systemtap-sdt-devel`
+(5.5-1.fc44) *is* installed — an earlier note in this spec claiming otherwise
+was wrong. A probe built with `DTRACE_PROBE1` compiles and `readelf -n` shows a
+valid `NT_STAPSDT` note carrying provider, name, location and argument
+descriptor. The inline-asm route compiles equally cleanly with no systemtap
+dependency and produces a note a consumer reads identically.
+
+Two findings that bear on Phase 3's choice between them:
+
+- The systemtap header emitted exactly one probe per call site. The hand-rolled
+  inline-asm version emitted the same probe **twice** — once inlined into the
+  caller and once standalone — because nothing stopped the compiler duplicating
+  the call site. A hand-rolled macro must account for inlining; the header
+  already does.
+- A plain `DTRACE_PROBE1` reports `Semaphore: 0x0`. §6's replay-on-late-attach
+  requirement depends on semaphore-count tracking to detect when a consumer
+  attaches, so the shim must use the semaphore-carrying variant
+  (`DTRACE_PROBE_ENABLED` guarding the fire) rather than the bare probe.
+  Getting this wrong is silent: the probe still works, and late attachment
+  simply never replays.
+
+On that evidence the systemtap header is the better default, and the inline-asm
+route stays a proven fallback rather than a hypothetical one — so the build
+dependency is not load-bearing.
 
 ## 7. Canonical event model
 

--- a/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
+++ b/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
@@ -132,6 +132,21 @@ Only five things are genuinely per-vendor: the injection mechanism
 event-kind mapping onto our record types, which timestamp call feeds the clock
 fit, and the PC-sampling enable/disable API. Everything else lives in `core/`.
 
+**`core/` is a static archive linked into each adapter, not a shared object.**
+Each vendor therefore ships as exactly one self-contained `.so`. This matters
+most for deployment: §11 puts the shim on an `emptyDir` mounted into both
+containers, and a shared `core` would have to be findable at runtime via RPATH or
+`LD_LIBRARY_PATH` inside the application's container — fragile, and secure-execution
+mode ignores `LD_LIBRARY_PATH` outright. One file to mount, nothing to resolve.
+It also removes any versioned interface between `core` and the adapters. The cost
+is that a transport fix requires rebuilding every adapter, which is acceptable at
+two of them.
+
+Because the result is injected into someone else's address space, `core/` must be
+built with hidden symbol visibility and the adapter must export only the entry
+points its vendor SDK requires. Leaking `core` symbols into the application's
+global namespace risks collisions with whatever else the process has loaded.
+
 This is the one place the design deliberately diverges from ParcaGPU rather than
 following it. Their probes are CUPTI-shaped (`cuda_correlation`, `cubin_loaded`),
 so a second vendor means a second ABI and a second consumer. Vendor-neutrality
@@ -434,7 +449,3 @@ Setup steps, none of them obstacles:
    which is most of what a spike would have bought.
 2. Sidecar or same-container as the shipping default. Sidecar plus shared volume
    is the design target; same-container is simpler but couples lifecycles.
-3. Does `core/` ship as a static archive linked into each adapter, or as a shared
-   object the adapters load? Static is simpler to inject and avoids a second
-   `.so` in the application's address space; shared allows fixing transport bugs
-   without rebuilding every adapter.

--- a/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
+++ b/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
@@ -238,6 +238,29 @@ On that evidence the systemtap header is the better default, and the inline-asm
 route stays a proven fallback rather than a hypothetical one — so the build
 dependency is not load-bearing.
 
+### 6.2 What the consumer side already gets, and what it must supply
+
+Checked against the `cilium/ebpf` version this repo already depends on (v0.21.0),
+so Phase 3 does not rediscover it:
+
+**Already provided.** `link.UprobeOptions.RefCtrOffset` exists and is passed to
+the kernel as `OffsetReferenceCount`, so the **kernel maintains the semaphore
+count** — the consumer does not write to the shim's memory, and attach/detach
+bookkeeping is not ours to get right. It is feature-gated on
+`/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset`, so a kernel
+without it degrades to an always-firing probe rather than failing; the shim's
+`if (semaphore)` guard simply always passes.
+
+**Not provided.** The module contains no `.note.stapsdt` parsing at all.
+Phase 3 must supply it: read the ELF note out of the shim `.so` to recover, per
+probe, the location offset and the semaphore address, then hand those to
+`Uprobe` as the offset and `RefCtrOffset`.
+
+That parser is worth building early. It is pure userspace ELF reading — no
+GPU, no CUPTI, no privileges, no dependence on the probe payloads — so it is
+the one piece of Phase 3 that can be written and fully tested before the ABI
+is frozen, and it is required no matter what shape the ABI takes.
+
 ## 7. Canonical event model
 
 Carried from PR #10 `gpu/types.go`, with changes:

--- a/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
+++ b/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
@@ -203,12 +203,36 @@ Two findings that bear on Phase 3's choice between them:
   caller and once standalone — because nothing stopped the compiler duplicating
   the call site. A hand-rolled macro must account for inlining; the header
   already does.
-- A plain `DTRACE_PROBE1` reports `Semaphore: 0x0`. §6's replay-on-late-attach
-  requirement depends on semaphore-count tracking to detect when a consumer
-  attaches, so the shim must use the semaphore-carrying variant
-  (`DTRACE_PROBE_ENABLED` guarding the fire) rather than the bare probe.
-  Getting this wrong is silent: the probe still works, and late attachment
-  simply never replays.
+- **Semaphores are not automatic, and the shim must supply them itself.** A
+  plain `DTRACE_PROBE1` reports `Semaphore: 0x0`. §6's replay-on-late-attach
+  requirement depends on the semaphore count to detect when a consumer attaches,
+  so the shim must:
+
+  ```c
+  #define _SDT_HAS_SEMAPHORES 1
+  #include <sys/sdt.h>
+
+  __extension__ unsigned short perfagent_gpu_launch_v1_semaphore
+      __attribute__((unused)) __attribute__((section(".probes")));
+
+  if (perfagent_gpu_launch_v1_semaphore) {   /* nobody listening: skip the work */
+      STAP_PROBE1(perfagent, gpu_launch_v1, ptr);
+  }
+  ```
+
+  Verified: the note then carries a real semaphore address rather than `0x0`,
+  and the variable reads 0 with nothing attached, so an unobserved shim does no
+  batching work at all.
+
+  The consumer does **not** need the symbol to be exported — it reads the
+  semaphore address out of the note and attaches with `ref_ctr_offset` pointing
+  at it, letting the kernel maintain the count. That is the same mechanism the
+  §11 sidecar deployment relies on, where the shim and agent share the file but
+  not a symbol table.
+
+  Getting this wrong is silent: the probe still fires, the shim still works, and
+  late attachment simply never replays — which surfaces much later as
+  unsymbolizable PC samples after an agent restart.
 
 On that evidence the systemtap header is the better default, and the inline-asm
 route stays a proven fallback rather than a hypothetical one — so the build

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -217,24 +217,32 @@ func assertConformanceInvariants(t *testing.T, h *conformanceHarness) Snapshot {
 	assertTimestampsMonotonic(t, snap)
 	assertBoundedMemory(t, snap, h.cacheCapacity)
 
-	// Invariant 5's literal formula - SinkStats.DroppedFull + DroppedInvalid
-	// plus LaunchCacheStats.EvictedCapacity + EvictedHorizon equals emitted
-	// minus retained - is only exact when the sink handled launches
-	// exclusively and no correlation ID was reused. SinkStats.DroppedFull/
-	// DroppedInvalid/DroppedDownstream are aggregate counters shared by all
-	// five event kinds, not per-type, so a scenario that also emits execs/
-	// pc-samples/modules/events would fold their drops into the same
-	// numbers and break the identity; a reused correlation ID adds a third
-	// loss category (LaunchCacheStats.Replaced) the literal formula doesn't
-	// mention at all. Both conditions are real gaps in what these
-	// components expose for a caller who wants exact reconciliation on a
-	// mixed workload - see the report. They are not a reason to weaken the
-	// assertion, only to scope it to the scenario where it is provably
-	// exact (overflow: launch-only, unique IDs).
-	if h.attempt.execAttempts == 0 && h.attempt.pcAttempts == 0 &&
-		h.attempt.moduleAttempts == 0 && h.attempt.eventAttempts == 0 {
-		assertLaunchLossesAccounted(t, snap, sinkStats, h.attempt.launchAttempts)
-	}
+	// Invariant 5's literal formula - SinkStats.Launches.DroppedFull +
+	// DroppedInvalid plus LaunchCacheStats.EvictedCapacity + EvictedHorizon
+	// equals emitted minus retained - used to be exact only when the sink
+	// handled launches exclusively, because DroppedFull/DroppedInvalid/
+	// DroppedDownstream were aggregate counters shared by all five event
+	// kinds: a scenario that also emitted execs/pc-samples/modules/events
+	// would fold their drops into the same numbers and break the identity.
+	// Review Important 2 broke SinkStats down per event kind
+	// (sinkStats.Launches is now exclusively about launches regardless of
+	// what else a scenario emits), which removes that restriction entirely -
+	// this now runs for every scenario in this file, not just the
+	// launch-only ones. The one restriction that survives is a reused
+	// correlation ID, which adds a third loss category
+	// (LaunchCacheStats.Replaced) the literal formula still doesn't mention;
+	// assertLaunchLossesAccounted itself requires Replaced == 0.
+	assertLaunchLossesAccounted(t, snap, sinkStats, h.attempt.launchAttempts)
+
+	// Extends invariant 5 to PC samples - review Important 2: the PC-sample
+	// path had no reconciliation at all (nothing counted attributed vs
+	// still-pending), so a sample could vanish between ingestion and the
+	// snapshot with nothing to notice. Holds for every scenario because
+	// Snapshot is only ever called once per harness here (see this
+	// function's own doc comment) - AttributedPCSamples/PendingSamples are
+	// this-call gauges, not cumulative, so a second Snapshot call would need
+	// its own reconciliation, not this one.
+	assertPCSampleLossesAccounted(t, snap, sinkStats, h.attempt.pcAttempts)
 
 	return snap
 }
@@ -338,20 +346,46 @@ func assertBoundedMemory(t *testing.T, snap Snapshot, capacity int) {
 
 // assertLaunchLossesAccounted is invariant 5, restricted (see
 // assertConformanceInvariants) to launch-only, non-reused-correlation-ID
-// scenarios, which is exactly where the brief's literal formula is exact.
+// scenarios, which is exactly where the brief's literal formula is exact -
+// and, since the scenario is launch-only, exactly where reading
+// sinkStats.Launches specifically (rather than some cross-kind aggregate;
+// SinkStats is now broken down per event kind - review Important 2) is
+// unambiguously correct.
 func assertLaunchLossesAccounted(t *testing.T, snap Snapshot, sinkStats SinkStats, launchAttempts uint64) {
 	t.Helper()
 	require.Equal(t, uint64(0), snap.LaunchCache.Replaced,
 		"this reconciliation assumes no correlation-ID reuse; a launch-only scenario that reuses IDs needs a different formula")
-	require.Equal(t, uint64(0), sinkStats.DroppedDownstream,
+	require.Equal(t, uint64(0), sinkStats.Launches.DroppedDownstream,
 		"the harness's inner sink is a Timeline, which never rejects a delivered event")
 
 	retained := uint64(snap.LaunchCache.Live)
 	require.GreaterOrEqual(t, launchAttempts, retained, "cannot have retained more launches than were attempted")
 	lost := launchAttempts - retained
-	accounted := sinkStats.DroppedFull + sinkStats.DroppedInvalid + snap.LaunchCache.EvictedCapacity + snap.LaunchCache.EvictedHorizon
+	accounted := sinkStats.Launches.DroppedFull + sinkStats.Launches.DroppedInvalid + snap.LaunchCache.EvictedCapacity + snap.LaunchCache.EvictedHorizon
 	assert.Equal(t, lost, accounted,
 		"every launch that isn't currently retained must be accounted for by a sink drop or a cache eviction")
+}
+
+// assertPCSampleLossesAccounted is invariant 5 extended to PC samples -
+// review Important 2. Every PC sample a producer attempted must land in
+// exactly one bucket: rejected by the sink (DroppedFull/DroppedInvalid/
+// DroppedDownstream, all per-kind since Important 2), attributed to an
+// execution in this snapshot, still pending a future one, or evicted from
+// the pending store (Timeline's own per-correlation cap, horizon or
+// cardinality bound - review Critical 5). Holds for every scenario, unlike
+// assertLaunchLossesAccounted: PC samples have no analogue of
+// LaunchCacheStats.Replaced complicating the count (a correlation's samples
+// simply accumulate in pending; there is no "replace" concept), and
+// PendingSamples/AttributedPCSamples are already scoped to a single
+// Snapshot call rather than needing a launch-only carve-out.
+func assertPCSampleLossesAccounted(t *testing.T, snap Snapshot, sinkStats SinkStats, pcAttempts uint64) {
+	t.Helper()
+	rejected := sinkStats.PCSamples.DroppedFull + sinkStats.PCSamples.DroppedInvalid + sinkStats.PCSamples.DroppedDownstream
+	accepted := sinkStats.PCSamples.Accepted
+	require.Equal(t, pcAttempts, accepted+rejected,
+		"every attempted PC sample must have been either accepted by the sink or rejected and counted")
+	assert.Equal(t, accepted, snap.AttributedPCSamples+uint64(snap.PendingSamples)+snap.Dropped.EvictedPendingSamples,
+		"every PC sample the sink accepted must be attributed, still pending, or evicted from the pending store - never unaccounted for")
 }
 
 // TestConformance runs the producer-scenario table against every invariant.
@@ -541,19 +575,25 @@ func driveMixedClockDomains(sink EventSink) error {
 // and valid zero-value (defaulted) ones. This test drives it through
 // runConformance - the same entry point a vendor backend uses - then adds
 // the two checks a generic invariant pass can't express: that the bad ones
-// were actually rejected (SinkStats.DroppedInvalid) and that none of them
-// leak into the snapshot under any correlation.
+// were actually rejected (SinkStats per-kind DroppedInvalid) and that none
+// of them leak into the snapshot under any correlation.
 //
 // Mutation this catches: CountingSink.admit's ValidateSupportedClockDomain
 // check being removed or weakened to accept a non-monotonic domain - the
 // "bad-*" correlations would then surface in the snapshot and the leak
-// assertion below would fail.
+// assertion below would fail. Checking Launches and Execs separately (not a
+// combined total) is itself a review Important 2 regression check: before
+// SinkStats was broken down per event kind, a bug that rejected every
+// launch but zero execs (or vice versa) could still sum to the same total
+// this test used to check.
 func TestConformanceRejectedClockDomainsNeverSurface(t *testing.T) {
 	h, snap := runConformance(t, "mixed-clock-domains", driveMixedClockDomains)
 	sinkStats := h.sink.Stats()
 
-	assert.Equal(t, uint64(2*2), sinkStats.DroppedInvalid,
-		"every unsupported-domain attempt (one launch, one exec, per bad domain) must be rejected and counted")
+	assert.Equal(t, uint64(2), sinkStats.Launches.DroppedInvalid,
+		"every unsupported-domain launch attempt (one per bad domain) must be rejected and counted")
+	assert.Equal(t, uint64(2), sinkStats.Execs.DroppedInvalid,
+		"every unsupported-domain exec attempt (one per bad domain) must be rejected and counted")
 
 	for _, view := range snap.Executions {
 		assert.NotContains(t, view.Exec.Correlation.Value, "bad-",
@@ -640,11 +680,11 @@ func TestConformanceLossAccountingCoversHorizonAndInvalidDomain(t *testing.T) {
 	sinkStats := h.sink.Stats()
 
 	require.Greater(t, snap.LaunchCache.EvictedHorizon, uint64(0), "the scenario must force a real horizon eviction")
-	require.Greater(t, sinkStats.DroppedInvalid, uint64(0), "the scenario must force a real clock-domain rejection")
+	require.Greater(t, sinkStats.Launches.DroppedInvalid, uint64(0), "the scenario must force a real clock-domain rejection")
 	require.Greater(t, snap.LaunchCache.EvictedCapacity, uint64(0), "the scenario must force a real capacity eviction too")
 
 	t.Logf("loss reconciliation: attempts=%d retained=%d droppedFull=%d droppedInvalid=%d evictedCapacity=%d evictedHorizon=%d replaced=%d",
-		h.attempt.launchAttempts, snap.LaunchCache.Live, sinkStats.DroppedFull, sinkStats.DroppedInvalid,
+		h.attempt.launchAttempts, snap.LaunchCache.Live, sinkStats.Launches.DroppedFull, sinkStats.Launches.DroppedInvalid,
 		snap.LaunchCache.EvictedCapacity, snap.LaunchCache.EvictedHorizon, snap.LaunchCache.Replaced)
 }
 
@@ -694,6 +734,93 @@ func TestConformanceEvictedLaunchDegradesToUnattributed(t *testing.T) {
 	assert.Nil(t, view.Launch,
 		"an execution whose launch was evicted must degrade to unattributed, never reattach to a different launch that merely shares its kernel name")
 	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+}
+
+// drivePCSampleMixedFate is the scenario that keeps
+// assertPCSampleLossesAccounted's PendingSamples/AttributedPCSamples/
+// EvictedPendingSamples terms honest. Every other PC-sample-emitting
+// scenario in this file (currently just all-exact) matches every sample to
+// an exec before the single Snapshot call, so PendingSamples and
+// Dropped.EvictedPendingSamples are structurally 0 wherever the
+// reconciliation actually runs - the same "dead term" trap invariant 5's
+// launch formula had before driveHorizonAndDomainLosses was added. This
+// scenario forces all three terms nonzero in one run: "attributed" (an
+// exec arrives for its samples), "pending" (samples with no exec at
+// Snapshot time), and "evicted" (two orphan correlations pushed out of
+// Timeline's pending store entirely by the cardinality bound - the
+// dedicated harness this scenario runs under sets the launch-cache
+// capacity, and therefore pendingCap, to 2).
+//
+// Ordering matters here: "evict-a"/"evict-b" are inserted first (oldest),
+// filling pendingCap exactly; "pending" then "attributed" each push a new
+// distinct correlation past that cap, evicting the two "evict-*"
+// correlations in FIFO order (oldest first) before either "pending" or
+// "attributed" is ever at risk. By the time Snapshot runs, "attributed" and
+// "pending" are the two live pending entries - Snapshot matches
+// "attributed" to its exec and leaves "pending" untouched.
+func drivePCSampleMixedFate(sink EventSink) error {
+	for _, id := range []string{"evict-a", "evict-b"} {
+		corr := CorrelationID{Backend: BackendCUPTI, Value: id}
+		if err := sink.EmitPCSample(GPUPCSample{Correlation: corr, TimeNs: 0}); err != nil {
+			return err
+		}
+	}
+
+	// Pending: samples with no exec at all, so they remain in Timeline's
+	// pending store when Snapshot runs. Inserted before "attributed" so
+	// eviction pressure below lands on the two "evict-*" correlations, not
+	// this one.
+	pendingCorr := CorrelationID{Backend: BackendCUPTI, Value: "pending"}
+	for i := 0; i < 3; i++ {
+		if err := sink.EmitPCSample(GPUPCSample{Correlation: pendingCorr, TimeNs: uint64(i)}); err != nil {
+			return err
+		}
+	}
+
+	// Attributed: a launch, its exec, and 2 samples that will be matched at
+	// Snapshot time.
+	if err := sink.EmitLaunch(launch("attributed", 1)); err != nil {
+		return err
+	}
+	if err := sink.EmitExec(execFor("attributed", 10, 20)); err != nil {
+		return err
+	}
+	attributedCorr := CorrelationID{Backend: BackendCUPTI, Value: "attributed"}
+	for i := 0; i < 2; i++ {
+		if err := sink.EmitPCSample(GPUPCSample{Correlation: attributedCorr, TimeNs: uint64(11 + i)}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestConformancePCSampleReconciliationCoversPendingAndEvicted drives
+// drivePCSampleMixedFate through a harness whose Timeline has a small
+// per-correlation sample cap, then - beyond the standard invariants
+// runConformanceWithHarness already checks, including
+// assertPCSampleLossesAccounted itself - asserts the three terms are
+// genuinely nonzero, the same way
+// TestConformanceLossAccountingCoversHorizonAndInvalidDomain does for the
+// launch formula's dead terms.
+//
+// Mutation this catches: deleting "+ uint64(snap.PendingSamples)" or
+// "+ snap.Dropped.EvictedPendingSamples" from assertPCSampleLossesAccounted's
+// sum - both now make the reconciliation check fail here, where deleting
+// either was invisible in every other scenario in this file.
+func TestConformancePCSampleReconciliationCoversPendingAndEvicted(t *testing.T) {
+	// LaunchCache capacity 2 -> pendingCap 2 (Timeline reuses the launch-
+	// cache capacity for pending's cardinality bound by default): exactly
+	// enough for "pending" and "attributed" to both survive, forcing
+	// "evict-a"/"evict-b" out entirely. See drivePCSampleMixedFate's doc
+	// comment for the exact ordering this depends on.
+	h := newConformanceHarnessWithConfig(LaunchCacheConfig{Capacity: 2}, conformanceSinkBurst)
+	snap := runConformanceWithHarness(t, "pc-sample-mixed-fate", h, drivePCSampleMixedFate)
+
+	assert.Equal(t, uint64(2), snap.AttributedPCSamples, "the attributed correlation's 2 samples must be attached to its exec")
+	assert.Equal(t, 3, snap.PendingSamples, "the pending correlation's 3 samples must remain, unmatched")
+	assert.Equal(t, 1, snap.PendingCorrelations)
+	assert.Equal(t, uint64(2), snap.Dropped.EvictedPendingSamples,
+		"evict-a and evict-b (1 sample each) must have been evicted from pending entirely by the cardinality bound")
 }
 
 // BenchmarkSnapshotAtScale is the Phase 2 gate: a million launches through a

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -834,7 +834,13 @@ func TestConformancePCSampleReconciliationCoversPendingAndEvicted(t *testing.T) 
 // exec (1 in 4, same as before) now also gets 3 PC samples under its own
 // correlation, which exercises both the per-correlation cap and the
 // proportional weight distribution's cost, not just the launch-cache path.
-func BenchmarkSnapshotAtScale(b *testing.B) {
+// newSnapshotScaleTimeline builds the fixture BenchmarkSnapshotAtScale
+// measures: 1M launches with unique correlation IDs (see the comment
+// inline), a quarter of them with a matched exec, each of those with 3 PC
+// samples. Factored out of the benchmark so it can be rebuilt once per
+// b.N iteration - see BenchmarkSnapshotAtScale's doc comment for why that
+// matters.
+func newSnapshotScaleTimeline() *Timeline {
 	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 65536}})
 	for i := 0; i < 1_000_000; i++ {
 		// Every launch gets its own correlation ID. Reusing one would mean the
@@ -851,8 +857,35 @@ func BenchmarkSnapshotAtScale(b *testing.B) {
 			}
 		}
 	}
-	b.ResetTimer()
+	return tl
+}
+
+// BenchmarkSnapshotAtScale is the Phase 2 exit gate: a million launches
+// through a bounded cache must snapshot in well under a second, with
+// allocation reflecting the bounded cache rather than a million retained
+// launches.
+//
+// The timeline is rebuilt inside the loop, with the timer stopped for the
+// rebuild, on every iteration - not built once outside the loop and
+// snapshotted b.N times. Review Critical 3 made Snapshot consume
+// executions/events/modules/matched-PC-samples, so a timeline built once
+// and snapshotted repeatedly is fully drained after iteration 1: every
+// iteration after the first would measure an empty structure. That is
+// exactly invisible under `-benchtime=1x` (the convention this project's
+// other GPU benchmarks rely on and what this benchmark itself used to be
+// measured with) since b.N is 1 there and the bug never gets a second
+// iteration to hide in - but it is exactly what `go test -bench .`
+// (b.N auto-tuned, almost always > 1, and what CI or a casual check
+// actually runs) would hit, reporting a few milliseconds and a few dozen
+// allocations for an empty timeline while believing it measured the real
+// one. A `b.Skip` on b.N > 1, or a doc comment demanding a flag, would
+// both still allow the benchmark to be run wrongly and lie; rebuilding the
+// fixture per iteration is correct unconditionally, at any -benchtime.
+func BenchmarkSnapshotAtScale(b *testing.B) {
 	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		tl := newSnapshotScaleTimeline()
+		b.StartTimer()
 		_ = tl.Snapshot()
 	}
 }

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -1,0 +1,477 @@
+package gpu
+
+// This suite replaces the earlier prototype's 53 checked-in replay goldens.
+// A golden pinned the exact JSON shape of the normalized model, so a single
+// added field regenerated all 53 and produced an unreviewable diff. Here we
+// instead assert invariants any producer's output must satisfy - replay, HIP
+// and CUPTI backends will all run the same table.
+//
+// Six invariants, each mapped to the scenario(s) below that can actually
+// violate it (not just pass vacuously):
+//
+//  1. Exact joins are never reported heuristic.
+//     Stressed by: all-exact (30 real JoinExact views) and correlation-gaps'
+//     exact group. Mutation caught: JoinExact path setting Heuristic=true, or
+//     the Join/Heuristic fields disagreeing.
+//  2. Heuristic joins are always marked.
+//     Stressed by: correlation-gaps' "gap-heur" group, which forces a real
+//     heuristic join (matching correlation deliberately absent; only kernel
+//     name + queue + causal timing can attach the launch). Mutation caught:
+//     findLaunchHeuristic's caller setting view.Launch without also setting
+//     Join/Heuristic (e.g. Heuristic=true dropped from the heuristic branch).
+//  3. No launch is fabricated.
+//     Stressed by: correlation-gaps' "gap-orphan" group (no launch was ever
+//     emitted for those execs) and the clock-domain test's rejected launches
+//     (never even reached the cache). Mutation caught: a miss path attaching
+//     a zero-value or otherwise invented *GPUKernelLaunch instead of leaving
+//     Launch nil.
+//  4. Timestamps are monotonic within the declared domain.
+//     Stressed two ways: all-exact emits two PC samples per execution with
+//     increasing TimeNs (catches a reordering bug in the pending-sample
+//     path), and TestConformanceRejectedClockDomainsNeverSurface emits
+//     genuinely unsupported domains (GPUDevice/Synced) alongside valid and
+//     zero-value ones (catches CountingSink's domain check being weakened or
+//     removed).
+//  5. Losses are accounted.
+//     Stressed by: overflow, the one scenario built so real drops
+//     (SinkStats.DroppedFull) and real evictions (LaunchCacheStats.
+//     EvictedCapacity) both happen in the same run, at very different
+//     magnitudes. See assertLaunchLossesAccounted's doc comment for why this
+//     check is scoped to launch-only, non-reused-ID scenarios rather than
+//     applied universally.
+//  6. Bounded memory.
+//     Stressed by: overflow (100k launches into a capacity-64 cache).
+//     Mutation caught: capacity eviction being skipped or the ring/cache
+//     silently growing.
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// conformanceCacheCapacity matches invariant 6's literal wording ("a
+	// cache of capacity 64") and is small enough that the overflow scenario's
+	// 100k launches genuinely evict almost everything.
+	conformanceCacheCapacity = 64
+
+	// conformanceSinkBurst is deliberately much larger than the low-volume
+	// correctness scenarios (a few dozen events each), so they never
+	// spuriously hit ErrSinkFull, and deliberately much smaller than the
+	// overflow scenario's 100k attempts, so that scenario still exhausts the
+	// token bucket for real. Sharing one harness constructor across every
+	// scenario means this number has to satisfy both jobs at once.
+	conformanceSinkBurst = 4096
+)
+
+// attemptSink wraps an EventSink and records ground truth about what a
+// producer actually attempted, independent of the wrapped sink's own
+// bookkeeping (SinkStats/LaunchCacheStats) - the whole point of this suite is
+// to check that bookkeeping, so "what was emitted" must not be derived from
+// the same counters under test.
+type attemptSink struct {
+	inner EventSink
+
+	launchAttempts uint64
+	// launchCarried holds the correlation ID of every launch the wrapped
+	// sink actually forwarded successfully (err == nil) - the only launches
+	// that could possibly reach a view's Launch pointer.
+	launchCarried  map[CorrelationID]struct{}
+	execAttempts   uint64
+	pcAttempts     uint64
+	moduleAttempts uint64
+	eventAttempts  uint64
+}
+
+func newAttemptSink(inner EventSink) *attemptSink {
+	return &attemptSink{inner: inner, launchCarried: make(map[CorrelationID]struct{})}
+}
+
+func (a *attemptSink) EmitLaunch(l GPUKernelLaunch) error {
+	a.launchAttempts++
+	err := a.inner.EmitLaunch(l)
+	if err == nil {
+		a.launchCarried[l.Correlation] = struct{}{}
+	}
+	return err
+}
+
+func (a *attemptSink) EmitExec(e GPUKernelExec) error {
+	a.execAttempts++
+	return a.inner.EmitExec(e)
+}
+
+func (a *attemptSink) EmitPCSample(p GPUPCSample) error {
+	a.pcAttempts++
+	return a.inner.EmitPCSample(p)
+}
+
+func (a *attemptSink) EmitModule(m GPUModule) error {
+	a.moduleAttempts++
+	return a.inner.EmitModule(m)
+}
+
+func (a *attemptSink) EmitEvent(e GPUTimelineEvent) error {
+	a.eventAttempts++
+	return a.inner.EmitEvent(e)
+}
+
+// conformanceHarness is a fresh Timeline + CountingSink pair, wired the way a
+// real backend is: producer -> CountingSink (admission control) ->
+// Timeline (join point). The clock is frozen (never advanced) so the token
+// bucket never refills mid-scenario: admission becomes a pure function of
+// attempt count instead of racing wall-clock time, which is what makes
+// invariant 5's reconciliation exact instead of flaky. reuses fakeClock from
+// sink_test.go.
+type conformanceHarness struct {
+	tl      *Timeline
+	sink    *CountingSink
+	attempt *attemptSink
+}
+
+func newConformanceHarness() *conformanceHarness {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: conformanceCacheCapacity}})
+	clock := newFakeClock(time.Unix(0, 0))
+	sink := NewCountingSinkWithRate(tl, conformanceSinkBurst, 0, clock.Now)
+	return &conformanceHarness{tl: tl, sink: sink, attempt: newAttemptSink(sink)}
+}
+
+// runConformance drives one producer scenario through a fresh harness and
+// checks every invariant a producer's output must satisfy. This is the
+// helper later vendor backends (replay, HIP, CUPTI) call with their own
+// drive functions.
+func runConformance(t *testing.T, name string, drive func(EventSink) error) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		h := newConformanceHarness()
+		require.NoError(t, drive(h.attempt))
+		assertConformanceInvariants(t, h)
+	})
+}
+
+// assertConformanceInvariants snapshots the harness exactly once (Snapshot
+// consumes matched PC samples - a second call would see none) and checks all
+// six invariants against that snapshot.
+func assertConformanceInvariants(t *testing.T, h *conformanceHarness) Snapshot {
+	t.Helper()
+	snap := h.tl.Snapshot()
+	sinkStats := h.sink.Stats()
+
+	assertNoFabricatedLaunch(t, snap, h.attempt.launchCarried)
+	assertExactNeverHeuristic(t, snap)
+	assertHeuristicAlwaysMarked(t, snap)
+	assertTimestampsMonotonic(t, snap)
+	assertBoundedMemory(t, snap)
+
+	// Invariant 5's literal formula - SinkStats.DroppedFull + DroppedInvalid
+	// plus LaunchCacheStats.EvictedCapacity + EvictedHorizon equals emitted
+	// minus retained - is only exact when the sink handled launches
+	// exclusively and no correlation ID was reused. SinkStats.DroppedFull/
+	// DroppedInvalid/DroppedDownstream are aggregate counters shared by all
+	// five event kinds, not per-type, so a scenario that also emits execs/
+	// pc-samples/modules/events would fold their drops into the same
+	// numbers and break the identity; a reused correlation ID adds a third
+	// loss category (LaunchCacheStats.Replaced) the literal formula doesn't
+	// mention at all. Both conditions are real gaps in what these
+	// components expose for a caller who wants exact reconciliation on a
+	// mixed workload - see the report. They are not a reason to weaken the
+	// assertion, only to scope it to the scenario where it is provably
+	// exact (overflow: launch-only, unique IDs).
+	if h.attempt.execAttempts == 0 && h.attempt.pcAttempts == 0 &&
+		h.attempt.moduleAttempts == 0 && h.attempt.eventAttempts == 0 {
+		assertLaunchLossesAccounted(t, snap, sinkStats, h.attempt.launchAttempts)
+	}
+
+	return snap
+}
+
+// assertNoFabricatedLaunch is invariant 3: every non-nil view.Launch must
+// carry a Correlation that some emitted launch actually carried, never a
+// zero-value or otherwise invented value.
+func assertNoFabricatedLaunch(t *testing.T, snap Snapshot, carried map[CorrelationID]struct{}) {
+	t.Helper()
+	for _, view := range snap.Executions {
+		if view.Launch == nil {
+			continue
+		}
+		_, ok := carried[view.Launch.Correlation]
+		assert.True(t, ok, "execution %+v was attached a launch (correlation %+v) that was never actually emitted",
+			view.Exec.Correlation, view.Launch.Correlation)
+	}
+}
+
+// assertExactNeverHeuristic is invariant 1.
+func assertExactNeverHeuristic(t *testing.T, snap Snapshot) {
+	t.Helper()
+	for _, view := range snap.Executions {
+		if view.Join == JoinExact {
+			assert.False(t, view.Heuristic, "an exact join (correlation %+v) must never be marked heuristic", view.Exec.Correlation)
+		}
+	}
+}
+
+// assertHeuristicAlwaysMarked is invariant 2.
+func assertHeuristicAlwaysMarked(t *testing.T, snap Snapshot) {
+	t.Helper()
+	for _, view := range snap.Executions {
+		if view.Join == JoinHeuristic {
+			assert.True(t, view.Heuristic, "a heuristic join (correlation %+v) must always be marked Heuristic", view.Exec.Correlation)
+		}
+	}
+}
+
+// assertTimestampsMonotonic is invariant 4, scoped exactly as the brief
+// states it: non-decreasing per correlation (not globally across unrelated
+// correlations, which real producers have no reason to keep ordered against
+// each other), plus every accepted event's ClockDomain normalizing to
+// ClockDomainCPUMonotonic.
+func assertTimestampsMonotonic(t *testing.T, snap Snapshot) {
+	t.Helper()
+	for _, view := range snap.Executions {
+		assert.LessOrEqual(t, view.Exec.StartNs, view.Exec.EndNs,
+			"execution %+v ends before it starts", view.Exec.Correlation)
+		assert.Equal(t, ClockDomainCPUMonotonic, NormalizeClockDomain(view.Exec.ClockDomain),
+			"an accepted exec must normalize to the CPU-monotonic domain")
+
+		if view.Launch != nil {
+			assert.LessOrEqual(t, view.Launch.TimeNs, view.Exec.StartNs,
+				"launch %+v is timestamped after the execution it was joined to", view.Launch.Correlation)
+			assert.Equal(t, ClockDomainCPUMonotonic, NormalizeClockDomain(view.Launch.ClockDomain),
+				"an accepted launch must normalize to the CPU-monotonic domain")
+		}
+
+		var lastPC uint64
+		for i, pcs := range view.PCSamples {
+			if i > 0 {
+				assert.LessOrEqual(t, lastPC, pcs.TimeNs,
+					"PC samples attached to execution %+v are out of order", view.Exec.Correlation)
+			}
+			lastPC = pcs.TimeNs
+			assert.Equal(t, ClockDomainCPUMonotonic, NormalizeClockDomain(pcs.ClockDomain),
+				"an accepted PC sample must normalize to the CPU-monotonic domain")
+		}
+	}
+}
+
+// assertBoundedMemory is invariant 6.
+func assertBoundedMemory(t *testing.T, snap Snapshot) {
+	t.Helper()
+	assert.LessOrEqual(t, snap.LaunchCache.Live, conformanceCacheCapacity,
+		"the launch cache must never hold more than its configured capacity")
+}
+
+// assertLaunchLossesAccounted is invariant 5, restricted (see
+// assertConformanceInvariants) to launch-only, non-reused-correlation-ID
+// scenarios, which is exactly where the brief's literal formula is exact.
+func assertLaunchLossesAccounted(t *testing.T, snap Snapshot, sinkStats SinkStats, launchAttempts uint64) {
+	t.Helper()
+	require.Equal(t, uint64(0), snap.LaunchCache.Replaced,
+		"this reconciliation assumes no correlation-ID reuse; a launch-only scenario that reuses IDs needs a different formula")
+	require.Equal(t, uint64(0), sinkStats.DroppedDownstream,
+		"the harness's inner sink is a Timeline, which never rejects a delivered event")
+
+	retained := uint64(snap.LaunchCache.Live)
+	require.GreaterOrEqual(t, launchAttempts, retained, "cannot have retained more launches than were attempted")
+	lost := launchAttempts - retained
+	accounted := sinkStats.DroppedFull + sinkStats.DroppedInvalid + snap.LaunchCache.EvictedCapacity + snap.LaunchCache.EvictedHorizon
+	assert.Equal(t, lost, accounted,
+		"every launch that isn't currently retained must be accounted for by a sink drop or a cache eviction")
+}
+
+// TestConformance runs the producer-scenario table against every invariant.
+func TestConformance(t *testing.T) {
+	scenarios := []struct {
+		name  string
+		drive func(EventSink) error
+	}{
+		{"all-exact", driveAllExact},
+		{"correlation-gaps", driveCorrelationGaps},
+		{"overflow", driveOverflow},
+	}
+	for _, sc := range scenarios {
+		runConformance(t, sc.name, sc.drive)
+	}
+}
+
+// driveAllExact is the happy-path scenario: every execution correlates
+// exactly to the launch that produced it, and each carries two PC samples
+// with increasing timestamps (stresses invariant 4's per-correlation
+// ordering on the PC-sample path, not just a single-sample no-op case).
+func driveAllExact(sink EventSink) error {
+	const n = 30
+	for i := 0; i < n; i++ {
+		id := "exact-" + strconv.Itoa(i)
+		base := uint64(i * 100)
+		if err := sink.EmitLaunch(launch(id, base+1)); err != nil {
+			return err
+		}
+		if err := sink.EmitExec(execFor(id, base+10, base+20)); err != nil {
+			return err
+		}
+		corr := CorrelationID{Backend: BackendCUPTI, Value: id}
+		if err := sink.EmitPCSample(GPUPCSample{Correlation: corr, TimeNs: base + 13, PCOffset: 0x10, Count: 1}); err != nil {
+			return err
+		}
+		if err := sink.EmitPCSample(GPUPCSample{Correlation: corr, TimeNs: base + 17, PCOffset: 0x20, Count: 2}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// driveCorrelationGaps deliberately breaks the exact-correlation path: some
+// executions must fall back to the heuristic join (same queue and kernel
+// name, launch precedes exec, but a different correlation ID), and some must
+// find no candidate at all.
+func driveCorrelationGaps(sink EventSink) error {
+	// Exact group: 5 launch/exec pairs sharing a correlation.
+	for i := 0; i < 5; i++ {
+		id := "gap-exact-" + strconv.Itoa(i)
+		base := uint64(i*100) + 1
+		if err := sink.EmitLaunch(launch(id, base)); err != nil {
+			return err
+		}
+		if err := sink.EmitExec(execFor(id, base+10, base+20)); err != nil {
+			return err
+		}
+	}
+
+	// Heuristic-recoverable group: launch and exec share a kernel name and
+	// queue but deliberately different correlation IDs, so the exact lookup
+	// misses and only the heuristic join (kernel name + queue + causal
+	// timing) can attach a launch.
+	for i := 0; i < 3; i++ {
+		l := launch("gap-heur-"+strconv.Itoa(i), uint64(i*100)+1) // KernelName -> "k_gap-heur-<i>"
+		if err := sink.EmitLaunch(l); err != nil {
+			return err
+		}
+		e := GPUKernelExec{
+			Correlation: CorrelationID{Backend: BackendCUPTI, Value: "gap-heur-exec-" + strconv.Itoa(i)},
+			KernelName:  l.KernelName,
+			Queue:       l.Queue,
+			StartNs:     uint64(i*100) + 10,
+			EndNs:       uint64(i*100) + 20,
+		}
+		if err := sink.EmitExec(e); err != nil {
+			return err
+		}
+	}
+
+	// Orphaned group: correlation and kernel name that never had any
+	// matching launch emitted at all.
+	for i := 0; i < 2; i++ {
+		e := execFor("gap-orphan-"+strconv.Itoa(i), uint64(9000+i*10), uint64(9000+i*10+5))
+		if err := sink.EmitExec(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// driveOverflow drives 100k launches with unique correlation IDs through a
+// capacity-64 cache behind a burst-4096 token bucket, deliberately
+// overflowing both by very different margins (~96k sink drops, ~4k cache
+// evictions - see conformanceSinkBurst's doc comment for why they differ).
+// Every ID is unique (strconv.Itoa(i)) for the same reason
+// BenchmarkSnapshotAtScale insists on it: a reused ID collapses the cache to
+// one entry and "overflow" becomes an illusion. Launch-only by design - see
+// assertConformanceInvariants for why mixing event types would break the
+// exactness of invariant 5's reconciliation.
+func driveOverflow(sink EventSink) error {
+	for i := 0; i < 100_000; i++ {
+		id := strconv.Itoa(i)
+		err := sink.EmitLaunch(launch(id, uint64(i)+1))
+		if err != nil && !errors.Is(err, ErrSinkFull) {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestConformanceRejectedClockDomainsNeverSurface targets invariant 4's
+// second clause directly: "every accepted event has ClockDomainCPUMonotonic
+// after normalization." The three table-driven scenarios above only ever
+// use the supported domain, so that clause holds for them vacuously -
+// nothing else was ever possible. This is the scenario that can actually
+// fail: launches and execs in the unsupported ClockDomainGPUDevice/
+// ClockDomainSynced domains, alongside valid explicit and valid zero-value
+// (defaulted) ones. It checks both that the bad ones are rejected
+// (SinkStats.DroppedInvalid) and that none of them leak into the snapshot
+// under any correlation.
+//
+// Mutation this catches: CountingSink.admit's ValidateSupportedClockDomain
+// check being removed or weakened to accept a non-monotonic domain - the
+// "bad-*" correlations would then surface in the snapshot and the leak
+// assertion below would fail.
+func TestConformanceRejectedClockDomainsNeverSurface(t *testing.T) {
+	h := newConformanceHarness()
+
+	for i := 0; i < 3; i++ { // valid, explicit domain
+		id := "good-" + strconv.Itoa(i)
+		l := launch(id, uint64(i*10)+1)
+		l.ClockDomain = ClockDomainCPUMonotonic
+		require.NoError(t, h.attempt.EmitLaunch(l))
+		e := execFor(id, uint64(i*10)+2, uint64(i*10)+3)
+		e.ClockDomain = ClockDomainCPUMonotonic
+		require.NoError(t, h.attempt.EmitExec(e))
+	}
+	for i := 0; i < 3; i++ { // zero-value domain must default, not reject
+		id := "zero-" + strconv.Itoa(i)
+		require.NoError(t, h.attempt.EmitLaunch(launch(id, uint64(1000+i))))
+		require.NoError(t, h.attempt.EmitExec(execFor(id, uint64(2000+i), uint64(2000+i+1))))
+	}
+
+	badDomains := []ClockDomain{ClockDomainGPUDevice, ClockDomainSynced}
+	for i, dom := range badDomains {
+		id := "bad-" + strconv.Itoa(i)
+		l := launch(id, uint64(5000+i))
+		l.ClockDomain = dom
+		require.Error(t, h.attempt.EmitLaunch(l), "an unsupported clock domain must be rejected, not silently accepted")
+
+		e := execFor(id, uint64(6000+i), uint64(6000+i+1))
+		e.ClockDomain = dom
+		require.Error(t, h.attempt.EmitExec(e))
+	}
+
+	snap := assertConformanceInvariants(t, h)
+	sinkStats := h.sink.Stats()
+
+	assert.Equal(t, uint64(len(badDomains)*2), sinkStats.DroppedInvalid,
+		"every unsupported-domain attempt (one launch, one exec, per bad domain) must be rejected and counted")
+
+	for _, view := range snap.Executions {
+		assert.NotContains(t, view.Exec.Correlation.Value, "bad-",
+			"an execution rejected for an unsupported clock domain must never appear in the snapshot")
+		if view.Launch != nil {
+			assert.NotContains(t, view.Launch.Correlation.Value, "bad-",
+				"a launch rejected for an unsupported clock domain must never surface via a join")
+		}
+	}
+}
+
+// BenchmarkSnapshotAtScale is the Phase 2 gate: a million launches through a
+// bounded cache must snapshot in well under a second, with allocation
+// reflecting the bounded cache rather than a million retained launches.
+func BenchmarkSnapshotAtScale(b *testing.B) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 65536}})
+	for i := 0; i < 1_000_000; i++ {
+		// Every launch gets its own correlation ID. Reusing one would mean the
+		// cache holds a single entry for the whole run, and this benchmark
+		// would report a fast snapshot precisely because the structure under
+		// test was empty - the phase gate would pass while measuring nothing.
+		id := strconv.Itoa(i)
+		_ = tl.EmitLaunch(launch(id, uint64(i)))
+		if i%4 == 0 {
+			_ = tl.EmitExec(execFor(id, uint64(i), uint64(i+10)))
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tl.Snapshot()
+	}
+}

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -13,12 +13,21 @@ package gpu
 //     Stressed by: all-exact (30 real JoinExact views) and correlation-gaps'
 //     exact group. Mutation caught: JoinExact path setting Heuristic=true, or
 //     the Join/Heuristic fields disagreeing.
-//  2. Heuristic joins are always marked.
+//  2. Heuristic joins are always marked, and only ever attach to an exec
+//     that never supplied a correlation ID at all (review Critical 2: an
+//     exec whose correlation missed the cache has told us its launch aged
+//     out, not that no correlation was ever available, and guessing there
+//     risks mis-attributing to a different, still-live launch - spec §13
+//     requires degrading to unattributed instead).
 //     Stressed by: correlation-gaps' "gap-heur" group, which forces a real
 //     heuristic join (matching correlation deliberately absent; only kernel
-//     name + queue + causal timing can attach the launch). Mutation caught:
-//     findLaunchHeuristic's caller setting view.Launch without also setting
-//     Join/Heuristic (e.g. Heuristic=true dropped from the heuristic branch).
+//     name + queue + causal timing can attach the launch), and
+//     driveEvictedLaunchDegradesToUnattributed, the named spec §13
+//     reproduction (see TestConformanceEvictedLaunchDegradesToUnattributed).
+//     Mutation caught: findLaunchHeuristic's caller setting view.Launch
+//     without also setting Join/Heuristic (e.g. Heuristic=true dropped from
+//     the heuristic branch), or the exec.Correlation zero-value gate in
+//     Snapshot being removed (assertHeuristicOnlyForCorrelationlessExecs).
 //  3. No launch is fabricated.
 //     Stressed by: correlation-gaps' "gap-orphan" group (no launch was ever
 //     emitted for those execs) and the clock-domain test's rejected launches
@@ -204,6 +213,7 @@ func assertConformanceInvariants(t *testing.T, h *conformanceHarness) Snapshot {
 	assertNoFabricatedLaunch(t, snap, h.attempt.launchCarried)
 	assertExactNeverHeuristic(t, snap)
 	assertHeuristicAlwaysMarked(t, snap)
+	assertHeuristicOnlyForCorrelationlessExecs(t, snap)
 	assertTimestampsMonotonic(t, snap)
 	assertBoundedMemory(t, snap, h.cacheCapacity)
 
@@ -260,6 +270,25 @@ func assertHeuristicAlwaysMarked(t *testing.T, snap Snapshot) {
 	for _, view := range snap.Executions {
 		if view.Join == JoinHeuristic {
 			assert.True(t, view.Heuristic, "a heuristic join (correlation %+v) must always be marked Heuristic", view.Exec.Correlation)
+		}
+	}
+}
+
+// assertHeuristicOnlyForCorrelationlessExecs is the general form of review
+// Critical 2's fix, checked against every scenario in this file: a
+// GPUKernelExec that carried a non-zero Correlation and still ended up
+// heuristically joined would mean an exec whose exact lookup missed (launch
+// evicted, or never arrived) got guessed-attached anyway, instead of
+// degrading to unattributed per spec §13. Only an exec with the zero-value
+// Correlation (a backend, like DRM, that never supplies one) may take the
+// heuristic path at all. See TestConformanceEvictedLaunchDegradesToUnattributed
+// below for the specific reproduction this generalizes.
+func assertHeuristicOnlyForCorrelationlessExecs(t *testing.T, snap Snapshot) {
+	t.Helper()
+	for _, view := range snap.Executions {
+		if view.Join == JoinHeuristic {
+			assert.Equal(t, CorrelationID{}, view.Exec.Correlation,
+				"a heuristic join must only ever attach to an exec that never supplied a correlation ID at all")
 		}
 	}
 }
@@ -340,6 +369,25 @@ func TestConformance(t *testing.T) {
 	}
 }
 
+// TestConformanceCorrelationGapsActuallyExercisesHeuristic closes a gap the
+// table-driven TestConformance above cannot: nothing in that loop ever reads
+// JoinStats, so a driveCorrelationGaps edit that silently stopped exercising
+// the heuristic join (e.g. the "gap-heur" group's exec correlation being
+// left non-zero, which review Critical 2's gate would then route to
+// UnmatchedExecutionCount instead) would still pass every invariant check -
+// an unmatched exec is exactly as invariant-compliant as a heuristically
+// matched one. This pins the counts the doc comment at the top of this file
+// claims: 3 heuristic joins (the "gap-heur" group) and 2 unmatched
+// executions (the "gap-orphan" group), independent of the harness's own
+// bookkeeping being otherwise self-consistent.
+func TestConformanceCorrelationGapsActuallyExercisesHeuristic(t *testing.T) {
+	_, snap := runConformance(t, "correlation-gaps-heuristic-check", driveCorrelationGaps)
+	assert.Equal(t, uint64(3), snap.JoinStats.HeuristicExecutionJoinCount,
+		"the gap-heur group must actually take the heuristic path, not silently degrade to unmatched")
+	assert.Equal(t, uint64(2), snap.JoinStats.UnmatchedExecutionCount,
+		"the gap-orphan group must remain genuinely unmatched")
+}
+
 // driveAllExact is the happy-path scenario: every execution correlates
 // exactly to the launch that produced it, and each carries two PC samples
 // with increasing timestamps (stresses invariant 4's per-correlation
@@ -384,20 +432,21 @@ func driveCorrelationGaps(sink EventSink) error {
 	}
 
 	// Heuristic-recoverable group: launch and exec share a kernel name and
-	// queue but deliberately different correlation IDs, so the exact lookup
-	// misses and only the heuristic join (kernel name + queue + causal
-	// timing) can attach a launch.
+	// queue, and the exec's Correlation is left at its zero value - review
+	// Critical 2 restricts the heuristic path to execs that never supplied a
+	// correlation ID at all (the exact case this group models: a backend,
+	// like DRM, with no correlation concept), so only the heuristic join
+	// (kernel name + queue + causal timing) can attach a launch here.
 	for i := 0; i < 3; i++ {
 		l := launch("gap-heur-"+strconv.Itoa(i), uint64(i*100)+1) // KernelName -> "k_gap-heur-<i>"
 		if err := sink.EmitLaunch(l); err != nil {
 			return err
 		}
 		e := GPUKernelExec{
-			Correlation: CorrelationID{Backend: BackendCUPTI, Value: "gap-heur-exec-" + strconv.Itoa(i)},
-			KernelName:  l.KernelName,
-			Queue:       l.Queue,
-			StartNs:     uint64(i*100) + 10,
-			EndNs:       uint64(i*100) + 20,
+			KernelName: l.KernelName,
+			Queue:      l.Queue,
+			StartNs:    uint64(i*100) + 10,
+			EndNs:      uint64(i*100) + 20,
 		}
 		if err := sink.EmitExec(e); err != nil {
 			return err
@@ -599,9 +648,65 @@ func TestConformanceLossAccountingCoversHorizonAndInvalidDomain(t *testing.T) {
 		snap.LaunchCache.EvictedCapacity, snap.LaunchCache.EvictedHorizon, snap.LaunchCache.Replaced)
 }
 
+// driveEvictedLaunchDegradesToUnattributed is the spec §13 fixture named in
+// the final whole-branch review's Critical 2 finding: "a sample whose launch
+// has been evicted degrades to unattributed rather than mis-attributed."
+// Reproduces the reviewer's exact scenario against a capacity-1 cache: two
+// launches sharing one kernel name ("hot_kernel") so the surviving launch is
+// a plausible-looking heuristic candidate for the evicted one's exec, then
+// an exec whose Correlation names the evicted launch. Before the review
+// Critical 2 fix, this exec would have been heuristically reattached to the
+// survivor - a different launch's PID/Tags entirely. The caller (the
+// dedicated test below, not the generic table) checks the specific outcome;
+// this drive func only needs to produce the scenario.
+func driveEvictedLaunchDegradesToUnattributed(sink EventSink) error {
+	a := launch("a", 10)
+	a.KernelName = "hot_kernel"
+	if err := sink.EmitLaunch(a); err != nil {
+		return err
+	}
+	b := launch("b", 20)
+	b.KernelName = "hot_kernel" // shares a's kernel name and queue
+	if err := sink.EmitLaunch(b); err != nil {
+		return err // evicts "a" from a capacity-1 cache
+	}
+	exec := execFor("a", 30, 40) // Correlation "a": exact lookup misses because "a" was evicted
+	exec.KernelName = "hot_kernel"
+	return sink.EmitExec(exec)
+}
+
+// TestConformanceEvictedLaunchDegradesToUnattributed drives the scenario
+// above through a dedicated capacity-1 harness and asserts the specific
+// outcome spec §13 requires: the exec attached to correlation "a" must have
+// no Launch at all, not the survivor "b". The general
+// assertHeuristicOnlyForCorrelationlessExecs invariant (run for every
+// scenario, including this one, via runConformanceWithHarness) already
+// guards the mechanism; this test pins the concrete, named reproduction so
+// a future change that broke the mechanism in a way the general invariant
+// couldn't see would still be caught here.
+func TestConformanceEvictedLaunchDegradesToUnattributed(t *testing.T) {
+	h := newConformanceHarnessWithConfig(LaunchCacheConfig{Capacity: 1}, conformanceSinkBurst)
+	snap := runConformanceWithHarness(t, "evicted-launch-degrades", h, driveEvictedLaunchDegradesToUnattributed)
+
+	require.Len(t, snap.Executions, 1)
+	view := snap.Executions[0]
+	assert.Equal(t, "a", view.Exec.Correlation.Value)
+	assert.Nil(t, view.Launch,
+		"an execution whose launch was evicted must degrade to unattributed, never reattach to a different launch that merely shares its kernel name")
+	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+}
+
 // BenchmarkSnapshotAtScale is the Phase 2 gate: a million launches through a
 // bounded cache must snapshot in well under a second, with allocation
 // reflecting the bounded cache rather than a million retained launches.
+//
+// PC samples were added to this benchmark for review Critical 5: before
+// that fix, a single pending correlation's samples could accumulate without
+// bound, and this benchmark - the phase's own memory/timing gate - emitted
+// zero PC samples, so it could not see that growth at all. Each sampled
+// exec (1 in 4, same as before) now also gets 3 PC samples under its own
+// correlation, which exercises both the per-correlation cap and the
+// proportional weight distribution's cost, not just the launch-cache path.
 func BenchmarkSnapshotAtScale(b *testing.B) {
 	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 65536}})
 	for i := 0; i < 1_000_000; i++ {
@@ -613,6 +718,10 @@ func BenchmarkSnapshotAtScale(b *testing.B) {
 		_ = tl.EmitLaunch(launch(id, uint64(i)))
 		if i%4 == 0 {
 			_ = tl.EmitExec(execFor(id, uint64(i), uint64(i+10)))
+			corr := CorrelationID{Backend: BackendCUPTI, Value: id}
+			for j := 0; j < 3; j++ {
+				_ = tl.EmitPCSample(GPUPCSample{Correlation: corr, TimeNs: uint64(i + j), PCOffset: uint64(j), Count: 1})
+			}
 		}
 	}
 	b.ResetTimer()

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -33,12 +33,17 @@ package gpu
 //     zero-value ones (catches CountingSink's domain check being weakened or
 //     removed).
 //  5. Losses are accounted.
-//     Stressed by: overflow, the one scenario built so real drops
-//     (SinkStats.DroppedFull) and real evictions (LaunchCacheStats.
-//     EvictedCapacity) both happen in the same run, at very different
-//     magnitudes. See assertLaunchLossesAccounted's doc comment for why this
-//     check is scoped to launch-only, non-reused-ID scenarios rather than
-//     applied universally.
+//     Stressed by: overflow, which puts real drops (SinkStats.DroppedFull)
+//     and real capacity evictions (LaunchCacheStats.EvictedCapacity) in the
+//     same run at very different magnitudes, AND
+//     horizon-and-domain-losses (see driveHorizonAndDomainLosses), which
+//     exists specifically because overflow's harness never sets HorizonNs
+//     and never attempts an unsupported clock domain - EvictedHorizon and
+//     DroppedInvalid are structurally 0 everywhere else the reconciliation
+//     formula runs, so those two of its four terms would be undetectable
+//     dead weight without it. See assertLaunchLossesAccounted's doc comment
+//     for why the check is scoped to launch-only, non-reused-ID scenarios
+//     rather than applied universally.
 //  6. Bounded memory.
 //     Stressed by: overflow (100k launches into a capacity-64 cache).
 //     Mutation caught: capacity eviction being skipped or the ring/cache
@@ -132,26 +137,60 @@ type conformanceHarness struct {
 	tl      *Timeline
 	sink    *CountingSink
 	attempt *attemptSink
+
+	// cacheCapacity is the launch-cache capacity this harness was built
+	// with, kept alongside tl so assertBoundedMemory can check a scenario's
+	// actual configured bound instead of assuming every harness shares
+	// conformanceCacheCapacity - not true once
+	// newConformanceHarnessWithConfig is used with a different capacity.
+	cacheCapacity int
+}
+
+// newConformanceHarnessWithConfig is newConformanceHarness generalized over
+// the launch-cache config, for the one scenario (horizon-and-domain-losses)
+// that needs a HorizonNs the shared default harness deliberately doesn't
+// set. The clock is always frozen, for the same reason newConformanceHarness
+// freezes it.
+func newConformanceHarnessWithConfig(cacheCfg LaunchCacheConfig, sinkBurst int) *conformanceHarness {
+	tl := NewTimeline(TimelineConfig{LaunchCache: cacheCfg})
+	clock := newFakeClock(time.Unix(0, 0))
+	sink := NewCountingSinkWithRate(tl, sinkBurst, 0, clock.Now)
+	return &conformanceHarness{tl: tl, sink: sink, attempt: newAttemptSink(sink), cacheCapacity: cacheCfg.Capacity}
 }
 
 func newConformanceHarness() *conformanceHarness {
-	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: conformanceCacheCapacity}})
-	clock := newFakeClock(time.Unix(0, 0))
-	sink := NewCountingSinkWithRate(tl, conformanceSinkBurst, 0, clock.Now)
-	return &conformanceHarness{tl: tl, sink: sink, attempt: newAttemptSink(sink)}
+	return newConformanceHarnessWithConfig(LaunchCacheConfig{Capacity: conformanceCacheCapacity}, conformanceSinkBurst)
 }
 
-// runConformance drives one producer scenario through a fresh harness and
-// checks every invariant a producer's output must satisfy. This is the
-// helper later vendor backends (replay, HIP, CUPTI) call with their own
-// drive functions.
-func runConformance(t *testing.T, name string, drive func(EventSink) error) {
+// runConformance drives one producer scenario through a fresh, default-
+// configured harness and checks every invariant a producer's output must
+// satisfy. This is the helper later vendor backends (replay, HIP, CUPTI)
+// call with their own drive functions. It returns the harness and the
+// snapshot checked against, for the rare scenario (e.g.
+// TestConformanceRejectedClockDomainsNeverSurface) that needs an additional,
+// scenario-specific assertion beyond the standard six - callers that don't
+// need that can simply ignore both.
+func runConformance(t *testing.T, name string, drive func(EventSink) error) (*conformanceHarness, Snapshot) {
 	t.Helper()
+	h := newConformanceHarness()
+	snap := runConformanceWithHarness(t, name, h, drive)
+	return h, snap
+}
+
+// runConformanceWithHarness is runConformance generalized over the harness,
+// for scenarios that need non-default configuration (a launch-cache
+// horizon, a different sink burst) to make a particular invariant term
+// reachable at all. It shares the exact same invariant checks as
+// runConformance - a scenario using this entry point still runs the
+// identical suite, just paired with a harness it built for itself.
+func runConformanceWithHarness(t *testing.T, name string, h *conformanceHarness, drive func(EventSink) error) Snapshot {
+	t.Helper()
+	var snap Snapshot
 	t.Run(name, func(t *testing.T) {
-		h := newConformanceHarness()
 		require.NoError(t, drive(h.attempt))
-		assertConformanceInvariants(t, h)
+		snap = assertConformanceInvariants(t, h)
 	})
+	return snap
 }
 
 // assertConformanceInvariants snapshots the harness exactly once (Snapshot
@@ -166,7 +205,7 @@ func assertConformanceInvariants(t *testing.T, h *conformanceHarness) Snapshot {
 	assertExactNeverHeuristic(t, snap)
 	assertHeuristicAlwaysMarked(t, snap)
 	assertTimestampsMonotonic(t, snap)
-	assertBoundedMemory(t, snap)
+	assertBoundedMemory(t, snap, h.cacheCapacity)
 
 	// Invariant 5's literal formula - SinkStats.DroppedFull + DroppedInvalid
 	// plus LaunchCacheStats.EvictedCapacity + EvictedHorizon equals emitted
@@ -258,10 +297,13 @@ func assertTimestampsMonotonic(t *testing.T, snap Snapshot) {
 	}
 }
 
-// assertBoundedMemory is invariant 6.
-func assertBoundedMemory(t *testing.T, snap Snapshot) {
+// assertBoundedMemory is invariant 6. capacity is the launch-cache capacity
+// the scenario's own harness was configured with (conformanceHarness.
+// cacheCapacity), not necessarily conformanceCacheCapacity - the
+// horizon-and-domain-losses scenario deliberately uses a different one.
+func assertBoundedMemory(t *testing.T, snap Snapshot, capacity int) {
 	t.Helper()
-	assert.LessOrEqual(t, snap.LaunchCache.Live, conformanceCacheCapacity,
+	assert.LessOrEqual(t, snap.LaunchCache.Live, capacity,
 		"the launch cache must never hold more than its configured capacity")
 }
 
@@ -393,55 +435,75 @@ func driveOverflow(sink EventSink) error {
 	return nil
 }
 
+// driveMixedClockDomains emits launches and execs in a mix of the supported
+// domain (explicit and zero-value/defaulted) and two unsupported domains.
+// Expressed as a plain drive func like every other scenario - a vendor
+// backend wired through runConformance inherits this coverage too, not just
+// this file's own tests - it deliberately discards each unsupported-domain
+// call's error rather than asserting on it inline (the same way
+// driveOverflow discards ErrSinkFull): rejection is still verified, just
+// after driving completes, via SinkStats and the snapshot (see
+// TestConformanceRejectedClockDomainsNeverSurface) rather than a per-call
+// assertion the drive signature has no *testing.T to make.
+func driveMixedClockDomains(sink EventSink) error {
+	for i := 0; i < 3; i++ { // valid, explicit domain
+		id := "good-" + strconv.Itoa(i)
+		l := launch(id, uint64(i*10)+1)
+		l.ClockDomain = ClockDomainCPUMonotonic
+		if err := sink.EmitLaunch(l); err != nil {
+			return err
+		}
+		e := execFor(id, uint64(i*10)+2, uint64(i*10)+3)
+		e.ClockDomain = ClockDomainCPUMonotonic
+		if err := sink.EmitExec(e); err != nil {
+			return err
+		}
+	}
+	for i := 0; i < 3; i++ { // zero-value domain must default, not reject
+		id := "zero-" + strconv.Itoa(i)
+		if err := sink.EmitLaunch(launch(id, uint64(1000+i))); err != nil {
+			return err
+		}
+		if err := sink.EmitExec(execFor(id, uint64(2000+i), uint64(2000+i+1))); err != nil {
+			return err
+		}
+	}
+	badDomains := []ClockDomain{ClockDomainGPUDevice, ClockDomainSynced}
+	for i, dom := range badDomains {
+		id := "bad-" + strconv.Itoa(i)
+		l := launch(id, uint64(5000+i))
+		l.ClockDomain = dom
+		_ = sink.EmitLaunch(l) // expected rejection; verified post-hoc below
+
+		e := execFor(id, uint64(6000+i), uint64(6000+i+1))
+		e.ClockDomain = dom
+		_ = sink.EmitExec(e)
+	}
+	return nil
+}
+
 // TestConformanceRejectedClockDomainsNeverSurface targets invariant 4's
 // second clause directly: "every accepted event has ClockDomainCPUMonotonic
-// after normalization." The three table-driven scenarios above only ever
-// use the supported domain, so that clause holds for them vacuously -
-// nothing else was ever possible. This is the scenario that can actually
-// fail: launches and execs in the unsupported ClockDomainGPUDevice/
-// ClockDomainSynced domains, alongside valid explicit and valid zero-value
-// (defaulted) ones. It checks both that the bad ones are rejected
-// (SinkStats.DroppedInvalid) and that none of them leak into the snapshot
-// under any correlation.
+// after normalization." The three table-driven scenarios in TestConformance
+// only ever use the supported domain, so that clause holds for them
+// vacuously - nothing else was ever possible. driveMixedClockDomains is the
+// scenario that can actually fail: launches and execs in the unsupported
+// ClockDomainGPUDevice/ClockDomainSynced domains, alongside valid explicit
+// and valid zero-value (defaulted) ones. This test drives it through
+// runConformance - the same entry point a vendor backend uses - then adds
+// the two checks a generic invariant pass can't express: that the bad ones
+// were actually rejected (SinkStats.DroppedInvalid) and that none of them
+// leak into the snapshot under any correlation.
 //
 // Mutation this catches: CountingSink.admit's ValidateSupportedClockDomain
 // check being removed or weakened to accept a non-monotonic domain - the
 // "bad-*" correlations would then surface in the snapshot and the leak
 // assertion below would fail.
 func TestConformanceRejectedClockDomainsNeverSurface(t *testing.T) {
-	h := newConformanceHarness()
-
-	for i := 0; i < 3; i++ { // valid, explicit domain
-		id := "good-" + strconv.Itoa(i)
-		l := launch(id, uint64(i*10)+1)
-		l.ClockDomain = ClockDomainCPUMonotonic
-		require.NoError(t, h.attempt.EmitLaunch(l))
-		e := execFor(id, uint64(i*10)+2, uint64(i*10)+3)
-		e.ClockDomain = ClockDomainCPUMonotonic
-		require.NoError(t, h.attempt.EmitExec(e))
-	}
-	for i := 0; i < 3; i++ { // zero-value domain must default, not reject
-		id := "zero-" + strconv.Itoa(i)
-		require.NoError(t, h.attempt.EmitLaunch(launch(id, uint64(1000+i))))
-		require.NoError(t, h.attempt.EmitExec(execFor(id, uint64(2000+i), uint64(2000+i+1))))
-	}
-
-	badDomains := []ClockDomain{ClockDomainGPUDevice, ClockDomainSynced}
-	for i, dom := range badDomains {
-		id := "bad-" + strconv.Itoa(i)
-		l := launch(id, uint64(5000+i))
-		l.ClockDomain = dom
-		require.Error(t, h.attempt.EmitLaunch(l), "an unsupported clock domain must be rejected, not silently accepted")
-
-		e := execFor(id, uint64(6000+i), uint64(6000+i+1))
-		e.ClockDomain = dom
-		require.Error(t, h.attempt.EmitExec(e))
-	}
-
-	snap := assertConformanceInvariants(t, h)
+	h, snap := runConformance(t, "mixed-clock-domains", driveMixedClockDomains)
 	sinkStats := h.sink.Stats()
 
-	assert.Equal(t, uint64(len(badDomains)*2), sinkStats.DroppedInvalid,
+	assert.Equal(t, uint64(2*2), sinkStats.DroppedInvalid,
 		"every unsupported-domain attempt (one launch, one exec, per bad domain) must be rejected and counted")
 
 	for _, view := range snap.Executions {
@@ -452,6 +514,89 @@ func TestConformanceRejectedClockDomainsNeverSurface(t *testing.T) {
 				"a launch rejected for an unsupported clock domain must never surface via a join")
 		}
 	}
+}
+
+// driveHorizonAndDomainLosses is the scenario that keeps invariant 5's
+// EvictedHorizon and DroppedInvalid terms honest. No other scenario in this
+// file sets LaunchCacheConfig.HorizonNs, so EvictedHorizon is structurally 0
+// everywhere else; driveMixedClockDomains does attempt unsupported clock
+// domains, but that scenario mixes in execs, so
+// assertConformanceInvariants's launch-only gate never runs the
+// reconciliation formula against it. That means DroppedInvalid was 0 in
+// every run that actually evaluated the sum, and EvictedHorizon was 0 in
+// all of them: `0 + X == X` means deleting either term from
+// assertLaunchLossesAccounted's sum would still pass the entire rest of the
+// suite. This scenario forces both nonzero - and, as a consequence of how
+// it's built, EvictedCapacity too - in one run where the reconciliation
+// formula is actually checked.
+//
+// Two phases against a cache of capacity 1000 / horizon 50ns:
+//   - Phase A: 200 launches spaced 10ns apart (TimeNs = 0, 10, 20, ...). The
+//     50ns horizon only lets entries within 50ns of the newest timestamp
+//     stay live, so as the anchor advances, older entries age out via
+//     EvictedHorizon long before the cache is anywhere near its capacity of
+//     1000.
+//   - Phase B: 1500 more launches that all carry the same TimeNs (2000,
+//     equal to Phase A's final horizon boundary), so the horizon anchor
+//     only advances once, at the very start of this phase, and horizon
+//     eviction cannot fire again after Phase A's last few survivors age
+//     out. Once no more entries can be aged out by horizon, filling the
+//     cache with 1500 more unique-correlation entries against a capacity of
+//     1000 has nowhere to go but EvictedCapacity.
+//   - 4 launches in unsupported clock domains, rejected outright
+//     (DroppedInvalid), touching neither the cache nor the token bucket.
+//
+// Every correlation ID is unique and every launch is emitted exactly once,
+// so LaunchCacheStats.Replaced stays 0 and assertLaunchLossesAccounted's
+// preconditions hold.
+func driveHorizonAndDomainLosses(sink EventSink) error {
+	for i := 0; i < 200; i++ {
+		if err := sink.EmitLaunch(launch("horizon-"+strconv.Itoa(i), uint64(i*10))); err != nil {
+			return err
+		}
+	}
+	for i := 0; i < 1500; i++ {
+		if err := sink.EmitLaunch(launch("capacity-"+strconv.Itoa(i), 2000)); err != nil {
+			return err
+		}
+	}
+	badDomains := []ClockDomain{ClockDomainGPUDevice, ClockDomainSynced, ClockDomainGPUDevice, ClockDomainSynced}
+	for i, dom := range badDomains {
+		l := launch("horizon-bad-"+strconv.Itoa(i), 2000)
+		l.ClockDomain = dom
+		_ = sink.EmitLaunch(l) // expected rejection; verified post-hoc below
+	}
+	return nil
+}
+
+// TestConformanceLossAccountingCoversHorizonAndInvalidDomain drives
+// driveHorizonAndDomainLosses through a harness with HorizonNs actually set
+// (runConformance's shared default harness deliberately never sets it), then
+// - beyond the standard six invariants runConformanceWithHarness already
+// checks, including the reconciliation formula itself, since this scenario
+// is launch-only and unique-ID by construction - asserts that the three
+// previously-dead-or-unchecked terms are genuinely nonzero here. Without
+// that extra guard, a future edit to this scenario's numbers could silently
+// regress it back into vacuity while the reconciliation assertion kept
+// passing for the wrong reason (both sides shrinking to 0 together).
+//
+// Mutation this catches: deleting "+ sinkStats.DroppedInvalid" or
+// "+ snap.LaunchCache.EvictedHorizon" from assertLaunchLossesAccounted's sum
+// - both now make the reconciliation check inside
+// runConformanceWithHarness/assertConformanceInvariants fail here, where
+// deleting either used to be invisible everywhere else in this file.
+func TestConformanceLossAccountingCoversHorizonAndInvalidDomain(t *testing.T) {
+	h := newConformanceHarnessWithConfig(LaunchCacheConfig{Capacity: 1000, HorizonNs: 50}, conformanceSinkBurst)
+	snap := runConformanceWithHarness(t, "horizon-and-domain-losses", h, driveHorizonAndDomainLosses)
+	sinkStats := h.sink.Stats()
+
+	require.Greater(t, snap.LaunchCache.EvictedHorizon, uint64(0), "the scenario must force a real horizon eviction")
+	require.Greater(t, sinkStats.DroppedInvalid, uint64(0), "the scenario must force a real clock-domain rejection")
+	require.Greater(t, snap.LaunchCache.EvictedCapacity, uint64(0), "the scenario must force a real capacity eviction too")
+
+	t.Logf("loss reconciliation: attempts=%d retained=%d droppedFull=%d droppedInvalid=%d evictedCapacity=%d evictedHorizon=%d replaced=%d",
+		h.attempt.launchAttempts, snap.LaunchCache.Live, sinkStats.DroppedFull, sinkStats.DroppedInvalid,
+		snap.LaunchCache.EvictedCapacity, snap.LaunchCache.EvictedHorizon, snap.LaunchCache.Replaced)
 }
 
 // BenchmarkSnapshotAtScale is the Phase 2 gate: a million launches through a

--- a/gpu/launchcache.go
+++ b/gpu/launchcache.go
@@ -13,29 +13,70 @@ import "sync"
 type LaunchCacheConfig struct {
 	Capacity  int
 	HorizonNs uint64
+
+	// MaxAdvanceNs bounds how far a single Put may advance the cache's
+	// observed-time horizon anchor (newestNs) in one step. Timestamps arrive
+	// out of order and asynchronously from potentially multiple producers;
+	// without a clamp, one corrupt sample (clock-domain bug, overflow, bad
+	// backend) can push the anchor far enough forward to evict every other
+	// live entry at once, which defeats the entire purpose of a horizon meant
+	// to survive late arrival. A Put whose TimeNs would advance the anchor by
+	// more than MaxAdvanceNs is treated as anomalous: the launch is still
+	// stored (no data is dropped), the anchor does not advance, and
+	// LaunchCacheStats.AnomalousTimestamp is incremented instead. Zero
+	// disables clamping entirely, for callers who genuinely want that. 60
+	// seconds (60_000_000_000 ns) is a reasonable default for callers that
+	// want protection.
+	MaxAdvanceNs uint64
 }
 
 // LaunchCacheStats reports what the cache holds and what it dropped. Every
 // eviction path is counted: a cache that loses attributions silently is
 // indistinguishable from a correlation bug.
 type LaunchCacheStats struct {
-	Live            int    `json:"live"`
-	EvictedCapacity uint64 `json:"evicted_capacity,omitempty"`
-	EvictedHorizon  uint64 `json:"evicted_horizon,omitempty"`
-	Replaced        uint64 `json:"replaced,omitempty"`
+	Live               int    `json:"live"`
+	EvictedCapacity    uint64 `json:"evicted_capacity,omitempty"`
+	EvictedHorizon     uint64 `json:"evicted_horizon,omitempty"`
+	Replaced           uint64 `json:"replaced,omitempty"`
+	AnomalousTimestamp uint64 `json:"anomalous_timestamp,omitempty"`
 }
 
 const defaultLaunchCacheCapacity = 65536
 
+// cacheEntry is a stored launch tagged with the Put sequence number that
+// produced it, so a stale order position (superseded by a later replace) can
+// be told apart from the entry currently live for that correlation ID.
+type cacheEntry struct {
+	launch GPUKernelLaunch
+	seq    uint64
+}
+
+// orderEntry names one FIFO position: the correlation ID inserted and the
+// sequence number it was inserted (or replaced) with. Comparing seq against
+// the current cacheEntry.seq for the same id is how eviction tells a live
+// position from one a later Put has superseded.
+type orderEntry struct {
+	id  CorrelationID
+	seq uint64
+}
+
 // LaunchCache is a bounded FIFO of recent launches indexed by correlation ID.
 // Put and Get are O(1) amortized. It replaces the unbounded slice plus linear
 // scan the earlier prototype used, which was quadratic at snapshot time.
+//
+// Put and Get do not deep-copy. A GPUKernelLaunch's LaunchContext.CPUStack
+// slice and Tags map are stored, and later returned, by reference: the value
+// Get returns shares backing arrays with the cache's own copy. This is the
+// ingestion hot path, so callers must treat both the value passed to Put
+// (after the call) and the value returned by Get as read-only rather than
+// pay for a per-launch clone.
 type LaunchCache struct {
 	mu       sync.Mutex
 	cfg      LaunchCacheConfig
-	byCorr   map[CorrelationID]GPUKernelLaunch
-	order    []CorrelationID // insertion order; entries before head are dead
+	byCorr   map[CorrelationID]cacheEntry
+	order    []orderEntry // insertion order; entries before head are dead
 	head     int
+	seq      uint64
 	newestNs uint64
 	stats    LaunchCacheStats
 }
@@ -46,36 +87,57 @@ func NewLaunchCache(cfg LaunchCacheConfig) *LaunchCache {
 	}
 	return &LaunchCache{
 		cfg:    cfg,
-		byCorr: make(map[CorrelationID]GPUKernelLaunch, cfg.Capacity),
-		order:  make([]CorrelationID, 0, cfg.Capacity),
+		byCorr: make(map[CorrelationID]cacheEntry, cfg.Capacity),
+		order:  make([]orderEntry, 0, cfg.Capacity),
 	}
 }
 
+// Put inserts or replaces the launch for its correlation ID. A repeated
+// correlation ID takes the newer launch without growing the cache: see the
+// LaunchCache doc comment for the aliasing contract.
 func (c *LaunchCache) Put(l GPUKernelLaunch) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if l.TimeNs > c.newestNs {
-		c.newestNs = l.TimeNs
-	}
+	c.observeTimestampLocked(l.TimeNs)
+
+	c.seq++
+	seq := c.seq
 	if _, exists := c.byCorr[l.Correlation]; exists {
-		// Same correlation seen again: take the newer launch without growing
-		// the FIFO. The stale order entry is skipped when it reaches the head.
-		c.byCorr[l.Correlation] = l
 		c.stats.Replaced++
-		c.evictLocked()
-		return
 	}
-	c.byCorr[l.Correlation] = l
-	c.order = append(c.order, l.Correlation)
+	c.byCorr[l.Correlation] = cacheEntry{launch: l, seq: seq}
+	c.order = append(c.order, orderEntry{id: l.Correlation, seq: seq})
 	c.evictLocked()
 }
 
+// observeTimestampLocked advances the horizon anchor (newestNs) to l's
+// timestamp, unless that would be an anomalous jump larger than
+// MaxAdvanceNs, in which case the anchor is left alone and the anomaly is
+// counted. The anchor is observed time, not wall-clock: wall-clock is wrong
+// for replay and out-of-order input. The caller must hold c.mu.
+func (c *LaunchCache) observeTimestampLocked(timeNs uint64) {
+	if timeNs <= c.newestNs {
+		return
+	}
+	if c.cfg.MaxAdvanceNs > 0 && c.newestNs != 0 && timeNs-c.newestNs > c.cfg.MaxAdvanceNs {
+		c.stats.AnomalousTimestamp++
+		return
+	}
+	c.newestNs = timeNs
+}
+
+// Get returns the launch stored for id, if any. A miss is reported as
+// (zero value, false), never fabricated. See the LaunchCache doc comment for
+// the aliasing contract on the returned value.
 func (c *LaunchCache) Get(id CorrelationID) (GPUKernelLaunch, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	l, ok := c.byCorr[id]
-	return l, ok
+	e, ok := c.byCorr[id]
+	if !ok {
+		return GPUKernelLaunch{}, false
+	}
+	return e.launch, true
 }
 
 func (c *LaunchCache) Len() int {
@@ -97,34 +159,56 @@ func (c *LaunchCache) Stats() LaunchCacheStats {
 func (c *LaunchCache) evictLocked() {
 	if c.cfg.HorizonNs > 0 {
 		for c.head < len(c.order) {
-			id := c.order[c.head]
-			l, live := c.byCorr[id]
-			if !live {
-				c.head++ // stale order entry from a replacement
+			e := c.order[c.head]
+			cur, superseded := c.currentIfLiveLocked(e)
+			if superseded {
+				c.head++
 				continue
 			}
-			if c.newestNs <= l.TimeNs || c.newestNs-l.TimeNs <= c.cfg.HorizonNs {
+			if c.newestNs <= cur.TimeNs || c.newestNs-cur.TimeNs <= c.cfg.HorizonNs {
 				break
 			}
-			delete(c.byCorr, id)
+			delete(c.byCorr, e.id)
 			c.head++
 			c.stats.EvictedHorizon++
 		}
 	}
 	for len(c.byCorr) > c.cfg.Capacity && c.head < len(c.order) {
-		id := c.order[c.head]
+		e := c.order[c.head]
 		c.head++
-		if _, live := c.byCorr[id]; !live {
+		if _, superseded := c.currentIfLiveLocked(e); superseded {
 			continue
 		}
-		delete(c.byCorr, id)
+		delete(c.byCorr, e.id)
 		c.stats.EvictedCapacity++
 	}
 	c.compactLocked()
 }
 
-// compactLocked reclaims the dead prefix of order once it dominates the slice,
-// so a long-running agent does not grow order without bound.
+// currentIfLiveLocked resolves an order position to the launch currently
+// live for its correlation ID, and reports whether that position is
+// superseded rather than real. A position is superseded in two cases: the id
+// has since been evicted outright (superseded && zero value; this should be
+// unreachable given eviction always consumes the order position it deletes
+// through, but is kept as a defensive guard), or — the case this exists to
+// fix — a later Put replaced the entry, so e.seq no longer matches the
+// sequence number the map holds for that id. Only a non-superseded position
+// is a real, currently-live entry eligible for eviction. The caller must
+// hold c.mu.
+func (c *LaunchCache) currentIfLiveLocked(e orderEntry) (GPUKernelLaunch, bool) {
+	cur, live := c.byCorr[e.id]
+	if !live || cur.seq != e.seq {
+		return GPUKernelLaunch{}, true
+	}
+	return cur.launch, false
+}
+
+// compactLocked reclaims the dead prefix of order once it dominates the
+// slice, so a long-running agent's order slice does not grow without bound.
+// It is not tight: compaction only fires once head >= 1024 && head*2 >=
+// len(order), so in steady state under sustained load order oscillates
+// between roughly capacity and roughly 2x capacity. That is bounded, but
+// len(order) should not be read as a proxy for live count.
 func (c *LaunchCache) compactLocked() {
 	if c.head < 1024 || c.head*2 < len(c.order) {
 		return

--- a/gpu/launchcache.go
+++ b/gpu/launchcache.go
@@ -23,10 +23,12 @@ type LaunchCacheConfig struct {
 	// to survive late arrival. A Put whose TimeNs would advance the anchor by
 	// more than MaxAdvanceNs is treated as anomalous: the launch is still
 	// stored (no data is dropped), the anchor does not advance, and
-	// LaunchCacheStats.AnomalousTimestamp is incremented instead. Zero
-	// disables clamping entirely, for callers who genuinely want that. 60
-	// seconds (60_000_000_000 ns) is a reasonable default for callers that
-	// want protection.
+	// LaunchCacheStats.AnomalousTimestamp is incremented instead.
+	//
+	// Zero means "use the default" (defaultMaxAdvanceNs, 60s): the callers
+	// exposed to this hazard are exactly the ones who set HorizonNs, so the
+	// guard must be on unless a caller explicitly turns it off. A caller who
+	// genuinely wants unclamped advance sets MaxAdvanceNs to math.MaxUint64.
 	MaxAdvanceNs uint64
 }
 
@@ -42,6 +44,12 @@ type LaunchCacheStats struct {
 }
 
 const defaultLaunchCacheCapacity = 65536
+
+// defaultMaxAdvanceNs bounds how far one Put may move the horizon anchor when
+// the caller has not chosen a bound (LaunchCacheConfig.MaxAdvanceNs == 0). A
+// corrupt or out-of-range timestamp would otherwise push every live entry
+// past the horizon in a single call.
+const defaultMaxAdvanceNs = 60 * 1e9 // 60s
 
 // cacheEntry is a stored launch tagged with the Put sequence number that
 // produced it, so a stale order position (superseded by a later replace) can
@@ -85,6 +93,9 @@ func NewLaunchCache(cfg LaunchCacheConfig) *LaunchCache {
 	if cfg.Capacity <= 0 {
 		cfg.Capacity = defaultLaunchCacheCapacity
 	}
+	if cfg.MaxAdvanceNs == 0 {
+		cfg.MaxAdvanceNs = defaultMaxAdvanceNs
+	}
 	return &LaunchCache{
 		cfg:    cfg,
 		byCorr: make(map[CorrelationID]cacheEntry, cfg.Capacity),
@@ -114,13 +125,16 @@ func (c *LaunchCache) Put(l GPUKernelLaunch) {
 // observeTimestampLocked advances the horizon anchor (newestNs) to l's
 // timestamp, unless that would be an anomalous jump larger than
 // MaxAdvanceNs, in which case the anchor is left alone and the anomaly is
-// counted. The anchor is observed time, not wall-clock: wall-clock is wrong
-// for replay and out-of-order input. The caller must hold c.mu.
+// counted. NewLaunchCache guarantees MaxAdvanceNs is never zero (it defaults
+// to defaultMaxAdvanceNs), so the only way to see unclamped advance here is
+// the explicit math.MaxUint64 opt-out, against which no real jump can ever
+// compare greater. The anchor is observed time, not wall-clock: wall-clock is
+// wrong for replay and out-of-order input. The caller must hold c.mu.
 func (c *LaunchCache) observeTimestampLocked(timeNs uint64) {
 	if timeNs <= c.newestNs {
 		return
 	}
-	if c.cfg.MaxAdvanceNs > 0 && c.newestNs != 0 && timeNs-c.newestNs > c.cfg.MaxAdvanceNs {
+	if c.newestNs != 0 && timeNs-c.newestNs > c.cfg.MaxAdvanceNs {
 		c.stats.AnomalousTimestamp++
 		return
 	}

--- a/gpu/launchcache.go
+++ b/gpu/launchcache.go
@@ -1,0 +1,135 @@
+package gpu
+
+import "sync"
+
+// LaunchCacheConfig bounds the cache two ways. Capacity caps memory; HorizonNs
+// caps how far back an attribution can reach.
+//
+// HorizonNs is the load-bearing tunable for PC sampling: samples arrive
+// asynchronously, sometimes seconds after the launch that produced them, and a
+// launch evicted before its samples land makes those samples unattributable.
+// Too small silently loses attribution; too large costs memory. Zero disables
+// horizon eviction and leaves only the capacity bound.
+type LaunchCacheConfig struct {
+	Capacity  int
+	HorizonNs uint64
+}
+
+// LaunchCacheStats reports what the cache holds and what it dropped. Every
+// eviction path is counted: a cache that loses attributions silently is
+// indistinguishable from a correlation bug.
+type LaunchCacheStats struct {
+	Live            int    `json:"live"`
+	EvictedCapacity uint64 `json:"evicted_capacity,omitempty"`
+	EvictedHorizon  uint64 `json:"evicted_horizon,omitempty"`
+	Replaced        uint64 `json:"replaced,omitempty"`
+}
+
+const defaultLaunchCacheCapacity = 65536
+
+// LaunchCache is a bounded FIFO of recent launches indexed by correlation ID.
+// Put and Get are O(1) amortized. It replaces the unbounded slice plus linear
+// scan the earlier prototype used, which was quadratic at snapshot time.
+type LaunchCache struct {
+	mu       sync.Mutex
+	cfg      LaunchCacheConfig
+	byCorr   map[CorrelationID]GPUKernelLaunch
+	order    []CorrelationID // insertion order; entries before head are dead
+	head     int
+	newestNs uint64
+	stats    LaunchCacheStats
+}
+
+func NewLaunchCache(cfg LaunchCacheConfig) *LaunchCache {
+	if cfg.Capacity <= 0 {
+		cfg.Capacity = defaultLaunchCacheCapacity
+	}
+	return &LaunchCache{
+		cfg:    cfg,
+		byCorr: make(map[CorrelationID]GPUKernelLaunch, cfg.Capacity),
+		order:  make([]CorrelationID, 0, cfg.Capacity),
+	}
+}
+
+func (c *LaunchCache) Put(l GPUKernelLaunch) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if l.TimeNs > c.newestNs {
+		c.newestNs = l.TimeNs
+	}
+	if _, exists := c.byCorr[l.Correlation]; exists {
+		// Same correlation seen again: take the newer launch without growing
+		// the FIFO. The stale order entry is skipped when it reaches the head.
+		c.byCorr[l.Correlation] = l
+		c.stats.Replaced++
+		c.evictLocked()
+		return
+	}
+	c.byCorr[l.Correlation] = l
+	c.order = append(c.order, l.Correlation)
+	c.evictLocked()
+}
+
+func (c *LaunchCache) Get(id CorrelationID) (GPUKernelLaunch, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	l, ok := c.byCorr[id]
+	return l, ok
+}
+
+func (c *LaunchCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.byCorr)
+}
+
+func (c *LaunchCache) Stats() LaunchCacheStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := c.stats
+	s.Live = len(c.byCorr)
+	return s
+}
+
+// evictLocked drops entries past the horizon first, then past capacity. The
+// caller must hold c.mu.
+func (c *LaunchCache) evictLocked() {
+	if c.cfg.HorizonNs > 0 {
+		for c.head < len(c.order) {
+			id := c.order[c.head]
+			l, live := c.byCorr[id]
+			if !live {
+				c.head++ // stale order entry from a replacement
+				continue
+			}
+			if c.newestNs <= l.TimeNs || c.newestNs-l.TimeNs <= c.cfg.HorizonNs {
+				break
+			}
+			delete(c.byCorr, id)
+			c.head++
+			c.stats.EvictedHorizon++
+		}
+	}
+	for len(c.byCorr) > c.cfg.Capacity && c.head < len(c.order) {
+		id := c.order[c.head]
+		c.head++
+		if _, live := c.byCorr[id]; !live {
+			continue
+		}
+		delete(c.byCorr, id)
+		c.stats.EvictedCapacity++
+	}
+	c.compactLocked()
+}
+
+// compactLocked reclaims the dead prefix of order once it dominates the slice,
+// so a long-running agent does not grow order without bound.
+func (c *LaunchCache) compactLocked() {
+	if c.head < 1024 || c.head*2 < len(c.order) {
+		return
+	}
+	rest := c.order[c.head:]
+	c.order = append(c.order[:0], rest...)
+	c.head = 0
+}

--- a/gpu/launchcache.go
+++ b/gpu/launchcache.go
@@ -154,6 +154,23 @@ func (c *LaunchCache) Get(id CorrelationID) (GPUKernelLaunch, bool) {
 	return e.launch, true
 }
 
+// Entries returns a snapshot of the launches currently live in the cache, in
+// no particular order. It exists for the heuristic join (Timeline), which
+// must consider more than one candidate launch: Get alone can only answer
+// "what is stored for this exact correlation ID." Because the cache is
+// bounded, scanning Entries costs at most O(capacity), not O(every launch
+// ever seen) - the quadratic behaviour this cache exists to remove. See the
+// LaunchCache doc comment for the aliasing contract on the returned values.
+func (c *LaunchCache) Entries() []GPUKernelLaunch {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]GPUKernelLaunch, 0, len(c.byCorr))
+	for _, e := range c.byCorr {
+		out = append(out, e.launch)
+	}
+	return out
+}
+
 func (c *LaunchCache) Len() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/gpu/launchcache_test.go
+++ b/gpu/launchcache_test.go
@@ -1,0 +1,81 @@
+package gpu
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func launch(value string, timeNs uint64) GPUKernelLaunch {
+	return GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: value},
+		KernelName:  "k_" + value,
+		TimeNs:      timeNs,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: timeNs},
+	}
+}
+
+func TestLaunchCacheGetsWhatItPut(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 4})
+	c.Put(launch("a", 10))
+
+	got, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "a"})
+	require.True(t, ok)
+	assert.Equal(t, "k_a", got.KernelName)
+}
+
+func TestLaunchCacheMissIsNotAnError(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 4})
+	_, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "nope"})
+	assert.False(t, ok, "a miss must be reported, not fabricated")
+}
+
+func TestLaunchCacheEvictsOldestOverCapacity(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 2})
+	c.Put(launch("a", 10))
+	c.Put(launch("b", 20))
+	c.Put(launch("c", 30))
+
+	_, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "a"})
+	assert.False(t, ok, "oldest entry must be evicted first")
+	_, ok = c.Get(CorrelationID{Backend: BackendCUPTI, Value: "c"})
+	assert.True(t, ok)
+
+	assert.Equal(t, uint64(1), c.Stats().EvictedCapacity)
+	assert.Equal(t, 2, c.Stats().Live)
+}
+
+func TestLaunchCacheEvictsBeyondHorizon(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 100, HorizonNs: 50})
+	c.Put(launch("old", 10))
+	c.Put(launch("new", 100)) // 100-10 = 90 > horizon 50
+
+	_, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "old"})
+	assert.False(t, ok, "entries older than the horizon must be evicted")
+	assert.Equal(t, uint64(1), c.Stats().EvictedHorizon)
+}
+
+func TestLaunchCacheMemoryIsBounded(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 16})
+	for i := 0; i < 100000; i++ {
+		// Unique correlation per launch: a repeated ID would exercise
+		// replacement rather than the capacity bound this test exists for.
+		c.Put(launch(strconv.Itoa(i), uint64(i)))
+	}
+	assert.LessOrEqual(t, c.Len(), 16, "cache must stay bounded under sustained load")
+	assert.Greater(t, c.Stats().EvictedCapacity, uint64(0), "evictions must be counted, not silent")
+}
+
+func TestLaunchCacheReplacesDuplicateCorrelation(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 4})
+	c.Put(launch("a", 10))
+	c.Put(launch("a", 20))
+
+	got, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "a"})
+	require.True(t, ok)
+	assert.Equal(t, uint64(20), got.TimeNs, "a repeated correlation ID must take the newer launch")
+	assert.Equal(t, 1, c.Stats().Live, "a replacement must not grow the cache")
+	assert.Equal(t, uint64(1), c.Stats().Replaced)
+}

--- a/gpu/launchcache_test.go
+++ b/gpu/launchcache_test.go
@@ -210,7 +210,8 @@ func TestLaunchCacheEntriesIsACopyNotAView(t *testing.T) {
 
 	entries := c.Entries()
 	entries[0].KernelName = "tampered"
-	entries = append(entries, launch("injected", 999))
+	grown := append(entries, launch("injected", 999)) //nolint:gocritic // appending to the caller's copy is the point
+	require.Len(t, grown, 2, "the caller's own slice must be growable independently of the cache")
 
 	got, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "a"})
 	require.True(t, ok)

--- a/gpu/launchcache_test.go
+++ b/gpu/launchcache_test.go
@@ -2,6 +2,7 @@ package gpu
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,4 +79,73 @@ func TestLaunchCacheReplacesDuplicateCorrelation(t *testing.T) {
 	assert.Equal(t, uint64(20), got.TimeNs, "a repeated correlation ID must take the newer launch")
 	assert.Equal(t, 1, c.Stats().Live, "a replacement must not grow the cache")
 	assert.Equal(t, uint64(1), c.Stats().Replaced)
+}
+
+func TestLaunchCacheRefreshSurvivesCapacityEviction(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 2})
+	c.Put(launch("a", 10))
+	c.Put(launch("b", 20))
+	c.Put(launch("a", 30)) // refresh: 'a' is now the newest entry
+	c.Put(launch("c", 40)) // forces one capacity eviction
+
+	_, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "a"})
+	assert.True(t, ok, "a refreshed entry must not be evicted ahead of an older untouched one")
+	_, ok = c.Get(CorrelationID{Backend: BackendCUPTI, Value: "b"})
+	assert.False(t, ok, "the older untouched entry must be evicted first")
+	_, ok = c.Get(CorrelationID{Backend: BackendCUPTI, Value: "c"})
+	assert.True(t, ok)
+}
+
+func TestLaunchCacheAnomalousTimestampDoesNotWipeCache(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 1000, HorizonNs: 1000, MaxAdvanceNs: 1000})
+	for i := 0; i < 10; i++ {
+		c.Put(launch(strconv.Itoa(i), uint64(i)))
+	}
+	require.Equal(t, 10, c.Stats().Live)
+
+	c.Put(launch("anomaly", 1<<62))
+
+	assert.Equal(t, 11, c.Stats().Live, "an anomalous timestamp must not evict previously-live entries")
+	assert.Equal(t, uint64(1), c.Stats().AnomalousTimestamp)
+	assert.Equal(t, uint64(0), c.Stats().EvictedHorizon, "the anomaly must not trigger horizon eviction of untouched entries")
+}
+
+// TestLaunchCacheConcurrentPutGetIsRaceFree exercises the cache's actual
+// concurrency contract: producer goroutines calling Put while readers call
+// Get/Stats/Len at snapshot time. Earlier race-detector runs only
+// re-executed single-goroutine tests, which proves nothing about concurrent
+// access. Run with -race; that is the assertion that matters here.
+func TestLaunchCacheConcurrentPutGetIsRaceFree(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 256, HorizonNs: 0})
+
+	const writers = 4
+	const readers = 4
+	const opsPerGoroutine = 3000
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				id := strconv.Itoa(w) + "-" + strconv.Itoa(i)
+				c.Put(launch(id, uint64(i+1)))
+			}
+		}(w)
+	}
+	for r := 0; r < readers; r++ {
+		go func(r int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				id := strconv.Itoa(r%writers) + "-" + strconv.Itoa(i)
+				c.Get(CorrelationID{Backend: BackendCUPTI, Value: id})
+				_ = c.Stats()
+				_ = c.Len()
+			}
+		}(r)
+	}
+	wg.Wait()
+
+	assert.LessOrEqual(t, c.Len(), 256, "cache must stay bounded under concurrent load")
 }

--- a/gpu/launchcache_test.go
+++ b/gpu/launchcache_test.go
@@ -166,3 +166,54 @@ func TestLaunchCacheConcurrentPutGetIsRaceFree(t *testing.T) {
 
 	assert.LessOrEqual(t, c.Len(), 256, "cache must stay bounded under concurrent load")
 }
+
+// TestLaunchCacheEntriesReturnsWhatWasPut is a direct test of Entries(),
+// added for review Important 7: Entries() (added to support Timeline's
+// heuristic join) was previously exercised only indirectly, and never
+// through a scenario with more than one live entry. Mutation this catches:
+// Entries() returning the wrong set (empty, partial, or with stale values).
+func TestLaunchCacheEntriesReturnsWhatWasPut(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 4})
+	c.Put(launch("a", 10))
+	c.Put(launch("b", 20))
+
+	entries := c.Entries()
+	require.Len(t, entries, 2)
+	byValue := make(map[string]uint64, len(entries))
+	for _, e := range entries {
+		byValue[e.Correlation.Value] = e.TimeNs
+	}
+	assert.Equal(t, map[string]uint64{"a": 10, "b": 20}, byValue)
+}
+
+// TestLaunchCacheEntriesReflectsEviction catches Entries() returning a
+// launch that capacity eviction already dropped (e.g. a cached/stale
+// snapshot taken before eviction, rather than reading current state).
+func TestLaunchCacheEntriesReflectsEviction(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 1})
+	c.Put(launch("a", 10))
+	c.Put(launch("b", 20)) // evicts "a"
+
+	entries := c.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "b", entries[0].Correlation.Value, "Entries must not return an evicted launch")
+}
+
+// TestLaunchCacheEntriesIsACopyNotAView catches Entries() handing out a
+// slice or elements that alias the cache's internal storage - e.g. returning
+// a view into the cache's own order/backing array - by mutating the
+// returned slice and its first element, then confirming neither the cache's
+// stored value nor its size changed.
+func TestLaunchCacheEntriesIsACopyNotAView(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 4})
+	c.Put(launch("a", 10))
+
+	entries := c.Entries()
+	entries[0].KernelName = "tampered"
+	entries = append(entries, launch("injected", 999))
+
+	got, ok := c.Get(CorrelationID{Backend: BackendCUPTI, Value: "a"})
+	require.True(t, ok)
+	assert.Equal(t, "k_a", got.KernelName, "mutating the returned slice must not affect the cache's stored value")
+	assert.Equal(t, 1, c.Len(), "appending to the returned slice must not grow the cache")
+}

--- a/gpu/launchcache_test.go
+++ b/gpu/launchcache_test.go
@@ -1,6 +1,7 @@
 package gpu
 
 import (
+	"math"
 	"strconv"
 	"sync"
 	"testing"
@@ -97,7 +98,10 @@ func TestLaunchCacheRefreshSurvivesCapacityEviction(t *testing.T) {
 }
 
 func TestLaunchCacheAnomalousTimestampDoesNotWipeCache(t *testing.T) {
-	c := NewLaunchCache(LaunchCacheConfig{Capacity: 1000, HorizonNs: 1000, MaxAdvanceNs: 1000})
+	// MaxAdvanceNs deliberately unset: the default must protect callers who
+	// set HorizonNs without opting in explicitly, since those are exactly the
+	// callers exposed to this hazard.
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 1000, HorizonNs: 1000})
 	for i := 0; i < 10; i++ {
 		c.Put(launch(strconv.Itoa(i), uint64(i)))
 	}
@@ -108,6 +112,19 @@ func TestLaunchCacheAnomalousTimestampDoesNotWipeCache(t *testing.T) {
 	assert.Equal(t, 11, c.Stats().Live, "an anomalous timestamp must not evict previously-live entries")
 	assert.Equal(t, uint64(1), c.Stats().AnomalousTimestamp)
 	assert.Equal(t, uint64(0), c.Stats().EvictedHorizon, "the anomaly must not trigger horizon eviction of untouched entries")
+}
+
+func TestLaunchCacheMaxAdvanceNsSentinelDisablesClamping(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 1000, HorizonNs: 1000, MaxAdvanceNs: math.MaxUint64})
+	for i := 0; i < 10; i++ {
+		c.Put(launch(strconv.Itoa(i), uint64(i)))
+	}
+	require.Equal(t, 10, c.Stats().Live)
+
+	c.Put(launch("far-future", 1<<62))
+
+	assert.Equal(t, uint64(0), c.Stats().AnomalousTimestamp, "the sentinel must disable anomaly clamping")
+	assert.Equal(t, uint64(10), c.Stats().EvictedHorizon, "with clamping disabled, the far-future timestamp genuinely advances the anchor and evicts the older entries")
 }
 
 // TestLaunchCacheConcurrentPutGetIsRaceFree exercises the cache's actual

--- a/gpu/projection.go
+++ b/gpu/projection.go
@@ -3,6 +3,7 @@ package gpu
 import (
 	"fmt"
 	"maps"
+	"math/bits"
 
 	pp "github.com/dpsoft/perf-agent/pprof"
 )
@@ -205,7 +206,15 @@ func distributeExecutionWeight(execWeight uint64, pcs []GPUPCSample) []uint64 {
 
 	var distributed uint64
 	for i, c := range counts {
-		w := execWeight * c / totalCount
+		// execWeight*c overflows uint64 for a large enough interval (nothing
+		// validates EndNs-StartNs against a malformed producer), and a wrapped
+		// product silently destroys proportionality: every share computes as 0
+		// and the residue below hands the whole duration to the last sample.
+		// bits.Mul64/Div64 carry the full 128-bit product, so the result is
+		// exact for every input. Div64 cannot panic here: c <= totalCount, so
+		// the quotient is at most execWeight and hi is therefore < totalCount.
+		hi, lo := bits.Mul64(execWeight, c)
+		w, _ := bits.Div64(hi, lo, totalCount)
 		weights[i] = w
 		distributed += w
 	}

--- a/gpu/projection.go
+++ b/gpu/projection.go
@@ -26,7 +26,7 @@ func ProjectExecutions(snap Snapshot) []pp.ProfileSample {
 		if len(view.PCSamples) == 0 {
 			samples = append(samples, pp.ProfileSample{
 				Pid:         pid,
-				SampleType:  pp.SampleTypeCpu,
+				SampleType:  pp.SampleTypeGpu,
 				Aggregation: pp.SampleAggregated,
 				Stack:       frames,
 				Value:       executionWeight(view.Exec),
@@ -35,7 +35,8 @@ func ProjectExecutions(snap Snapshot) []pp.ProfileSample {
 			continue
 		}
 
-		for _, pcs := range view.PCSamples {
+		weights := distributeExecutionWeight(executionWeight(view.Exec), view.PCSamples)
+		for i, pcs := range view.PCSamples {
 			labels := maps.Clone(common)
 			if labels == nil {
 				labels = make(map[string]string, 2)
@@ -47,10 +48,10 @@ func ProjectExecutions(snap Snapshot) []pp.ProfileSample {
 
 			samples = append(samples, pp.ProfileSample{
 				Pid:         pid,
-				SampleType:  pp.SampleTypeCpu,
+				SampleType:  pp.SampleTypeGpu,
 				Aggregation: pp.SampleAggregated,
 				Stack:       frames,
-				Value:       pcSampleWeight(pcs),
+				Value:       weights[i],
 				Labels:      labels,
 			})
 		}
@@ -113,6 +114,21 @@ func projectionPID(view ExecutionView) uint32 {
 // honestly (present-if-nonzero, exactly as for an exact join) rather than
 // borrowing the launch's Correlation and presenting an inference as an
 // observation.
+//
+// gpu_join and gpu_ambiguous are the review Critical 1 fix: ExecutionView
+// already carried Join/Heuristic/Ambiguous, but nothing ever read them on
+// the way to a pprof sample, so a heuristic join (a guess) and an exact join
+// (vendor-provided truth) were indistinguishable in the output - including
+// the launch's Tags (pod_uid/container_id), which a heuristic join can
+// attach to the wrong container. gpu_join is set unconditionally (not
+// omitempty, no "only if non-default" branch) to exactly "exact",
+// "heuristic" or "unmatched": an ABSENT label must never be readable as
+// "exact" by a consumer that doesn't know to check for its absence.
+// gpu_ambiguous is set (to "true") only when view.Ambiguous, since false is
+// the overwhelmingly common case and the presence check on the exact/
+// unmatched paths is unambiguous either way. Like every other gpu_* label,
+// both are set after the Tags copy so a producer-supplied tag can never
+// forge them.
 func projectionLabels(view ExecutionView) map[string]string {
 	labels := make(map[string]string)
 	if view.Launch != nil {
@@ -127,6 +143,17 @@ func projectionLabels(view ExecutionView) map[string]string {
 	if view.Exec.Correlation.Value != "" {
 		labels["gpu_correlation"] = fmt.Sprintf("%s:%s", view.Exec.Correlation.Backend, view.Exec.Correlation.Value)
 	}
+	switch view.Join {
+	case JoinExact:
+		labels["gpu_join"] = "exact"
+	case JoinHeuristic:
+		labels["gpu_join"] = "heuristic"
+	default:
+		labels["gpu_join"] = "unmatched"
+	}
+	if view.Ambiguous {
+		labels["gpu_ambiguous"] = "true"
+	}
 	return labels
 }
 
@@ -140,11 +167,50 @@ func executionWeight(exec GPUKernelExec) uint64 {
 	return exec.EndNs - exec.StartNs
 }
 
-// pcSampleWeight is a PC sample's own weight: its aggregated Count, floored
-// at 1 for the same reason as executionWeight.
-func pcSampleWeight(pcs GPUPCSample) uint64 {
-	if pcs.Count < 1 {
-		return 1
+// distributeExecutionWeight is the review Critical 4 fix, part 2: a PC
+// sample's weight used to be its own aggregated Count, fed into the same
+// value dimension (SampleTypeCpu, nanoseconds-by-convention-but-not-really)
+// as executionWeight's nanosecond duration. That mixed counts and
+// nanoseconds in one field, and - independent of that - meant a kernel's
+// total attributed time was its sample count, not its actual duration: a
+// kernel sampled once for a count of 1 attributed 1ns; the same kernel
+// running for 70us but never sampled attributed 70000ns via the no-PC-
+// samples branch above. Two unrelated numbers, both mislabeled as the same
+// unit.
+//
+// The fix: PC samples no longer get their own independent weight. Instead
+// execWeight - the execution's real duration in nanoseconds, exactly what
+// executionWeight returns - is split across pcs proportionally by each
+// sample's Count, so the parts sum to the whole: a kernel's total attributed
+// time equals its actual duration regardless of how many PC samples it
+// received or how their counts are distributed. Integer division leaves a
+// remainder (up to len(pcs)-1 nanoseconds); rather than let it vanish, it is
+// added to the last sample's weight so sum(weights) == execWeight exactly.
+func distributeExecutionWeight(execWeight uint64, pcs []GPUPCSample) []uint64 {
+	weights := make([]uint64, len(pcs))
+	if len(pcs) == 0 {
+		return weights
 	}
-	return pcs.Count
+
+	counts := make([]uint64, len(pcs))
+	var totalCount uint64
+	for i, s := range pcs {
+		c := s.Count
+		if c < 1 {
+			c = 1
+		}
+		counts[i] = c
+		totalCount += c
+	}
+
+	var distributed uint64
+	for i, c := range counts {
+		w := execWeight * c / totalCount
+		weights[i] = w
+		distributed += w
+	}
+	if distributed < execWeight {
+		weights[len(weights)-1] += execWeight - distributed
+	}
+	return weights
 }

--- a/gpu/projection.go
+++ b/gpu/projection.go
@@ -85,11 +85,39 @@ func projectionPID(view ExecutionView) uint32 {
 }
 
 // projectionLabels builds the labels shared by every sample projected from
-// one execution: queue, device, correlation, and the launch's tags (pod/
-// container/cgroup). Per-PC-sample labels (gpu_stall, gpu_pc) are layered on
-// top of a clone of this map by the caller.
+// one execution: the launch's tags (pod/container/cgroup) plus queue, device
+// and correlation. Per-PC-sample labels (gpu_stall, gpu_pc) are layered on
+// top of a clone of this map by the caller, after this function returns -
+// see the reserved-name note below for why that ordering matters there too.
+//
+// Tags are copied in FIRST, and every gpu_* reserved label is set AFTER that
+// copy, deliberately: Tags are producer-supplied (a launch's Tags come from
+// CLI --tag flags and cgroup/k8s attribution, both attacker/operator
+// controlled) while the gpu_* names carry facts this package itself derived
+// from the joined execution and PC sample. A tag literally named "gpu_queue"
+// or "gpu_correlation" must not be able to overwrite - and thereby forge -
+// the real profiler-derived value; reserved names always win. gpu_stall and
+// gpu_pc get the same protection by virtue of being set in ProjectExecutions
+// after this function's map is cloned, i.e. also strictly after Tags.
+//
+// gpu_correlation is built from view.Exec.Correlation - the execution's own,
+// vendor-reported correlation - not from the joined launch's Correlation.
+// For an exact join the two are identical by construction (that's how the
+// join found the launch), so it makes no observable difference. For a
+// heuristic join, though, Exec.Correlation may be empty or may not equal the
+// joined launch's Correlation: the exec's own correlation, if any, simply
+// didn't match anything in the cache, which is why the heuristic path ran at
+// all. This label reports what was actually observed on the execution, not
+// what was inferred by the join; a heuristic match has no vendor-provided
+// correlation for this execution to report, so the label reflects that
+// honestly (present-if-nonzero, exactly as for an exact join) rather than
+// borrowing the launch's Correlation and presenting an inference as an
+// observation.
 func projectionLabels(view ExecutionView) map[string]string {
 	labels := make(map[string]string)
+	if view.Launch != nil {
+		maps.Copy(labels, view.Launch.Launch.Tags)
+	}
 	if view.Exec.Queue.QueueID != "" {
 		labels["gpu_queue"] = view.Exec.Queue.QueueID
 	}
@@ -98,9 +126,6 @@ func projectionLabels(view ExecutionView) map[string]string {
 	}
 	if view.Exec.Correlation.Value != "" {
 		labels["gpu_correlation"] = fmt.Sprintf("%s:%s", view.Exec.Correlation.Backend, view.Exec.Correlation.Value)
-	}
-	if view.Launch != nil {
-		maps.Copy(labels, view.Launch.Launch.Tags)
 	}
 	return labels
 }

--- a/gpu/projection.go
+++ b/gpu/projection.go
@@ -1,0 +1,125 @@
+package gpu
+
+import (
+	"fmt"
+	"maps"
+
+	pp "github.com/dpsoft/perf-agent/pprof"
+)
+
+// ProjectExecutions turns a joined Snapshot into pprof samples.
+//
+// The split between frames and labels is deliberate: frames are stack
+// identity, so only what should nest in a flame graph goes there - the
+// launch's real CPU stack, the [gpu:launch] boundary marker, then
+// [gpu:kernel:<name>]. Everything that would otherwise fragment that
+// identity (the per-sample PC, stall reason, queue/device/correlation, and
+// the launch's tags) goes into per-sample labels instead. Two PC samples
+// from the same kernel therefore share one stack and differ only by label.
+func ProjectExecutions(snap Snapshot) []pp.ProfileSample {
+	samples := make([]pp.ProfileSample, 0, len(snap.Executions))
+	for _, view := range snap.Executions {
+		frames := projectionFrames(view)
+		pid := projectionPID(view)
+		common := projectionLabels(view)
+
+		if len(view.PCSamples) == 0 {
+			samples = append(samples, pp.ProfileSample{
+				Pid:         pid,
+				SampleType:  pp.SampleTypeCpu,
+				Aggregation: pp.SampleAggregated,
+				Stack:       frames,
+				Value:       executionWeight(view.Exec),
+				Labels:      common,
+			})
+			continue
+		}
+
+		for _, pcs := range view.PCSamples {
+			labels := maps.Clone(common)
+			if labels == nil {
+				labels = make(map[string]string, 2)
+			}
+			if pcs.StallReason != "" {
+				labels["gpu_stall"] = pcs.StallReason
+			}
+			labels["gpu_pc"] = fmt.Sprintf("%#x", pcs.PCOffset)
+
+			samples = append(samples, pp.ProfileSample{
+				Pid:         pid,
+				SampleType:  pp.SampleTypeCpu,
+				Aggregation: pp.SampleAggregated,
+				Stack:       frames,
+				Value:       pcSampleWeight(pcs),
+				Labels:      labels,
+			})
+		}
+	}
+	return samples
+}
+
+// projectionFrames builds the frame slice: the launch's real CPU stack (if
+// any), the [gpu:launch] boundary, then the kernel frame. Nothing else - not
+// the PC, not the stall reason, not the queue/device/correlation - belongs
+// here; those go through projectionLabels instead.
+func projectionFrames(view ExecutionView) []pp.Frame {
+	var frames []pp.Frame
+	if view.Launch != nil {
+		frames = append(frames, view.Launch.Launch.CPUStack...)
+	}
+	frames = append(frames, pp.FrameFromName("[gpu:launch]"))
+	if view.Exec.KernelName != "" {
+		frames = append(frames, pp.FrameFromName(fmt.Sprintf("[gpu:kernel:%s]", view.Exec.KernelName)))
+	}
+	return frames
+}
+
+// projectionPID resolves the pid to attribute the sample to. An unmatched
+// execution has no launch to take it from, so it projects with pid 0 rather
+// than a fabricated one.
+func projectionPID(view ExecutionView) uint32 {
+	if view.Launch != nil {
+		return view.Launch.Launch.PID
+	}
+	return 0
+}
+
+// projectionLabels builds the labels shared by every sample projected from
+// one execution: queue, device, correlation, and the launch's tags (pod/
+// container/cgroup). Per-PC-sample labels (gpu_stall, gpu_pc) are layered on
+// top of a clone of this map by the caller.
+func projectionLabels(view ExecutionView) map[string]string {
+	labels := make(map[string]string)
+	if view.Exec.Queue.QueueID != "" {
+		labels["gpu_queue"] = view.Exec.Queue.QueueID
+	}
+	if view.Exec.Queue.Device.DeviceID != "" {
+		labels["gpu_device"] = view.Exec.Queue.Device.DeviceID
+	}
+	if view.Exec.Correlation.Value != "" {
+		labels["gpu_correlation"] = fmt.Sprintf("%s:%s", view.Exec.Correlation.Backend, view.Exec.Correlation.Value)
+	}
+	if view.Launch != nil {
+		maps.Copy(labels, view.Launch.Launch.Tags)
+	}
+	return labels
+}
+
+// executionWeight is the fallback sample weight when an execution has no PC
+// samples: the execution's own interval, floored at 1 so a zero-or-negative
+// window still counts as one occurrence rather than vanishing.
+func executionWeight(exec GPUKernelExec) uint64 {
+	if exec.EndNs <= exec.StartNs {
+		return 1
+	}
+	return exec.EndNs - exec.StartNs
+}
+
+// pcSampleWeight is a PC sample's own weight: its aggregated Count, floored
+// at 1 for the same reason as executionWeight.
+func pcSampleWeight(pcs GPUPCSample) uint64 {
+	if pcs.Count < 1 {
+		return 1
+	}
+	return pcs.Count
+}

--- a/gpu/projection.go
+++ b/gpu/projection.go
@@ -37,10 +37,10 @@ func ProjectExecutions(snap Snapshot) []pp.ProfileSample {
 
 		weights := distributeExecutionWeight(executionWeight(view.Exec), view.PCSamples)
 		for i, pcs := range view.PCSamples {
+			// common is projectionLabels' return value, which always starts
+			// from `make(map[string]string)` - never nil - so maps.Clone(common)
+			// is never nil either; no separate nil-guard is needed here.
 			labels := maps.Clone(common)
-			if labels == nil {
-				labels = make(map[string]string, 2)
-			}
 			if pcs.StallReason != "" {
 				labels["gpu_stall"] = pcs.StallReason
 			}

--- a/gpu/projection_test.go
+++ b/gpu/projection_test.go
@@ -115,7 +115,8 @@ func TestProjectionSetsPidSampleTypeAndAggregationFromLaunch(t *testing.T) {
 	require.Len(t, samples, 1)
 
 	assert.Equal(t, uint32(42), samples[0].Pid, "pid must come from the joined launch's PID, not TID or anything else")
-	assert.Equal(t, pp.SampleTypeCpu, samples[0].SampleType)
+	assert.Equal(t, pp.SampleTypeGpu, samples[0].SampleType,
+		"GPU samples must use SampleTypeGpu (period 1), not SampleTypeCpu - see review Critical 4")
 	assert.Equal(t, pp.SampleAggregated, samples[0].Aggregation)
 }
 
@@ -130,6 +131,147 @@ func TestProjectionFallsBackToExecutionDuration(t *testing.T) {
 		"with no PC samples the execution interval is the weight")
 }
 
+// TestProjectionRendersMicrosecondKernelInNanoseconds is the regression test
+// for review Critical 4: executionWeight already returned nanoseconds, but
+// every sample - including this one - went out as SampleTypeCpu, which
+// pprof/pprof.go's BuilderForSample multiplies by Profile.Period (~10.1ms at
+// 99Hz). A 70us kernel rendered as 707.1 seconds - off by roughly 10
+// million. This asserts the gpu package's half of the fix (SampleTypeGpu
+// instead of SampleTypeCpu on the ProfileSample); pprof's
+// TestGpuValueNotScaledByCpuPeriod asserts the other half (period 1, no
+// rescaling once it reaches the builder).
+func TestProjectionRendersMicrosecondKernelInNanoseconds(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 0)))
+	require.NoError(t, tl.EmitExec(execFor("a", 1_000, 71_000))) // a 70us kernel
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+	assert.Equal(t, uint64(70_000), samples[0].Value, "a 70us kernel must project as ~70000ns")
+	assert.Equal(t, pp.SampleTypeGpu, samples[0].SampleType)
+}
+
+// TestProjectionDistributesExecutionWeightAcrossPCSamples is the second
+// Critical 4 regression test: pcSampleWeight used to return each PC sample's
+// own Count, mixing "a count of samples" and "a duration in nanoseconds" in
+// the same value dimension, and made a kernel's total attributed time equal
+// its sample count rather than its actual duration. The fix distributes the
+// execution's real duration across its PC samples in proportion to Count,
+// so the parts sum to exactly the whole (remainder to the last sample).
+// Three samples with counts 1:2:1 (total 4) against a 100ns execution:
+// expected shares are 25, 50, 25 - evenly divisible, so this alone wouldn't
+// catch the remainder-handling; TestProjectionDistributionHandlesRemainder
+// below covers that separately. Mutation this catches: reverting to
+// per-sample Count as the weight (would yield 1, 2, 1 - nowhere near 100),
+// or distributing without proportion to Count (e.g. splitting evenly
+// regardless of Count, which coincidentally would also look like 33/33/33
+// here - the differing counts below rule that out).
+func TestProjectionDistributesExecutionWeightAcrossPCSamples(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 0)))
+	require.NoError(t, tl.EmitExec(execFor("a", 0, 100)))
+	corr := CorrelationID{Backend: BackendCUPTI, Value: "a"}
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: corr, TimeNs: 1, PCOffset: 0x1, Count: 1}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: corr, TimeNs: 2, PCOffset: 0x2, Count: 2}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: corr, TimeNs: 3, PCOffset: 0x3, Count: 1}))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 3)
+
+	var total uint64
+	for _, s := range samples {
+		total += s.Value
+	}
+	assert.Equal(t, uint64(100), total, "the PC samples' weights must sum to the execution's actual duration")
+	assert.Equal(t, []uint64{25, 50, 25}, []uint64{samples[0].Value, samples[1].Value, samples[2].Value},
+		"weights must be proportional to each sample's Count (1:2:1 of a 100ns duration)")
+}
+
+// TestProjectionDistributionHandlesRemainder targets the explicit rounding
+// requirement: integer division of a duration that doesn't divide evenly
+// across sample counts must not silently drop the remainder - it goes to
+// the last sample, so the parts still sum to the whole exactly. 100ns split
+// three ways evenly (counts 1:1:1) gives 33+33+33=99, one short; the
+// remainder (1) must land on the last sample. Mutation this catches:
+// dropping the "give the remainder to the last sample" step, which would
+// leave the sum at 99 instead of 100.
+func TestProjectionDistributionHandlesRemainder(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 0)))
+	require.NoError(t, tl.EmitExec(execFor("a", 0, 100)))
+	corr := CorrelationID{Backend: BackendCUPTI, Value: "a"}
+	for i := 0; i < 3; i++ {
+		require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: corr, TimeNs: uint64(i + 1), PCOffset: uint64(i), Count: 1}))
+	}
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 3)
+
+	var total uint64
+	for _, s := range samples {
+		total += s.Value
+	}
+	assert.Equal(t, uint64(100), total, "the remainder must be accounted for, not dropped")
+	assert.Equal(t, uint64(34), samples[2].Value, "the remainder must land on the last sample (33+33+34=100)")
+}
+
+// TestProjectionEmitsGpuJoinExact is part of the regression test pair for
+// review Critical 1: ExecutionView carried Join/Heuristic/Ambiguous, but
+// grep for those identifiers in projection.go returned nothing - the join
+// marking was computed and then discarded on the way to a pprof sample, so
+// a heuristic (guessed) join was indistinguishable from an exact
+// (vendor-provided) one in the output, including which container's
+// pod_uid/container_id Tags rode along. Mutation this catches: the
+// gpu_join assignment being removed, or an exact join emitting anything
+// other than "exact".
+func TestProjectionEmitsGpuJoinExact(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+	assert.Equal(t, "exact", samples[0].Labels["gpu_join"])
+	_, hasAmbiguous := samples[0].Labels["gpu_ambiguous"]
+	assert.False(t, hasAmbiguous, "an exact join must not carry gpu_ambiguous")
+}
+
+// TestProjectionEmitsGpuJoinHeuristicAndAmbiguous is the second half of the
+// Critical 1 regression pair: a real heuristic join (exec Correlation left
+// at its zero value - see review Critical 2 - with two candidate launches
+// so Ambiguous is also genuinely exercised) must carry both gpu_join and
+// gpu_ambiguous through to the projected sample. Before the fix, a
+// heuristic join's launch (and therefore its Tags - pod_uid/container_id)
+// projected identically to an exact join's, silently billing GPU time to a
+// container chosen by a guess. Mutation this catches: gpu_join reading
+// "exact" (or being absent) for a heuristic join, or gpu_ambiguous not
+// being set when view.Ambiguous is true.
+func TestProjectionEmitsGpuJoinHeuristicAndAmbiguous(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "older"},
+		KernelName:  "k_x",
+		TimeNs:      10,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 10, Tags: map[string]string{"pod_uid": "guessed-pod"}},
+	}))
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "newer"},
+		KernelName:  "k_x",
+		TimeNs:      15,
+		Launch:      LaunchContext{PID: 2, TID: 2, TimeNs: 15},
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		// Correlation deliberately zero-valued so the heuristic runs at all.
+		KernelName: "k_x",
+		StartNs:    20, EndNs: 30,
+	}))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+	assert.Equal(t, "heuristic", samples[0].Labels["gpu_join"])
+	assert.Equal(t, "true", samples[0].Labels["gpu_ambiguous"])
+}
+
 func TestProjectionHandlesUnmatchedExecution(t *testing.T) {
 	tl := NewTimeline(TimelineConfig{})
 	require.NoError(t, tl.EmitExec(execFor("ghost", 20, 30)))
@@ -140,6 +282,8 @@ func TestProjectionHandlesUnmatchedExecution(t *testing.T) {
 		"an execution with no launch still projects, without a fabricated CPU stack")
 	assert.Equal(t, uint32(0), samples[0].Pid,
 		"no launch means no pid to read - pinned at 0 rather than fabricated")
-	assert.Equal(t, pp.SampleTypeCpu, samples[0].SampleType)
+	assert.Equal(t, pp.SampleTypeGpu, samples[0].SampleType)
 	assert.Equal(t, pp.SampleAggregated, samples[0].Aggregation)
+	assert.Equal(t, "unmatched", samples[0].Labels["gpu_join"],
+		"an unmatched execution's gpu_join must read 'unmatched', never absent (which could be misread as exact)")
 }

--- a/gpu/projection_test.go
+++ b/gpu/projection_test.go
@@ -287,3 +287,29 @@ func TestProjectionHandlesUnmatchedExecution(t *testing.T) {
 	assert.Equal(t, "unmatched", samples[0].Labels["gpu_join"],
 		"an unmatched execution's gpu_join must read 'unmatched', never absent (which could be misread as exact)")
 }
+
+// TestProjectionDistributionSurvivesOverflow pins proportionality for an
+// execution interval large enough that execWeight*Count exceeds uint64.
+// Nothing validates EndNs-StartNs against a malformed producer, and a wrapped
+// product is silently destructive rather than loud: every share computes as 0
+// and the residue guard hands the entire duration to the last sample, so the
+// weights still sum correctly while the distribution is completely wrong.
+//
+// Mutation caught: replacing bits.Mul64/Div64 with `execWeight * c / totalCount`
+// makes the two equal-count samples receive 0 and execWeight respectively.
+func TestProjectionDistributionSurvivesOverflow(t *testing.T) {
+	execWeight := uint64(1) << 62
+	pcs := []GPUPCSample{{Count: 8}, {Count: 8}}
+
+	weights := distributeExecutionWeight(execWeight, pcs)
+
+	require.Len(t, weights, 2)
+	assert.Equal(t, weights[0], weights[1],
+		"equal sample counts must receive equal shares; unequal means the product wrapped")
+
+	var sum uint64
+	for _, w := range weights {
+		sum += w
+	}
+	assert.Equal(t, execWeight, sum, "distributed weights must sum to the execution duration")
+}

--- a/gpu/projection_test.go
+++ b/gpu/projection_test.go
@@ -1,0 +1,87 @@
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pp "github.com/dpsoft/perf-agent/pprof"
+)
+
+func frameNames(frames []pp.Frame) []string {
+	out := make([]string, 0, len(frames))
+	for _, f := range frames {
+		out = append(out, f.Name)
+	}
+	return out
+}
+
+func TestProjectionPutsStackInFramesAndDetailInLabels(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	l := launch("a", 10)
+	l.Launch.CPUStack = pp.FramesFromNames([]string{"train_step", "cudaLaunchKernel"})
+	l.Launch.Tags = map[string]string{"pod_uid": "pod-a"}
+	require.NoError(t, tl.EmitLaunch(l))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+		PCOffset:    0x1a40, StallReason: "long_scoreboard", Count: 5, TimeNs: 25,
+	}))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+
+	assert.Equal(t,
+		[]string{"train_step", "cudaLaunchKernel", "[gpu:launch]", "[gpu:kernel:k_a]"},
+		frameNames(samples[0].Stack),
+		"frames carry the CPU stack, the boundary marker and the kernel - nothing else")
+
+	assert.Equal(t, "long_scoreboard", samples[0].Labels["gpu_stall"])
+	assert.Equal(t, "0x1a40", samples[0].Labels["gpu_pc"])
+	assert.Equal(t, "pod-a", samples[0].Labels["pod_uid"])
+}
+
+func TestProjectionKeepsPCOutOfStackIdentity(t *testing.T) {
+	// Two PC samples from one kernel must share a stack and differ only by
+	// label. Putting the PC in a frame would make every sampled instruction a
+	// distinct flame-graph leaf.
+	tl := NewTimeline(TimelineConfig{})
+	l := launch("a", 10)
+	l.Launch.CPUStack = pp.FramesFromNames([]string{"train_step"})
+	require.NoError(t, tl.EmitLaunch(l))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+	for _, pc := range []uint64{0x100, 0x200} {
+		require.NoError(t, tl.EmitPCSample(GPUPCSample{
+			Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+			PCOffset:    pc, StallReason: "barrier", Count: 1, TimeNs: 25,
+		}))
+	}
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 2)
+	assert.Equal(t, frameNames(samples[0].Stack), frameNames(samples[1].Stack),
+		"PC must not appear in frames")
+	assert.NotEqual(t, samples[0].Labels["gpu_pc"], samples[1].Labels["gpu_pc"])
+}
+
+func TestProjectionFallsBackToExecutionDuration(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 90)))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+	assert.Equal(t, uint64(70), samples[0].Value,
+		"with no PC samples the execution interval is the weight")
+}
+
+func TestProjectionHandlesUnmatchedExecution(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitExec(execFor("ghost", 20, 30)))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+	assert.Equal(t, []string{"[gpu:launch]", "[gpu:kernel:k_ghost]"}, frameNames(samples[0].Stack),
+		"an execution with no launch still projects, without a fabricated CPU stack")
+}

--- a/gpu/projection_test.go
+++ b/gpu/projection_test.go
@@ -65,6 +65,60 @@ func TestProjectionKeepsPCOutOfStackIdentity(t *testing.T) {
 	assert.NotEqual(t, samples[0].Labels["gpu_pc"], samples[1].Labels["gpu_pc"])
 }
 
+func TestProjectionReservedLabelsWinOverTags(t *testing.T) {
+	// A launch's Tags are producer-supplied (CLI --tag flags, cgroup/k8s
+	// attribution) and can carry any key, including one that collides with a
+	// name this package itself derives from the joined execution/PC sample.
+	// Reserved gpu_* names must always report the real, profiler-derived
+	// value - a tag must never be able to forge it.
+	tl := NewTimeline(TimelineConfig{})
+	l := launch("a", 10)
+	l.Launch.Tags = map[string]string{
+		"gpu_queue":       "HIJACKED",
+		"gpu_device":      "HIJACKED",
+		"gpu_correlation": "HIJACKED",
+		"gpu_stall":       "HIJACKED",
+		"gpu_pc":          "HIJACKED",
+	}
+	require.NoError(t, tl.EmitLaunch(l))
+
+	exec := execFor("a", 20, 30)
+	exec.Queue = GPUQueueRef{Backend: BackendCUPTI, QueueID: "q1", Device: GPUDeviceRef{DeviceID: "dev1"}}
+	require.NoError(t, tl.EmitExec(exec))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+		PCOffset:    0x1a40, StallReason: "long_scoreboard", Count: 1, TimeNs: 25,
+	}))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+
+	assert.Equal(t, "q1", samples[0].Labels["gpu_queue"], "a tag named gpu_queue must not override the real queue")
+	assert.Equal(t, "dev1", samples[0].Labels["gpu_device"], "a tag named gpu_device must not override the real device")
+	assert.Equal(t, "cupti:a", samples[0].Labels["gpu_correlation"], "a tag named gpu_correlation must not override the real correlation")
+	assert.Equal(t, "long_scoreboard", samples[0].Labels["gpu_stall"], "a tag named gpu_stall must not override the real stall reason")
+	assert.Equal(t, "0x1a40", samples[0].Labels["gpu_pc"], "a tag named gpu_pc must not override the real pc")
+}
+
+func TestProjectionSetsPidSampleTypeAndAggregationFromLaunch(t *testing.T) {
+	// PID must come from the joined launch's LaunchContext.PID specifically,
+	// not TID - launch()'s default fixture sets both to 1, which would hide
+	// a PID/TID mix-up, so this test deliberately makes them differ.
+	tl := NewTimeline(TimelineConfig{})
+	l := launch("a", 10)
+	l.Launch.PID = 42
+	l.Launch.TID = 99
+	require.NoError(t, tl.EmitLaunch(l))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+
+	samples := ProjectExecutions(tl.Snapshot())
+	require.Len(t, samples, 1)
+
+	assert.Equal(t, uint32(42), samples[0].Pid, "pid must come from the joined launch's PID, not TID or anything else")
+	assert.Equal(t, pp.SampleTypeCpu, samples[0].SampleType)
+	assert.Equal(t, pp.SampleAggregated, samples[0].Aggregation)
+}
+
 func TestProjectionFallsBackToExecutionDuration(t *testing.T) {
 	tl := NewTimeline(TimelineConfig{})
 	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
@@ -84,4 +138,8 @@ func TestProjectionHandlesUnmatchedExecution(t *testing.T) {
 	require.Len(t, samples, 1)
 	assert.Equal(t, []string{"[gpu:launch]", "[gpu:kernel:k_ghost]"}, frameNames(samples[0].Stack),
 		"an execution with no launch still projects, without a fabricated CPU stack")
+	assert.Equal(t, uint32(0), samples[0].Pid,
+		"no launch means no pid to read - pinned at 0 rather than fabricated")
+	assert.Equal(t, pp.SampleTypeCpu, samples[0].SampleType)
+	assert.Equal(t, pp.SampleAggregated, samples[0].Aggregation)
 }

--- a/gpu/sink.go
+++ b/gpu/sink.go
@@ -1,0 +1,118 @@
+package gpu
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// ErrSinkFull is returned when the sink has reached capacity. A backend
+// receiving it should drop the event and count it locally rather than block:
+// blocking a producer inside a profiled application is worse than losing a
+// sample, and the loss is visible in SinkStats either way.
+var ErrSinkFull = errors.New("gpu: sink full")
+
+// SinkStats is the ingestion-side loss record. JoinStats reports what could not
+// be correlated; this reports what never arrived.
+type SinkStats struct {
+	Launches  uint64 `json:"launches,omitempty"`
+	Execs     uint64 `json:"execs,omitempty"`
+	PCSamples uint64 `json:"pc_samples,omitempty"`
+	Modules   uint64 `json:"modules,omitempty"`
+	Events    uint64 `json:"events,omitempty"`
+
+	DroppedFull    uint64 `json:"dropped_full,omitempty"`
+	DroppedInvalid uint64 `json:"dropped_invalid,omitempty"`
+}
+
+// CountingSink wraps a sink with admission control and accounting. capacity is
+// the total accepted-event budget; zero means unbounded.
+type CountingSink struct {
+	mu       sync.Mutex
+	inner    EventSink
+	capacity int
+	accepted int
+	stats    SinkStats
+}
+
+func NewCountingSink(inner EventSink, capacity int) *CountingSink {
+	return &CountingSink{inner: inner, capacity: capacity}
+}
+
+func (s *CountingSink) Stats() SinkStats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stats
+}
+
+// admit applies the clock-domain contract and the capacity bound. It returns
+// nil when the event may proceed, and has already counted the drop otherwise.
+func (s *CountingSink) admit(domain ClockDomain) error {
+	if err := ValidateSupportedClockDomain(domain); err != nil {
+		s.stats.DroppedInvalid++
+		return fmt.Errorf("gpu: rejected event: %w", err)
+	}
+	if s.capacity > 0 && s.accepted >= s.capacity {
+		s.stats.DroppedFull++
+		return ErrSinkFull
+	}
+	s.accepted++
+	return nil
+}
+
+func (s *CountingSink) EmitLaunch(l GPUKernelLaunch) error {
+	s.mu.Lock()
+	if err := s.admit(l.ClockDomain); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.stats.Launches++
+	s.mu.Unlock()
+	return s.inner.EmitLaunch(l)
+}
+
+func (s *CountingSink) EmitExec(e GPUKernelExec) error {
+	s.mu.Lock()
+	if err := s.admit(e.ClockDomain); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.stats.Execs++
+	s.mu.Unlock()
+	return s.inner.EmitExec(e)
+}
+
+func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
+	s.mu.Lock()
+	if err := s.admit(p.ClockDomain); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.stats.PCSamples++
+	s.mu.Unlock()
+	return s.inner.EmitPCSample(p)
+}
+
+func (s *CountingSink) EmitModule(m GPUModule) error {
+	s.mu.Lock()
+	if s.capacity > 0 && s.accepted >= s.capacity {
+		s.stats.DroppedFull++
+		s.mu.Unlock()
+		return ErrSinkFull
+	}
+	s.accepted++
+	s.stats.Modules++
+	s.mu.Unlock()
+	return s.inner.EmitModule(m)
+}
+
+func (s *CountingSink) EmitEvent(e GPUTimelineEvent) error {
+	s.mu.Lock()
+	if err := s.admit(e.ClockDomain); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.stats.Events++
+	s.mu.Unlock()
+	return s.inner.EmitEvent(e)
+}

--- a/gpu/sink.go
+++ b/gpu/sink.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 )
 
 // ErrSinkFull is returned when the sink has reached capacity. A backend
@@ -23,20 +24,79 @@ type SinkStats struct {
 
 	DroppedFull    uint64 `json:"dropped_full,omitempty"`
 	DroppedInvalid uint64 `json:"dropped_invalid,omitempty"`
+
+	// DroppedDownstream counts events that passed admission (clock domain
+	// and capacity) but that inner failed to accept. They are not counted in
+	// the per-type accepted counters above, and the capacity they reserved
+	// is returned to the bucket - a downstream hiccup must not permanently
+	// shrink what the sink can admit.
+	DroppedDownstream uint64 `json:"dropped_downstream,omitempty"`
 }
 
-// CountingSink wraps a sink with admission control and accounting. capacity is
-// the total accepted-event budget; zero means unbounded.
+// CountingSink wraps a sink with admission control and accounting. Admission
+// is a token bucket: burst is the maximum number of events admitted at once,
+// refilled continuously at refillRate tokens/second. capacity <= 0 means
+// unbounded - no admission limit is ever applied.
+//
+// A lifetime budget that only ever decreases would be wrong for a
+// continuously-running profiler: once spent it would reject forever. The
+// token bucket recovers over time instead, the way a rate limiter does.
 type CountingSink struct {
-	mu       sync.Mutex
-	inner    EventSink
-	capacity int
-	accepted int
-	stats    SinkStats
+	mu    sync.Mutex
+	inner EventSink
+
+	unbounded  bool
+	burst      float64
+	tokens     float64
+	refillRate float64 // tokens per second
+	lastRefill time.Time
+	now        func() time.Time
+
+	stats SinkStats
 }
 
+// defaultRefillRate is used by NewCountingSink when no explicit rate is
+// given: the bucket refills fully within one second of being exhausted, so a
+// producer that pauses briefly regains its full burst rather than being
+// throttled forever. Callers that need a different steady-state rate should
+// use NewCountingSinkWithRate.
+func defaultRefillRate(capacity int) float64 {
+	return float64(capacity)
+}
+
+// NewCountingSink constructs a CountingSink whose admission control is a
+// token bucket with capacity as the burst size, refilled at
+// defaultRefillRate (capacity tokens/second) using the real wall clock.
+// capacity <= 0 means unbounded, matching the historical "0 means unbounded"
+// contract - a negative capacity is not a smaller-than-zero budget, it is
+// simply also unbounded.
 func NewCountingSink(inner EventSink, capacity int) *CountingSink {
-	return &CountingSink{inner: inner, capacity: capacity}
+	return NewCountingSinkWithRate(inner, capacity, defaultRefillRate(capacity), nil)
+}
+
+// NewCountingSinkWithRate is NewCountingSink with the refill rate (tokens per
+// second) and clock made explicit, for callers that need a different
+// steady-state rate or deterministic tests. now defaults to time.Now when
+// nil. capacity <= 0 means unbounded, independent of refillPerSecond.
+func NewCountingSinkWithRate(inner EventSink, capacity int, refillPerSecond float64, now func() time.Time) *CountingSink {
+	if now == nil {
+		now = time.Now
+	}
+	s := &CountingSink{
+		inner:      inner,
+		refillRate: refillPerSecond,
+		now:        now,
+		lastRefill: now(),
+	}
+	if capacity <= 0 {
+		// Explicit rather than relying on a ">0" guard at every call site,
+		// so the unbounded case can't silently diverge if the guard changes.
+		s.unbounded = true
+	} else {
+		s.burst = float64(capacity)
+		s.tokens = float64(capacity)
+	}
+	return s
 }
 
 func (s *CountingSink) Stats() SinkStats {
@@ -45,19 +105,62 @@ func (s *CountingSink) Stats() SinkStats {
 	return s.stats
 }
 
-// admit applies the clock-domain contract and the capacity bound. It returns
-// nil when the event may proceed, and has already counted the drop otherwise.
+// refill adds tokens for elapsed time since the last refill, capped at
+// burst. Caller holds mu.
+func (s *CountingSink) refill() {
+	if s.unbounded {
+		return
+	}
+	now := s.now()
+	elapsed := now.Sub(s.lastRefill)
+	if elapsed <= 0 {
+		return
+	}
+	s.lastRefill = now
+	s.tokens += elapsed.Seconds() * s.refillRate
+	if s.tokens > s.burst {
+		s.tokens = s.burst
+	}
+}
+
+// admitCapacity applies the token-bucket bound only - the one rule EmitModule
+// shares with every other event type. On success it has reserved one token;
+// call release if the reservation turns out not to be used. Caller holds mu.
+func (s *CountingSink) admitCapacity() error {
+	if s.unbounded {
+		return nil
+	}
+	s.refill()
+	if s.tokens < 1 {
+		s.stats.DroppedFull++
+		return ErrSinkFull
+	}
+	s.tokens--
+	return nil
+}
+
+// release returns a reserved token after inner fails to accept a delegated
+// event, so a downstream rejection does not permanently shrink capacity.
+// Caller holds mu.
+func (s *CountingSink) release() {
+	if s.unbounded {
+		return
+	}
+	s.tokens++
+	if s.tokens > s.burst {
+		s.tokens = s.burst
+	}
+}
+
+// admit applies the clock-domain contract, then the capacity bound. Caller
+// holds mu. EmitModule bypasses this and calls admitCapacity directly: a
+// GPUModule has no ClockDomain field to validate.
 func (s *CountingSink) admit(domain ClockDomain) error {
 	if err := ValidateSupportedClockDomain(domain); err != nil {
 		s.stats.DroppedInvalid++
 		return fmt.Errorf("gpu: rejected event: %w", err)
 	}
-	if s.capacity > 0 && s.accepted >= s.capacity {
-		s.stats.DroppedFull++
-		return ErrSinkFull
-	}
-	s.accepted++
-	return nil
+	return s.admitCapacity()
 }
 
 func (s *CountingSink) EmitLaunch(l GPUKernelLaunch) error {
@@ -66,9 +169,19 @@ func (s *CountingSink) EmitLaunch(l GPUKernelLaunch) error {
 		s.mu.Unlock()
 		return err
 	}
-	s.stats.Launches++
 	s.mu.Unlock()
-	return s.inner.EmitLaunch(l)
+
+	err := s.inner.EmitLaunch(l)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.release()
+		s.stats.DroppedDownstream++
+		return err
+	}
+	s.stats.Launches++
+	return nil
 }
 
 func (s *CountingSink) EmitExec(e GPUKernelExec) error {
@@ -77,9 +190,19 @@ func (s *CountingSink) EmitExec(e GPUKernelExec) error {
 		s.mu.Unlock()
 		return err
 	}
-	s.stats.Execs++
 	s.mu.Unlock()
-	return s.inner.EmitExec(e)
+
+	err := s.inner.EmitExec(e)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.release()
+		s.stats.DroppedDownstream++
+		return err
+	}
+	s.stats.Execs++
+	return nil
 }
 
 func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
@@ -88,22 +211,44 @@ func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
 		s.mu.Unlock()
 		return err
 	}
-	s.stats.PCSamples++
 	s.mu.Unlock()
-	return s.inner.EmitPCSample(p)
+
+	err := s.inner.EmitPCSample(p)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.release()
+		s.stats.DroppedDownstream++
+		return err
+	}
+	s.stats.PCSamples++
+	return nil
 }
 
+// EmitModule deliberately skips the clock-domain check: GPUModule is
+// symbolization metadata with no ClockDomain field. It still goes through
+// the same token-bucket admission (admitCapacity) and the same
+// reserve/delegate/settle sequence as every other event type.
 func (s *CountingSink) EmitModule(m GPUModule) error {
 	s.mu.Lock()
-	if s.capacity > 0 && s.accepted >= s.capacity {
-		s.stats.DroppedFull++
+	if err := s.admitCapacity(); err != nil {
 		s.mu.Unlock()
-		return ErrSinkFull
+		return err
 	}
-	s.accepted++
-	s.stats.Modules++
 	s.mu.Unlock()
-	return s.inner.EmitModule(m)
+
+	err := s.inner.EmitModule(m)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.release()
+		s.stats.DroppedDownstream++
+		return err
+	}
+	s.stats.Modules++
+	return nil
 }
 
 func (s *CountingSink) EmitEvent(e GPUTimelineEvent) error {
@@ -112,7 +257,17 @@ func (s *CountingSink) EmitEvent(e GPUTimelineEvent) error {
 		s.mu.Unlock()
 		return err
 	}
-	s.stats.Events++
 	s.mu.Unlock()
-	return s.inner.EmitEvent(e)
+
+	err := s.inner.EmitEvent(e)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.release()
+		s.stats.DroppedDownstream++
+		return err
+	}
+	s.stats.Events++
+	return nil
 }

--- a/gpu/sink.go
+++ b/gpu/sink.go
@@ -153,7 +153,9 @@ func NewCountingSink(inner EventSink, capacity int) *CountingSink {
 // nil. capacity <= 0 means unbounded, independent of refillPerSecond.
 //
 // Each eventClass (see its doc comment) gets its own independent token
-// bucket, each sized at capacity/refillPerSecond - review Important 5. This
+// bucket, each with burst size == capacity and refilled at refillPerSecond
+// tokens/second, so a full refill takes capacity/refillPerSecond seconds - see
+// review Important 5. This
 // is deliberately not capacity split across the two classes: launches/
 // modules must never be crowded out by exec/sample/event volume, so the
 // anchor class needs its own full, untouched budget regardless of how

--- a/gpu/sink.go
+++ b/gpu/sink.go
@@ -33,10 +33,41 @@ type SinkStats struct {
 	DroppedDownstream uint64 `json:"dropped_downstream,omitempty"`
 }
 
+// eventClass groups EventSink methods by admission priority - review
+// Important 5. A single, undifferentiated token bucket meant launches and
+// modules (the correlation anchors every later exec/PC-sample join depends
+// on) were dropped exactly as readily as the much higher-volume exec/
+// sample/event traffic under overload. Per review Critical 2, a dropped
+// launch turns every subsequent exec referencing it into a permanent miss -
+// so losing an anchor is structurally more expensive than losing one data
+// point, and admission must reflect that rather than treat all five event
+// kinds as fungible.
+type eventClass int
+
+const (
+	// classAnchor is EmitLaunch/EmitModule: correlation anchors that later
+	// exact and heuristic joins depend on. Given its own token bucket so
+	// exec/sample/event volume can never starve it.
+	classAnchor eventClass = iota
+	// classData is EmitExec/EmitPCSample/EmitEvent: everything joined
+	// against an anchor rather than being one itself.
+	classData
+)
+
+// tokenBucket is one admission budget: burst is the maximum admitted at
+// once, refilled continuously at the CountingSink's shared refillRate.
+// unbounded means no admission limit is ever applied (capacity <= 0).
+type tokenBucket struct {
+	unbounded bool
+	burst     float64
+	tokens    float64
+}
+
 // CountingSink wraps a sink with admission control and accounting. Admission
-// is a token bucket: burst is the maximum number of events admitted at once,
-// refilled continuously at refillRate tokens/second. capacity <= 0 means
-// unbounded - no admission limit is ever applied.
+// is a token bucket per eventClass (see its doc comment): burst is the
+// maximum number of events of that class admitted at once, refilled
+// continuously at refillRate tokens/second. capacity <= 0 means unbounded -
+// no admission limit is ever applied, for either class.
 //
 // A lifetime budget that only ever decreases would be wrong for a
 // continuously-running profiler: once spent it would reject forever. The
@@ -45,10 +76,10 @@ type CountingSink struct {
 	mu    sync.Mutex
 	inner EventSink
 
-	unbounded  bool
-	burst      float64
-	tokens     float64
-	refillRate float64 // tokens per second
+	anchor tokenBucket
+	data   tokenBucket
+
+	refillRate float64 // tokens per second, shared by both buckets
 	lastRefill time.Time
 	now        func() time.Time
 
@@ -78,6 +109,12 @@ func NewCountingSink(inner EventSink, capacity int) *CountingSink {
 // second) and clock made explicit, for callers that need a different
 // steady-state rate or deterministic tests. now defaults to time.Now when
 // nil. capacity <= 0 means unbounded, independent of refillPerSecond.
+// NewCountingSinkWithRate gives each eventClass (see its doc comment) its
+// own independent token bucket, each sized at capacity/refillPerSecond -
+// review Important 5. This is deliberately not capacity split across the
+// two classes: launches/modules must never be crowded out by exec/sample/
+// event volume, so the anchor class needs its own full, untouched budget
+// regardless of how saturated the data class is.
 func NewCountingSinkWithRate(inner EventSink, capacity int, refillPerSecond float64, now func() time.Time) *CountingSink {
 	if now == nil {
 		now = time.Now
@@ -91,10 +128,11 @@ func NewCountingSinkWithRate(inner EventSink, capacity int, refillPerSecond floa
 	if capacity <= 0 {
 		// Explicit rather than relying on a ">0" guard at every call site,
 		// so the unbounded case can't silently diverge if the guard changes.
-		s.unbounded = true
+		s.anchor.unbounded = true
+		s.data.unbounded = true
 	} else {
-		s.burst = float64(capacity)
-		s.tokens = float64(capacity)
+		s.anchor.burst, s.anchor.tokens = float64(capacity), float64(capacity)
+		s.data.burst, s.data.tokens = float64(capacity), float64(capacity)
 	}
 	return s
 }
@@ -105,67 +143,84 @@ func (s *CountingSink) Stats() SinkStats {
 	return s.stats
 }
 
-// refill adds tokens for elapsed time since the last refill, capped at
-// burst. Caller holds mu.
-func (s *CountingSink) refill() {
-	if s.unbounded {
-		return
+// bucketFor returns the token bucket for class. Caller holds mu.
+func (s *CountingSink) bucketFor(class eventClass) *tokenBucket {
+	if class == classAnchor {
+		return &s.anchor
 	}
+	return &s.data
+}
+
+// refill adds tokens for elapsed time since the last refill to both buckets,
+// each capped at its own burst. Both buckets refill from the same shared
+// refillRate and share one lastRefill clock reading (a single elapsed
+// duration applied to both), so neither class's replenishment rate depends
+// on the other's admission traffic. Caller holds mu.
+func (s *CountingSink) refill() {
 	now := s.now()
 	elapsed := now.Sub(s.lastRefill)
 	if elapsed <= 0 {
 		return
 	}
 	s.lastRefill = now
-	s.tokens += elapsed.Seconds() * s.refillRate
-	if s.tokens > s.burst {
-		s.tokens = s.burst
+	add := elapsed.Seconds() * s.refillRate
+	for _, b := range []*tokenBucket{&s.anchor, &s.data} {
+		if b.unbounded {
+			continue
+		}
+		b.tokens += add
+		if b.tokens > b.burst {
+			b.tokens = b.burst
+		}
 	}
 }
 
-// admitCapacity applies the token-bucket bound only - the one rule EmitModule
-// shares with every other event type. On success it has reserved one token;
-// call release if the reservation turns out not to be used. Caller holds mu.
-func (s *CountingSink) admitCapacity() error {
-	if s.unbounded {
+// admitCapacity applies class's own token-bucket bound - the one rule
+// EmitModule shares with every other event type. On success it has reserved
+// one token from class's bucket; call release(class) if the reservation
+// turns out not to be used. Caller holds mu.
+func (s *CountingSink) admitCapacity(class eventClass) error {
+	b := s.bucketFor(class)
+	if b.unbounded {
 		return nil
 	}
 	s.refill()
-	if s.tokens < 1 {
+	if b.tokens < 1 {
 		s.stats.DroppedFull++
 		return ErrSinkFull
 	}
-	s.tokens--
+	b.tokens--
 	return nil
 }
 
-// release returns a reserved token after inner fails to accept a delegated
-// event, so a downstream rejection does not permanently shrink capacity.
-// Caller holds mu.
-func (s *CountingSink) release() {
-	if s.unbounded {
+// release returns a reserved token to class's bucket after inner fails to
+// accept a delegated event, so a downstream rejection does not permanently
+// shrink that class's capacity. Caller holds mu.
+func (s *CountingSink) release(class eventClass) {
+	b := s.bucketFor(class)
+	if b.unbounded {
 		return
 	}
-	s.tokens++
-	if s.tokens > s.burst {
-		s.tokens = s.burst
+	b.tokens++
+	if b.tokens > b.burst {
+		b.tokens = b.burst
 	}
 }
 
-// admit applies the clock-domain contract, then the capacity bound. Caller
-// holds mu. EmitModule bypasses this and calls admitCapacity directly: a
-// GPUModule has no ClockDomain field to validate.
-func (s *CountingSink) admit(domain ClockDomain) error {
+// admit applies the clock-domain contract, then class's capacity bound.
+// Caller holds mu. EmitModule bypasses this and calls admitCapacity
+// directly: a GPUModule has no ClockDomain field to validate.
+func (s *CountingSink) admit(class eventClass, domain ClockDomain) error {
 	if err := ValidateSupportedClockDomain(domain); err != nil {
 		s.stats.DroppedInvalid++
 		return fmt.Errorf("gpu: rejected event: %w", err)
 	}
-	return s.admitCapacity()
+	return s.admitCapacity(class)
 }
 
 func (s *CountingSink) EmitLaunch(l GPUKernelLaunch) error {
 	s.mu.Lock()
-	if err := s.admit(l.ClockDomain); err != nil {
+	if err := s.admit(classAnchor, l.ClockDomain); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -176,7 +231,7 @@ func (s *CountingSink) EmitLaunch(l GPUKernelLaunch) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err != nil {
-		s.release()
+		s.release(classAnchor)
 		s.stats.DroppedDownstream++
 		return err
 	}
@@ -186,7 +241,7 @@ func (s *CountingSink) EmitLaunch(l GPUKernelLaunch) error {
 
 func (s *CountingSink) EmitExec(e GPUKernelExec) error {
 	s.mu.Lock()
-	if err := s.admit(e.ClockDomain); err != nil {
+	if err := s.admit(classData, e.ClockDomain); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -197,7 +252,7 @@ func (s *CountingSink) EmitExec(e GPUKernelExec) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err != nil {
-		s.release()
+		s.release(classData)
 		s.stats.DroppedDownstream++
 		return err
 	}
@@ -207,7 +262,7 @@ func (s *CountingSink) EmitExec(e GPUKernelExec) error {
 
 func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
 	s.mu.Lock()
-	if err := s.admit(p.ClockDomain); err != nil {
+	if err := s.admit(classData, p.ClockDomain); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -218,7 +273,7 @@ func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err != nil {
-		s.release()
+		s.release(classData)
 		s.stats.DroppedDownstream++
 		return err
 	}
@@ -228,11 +283,13 @@ func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
 
 // EmitModule deliberately skips the clock-domain check: GPUModule is
 // symbolization metadata with no ClockDomain field. It still goes through
-// the same token-bucket admission (admitCapacity) and the same
-// reserve/delegate/settle sequence as every other event type.
+// the same token-bucket admission (admitCapacity, classAnchor - modules are
+// correlation anchors for symbolization the same way launches are for
+// execs) and the same reserve/delegate/settle sequence as every other event
+// type.
 func (s *CountingSink) EmitModule(m GPUModule) error {
 	s.mu.Lock()
-	if err := s.admitCapacity(); err != nil {
+	if err := s.admitCapacity(classAnchor); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -243,7 +300,7 @@ func (s *CountingSink) EmitModule(m GPUModule) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err != nil {
-		s.release()
+		s.release(classAnchor)
 		s.stats.DroppedDownstream++
 		return err
 	}
@@ -253,7 +310,7 @@ func (s *CountingSink) EmitModule(m GPUModule) error {
 
 func (s *CountingSink) EmitEvent(e GPUTimelineEvent) error {
 	s.mu.Lock()
-	if err := s.admit(e.ClockDomain); err != nil {
+	if err := s.admit(classData, e.ClockDomain); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -264,7 +321,7 @@ func (s *CountingSink) EmitEvent(e GPUTimelineEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err != nil {
-		s.release()
+		s.release(classData)
 		s.stats.DroppedDownstream++
 		return err
 	}

--- a/gpu/sink.go
+++ b/gpu/sink.go
@@ -13,24 +13,66 @@ import (
 // sample, and the loss is visible in SinkStats either way.
 var ErrSinkFull = errors.New("gpu: sink full")
 
-// SinkStats is the ingestion-side loss record. JoinStats reports what could not
-// be correlated; this reports what never arrived.
-type SinkStats struct {
-	Launches  uint64 `json:"launches,omitempty"`
-	Execs     uint64 `json:"execs,omitempty"`
-	PCSamples uint64 `json:"pc_samples,omitempty"`
-	Modules   uint64 `json:"modules,omitempty"`
-	Events    uint64 `json:"events,omitempty"`
-
+// EventKindStats is the ingestion outcome breakdown for one event kind -
+// review Important 2. SinkStats used to keep DroppedFull/DroppedInvalid/
+// DroppedDownstream as three aggregate counters shared by all five event
+// kinds, so a drop could never be attributed to (say) launches vs PC
+// samples - exactly the information an operator needs to tell "we're
+// losing correlation anchors" from "we're losing sampling detail, joins are
+// still fine".
+type EventKindStats struct {
+	Accepted       uint64 `json:"accepted,omitempty"`
 	DroppedFull    uint64 `json:"dropped_full,omitempty"`
 	DroppedInvalid uint64 `json:"dropped_invalid,omitempty"`
-
-	// DroppedDownstream counts events that passed admission (clock domain
-	// and capacity) but that inner failed to accept. They are not counted in
-	// the per-type accepted counters above, and the capacity they reserved
-	// is returned to the bucket - a downstream hiccup must not permanently
-	// shrink what the sink can admit.
+	// DroppedDownstream counts events of this kind that passed admission
+	// (clock domain and capacity) but that inner failed to accept. Not
+	// counted in Accepted, and the capacity they reserved is returned to
+	// the bucket - a downstream hiccup must not permanently shrink what the
+	// sink can admit.
 	DroppedDownstream uint64 `json:"dropped_downstream,omitempty"`
+}
+
+// SinkStats is the ingestion-side loss record, broken down per event kind.
+// JoinStats reports what could not be correlated; this reports what never
+// arrived.
+type SinkStats struct {
+	Launches  EventKindStats `json:"launches,omitempty"`
+	Execs     EventKindStats `json:"execs,omitempty"`
+	PCSamples EventKindStats `json:"pc_samples,omitempty"`
+	Modules   EventKindStats `json:"modules,omitempty"`
+	Events    EventKindStats `json:"events,omitempty"`
+}
+
+// eventKind identifies which EventKindStats an admission outcome is
+// recorded against. Distinct from eventClass: eventClass groups kinds by
+// which token bucket they draw from (review Important 5), eventKind
+// identifies exactly one of the five EventSink methods for accounting
+// (review Important 2). EmitLaunch is both classAnchor and kindLaunch.
+type eventKind int
+
+const (
+	kindLaunch eventKind = iota
+	kindExec
+	kindPCSample
+	kindModule
+	kindEvent
+)
+
+// statsFor returns the EventKindStats field to record kind's outcome
+// against. Caller holds mu.
+func (s *CountingSink) statsFor(kind eventKind) *EventKindStats {
+	switch kind {
+	case kindLaunch:
+		return &s.stats.Launches
+	case kindExec:
+		return &s.stats.Execs
+	case kindPCSample:
+		return &s.stats.PCSamples
+	case kindModule:
+		return &s.stats.Modules
+	default:
+		return &s.stats.Events
+	}
 }
 
 // eventClass groups EventSink methods by admission priority - review
@@ -109,12 +151,13 @@ func NewCountingSink(inner EventSink, capacity int) *CountingSink {
 // second) and clock made explicit, for callers that need a different
 // steady-state rate or deterministic tests. now defaults to time.Now when
 // nil. capacity <= 0 means unbounded, independent of refillPerSecond.
-// NewCountingSinkWithRate gives each eventClass (see its doc comment) its
-// own independent token bucket, each sized at capacity/refillPerSecond -
-// review Important 5. This is deliberately not capacity split across the
-// two classes: launches/modules must never be crowded out by exec/sample/
-// event volume, so the anchor class needs its own full, untouched budget
-// regardless of how saturated the data class is.
+//
+// Each eventClass (see its doc comment) gets its own independent token
+// bucket, each sized at capacity/refillPerSecond - review Important 5. This
+// is deliberately not capacity split across the two classes: launches/
+// modules must never be crowded out by exec/sample/event volume, so the
+// anchor class needs its own full, untouched budget regardless of how
+// saturated the data class is.
 func NewCountingSinkWithRate(inner EventSink, capacity int, refillPerSecond float64, now func() time.Time) *CountingSink {
 	if now == nil {
 		now = time.Now
@@ -178,15 +221,16 @@ func (s *CountingSink) refill() {
 // admitCapacity applies class's own token-bucket bound - the one rule
 // EmitModule shares with every other event type. On success it has reserved
 // one token from class's bucket; call release(class) if the reservation
-// turns out not to be used. Caller holds mu.
-func (s *CountingSink) admitCapacity(class eventClass) error {
+// turns out not to be used. kind attributes a drop to the right
+// EventKindStats. Caller holds mu.
+func (s *CountingSink) admitCapacity(kind eventKind, class eventClass) error {
 	b := s.bucketFor(class)
 	if b.unbounded {
 		return nil
 	}
 	s.refill()
 	if b.tokens < 1 {
-		s.stats.DroppedFull++
+		s.statsFor(kind).DroppedFull++
 		return ErrSinkFull
 	}
 	b.tokens--
@@ -210,17 +254,17 @@ func (s *CountingSink) release(class eventClass) {
 // admit applies the clock-domain contract, then class's capacity bound.
 // Caller holds mu. EmitModule bypasses this and calls admitCapacity
 // directly: a GPUModule has no ClockDomain field to validate.
-func (s *CountingSink) admit(class eventClass, domain ClockDomain) error {
+func (s *CountingSink) admit(kind eventKind, class eventClass, domain ClockDomain) error {
 	if err := ValidateSupportedClockDomain(domain); err != nil {
-		s.stats.DroppedInvalid++
+		s.statsFor(kind).DroppedInvalid++
 		return fmt.Errorf("gpu: rejected event: %w", err)
 	}
-	return s.admitCapacity(class)
+	return s.admitCapacity(kind, class)
 }
 
 func (s *CountingSink) EmitLaunch(l GPUKernelLaunch) error {
 	s.mu.Lock()
-	if err := s.admit(classAnchor, l.ClockDomain); err != nil {
+	if err := s.admit(kindLaunch, classAnchor, l.ClockDomain); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -232,16 +276,16 @@ func (s *CountingSink) EmitLaunch(l GPUKernelLaunch) error {
 	defer s.mu.Unlock()
 	if err != nil {
 		s.release(classAnchor)
-		s.stats.DroppedDownstream++
+		s.statsFor(kindLaunch).DroppedDownstream++
 		return err
 	}
-	s.stats.Launches++
+	s.statsFor(kindLaunch).Accepted++
 	return nil
 }
 
 func (s *CountingSink) EmitExec(e GPUKernelExec) error {
 	s.mu.Lock()
-	if err := s.admit(classData, e.ClockDomain); err != nil {
+	if err := s.admit(kindExec, classData, e.ClockDomain); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -253,16 +297,16 @@ func (s *CountingSink) EmitExec(e GPUKernelExec) error {
 	defer s.mu.Unlock()
 	if err != nil {
 		s.release(classData)
-		s.stats.DroppedDownstream++
+		s.statsFor(kindExec).DroppedDownstream++
 		return err
 	}
-	s.stats.Execs++
+	s.statsFor(kindExec).Accepted++
 	return nil
 }
 
 func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
 	s.mu.Lock()
-	if err := s.admit(classData, p.ClockDomain); err != nil {
+	if err := s.admit(kindPCSample, classData, p.ClockDomain); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -274,10 +318,10 @@ func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
 	defer s.mu.Unlock()
 	if err != nil {
 		s.release(classData)
-		s.stats.DroppedDownstream++
+		s.statsFor(kindPCSample).DroppedDownstream++
 		return err
 	}
-	s.stats.PCSamples++
+	s.statsFor(kindPCSample).Accepted++
 	return nil
 }
 
@@ -289,7 +333,7 @@ func (s *CountingSink) EmitPCSample(p GPUPCSample) error {
 // type.
 func (s *CountingSink) EmitModule(m GPUModule) error {
 	s.mu.Lock()
-	if err := s.admitCapacity(classAnchor); err != nil {
+	if err := s.admitCapacity(kindModule, classAnchor); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -301,16 +345,16 @@ func (s *CountingSink) EmitModule(m GPUModule) error {
 	defer s.mu.Unlock()
 	if err != nil {
 		s.release(classAnchor)
-		s.stats.DroppedDownstream++
+		s.statsFor(kindModule).DroppedDownstream++
 		return err
 	}
-	s.stats.Modules++
+	s.statsFor(kindModule).Accepted++
 	return nil
 }
 
 func (s *CountingSink) EmitEvent(e GPUTimelineEvent) error {
 	s.mu.Lock()
-	if err := s.admit(classData, e.ClockDomain); err != nil {
+	if err := s.admit(kindEvent, classData, e.ClockDomain); err != nil {
 		s.mu.Unlock()
 		return err
 	}
@@ -322,9 +366,24 @@ func (s *CountingSink) EmitEvent(e GPUTimelineEvent) error {
 	defer s.mu.Unlock()
 	if err != nil {
 		s.release(classData)
-		s.stats.DroppedDownstream++
+		s.statsFor(kindEvent).DroppedDownstream++
 		return err
 	}
-	s.stats.Events++
+	s.statsFor(kindEvent).Accepted++
 	return nil
+}
+
+// SnapshotWith calls tl.Snapshot() and embeds s's own SinkStats into the
+// result - review Important 2: Timeline has no reference to the
+// CountingSink wrapping it (EventSink is the only contract between them),
+// so it cannot fill Snapshot.SinkStats in on its own. A caller that wires
+// producer -> CountingSink -> Timeline the way this package's own
+// conformance harness does should call this instead of tl.Snapshot()
+// directly whenever the result will be serialized or inspected for loss
+// accounting, so admission-side losses (a full token bucket, a rejected
+// clock domain) are reachable from the same Snapshot as everything else.
+func (s *CountingSink) SnapshotWith(tl *Timeline) Snapshot {
+	snap := tl.Snapshot()
+	snap.SinkStats = s.Stats()
+	return snap
 }

--- a/gpu/sink_test.go
+++ b/gpu/sink_test.go
@@ -85,8 +85,8 @@ func TestCountingSinkForwardsAndCounts(t *testing.T) {
 
 	assert.Equal(t, 1, inner.launches)
 	assert.Equal(t, 1, inner.execs)
-	assert.Equal(t, uint64(1), s.Stats().Launches)
-	assert.Equal(t, uint64(1), s.Stats().Execs)
+	assert.Equal(t, uint64(1), s.Stats().Launches.Accepted)
+	assert.Equal(t, uint64(1), s.Stats().Execs.Accepted)
 }
 
 func TestCountingSinkReturnsErrSinkFullAtCapacity(t *testing.T) {
@@ -98,7 +98,7 @@ func TestCountingSinkReturnsErrSinkFullAtCapacity(t *testing.T) {
 
 	require.Error(t, err, "a sink at capacity must push back, not absorb silently")
 	assert.True(t, errors.Is(err, ErrSinkFull))
-	assert.Equal(t, uint64(1), s.Stats().DroppedFull, "the drop must be counted")
+	assert.Equal(t, uint64(1), s.Stats().Launches.DroppedFull, "the drop must be counted")
 }
 
 func TestCountingSinkRejectsUnsupportedClockDomain(t *testing.T) {
@@ -109,8 +109,8 @@ func TestCountingSinkRejectsUnsupportedClockDomain(t *testing.T) {
 	err := s.EmitLaunch(l)
 
 	require.Error(t, err, "producers must convert device clocks before emitting")
-	assert.Equal(t, uint64(1), s.Stats().DroppedInvalid)
-	assert.Equal(t, uint64(0), s.Stats().Launches, "a rejected event is not counted as accepted")
+	assert.Equal(t, uint64(1), s.Stats().Launches.DroppedInvalid)
+	assert.Equal(t, uint64(0), s.Stats().Launches.Accepted, "a rejected event is not counted as accepted")
 }
 
 func TestCountingSinkZeroCapacityIsUnbounded(t *testing.T) {
@@ -118,7 +118,7 @@ func TestCountingSinkZeroCapacityIsUnbounded(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		require.NoError(t, s.EmitLaunch(launch("x", uint64(i))))
 	}
-	assert.Equal(t, uint64(0), s.Stats().DroppedFull)
+	assert.Equal(t, uint64(0), s.Stats().Launches.DroppedFull)
 }
 
 // TestCountingSinkDownstreamFailureIsNotCountedAsAccepted pins the
@@ -136,8 +136,8 @@ func TestCountingSinkDownstreamFailureIsNotCountedAsAccepted(t *testing.T) {
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, innerErr), "the downstream error must reach the caller")
-	assert.Equal(t, uint64(0), s.Stats().Launches, "a delivery inner rejects is not an accepted event")
-	assert.Equal(t, uint64(1), s.Stats().DroppedDownstream)
+	assert.Equal(t, uint64(0), s.Stats().Launches.Accepted, "a delivery inner rejects is not an accepted event")
+	assert.Equal(t, uint64(1), s.Stats().Launches.DroppedDownstream)
 
 	// The reservation must have been released: two more emissions still fit
 	// in a capacity-2 sink even though the first attempt never delivered.
@@ -177,7 +177,7 @@ func TestCountingSinkEmitPCSampleForwardsCountsAndEnforcesCapacity(t *testing.T)
 		TimeNs:      10,
 	}))
 	assert.Equal(t, 1, inner.pcSamples)
-	assert.Equal(t, uint64(1), s.Stats().PCSamples)
+	assert.Equal(t, uint64(1), s.Stats().PCSamples.Accepted)
 
 	err := s.EmitPCSample(GPUPCSample{
 		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "b"},
@@ -185,7 +185,7 @@ func TestCountingSinkEmitPCSampleForwardsCountsAndEnforcesCapacity(t *testing.T)
 	})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrSinkFull))
-	assert.Equal(t, uint64(1), s.Stats().DroppedFull)
+	assert.Equal(t, uint64(1), s.Stats().PCSamples.DroppedFull)
 }
 
 func TestCountingSinkEmitEventForwardsCountsAndEnforcesCapacity(t *testing.T) {
@@ -196,14 +196,14 @@ func TestCountingSinkEmitEventForwardsCountsAndEnforcesCapacity(t *testing.T) {
 		Backend: BackendCUPTI, Kind: TimelineEventRuntime, TimeNs: 10,
 	}))
 	assert.Equal(t, 1, inner.events)
-	assert.Equal(t, uint64(1), s.Stats().Events)
+	assert.Equal(t, uint64(1), s.Stats().Events.Accepted)
 
 	err := s.EmitEvent(GPUTimelineEvent{
 		Backend: BackendCUPTI, Kind: TimelineEventRuntime, TimeNs: 20,
 	})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrSinkFull))
-	assert.Equal(t, uint64(1), s.Stats().DroppedFull)
+	assert.Equal(t, uint64(1), s.Stats().Events.DroppedFull)
 }
 
 // TestCountingSinkEmitModuleForwardsCountsAndEnforcesCapacity pins both
@@ -221,12 +221,12 @@ func TestCountingSinkEmitModuleForwardsCountsAndEnforcesCapacity(t *testing.T) {
 		LoadedNs:  10,
 	}))
 	assert.Equal(t, 1, inner.modules)
-	assert.Equal(t, uint64(1), s.Stats().Modules)
+	assert.Equal(t, uint64(1), s.Stats().Modules.Accepted)
 
 	err := s.EmitModule(GPUModule{Ref: ModuleRef{Backend: BackendCUPTI, CRC: 2}, LoadedNs: 20})
 	require.Error(t, err, "capacity must still be enforced for modules")
 	assert.True(t, errors.Is(err, ErrSinkFull))
-	assert.Equal(t, uint64(1), s.Stats().DroppedFull)
+	assert.Equal(t, uint64(1), s.Stats().Modules.DroppedFull)
 }
 
 // TestCountingSinkConcurrentEmitAndStats exercises CountingSink from many
@@ -261,7 +261,7 @@ func TestCountingSinkConcurrentEmitAndStats(t *testing.T) {
 	wg.Wait()
 
 	assert.Equal(t, int64(n), inner.launches.Load())
-	assert.Equal(t, uint64(n), s.Stats().Launches)
+	assert.Equal(t, uint64(n), s.Stats().Launches.Accepted)
 }
 
 // TestCountingSinkAnchorClassSurvivesDataOverload is the regression test for
@@ -296,6 +296,6 @@ func TestCountingSinkAnchorClassSurvivesDataOverload(t *testing.T) {
 	require.NoError(t, s.EmitLaunch(launch("a", 10)), "a launch must not be dropped because data-class volume exhausted its own bucket")
 	require.NoError(t, s.EmitModule(GPUModule{Ref: ModuleRef{CRC: 1}, LoadedNs: 10}))
 
-	assert.Equal(t, uint64(1), s.Stats().Launches)
-	assert.Equal(t, uint64(1), s.Stats().Modules)
+	assert.Equal(t, uint64(1), s.Stats().Launches.Accepted)
+	assert.Equal(t, uint64(1), s.Stats().Modules.Accepted)
 }

--- a/gpu/sink_test.go
+++ b/gpu/sink_test.go
@@ -2,22 +2,76 @@ package gpu
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type recordingSink struct {
-	launches int
-	execs    int
+	launches  int
+	execs     int
+	pcSamples int
+	modules   int
+	events    int
 }
 
 func (r *recordingSink) EmitLaunch(GPUKernelLaunch) error { r.launches++; return nil }
 func (r *recordingSink) EmitExec(GPUKernelExec) error     { r.execs++; return nil }
-func (r *recordingSink) EmitPCSample(GPUPCSample) error   { return nil }
-func (r *recordingSink) EmitModule(GPUModule) error       { return nil }
-func (r *recordingSink) EmitEvent(GPUTimelineEvent) error { return nil }
+func (r *recordingSink) EmitPCSample(GPUPCSample) error   { r.pcSamples++; return nil }
+func (r *recordingSink) EmitModule(GPUModule) error       { r.modules++; return nil }
+func (r *recordingSink) EmitEvent(GPUTimelineEvent) error { r.events++; return nil }
+
+// erroringSink lets a test control exactly what the downstream sink returns,
+// to exercise the reserve/delegate/settle path when delivery fails.
+type erroringSink struct {
+	err error
+}
+
+func (e *erroringSink) EmitLaunch(GPUKernelLaunch) error { return e.err }
+func (e *erroringSink) EmitExec(GPUKernelExec) error     { return e.err }
+func (e *erroringSink) EmitPCSample(GPUPCSample) error   { return e.err }
+func (e *erroringSink) EmitModule(GPUModule) error       { return e.err }
+func (e *erroringSink) EmitEvent(GPUTimelineEvent) error { return e.err }
+
+// atomicSink is a genuinely concurrency-safe EventSink, used only by the
+// concurrent-access test so a data race in the test double itself can never
+// be mistaken for a race in CountingSink.
+type atomicSink struct {
+	launches atomic.Int64
+}
+
+func (a *atomicSink) EmitLaunch(GPUKernelLaunch) error { a.launches.Add(1); return nil }
+func (a *atomicSink) EmitExec(GPUKernelExec) error     { return nil }
+func (a *atomicSink) EmitPCSample(GPUPCSample) error   { return nil }
+func (a *atomicSink) EmitModule(GPUModule) error       { return nil }
+func (a *atomicSink) EmitEvent(GPUTimelineEvent) error { return nil }
+
+// fakeClock is an injectable, manually-advanced clock so the token-bucket
+// refill can be tested deterministically instead of racing the wall clock.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock(start time.Time) *fakeClock {
+	return &fakeClock{now: start}
+}
+
+func (f *fakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+func (f *fakeClock) Advance(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(d)
+}
 
 func TestCountingSinkForwardsAndCounts(t *testing.T) {
 	inner := &recordingSink{}
@@ -65,4 +119,147 @@ func TestCountingSinkZeroCapacityIsUnbounded(t *testing.T) {
 		require.NoError(t, s.EmitLaunch(launch("x", uint64(i))))
 	}
 	assert.Equal(t, uint64(0), s.Stats().DroppedFull)
+}
+
+// TestCountingSinkDownstreamFailureIsNotCountedAsAccepted pins the
+// reserve/delegate/settle contract: a delivery inner rejects must not be
+// credited to the per-type accepted counter, must be visible in
+// DroppedDownstream, and must not permanently consume the sink's capacity -
+// the reserved slot has to come back so a downstream hiccup doesn't
+// masquerade as a shrinking budget.
+func TestCountingSinkDownstreamFailureIsNotCountedAsAccepted(t *testing.T) {
+	innerErr := errors.New("downstream unavailable")
+	inner := &erroringSink{err: innerErr}
+	s := NewCountingSink(inner, 2)
+
+	err := s.EmitLaunch(launch("a", 10))
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, innerErr), "the downstream error must reach the caller")
+	assert.Equal(t, uint64(0), s.Stats().Launches, "a delivery inner rejects is not an accepted event")
+	assert.Equal(t, uint64(1), s.Stats().DroppedDownstream)
+
+	// The reservation must have been released: two more emissions still fit
+	// in a capacity-2 sink even though the first attempt never delivered.
+	inner.err = nil
+	require.NoError(t, s.EmitLaunch(launch("b", 20)))
+	require.NoError(t, s.EmitLaunch(launch("c", 30)))
+	err = s.EmitLaunch(launch("d", 40))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSinkFull))
+}
+
+// TestCountingSinkTokenBucketRefillsOverTime pins the fix for the lifetime-
+// budget defect: capacity must recover over time rather than expiring for
+// the life of the process. A fake clock makes the recovery deterministic.
+func TestCountingSinkTokenBucketRefillsOverTime(t *testing.T) {
+	clock := newFakeClock(time.Unix(0, 0))
+	s := NewCountingSinkWithRate(&recordingSink{}, 1, 1, clock.Now) // burst 1, 1 token/sec
+
+	require.NoError(t, s.EmitLaunch(launch("a", 10)), "the initial burst token must be available")
+
+	err := s.EmitLaunch(launch("b", 20))
+	require.Error(t, err, "the burst is exhausted and no time has passed to refill it")
+	assert.True(t, errors.Is(err, ErrSinkFull))
+
+	clock.Advance(time.Second)
+
+	require.NoError(t, s.EmitLaunch(launch("c", 30)),
+		"a lifetime budget could never recover; a token bucket must after a full refill interval")
+}
+
+func TestCountingSinkEmitPCSampleForwardsCountsAndEnforcesCapacity(t *testing.T) {
+	inner := &recordingSink{}
+	s := NewCountingSink(inner, 1)
+
+	require.NoError(t, s.EmitPCSample(GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+		TimeNs:      10,
+	}))
+	assert.Equal(t, 1, inner.pcSamples)
+	assert.Equal(t, uint64(1), s.Stats().PCSamples)
+
+	err := s.EmitPCSample(GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "b"},
+		TimeNs:      20,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSinkFull))
+	assert.Equal(t, uint64(1), s.Stats().DroppedFull)
+}
+
+func TestCountingSinkEmitEventForwardsCountsAndEnforcesCapacity(t *testing.T) {
+	inner := &recordingSink{}
+	s := NewCountingSink(inner, 1)
+
+	require.NoError(t, s.EmitEvent(GPUTimelineEvent{
+		Backend: BackendCUPTI, Kind: TimelineEventRuntime, TimeNs: 10,
+	}))
+	assert.Equal(t, 1, inner.events)
+	assert.Equal(t, uint64(1), s.Stats().Events)
+
+	err := s.EmitEvent(GPUTimelineEvent{
+		Backend: BackendCUPTI, Kind: TimelineEventRuntime, TimeNs: 20,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSinkFull))
+	assert.Equal(t, uint64(1), s.Stats().DroppedFull)
+}
+
+// TestCountingSinkEmitModuleForwardsCountsAndEnforcesCapacity pins both
+// halves of GPUModule's contract: it still enforces capacity like every
+// other event type, but - because GPUModule carries no ClockDomain field -
+// there is structurally nothing for a clock-domain check to reject, so
+// admission for it is capacity-only.
+func TestCountingSinkEmitModuleForwardsCountsAndEnforcesCapacity(t *testing.T) {
+	inner := &recordingSink{}
+	s := NewCountingSink(inner, 1)
+
+	require.NoError(t, s.EmitModule(GPUModule{
+		Ref:       ModuleRef{Backend: BackendCUPTI, CRC: 1},
+		SizeBytes: 100,
+		LoadedNs:  10,
+	}))
+	assert.Equal(t, 1, inner.modules)
+	assert.Equal(t, uint64(1), s.Stats().Modules)
+
+	err := s.EmitModule(GPUModule{Ref: ModuleRef{Backend: BackendCUPTI, CRC: 2}, LoadedNs: 20})
+	require.Error(t, err, "capacity must still be enforced for modules")
+	assert.True(t, errors.Is(err, ErrSinkFull))
+	assert.Equal(t, uint64(1), s.Stats().DroppedFull)
+}
+
+// TestCountingSinkConcurrentEmitAndStats exercises CountingSink from many
+// goroutines at once - the point a clean sequential -race run cannot make.
+// It uses atomicSink so any race reported by -race can only be inside
+// CountingSink itself, never in the test double.
+func TestCountingSinkConcurrentEmitAndStats(t *testing.T) {
+	inner := &atomicSink{}
+	s := NewCountingSink(inner, 0) // unbounded: this test is about the lock, not the token bucket
+
+	const n = 200
+	var wg sync.WaitGroup
+	wg.Add(n + 1)
+
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			// assert, not require: FailNow (which require calls on failure)
+			// must only be called from the test's own goroutine, not a
+			// spawned one.
+			assert.NoError(t, s.EmitLaunch(launch("concurrent", uint64(i))))
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			_ = s.Stats()
+		}
+	}()
+
+	wg.Wait()
+
+	assert.Equal(t, int64(n), inner.launches.Load())
+	assert.Equal(t, uint64(n), s.Stats().Launches)
 }

--- a/gpu/sink_test.go
+++ b/gpu/sink_test.go
@@ -1,0 +1,68 @@
+package gpu
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingSink struct {
+	launches int
+	execs    int
+}
+
+func (r *recordingSink) EmitLaunch(GPUKernelLaunch) error { r.launches++; return nil }
+func (r *recordingSink) EmitExec(GPUKernelExec) error     { r.execs++; return nil }
+func (r *recordingSink) EmitPCSample(GPUPCSample) error   { return nil }
+func (r *recordingSink) EmitModule(GPUModule) error       { return nil }
+func (r *recordingSink) EmitEvent(GPUTimelineEvent) error { return nil }
+
+func TestCountingSinkForwardsAndCounts(t *testing.T) {
+	inner := &recordingSink{}
+	s := NewCountingSink(inner, 10)
+
+	require.NoError(t, s.EmitLaunch(launch("a", 10)))
+	require.NoError(t, s.EmitExec(GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+		StartNs:     20, EndNs: 30,
+	}))
+
+	assert.Equal(t, 1, inner.launches)
+	assert.Equal(t, 1, inner.execs)
+	assert.Equal(t, uint64(1), s.Stats().Launches)
+	assert.Equal(t, uint64(1), s.Stats().Execs)
+}
+
+func TestCountingSinkReturnsErrSinkFullAtCapacity(t *testing.T) {
+	s := NewCountingSink(&recordingSink{}, 2)
+
+	require.NoError(t, s.EmitLaunch(launch("a", 10)))
+	require.NoError(t, s.EmitLaunch(launch("b", 20)))
+	err := s.EmitLaunch(launch("c", 30))
+
+	require.Error(t, err, "a sink at capacity must push back, not absorb silently")
+	assert.True(t, errors.Is(err, ErrSinkFull))
+	assert.Equal(t, uint64(1), s.Stats().DroppedFull, "the drop must be counted")
+}
+
+func TestCountingSinkRejectsUnsupportedClockDomain(t *testing.T) {
+	s := NewCountingSink(&recordingSink{}, 10)
+
+	l := launch("a", 10)
+	l.ClockDomain = ClockDomainGPUDevice
+	err := s.EmitLaunch(l)
+
+	require.Error(t, err, "producers must convert device clocks before emitting")
+	assert.Equal(t, uint64(1), s.Stats().DroppedInvalid)
+	assert.Equal(t, uint64(0), s.Stats().Launches, "a rejected event is not counted as accepted")
+}
+
+func TestCountingSinkZeroCapacityIsUnbounded(t *testing.T) {
+	s := NewCountingSink(&recordingSink{}, 0)
+	for i := 0; i < 1000; i++ {
+		require.NoError(t, s.EmitLaunch(launch("x", uint64(i))))
+	}
+	assert.Equal(t, uint64(0), s.Stats().DroppedFull)
+}

--- a/gpu/sink_test.go
+++ b/gpu/sink_test.go
@@ -263,3 +263,39 @@ func TestCountingSinkConcurrentEmitAndStats(t *testing.T) {
 	assert.Equal(t, int64(n), inner.launches.Load())
 	assert.Equal(t, uint64(n), s.Stats().Launches)
 }
+
+// TestCountingSinkAnchorClassSurvivesDataOverload is the regression test for
+// review Important 5: a single, undifferentiated token bucket meant a flood
+// of PC samples (high-volume, per spec §7/§12 plausibly the bulk of GPU
+// event traffic) could exhaust the sink's entire admission budget, dropping
+// launches exactly as readily as samples. Per review Critical 2, a dropped
+// launch turns every subsequent exec referencing it into a permanent
+// unattributed miss - losing an anchor is categorically worse than losing
+// one data point, so anchors (launches, modules) must have their own budget
+// that data-class volume can never touch.
+//
+// capacity 2 (2 tokens for classAnchor's bucket): exhaust the *data* class
+// with PC samples first, then confirm launches still admit normally.
+// Mutation this catches: reverting to one shared token bucket for every
+// event kind - the launch below would then fail with ErrSinkFull because
+// the PC-sample flood already spent the shared budget.
+func TestCountingSinkAnchorClassSurvivesDataOverload(t *testing.T) {
+	s := NewCountingSink(&recordingSink{}, 2)
+
+	// Flood and exhaust the data class - well past its own capacity, to be
+	// sure it is genuinely spent.
+	for i := 0; i < 10; i++ {
+		_ = s.EmitPCSample(GPUPCSample{Correlation: CorrelationID{Backend: BackendCUPTI, Value: "x"}, TimeNs: uint64(i)})
+	}
+	dataExhausted := s.EmitExec(GPUKernelExec{Correlation: CorrelationID{Backend: BackendCUPTI, Value: "y"}})
+	require.Error(t, dataExhausted, "sanity: the data class must actually be exhausted by the flood above")
+	assert.True(t, errors.Is(dataExhausted, ErrSinkFull))
+
+	// Anchors must be completely unaffected: both of classAnchor's tokens
+	// are still available.
+	require.NoError(t, s.EmitLaunch(launch("a", 10)), "a launch must not be dropped because data-class volume exhausted its own bucket")
+	require.NoError(t, s.EmitModule(GPUModule{Ref: ModuleRef{CRC: 1}, LoadedNs: 10}))
+
+	assert.Equal(t, uint64(1), s.Stats().Launches)
+	assert.Equal(t, uint64(1), s.Stats().Modules)
+}

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -1,7 +1,10 @@
 package gpu
 
 import (
+	"cmp"
 	"maps"
+	"slices"
+	"sort"
 	"sync"
 )
 
@@ -319,10 +322,14 @@ func (t *Timeline) Snapshot() Snapshot {
 	// The heuristic's candidate set is materialized once per Snapshot call
 	// (not once per miss): LaunchCache.Entries() allocates, and calling it
 	// inside the per-execution loop was exactly the quadratic-with-
-	// allocation behaviour this phase exists to remove. Grouping by queue
-	// also means each miss only scans the launches that could possibly
-	// match its queue, not the whole cache.
-	candidatesByQueue := groupLaunchesByQueue(t.cache.Entries())
+	// allocation behaviour this phase exists to remove. Grouping by (queue,
+	// kernel name) and sorting each group by TimeNs turns each miss into a
+	// binary search - O(log candidates) - instead of a linear scan: a
+	// single-queue, single-kernel-name workload (one submission stream) is
+	// not a pathological input, it is what most workloads look like, and a
+	// linear scan there is still O(misses x candidates) even after the
+	// per-miss allocation was removed.
+	candidateIndex := buildHeuristicCandidateIndex(t.cache.Entries())
 
 	views := make([]ExecutionView, 0, len(execs))
 	stats := JoinStats{LaunchCount: launchCount}
@@ -342,7 +349,8 @@ func (t *Timeline) Snapshot() Snapshot {
 			}
 		}
 
-		if match := findLaunchHeuristic(candidatesByQueue[queueKeyOf(exec.Queue)], exec); match.launch != nil {
+		key := candidateGroupKey{queue: queueKeyOf(exec.Queue), kernelName: exec.KernelName}
+		if match := findLaunchHeuristic(candidateIndex[key], exec); match.launch != nil {
 			view.Launch = match.launch
 			view.Join = JoinHeuristic
 			view.Heuristic = true
@@ -395,62 +403,72 @@ func queueKeyOf(q GPUQueueRef) queueKey {
 	return queueKey{backend: q.Backend, queueID: q.QueueID}
 }
 
-// groupLaunchesByQueue indexes entries by queueKey once, so Snapshot's
-// per-execution heuristic lookup is a map access plus a scan of only that
-// queue's candidates, not a scan of the entire cache per miss.
-func groupLaunchesByQueue(entries []GPUKernelLaunch) map[queueKey][]GPUKernelLaunch {
-	out := make(map[queueKey][]GPUKernelLaunch, len(entries))
+// candidateGroupKey is the exact equivalence launchKernelNamesCompatible
+// defines (queue match plus kernel-name equality) turned into a map key.
+// Grouping candidates by this key and looking a miss up by its own
+// (queue, kernel name) is equivalent to scanning every candidate and
+// filtering with launchKernelNamesCompatible - PROVIDED that function stays
+// pure string equality on KernelName, which is what it is today (see its
+// doc comment: the one case it might have needed to be looser, the AMD/HIP
+// fallback, was deliberately left unported). If a future backend reintroduces
+// that fallback, this key must change - grouping by queue alone and
+// filtering the qualifying (binary-searched) prefix by name would be the
+// fallback design, at the cost of an O(prefix) scan per miss instead of
+// O(log candidates).
+type candidateGroupKey struct {
+	queue      queueKey
+	kernelName string
+}
+
+// buildHeuristicCandidateIndex groups cache entries by candidateGroupKey and
+// sorts each group by TimeNs ascending, once per Snapshot call. This is what
+// turns each miss's lookup into a binary search (findLaunchHeuristic) rather
+// than a linear scan: grouping alone (this function's predecessor,
+// groupLaunchesByQueue) removed the per-miss allocation but left an all-miss
+// Snapshot at O(misses x candidates-in-queue) - fine for a multi-queue
+// workload, but a single submission stream puts every launch in one group,
+// and a linear scan of that group per miss is the same quadratic shape this
+// phase exists to remove, just without the allocation on top.
+func buildHeuristicCandidateIndex(entries []GPUKernelLaunch) map[candidateGroupKey][]GPUKernelLaunch {
+	byGroup := make(map[candidateGroupKey][]GPUKernelLaunch, len(entries))
 	for _, l := range entries {
-		k := queueKeyOf(l.Queue)
-		out[k] = append(out[k], l)
+		k := candidateGroupKey{queue: queueKeyOf(l.Queue), kernelName: l.KernelName}
+		byGroup[k] = append(byGroup[k], l)
 	}
-	return out
+	for _, group := range byGroup {
+		// Sorts in place: group's backing array is the same one stored in
+		// byGroup, so no re-assignment into the map is needed.
+		slices.SortFunc(group, func(a, b GPUKernelLaunch) int {
+			return cmp.Compare(a.TimeNs, b.TimeNs)
+		})
+	}
+	return byGroup
 }
 
 // findLaunchHeuristic is the fallback path when an exec's Correlation misses
-// the cache (never arrived, or aged out). Ported from the prototype's
-// findLaunchHeuristic: a kernel-name match and a launch that precedes the
-// exec's start - picking the most recent such launch as best, and flagging
-// Ambiguous when more than one candidate qualified. candidates is expected
-// to already be filtered to the exec's queue (see groupLaunchesByQueue);
-// this function no longer does that filtering itself.
+// the cache (never arrived, or aged out). Ported decision from the
+// prototype's findLaunchHeuristic: a launch that precedes the exec's start,
+// preferring the most recent such launch, and flagging Ambiguous when more
+// than one candidate qualified.
+//
+// candidates must already be filtered to the exec's exact (queue, kernel
+// name) group (see buildHeuristicCandidateIndex) and sorted by TimeNs
+// ascending. Because the group is already filtered, every entry satisfies
+// the queue/name half of the original filter; sort.Search finds the
+// insertion point of exec.StartNs - the count of entries with
+// TimeNs <= StartNs, which is simultaneously the ambiguity count (>1 means
+// more than one qualifying candidate) and locates the best candidate
+// (immediately before the insertion point, i.e. the most recent one that
+// still precedes the exec) in O(log n) instead of an O(n) scan.
 func findLaunchHeuristic(candidates []GPUKernelLaunch, exec GPUKernelExec) launchMatch {
-	var best *GPUKernelLaunch
-	var candidateCount int
-	for _, l := range candidates {
-		if !launchKernelNamesCompatible(l, exec) {
-			continue
-		}
-		if l.TimeNs > exec.StartNs {
-			continue
-		}
-		candidateCount++
-		if best == nil || l.TimeNs > best.TimeNs {
-			candidate := l
-			best = &candidate
-		}
-	}
-	if best == nil {
+	insertionPoint := sort.Search(len(candidates), func(i int) bool {
+		return candidates[i].TimeNs > exec.StartNs
+	})
+	if insertionPoint == 0 {
 		return launchMatch{}
 	}
-	return launchMatch{launch: best, ambiguous: candidateCount > 1}
-}
-
-// launchKernelNamesCompatible decides whether launch could plausibly be the
-// origin of exec, for the heuristic join's candidate filter.
-//
-// The prototype this is ported from also accepted a HIP launch's synthetic
-// "hip_kernel@..." name for any AMD exec reported under a separate
-// execution-side backend id (BackendAMDSample), gated on the launch's CPU
-// stack showing a HIP entrypoint. That launch-side/exec-side backend split
-// doesn't exist in this model (only BackendHIP, used on both sides), so
-// nothing on the exec side can distinguish "same backend, different name"
-// from "different kernel" - porting the special case as-is would accept any
-// HIP launch for any exec, looser than the original rule. Left out rather
-// than ported incorrectly; exact kernel-name match is the only rule here
-// until a future backend reintroduces that split.
-func launchKernelNamesCompatible(launch GPUKernelLaunch, exec GPUKernelExec) bool {
-	return launch.KernelName == exec.KernelName
+	best := candidates[insertionPoint-1]
+	return launchMatch{launch: &best, ambiguous: insertionPoint > 1}
 }
 
 // ring is a fixed-capacity FIFO: push is O(1) amortized (no shifting), and

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -63,6 +63,33 @@ type Snapshot struct {
 	JoinStats   JoinStats          `json:"join_stats,omitempty"`
 	LaunchCache LaunchCacheStats   `json:"launch_cache,omitempty"`
 	Dropped     TimelineDropStats  `json:"dropped,omitempty"`
+
+	// SinkStats is the ingestion-side loss record - review Important 2. It
+	// is the zero value unless populated by the caller (see
+	// CountingSink.SnapshotWith): Timeline itself never sees a
+	// CountingSink, only whatever EventSink wraps it, so it cannot fill
+	// this in on its own. Without it, admission-side losses (a full token
+	// bucket, a rejected clock domain) were unreachable from a serialized
+	// Snapshot even though they directly affect what the profile can show.
+	SinkStats SinkStats `json:"sink_stats,omitempty"`
+
+	// AttributedPCSamples counts PC samples that were attached to an
+	// execution in THIS snapshot (i.e. included in some ExecutionView's
+	// PCSamples above) - review Important 2's PC-sample reconciliation: the
+	// exec path had no accounting at all for "attributed" vs "still
+	// pending" before this.
+	AttributedPCSamples uint64 `json:"attributed_pc_samples,omitempty"`
+
+	// PendingSamples and PendingCorrelations are gauges (not deltas) of
+	// what remains in Timeline's pending store immediately after this
+	// snapshot: PendingCorrelations counts distinct not-yet-matched
+	// correlations, PendingSamples counts the individual GPUPCSample
+	// entries they hold in total. Together with AttributedPCSamples and
+	// Dropped.EvictedPendingSamples, these let a caller reconcile every PC
+	// sample ingested into exactly one of attributed / still pending /
+	// evicted.
+	PendingSamples      int `json:"pending_samples,omitempty"`
+	PendingCorrelations int `json:"pending_correlations,omitempty"`
 }
 
 // TimelineConfig configures Timeline's storage bounds.
@@ -199,6 +226,15 @@ type Timeline struct {
 	pendingHorizonNs uint64
 	pendingNewestNs  uint64
 
+	// pendingSampleTotal is the running count of individual GPUPCSample
+	// entries currently stored across every pending correlation - review
+	// Important 2's PendingSamples gauge. Maintained incrementally (+1 on
+	// every successful append, -len(samples) at every deletion site, in
+	// EmitPCSample/evictPendingLocked/Snapshot) rather than recomputed by
+	// scanning t.pending on every Snapshot call, which would add an
+	// O(pendingCap) cost to every snapshot even when nothing changed.
+	pendingSampleTotal uint64
+
 	events  *ring[GPUTimelineEvent]
 	modules *ring[GPUModule]
 
@@ -317,6 +353,7 @@ func (t *Timeline) EmitPCSample(p GPUPCSample) error {
 
 	entry.samples = append(entry.samples, p)
 	t.pending[p.Correlation] = entry
+	t.pendingSampleTotal++
 	t.evictPendingLocked()
 	return nil
 }
@@ -373,6 +410,7 @@ func (t *Timeline) evictPendingLocked() {
 			}
 			delete(t.pending, e.id)
 			t.pendingHead++
+			t.pendingSampleTotal -= uint64(len(cur.samples))
 			t.dropped.EvictedPendingSamples += uint64(len(cur.samples))
 		}
 	}
@@ -384,6 +422,7 @@ func (t *Timeline) evictPendingLocked() {
 			continue
 		}
 		delete(t.pending, e.id)
+		t.pendingSampleTotal -= uint64(len(cur.samples))
 		t.dropped.EvictedPendingSamples += uint64(len(cur.samples))
 	}
 	t.compactPendingOrderLocked()
@@ -491,14 +530,19 @@ func (t *Timeline) Snapshot() Snapshot {
 	// actually use, rather than copying the whole map: a correlation with
 	// no live exec this round is left untouched (still eligible for a
 	// later snapshot, or eventual orphan eviction).
+	var attributedPCSamples uint64
 	t.mu.Lock()
 	execSamples := make([][]GPUPCSample, len(execs))
 	for i, exec := range execs {
 		if entry, ok := t.pending[exec.Correlation]; ok {
 			execSamples[i] = entry.samples
 			delete(t.pending, exec.Correlation)
+			t.pendingSampleTotal -= uint64(len(entry.samples))
+			attributedPCSamples += uint64(len(entry.samples))
 		}
 	}
+	pendingCorrelations := len(t.pending)
+	pendingSamples := t.pendingSampleTotal
 	t.mu.Unlock()
 
 	// The heuristic's candidate set is built lazily - only once the loop
@@ -571,12 +615,15 @@ func (t *Timeline) Snapshot() Snapshot {
 	}
 
 	return Snapshot{
-		Executions:  views,
-		Events:      events,
-		Modules:     modules,
-		JoinStats:   stats,
-		LaunchCache: t.cache.Stats(),
-		Dropped:     dropped,
+		Executions:          views,
+		Events:              events,
+		Modules:             modules,
+		JoinStats:           stats,
+		LaunchCache:         t.cache.Stats(),
+		Dropped:             dropped,
+		AttributedPCSamples: attributedPCSamples,
+		PendingSamples:      int(pendingSamples),
+		PendingCorrelations: pendingCorrelations,
 	}
 }
 

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -68,16 +68,58 @@ type Snapshot struct {
 // TimelineConfig configures Timeline's storage bounds.
 type TimelineConfig struct {
 	// LaunchCache bounds the launch cache (see LaunchCacheConfig). Its
-	// normalized Capacity also bounds Timeline's exec/event/module ring
-	// buffers and the pending-PC-sample map: there is no separate capacity
-	// field for them, and their volume tracks launch volume closely enough
-	// to share one dial.
+	// normalized Capacity also bounds Timeline's exec/module ring buffers and
+	// the pending-PC-sample map's cardinality: there is no separate capacity
+	// field for them, and their volume tracks launch volume closely enough to
+	// share one dial. EventCapacity is the one exception - see its own doc
+	// comment.
 	LaunchCache LaunchCacheConfig
-	// LaunchEventJoinWindowNs is reserved for a future launch/event join
-	// (the prototype's findLaunchForEvent). Timeline does not join
-	// GPUTimelineEvent to launches yet, so this field is currently inert;
-	// kept here so callers don't need to change TimelineConfig's shape later.
+
+	// EventCapacity bounds the GPUTimelineEvent ring independently of
+	// LaunchCache.Capacity. Spec §7/§12 describes GPUTimelineEvent as raw
+	// syscall/ioctl traffic, plausibly 10-100x launch volume - sizing it off
+	// the launch-cache capacity (as every other store here does) would be
+	// wrong in either direction: too small for event volume, or forced
+	// artificially large just to fit events, wasting memory on the launch
+	// cache and exec/module rings. Zero means "use LaunchCache's normalized
+	// capacity", the historical default, so existing callers don't change
+	// behavior.
+	EventCapacity int
+
+	// LaunchEventJoinWindowNs bounds how far back (in nanoseconds, in the CPU
+	// monotonic domain) the heuristic join in Snapshot may look for a
+	// candidate launch preceding an execution's StartNs. Without a bound, a
+	// long-running kernel name shared across a workload's whole lifetime
+	// makes every earlier launch on that (queue, kernel name) group a
+	// "qualifying" candidate forever, which both risks attaching an
+	// execution to a launch from an unrelated iteration and makes Ambiguous
+	// permanently true (every repeated kernel accumulates candidates without
+	// bound), carrying no information. Spec §10 calls the heuristic
+	// "bounded-time"; this is that bound. Zero means unbounded - preserved
+	// as the default so existing callers and tests that never set it keep
+	// today's behavior; a caller that wants the bound (any real backend
+	// using the heuristic path) sets this explicitly.
 	LaunchEventJoinWindowNs uint64
+
+	// MaxPendingSamplesPerCorrelation caps how many PC samples one
+	// not-yet-matched correlation may accumulate in Timeline.pending before
+	// further samples for it are dropped and counted in
+	// Dropped.EvictedPendingSamples, instead of appended without bound.
+	// evictPendingLocked's cardinality eviction bounds the number of
+	// *distinct* orphaned correlations; without this, a single correlation
+	// below that bound (e.g. one that never gets an exec, or an exec that
+	// keeps producing samples under a stale ID) can still accumulate
+	// unbounded memory on its own. Zero means
+	// defaultMaxPendingSamplesPerCorrelation.
+	MaxPendingSamplesPerCorrelation int
+
+	// PendingSampleHorizonNs bounds how far behind the newest observed
+	// PC-sample timestamp a pending correlation's most recent sample may
+	// fall before that correlation is evicted as an orphan, in addition to
+	// the cardinality bound (pendingCap). Mirrors LaunchCacheConfig.HorizonNs.
+	// Zero disables horizon-based pending eviction, leaving only the
+	// cardinality bound.
+	PendingSampleHorizonNs uint64
 }
 
 // Timeline is the indexed join point: it ingests launches, executions, PC
@@ -90,7 +132,18 @@ type Timeline struct {
 
 	cache *LaunchCache
 
-	launchCount uint64
+	// launchesSinceSnapshot counts EmitLaunch calls since the last Snapshot,
+	// reset to 0 by Snapshot. It used to be a lifetime cumulative counter
+	// (launchCount), which review Important 1 flagged as meaningless once
+	// every other JoinStats field is per-snapshot: after the second
+	// Snapshot, "unmatched = lifetime launches - this snapshot's matches"
+	// mixes two different time scales and is not a loss figure.
+	launchesSinceSnapshot uint64
+
+	// joinWindowNs is TimelineConfig.LaunchEventJoinWindowNs, copied out at
+	// construction time. Zero means unbounded (see that field's doc
+	// comment).
+	joinWindowNs uint64
 
 	execs *ring[GPUKernelExec]
 
@@ -128,6 +181,24 @@ type Timeline struct {
 	pendingSeq   uint64
 	pendingCap   int
 
+	// pendingSampleCap bounds how many samples a single pending correlation's
+	// entry may accumulate - review Critical 5: pendingCap above bounds the
+	// number of distinct orphaned correlations, not the samples within any
+	// one of them, so a single correlation below that bound could still grow
+	// without bound. See TimelineConfig.MaxPendingSamplesPerCorrelation.
+	pendingSampleCap int
+
+	// pendingHorizonNs/pendingNewestNs age pending entries by time, the same
+	// way LaunchCache's HorizonNs/newestNs age launches: pendingNewestNs
+	// tracks the largest PC-sample TimeNs observed (clamped against a single
+	// anomalous jump the same way LaunchCache.observeTimestampLocked is, via
+	// the shared defaultMaxAdvanceNs bound); evictPendingLocked drops
+	// pending entries whose most recent sample has fallen more than
+	// pendingHorizonNs behind that anchor. Zero pendingHorizonNs disables
+	// this pass, leaving only the cardinality-based eviction below it.
+	pendingHorizonNs uint64
+	pendingNewestNs  uint64
+
 	events  *ring[GPUTimelineEvent]
 	modules *ring[GPUModule]
 
@@ -152,28 +223,52 @@ type pendingOrderEntry struct {
 	seq uint64
 }
 
+// defaultMaxPendingSamplesPerCorrelation bounds a single pending
+// correlation's accumulated samples when TimelineConfig doesn't set
+// MaxPendingSamplesPerCorrelation. Chosen generously relative to a realistic
+// PC-sampling batch (tens to low hundreds of samples between exec arrivals)
+// while still being a real, enforced bound rather than the previous
+// unbounded append.
+const defaultMaxPendingSamplesPerCorrelation = 4096
+
 // NewTimeline constructs a Timeline. cfg.LaunchCache is passed through to
 // NewLaunchCache unmodified (including its own zero-value defaulting); the
-// cache's own normalized capacity is reused for the exec/event/module rings
-// and the pending-sample bound rather than re-deriving it, so the default
-// can't drift between LaunchCache and Timeline.
+// cache's own normalized capacity is reused for the exec/module rings and
+// the pending-sample cardinality bound rather than re-deriving it, so the
+// default can't drift between LaunchCache and Timeline. EventCapacity,
+// MaxPendingSamplesPerCorrelation and PendingSampleHorizonNs each get their
+// own defaulting - see their doc comments on TimelineConfig.
 func NewTimeline(cfg TimelineConfig) *Timeline {
 	cache := NewLaunchCache(cfg.LaunchCache)
 	capacity := cache.cfg.Capacity
+
+	eventCapacity := cfg.EventCapacity
+	if eventCapacity <= 0 {
+		eventCapacity = capacity
+	}
+
+	sampleCap := cfg.MaxPendingSamplesPerCorrelation
+	if sampleCap <= 0 {
+		sampleCap = defaultMaxPendingSamplesPerCorrelation
+	}
+
 	return &Timeline{
-		cache:      cache,
-		execs:      newRing[GPUKernelExec](capacity),
-		events:     newRing[GPUTimelineEvent](capacity),
-		modules:    newRing[GPUModule](capacity),
-		pending:    make(map[CorrelationID]pendingSamples),
-		pendingCap: capacity,
+		cache:            cache,
+		joinWindowNs:     cfg.LaunchEventJoinWindowNs,
+		execs:            newRing[GPUKernelExec](capacity),
+		events:           newRing[GPUTimelineEvent](eventCapacity),
+		modules:          newRing[GPUModule](capacity),
+		pending:          make(map[CorrelationID]pendingSamples),
+		pendingCap:       capacity,
+		pendingSampleCap: sampleCap,
+		pendingHorizonNs: cfg.PendingSampleHorizonNs,
 	}
 }
 
 func (t *Timeline) EmitLaunch(l GPUKernelLaunch) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.launchCount++
+	t.launchesSinceSnapshot++
 	t.cache.Put(l)
 	return nil
 }
@@ -190,6 +285,9 @@ func (t *Timeline) EmitExec(e GPUKernelExec) error {
 func (t *Timeline) EmitPCSample(p GPUPCSample) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	t.observePendingTimestampLocked(p.TimeNs)
+
 	entry, exists := t.pending[p.Correlation]
 	if !exists {
 		// Absent-to-present transition: either a brand new correlation, or
@@ -202,22 +300,82 @@ func (t *Timeline) EmitPCSample(p GPUPCSample) error {
 		entry.seq = t.pendingSeq
 		t.pendingOrder = append(t.pendingOrder, pendingOrderEntry{id: p.Correlation, seq: entry.seq})
 	}
+
+	if len(entry.samples) >= t.pendingSampleCap {
+		// Review Critical 5: evictPendingLocked's cardinality bound only
+		// limits the number of distinct pending correlations, not the
+		// samples within any single one of them. Without this check, one
+		// orphaned (or stale-ID-reused) correlation below that bound could
+		// still accumulate samples forever. The entry (and its order
+		// position/generation) is left exactly as it was; only the new
+		// sample is dropped and counted.
+		t.dropped.EvictedPendingSamples++
+		t.pending[p.Correlation] = entry
+		t.evictPendingLocked()
+		return nil
+	}
+
 	entry.samples = append(entry.samples, p)
 	t.pending[p.Correlation] = entry
 	t.evictPendingLocked()
 	return nil
 }
 
-// evictPendingLocked drops the oldest pending correlation groups once the
-// map holds more distinct correlations than pendingCap. An order position
-// whose sequence no longer matches the map's current entry for that id -
-// because Snapshot already consumed it, or a later re-insertion superseded
-// it - is skipped rather than double-counted or, worse, mistaken for the
-// live generation and evicted in its place. This mirrors
+// observePendingTimestampLocked advances pendingNewestNs the same way
+// LaunchCache.observeTimestampLocked advances newestNs: a single jump larger
+// than defaultMaxAdvanceNs is treated as anomalous and does not move the
+// anchor, so one corrupt PC-sample timestamp can't push every pending
+// correlation past the horizon at once. Caller holds t.mu.
+func (t *Timeline) observePendingTimestampLocked(timeNs uint64) {
+	if timeNs <= t.pendingNewestNs {
+		return
+	}
+	if t.pendingNewestNs != 0 && timeNs-t.pendingNewestNs > defaultMaxAdvanceNs {
+		return
+	}
+	t.pendingNewestNs = timeNs
+}
+
+// latestSampleTimeNs returns the largest TimeNs among samples, for aging a
+// pending entry against pendingNewestNs.
+func latestSampleTimeNs(samples []GPUPCSample) uint64 {
+	var latest uint64
+	for _, s := range samples {
+		if s.TimeNs > latest {
+			latest = s.TimeNs
+		}
+	}
+	return latest
+}
+
+// evictPendingLocked drops pending correlation groups past the horizon
+// first (if pendingHorizonNs > 0), then the oldest ones once the map holds
+// more distinct correlations than pendingCap. An order position whose
+// sequence no longer matches the map's current entry for that id - because
+// Snapshot already consumed it, or a later re-insertion superseded it - is
+// skipped rather than double-counted or, worse, mistaken for the live
+// generation and evicted in its place. This mirrors
 // LaunchCache.evictLocked/currentIfLiveLocked exactly, for the same reason:
 // presence in the map is not a sufficient liveness check when a key can be
 // deleted and then reused. Caller holds t.mu.
 func (t *Timeline) evictPendingLocked() {
+	if t.pendingHorizonNs > 0 {
+		for t.pendingHead < len(t.pendingOrder) {
+			e := t.pendingOrder[t.pendingHead]
+			cur, live := t.pending[e.id]
+			if !live || cur.seq != e.seq {
+				t.pendingHead++
+				continue
+			}
+			latest := latestSampleTimeNs(cur.samples)
+			if t.pendingNewestNs <= latest || t.pendingNewestNs-latest <= t.pendingHorizonNs {
+				break
+			}
+			delete(t.pending, e.id)
+			t.pendingHead++
+			t.dropped.EvictedPendingSamples += uint64(len(cur.samples))
+		}
+	}
 	for len(t.pending) > t.pendingCap && t.pendingHead < len(t.pendingOrder) {
 		e := t.pendingOrder[t.pendingHead]
 		t.pendingHead++
@@ -283,30 +441,57 @@ func cloneTimelineEvent(in GPUTimelineEvent) GPUTimelineEvent {
 	return out
 }
 
-// Snapshot builds the joined view. It copies/consumes everything Timeline
-// itself guards (execs, events, modules, matched pending samples, counters)
-// while holding the lock, then releases it before touching LaunchCache -
-// which guards itself - so the join work below never runs under Timeline's
-// own mutex.
+// Snapshot builds the joined view and CONSUMES everything Timeline itself
+// guards: execs, events and modules are drained from their rings (a second
+// consecutive Snapshot call returns none of them unless new ones arrived in
+// between), and PC samples matched to an execution in this call are removed
+// from the pending store the same way. This is a deliberate, uniform
+// lifecycle across all five stores - see review Critical 3: execs used to be
+// merely copied (re-reported in every Snapshot until the ring rotated, so a
+// polling caller double-, triple-, N-counted the same kernel time) while PC
+// samples were already consumed, two different lifecycles in one call. For a
+// profiler emitting periodic profiles, each execution/event/module/sample
+// belongs to exactly one output; accumulating instead would double-count
+// across snapshots exactly like the pre-fix exec bug did.
 //
-// PC samples are consumed, not cached: once a sample is attached to an
-// execution's PCSamples here, it is removed from Timeline's pending store.
-// A second consecutive Snapshot call for a still-live execution therefore
-// returns no PC samples for it unless new ones arrived since the previous
-// call. A caller polling Snapshot for metrics sees each sample exactly
-// once - it belongs to whichever profile it was reported in, not to every
-// later one - so samples should be taken away from the profile that
-// received them, not expected to reappear in the next.
+// A caller snapshotting purely for a metrics endpoint (not to emit a
+// profile) should be aware this is destructive: values are taken away from
+// the profile that received them, not retained for the next call. Only
+// LaunchCache (a live join index, not an output) and not-yet-matched pending
+// PC samples (which may still match a future execution) survive a Snapshot
+// call.
+//
+// Draining execs/events/modules is done by swapping in a fresh, empty ring
+// under the lock (O(1)) rather than copying the old ring's contents while
+// holding it (O(capacity)) - review Important 4. The O(capacity) unwrap into
+// an ordered slice happens below, against rings this goroutine now
+// exclusively owns, so it no longer serializes concurrent EmitLaunch/
+// EmitExec/etc calls. Pending PC samples cannot be swapped wholesale the
+// same way: most entries typically do not match this round and must survive
+// for a future one, so that pass takes a second, much shorter lock
+// (O(len(execs)) map operations, not O(capacity)).
 func (t *Timeline) Snapshot() Snapshot {
 	t.mu.Lock()
-	execs := t.execs.items()
-	events := t.events.items()
-	modules := t.modules.items()
+	oldExecs := t.execs
+	t.execs = newRing[GPUKernelExec](len(oldExecs.buf))
+	oldEvents := t.events
+	t.events = newRing[GPUTimelineEvent](len(oldEvents.buf))
+	oldModules := t.modules
+	t.modules = newRing[GPUModule](len(oldModules.buf))
+	launchCount := t.launchesSinceSnapshot
+	t.launchesSinceSnapshot = 0
+	dropped := t.dropped
+	t.mu.Unlock()
+
+	execs := oldExecs.items()
+	events := oldEvents.items()
+	modules := oldModules.items()
 
 	// Only pop the pending samples the executions in this snapshot can
 	// actually use, rather than copying the whole map: a correlation with
 	// no live exec this round is left untouched (still eligible for a
 	// later snapshot, or eventual orphan eviction).
+	t.mu.Lock()
 	execSamples := make([][]GPUPCSample, len(execs))
 	for i, exec := range execs {
 		if entry, ok := t.pending[exec.Correlation]; ok {
@@ -314,22 +499,21 @@ func (t *Timeline) Snapshot() Snapshot {
 			delete(t.pending, exec.Correlation)
 		}
 	}
-
-	launchCount := t.launchCount
-	dropped := t.dropped
 	t.mu.Unlock()
 
-	// The heuristic's candidate set is materialized once per Snapshot call
-	// (not once per miss): LaunchCache.Entries() allocates, and calling it
-	// inside the per-execution loop was exactly the quadratic-with-
-	// allocation behaviour this phase exists to remove. Grouping by (queue,
-	// kernel name) and sorting each group by TimeNs turns each miss into a
-	// binary search - O(log candidates) - instead of a linear scan: a
+	// The heuristic's candidate set is built lazily - only once the loop
+	// below hits its first exec that actually needs it (see the
+	// exec.Correlation zero-value branch), not unconditionally on every
+	// Snapshot call - review Important 4. LaunchCache.Entries() and the
+	// per-group sort are O(capacity); a CUPTI-style workload where every
+	// join is exact never touches this at all. Grouping by (queue, kernel
+	// name) and sorting each group by TimeNs turns each miss into a binary
+	// search - O(log candidates) - instead of a linear scan: a
 	// single-queue, single-kernel-name workload (one submission stream) is
 	// not a pathological input, it is what most workloads look like, and a
-	// linear scan there is still O(misses x candidates) even after the
-	// per-miss allocation was removed.
-	candidateIndex := buildHeuristicCandidateIndex(t.cache.Entries())
+	// linear scan there is still O(misses x candidates) even without a
+	// per-miss allocation.
+	var candidateIndex map[candidateGroupKey][]GPUKernelLaunch
 
 	views := make([]ExecutionView, 0, len(execs))
 	stats := JoinStats{LaunchCount: launchCount}
@@ -347,10 +531,25 @@ func (t *Timeline) Snapshot() Snapshot {
 				views = append(views, view)
 				continue
 			}
+			// Review Critical 2: a correlation ID was supplied but missed
+			// the cache. That tells us the truth - the launch aged out (or,
+			// less commonly, never arrived) - it does not tell us "no
+			// correlation was ever available", which is the one situation
+			// the heuristic below exists for (DRM, which never supplies a
+			// correlation ID at all). Guessing here risks attaching a
+			// different, still-live launch's PID and Tags to this
+			// execution merely because it shares a kernel name and queue -
+			// spec §13 requires degrading to unattributed instead.
+			stats.UnmatchedExecutionCount++
+			views = append(views, view)
+			continue
 		}
 
+		if candidateIndex == nil {
+			candidateIndex = buildHeuristicCandidateIndex(t.cache.Entries())
+		}
 		key := candidateGroupKey{queue: queueKeyOf(exec.Queue), kernelName: exec.KernelName}
-		if match := findLaunchHeuristic(candidateIndex[key], exec); match.launch != nil {
+		if match := findLaunchHeuristic(candidateIndex[key], exec, t.joinWindowNs); match.launch != nil {
 			view.Launch = match.launch
 			view.Join = JoinHeuristic
 			view.Heuristic = true
@@ -445,30 +644,56 @@ func buildHeuristicCandidateIndex(entries []GPUKernelLaunch) map[candidateGroupK
 	return byGroup
 }
 
-// findLaunchHeuristic is the fallback path when an exec's Correlation misses
-// the cache (never arrived, or aged out). Ported decision from the
-// prototype's findLaunchHeuristic: a launch that precedes the exec's start,
-// preferring the most recent such launch, and flagging Ambiguous when more
-// than one candidate qualified.
+// findLaunchHeuristic is the fallback path when an exec never carried a
+// correlation ID at all (see the exec.Correlation zero-value branch in
+// Snapshot). Ported decision from the prototype's findLaunchHeuristic: a
+// launch that precedes the exec's start, preferring the most recent such
+// launch, and flagging Ambiguous when more than one candidate qualified.
 //
 // candidates must already be filtered to the exec's exact (queue, kernel
 // name) group (see buildHeuristicCandidateIndex) and sorted by TimeNs
 // ascending. Because the group is already filtered, every entry satisfies
 // the queue/name half of the original filter; sort.Search finds the
 // insertion point of exec.StartNs - the count of entries with
-// TimeNs <= StartNs, which is simultaneously the ambiguity count (>1 means
-// more than one qualifying candidate) and locates the best candidate
-// (immediately before the insertion point, i.e. the most recent one that
-// still precedes the exec) in O(log n) instead of an O(n) scan.
-func findLaunchHeuristic(candidates []GPUKernelLaunch, exec GPUKernelExec) launchMatch {
+// TimeNs <= StartNs, which locates the best candidate (immediately before
+// the insertion point, i.e. the most recent one that still precedes the
+// exec) in O(log n) instead of an O(n) scan.
+//
+// windowNs is review Important 3's fix: spec §10 calls the heuristic
+// "bounded-time", but this used to accept any candidate preceding the exec
+// with no time bound at all, and Ambiguous counted every such candidate -
+// for a kernel name reused throughout a workload's life, that count only
+// grows, making Ambiguous permanently true and carrying no information.
+// windowNs == 0 keeps the historical unbounded behavior (TimelineConfig's
+// default); windowNs > 0 restricts both which candidate can match and what
+// Ambiguous counts to the [exec.StartNs-windowNs, exec.StartNs] range, via a
+// second binary search for the window's lower bound within the same
+// already-sorted, already-filtered slice.
+func findLaunchHeuristic(candidates []GPUKernelLaunch, exec GPUKernelExec, windowNs uint64) launchMatch {
 	insertionPoint := sort.Search(len(candidates), func(i int) bool {
 		return candidates[i].TimeNs > exec.StartNs
 	})
 	if insertionPoint == 0 {
 		return launchMatch{}
 	}
+
+	lowerBound := 0
+	if windowNs > 0 {
+		var earliest uint64
+		if exec.StartNs > windowNs {
+			earliest = exec.StartNs - windowNs
+		}
+		lowerBound = sort.Search(insertionPoint, func(i int) bool {
+			return candidates[i].TimeNs >= earliest
+		})
+	}
+
+	inWindow := insertionPoint - lowerBound
+	if inWindow == 0 {
+		return launchMatch{}
+	}
 	best := candidates[insertionPoint-1]
-	return launchMatch{launch: &best, ambiguous: insertionPoint > 1}
+	return launchMatch{launch: &best, ambiguous: inWindow > 1}
 }
 
 // ring is a fixed-capacity FIFO: push is O(1) amortized (no shifting), and

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -605,6 +605,9 @@ func (t *Timeline) Snapshot() Snapshot {
 			matched[match.launch.Correlation] = struct{}{}
 		} else {
 			stats.UnmatchedExecutionCount++
+			if match.outOfWindow {
+				stats.OutOfWindowDropCount++
+			}
 		}
 		views = append(views, view)
 	}
@@ -628,11 +631,16 @@ func (t *Timeline) Snapshot() Snapshot {
 }
 
 // launchMatch is the result of the heuristic join: the best candidate found
-// (nil on a miss - a miss must never attach a launch), and whether more than
-// one candidate matched (Ambiguous).
+// (nil on a miss - a miss must never attach a launch), whether more than one
+// candidate matched (ambiguous), and - on a miss only - whether the window
+// (windowNs) is specifically what excluded it: outOfWindow is true when at
+// least one candidate precedes the exec but none fall within the window,
+// distinct from a miss with no preceding candidate at all. Feeds
+// JoinStats.OutOfWindowDropCount (review Important 3 / minors cleanup).
 type launchMatch struct {
-	launch    *GPUKernelLaunch
-	ambiguous bool
+	launch      *GPUKernelLaunch
+	ambiguous   bool
+	outOfWindow bool
 }
 
 // queueKey is the subset of GPUQueueRef the heuristic join actually
@@ -737,7 +745,11 @@ func findLaunchHeuristic(candidates []GPUKernelLaunch, exec GPUKernelExec, windo
 
 	inWindow := insertionPoint - lowerBound
 	if inWindow == 0 {
-		return launchMatch{}
+		// insertionPoint > 0 here (checked above), so at least one candidate
+		// precedes the exec - the window is specifically what excluded all
+		// of them. Distinct from insertionPoint == 0 above (no preceding
+		// candidate existed at all), which is not an out-of-window drop.
+		return launchMatch{outOfWindow: true}
 	}
 	best := candidates[insertionPoint-1]
 	return launchMatch{launch: &best, ambiguous: inWindow > 1}

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -177,15 +177,22 @@ type Timeline struct {
 	// pending holds PC samples keyed by correlation ID until an exec with a
 	// matching Correlation is joined at Snapshot time. A correlation's
 	// samples are deleted from pending the moment they are attached to an
-	// execution's view - they are consumed, not cached indefinitely. As a
-	// direct consequence, if the same still-live execution is included in a
-	// later Snapshot call, that later call sees only samples that arrived
-	// since the previous attach, not the full history: PCSamples is a
-	// once-delivered view, not an accumulating one. Samples that are never
-	// claimed (exec never arrives, or ages out of the ring first) are
-	// orphans; pendingCap/pendingOrder/pendingHead bound how many distinct
-	// correlations' worth of orphans can accumulate, evicting the oldest
-	// and counting it in Dropped.EvictedPendingSamples.
+	// execution's view - they are consumed, not cached indefinitely. Since
+	// review Critical 3 made Snapshot drain execs the same way (an exec is
+	// reported in exactly one Snapshot call, never re-reported in a later
+	// one), an exec's attach is a one-time event by construction: whatever
+	// samples had accumulated in pending for its Correlation by that moment
+	// are handed to it, once, and there is no "later Snapshot call for the
+	// same still-live execution" for more to arrive into. A PC sample that
+	// arrives under that same correlation ID afterward - the ID having been
+	// consumed already - starts a fresh, ordinary pending entry (a new
+	// generation; see the seq discussion below), exactly like any other
+	// correlation whose exec hasn't arrived yet, not a continuation of the
+	// one already delivered. Samples that are never claimed (exec never
+	// arrives, or ages out of the ring first) are orphans; pendingCap/
+	// pendingOrder/pendingHead bound how many distinct correlations' worth
+	// of orphans can accumulate, evicting the oldest and counting it in
+	// Dropped.EvictedPendingSamples.
 	//
 	// Both pending's entries and pendingOrder's positions carry a sequence
 	// number, the same way LaunchCache pairs cacheEntry.seq with

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -103,15 +103,50 @@ type Timeline struct {
 	// orphans; pendingCap/pendingOrder/pendingHead bound how many distinct
 	// correlations' worth of orphans can accumulate, evicting the oldest
 	// and counting it in Dropped.EvictedPendingSamples.
-	pending      map[CorrelationID][]GPUPCSample
-	pendingOrder []CorrelationID
+	//
+	// Both pending's entries and pendingOrder's positions carry a sequence
+	// number, the same way LaunchCache pairs cacheEntry.seq with
+	// orderEntry.seq (see currentIfLiveLocked there). This exists to solve
+	// the identical hazard: a correlation ID consumed by Snapshot leaves its
+	// old pendingOrder position behind with no map entry; if that same ID is
+	// then reused by a later EmitPCSample, presence-only eviction cannot
+	// tell that stale position apart from the ID's new, live generation, and
+	// would delete the freshly re-inserted entry instead of the position it
+	// actually corresponds to. A new sequence is assigned only on the
+	// absent-to-present transition (a brand new correlation, or a reused one
+	// after consumption/eviction), not on every append to an already-live
+	// entry - unlike LaunchCache.Put, which always replaces the whole value,
+	// pending accumulates samples across many EmitPCSample calls for the
+	// same still-live generation, so an in-place append must not look like a
+	// new generation.
+	pending      map[CorrelationID]pendingSamples
+	pendingOrder []pendingOrderEntry
 	pendingHead  int
+	pendingSeq   uint64
 	pendingCap   int
 
 	events  *ring[GPUTimelineEvent]
 	modules *ring[GPUModule]
 
 	dropped TimelineDropStats
+}
+
+// pendingSamples is a pending correlation's accumulated samples, tagged with
+// the sequence number of its current (live) generation - see the pending
+// field's doc comment.
+type pendingSamples struct {
+	samples []GPUPCSample
+	seq     uint64
+}
+
+// pendingOrderEntry names one FIFO position: the correlation ID inserted and
+// the sequence number it was inserted with. Comparing seq against the
+// current pendingSamples.seq for the same id is how eviction tells a live
+// position from one a later re-insertion (after consumption or eviction) has
+// superseded. Mirrors LaunchCache's orderEntry.
+type pendingOrderEntry struct {
+	id  CorrelationID
+	seq uint64
 }
 
 // NewTimeline constructs a Timeline. cfg.LaunchCache is passed through to
@@ -127,7 +162,7 @@ func NewTimeline(cfg TimelineConfig) *Timeline {
 		execs:      newRing[GPUKernelExec](capacity),
 		events:     newRing[GPUTimelineEvent](capacity),
 		modules:    newRing[GPUModule](capacity),
-		pending:    make(map[CorrelationID][]GPUPCSample),
+		pending:    make(map[CorrelationID]pendingSamples),
 		pendingCap: capacity,
 	}
 }
@@ -152,32 +187,43 @@ func (t *Timeline) EmitExec(e GPUKernelExec) error {
 func (t *Timeline) EmitPCSample(p GPUPCSample) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if _, exists := t.pending[p.Correlation]; !exists {
-		t.pendingOrder = append(t.pendingOrder, p.Correlation)
+	entry, exists := t.pending[p.Correlation]
+	if !exists {
+		// Absent-to-present transition: either a brand new correlation, or
+		// this ID being reused after its previous generation was consumed
+		// or evicted. Either way it is a new generation and gets a new
+		// sequence number plus a new order position - see the pending
+		// field's doc comment for why this must not also happen on every
+		// append to an already-live entry.
+		t.pendingSeq++
+		entry.seq = t.pendingSeq
+		t.pendingOrder = append(t.pendingOrder, pendingOrderEntry{id: p.Correlation, seq: entry.seq})
 	}
-	t.pending[p.Correlation] = append(t.pending[p.Correlation], p)
+	entry.samples = append(entry.samples, p)
+	t.pending[p.Correlation] = entry
 	t.evictPendingLocked()
 	return nil
 }
 
 // evictPendingLocked drops the oldest pending correlation groups once the
-// map holds more distinct correlations than pendingCap. A correlation
-// already consumed by Snapshot (its map entry deleted there; its order
-// entry left behind) is skipped rather than double-counted as an eviction -
-// presence in t.pending is a sufficient liveness check here because, unlike
-// LaunchCache, a pending entry is never replaced in place, only appended to
-// or deleted whole, so there is no stale-versus-live ambiguity to resolve.
-// Caller holds t.mu.
+// map holds more distinct correlations than pendingCap. An order position
+// whose sequence no longer matches the map's current entry for that id -
+// because Snapshot already consumed it, or a later re-insertion superseded
+// it - is skipped rather than double-counted or, worse, mistaken for the
+// live generation and evicted in its place. This mirrors
+// LaunchCache.evictLocked/currentIfLiveLocked exactly, for the same reason:
+// presence in the map is not a sufficient liveness check when a key can be
+// deleted and then reused. Caller holds t.mu.
 func (t *Timeline) evictPendingLocked() {
 	for len(t.pending) > t.pendingCap && t.pendingHead < len(t.pendingOrder) {
-		id := t.pendingOrder[t.pendingHead]
+		e := t.pendingOrder[t.pendingHead]
 		t.pendingHead++
-		samples, ok := t.pending[id]
-		if !ok {
+		cur, live := t.pending[e.id]
+		if !live || cur.seq != e.seq {
 			continue
 		}
-		delete(t.pending, id)
-		t.dropped.EvictedPendingSamples += uint64(len(samples))
+		delete(t.pending, e.id)
+		t.dropped.EvictedPendingSamples += uint64(len(cur.samples))
 	}
 	t.compactPendingOrderLocked()
 }
@@ -239,6 +285,15 @@ func cloneTimelineEvent(in GPUTimelineEvent) GPUTimelineEvent {
 // while holding the lock, then releases it before touching LaunchCache -
 // which guards itself - so the join work below never runs under Timeline's
 // own mutex.
+//
+// PC samples are consumed, not cached: once a sample is attached to an
+// execution's PCSamples here, it is removed from Timeline's pending store.
+// A second consecutive Snapshot call for a still-live execution therefore
+// returns no PC samples for it unless new ones arrived since the previous
+// call. A caller polling Snapshot for metrics sees each sample exactly
+// once - it belongs to whichever profile it was reported in, not to every
+// later one - so samples should be taken away from the profile that
+// received them, not expected to reappear in the next.
 func (t *Timeline) Snapshot() Snapshot {
 	t.mu.Lock()
 	execs := t.execs.items()
@@ -251,8 +306,8 @@ func (t *Timeline) Snapshot() Snapshot {
 	// later snapshot, or eventual orphan eviction).
 	execSamples := make([][]GPUPCSample, len(execs))
 	for i, exec := range execs {
-		if samples, ok := t.pending[exec.Correlation]; ok {
-			execSamples[i] = samples
+		if entry, ok := t.pending[exec.Correlation]; ok {
+			execSamples[i] = entry.samples
 			delete(t.pending, exec.Correlation)
 		}
 	}

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -1,6 +1,9 @@
 package gpu
 
-import "sync"
+import (
+	"maps"
+	"sync"
+)
 
 var _ EventSink = (*Timeline)(nil)
 
@@ -31,15 +34,25 @@ type ExecutionView struct {
 
 // TimelineDropStats counts what Timeline's own bounded storage evicted.
 // LaunchCacheStats already covers launch attribution loss; this covers the
-// exec and event ring buffers layered on top of it. Modeled after SinkStats:
-// nothing bounded is allowed to evict silently.
+// exec/event/module ring buffers and the pending-PC-sample map layered on
+// top of it. Modeled after SinkStats: nothing bounded is allowed to evict
+// silently.
 type TimelineDropStats struct {
-	EvictedExecutions uint64 `json:"evicted_executions,omitempty"`
-	EvictedEvents     uint64 `json:"evicted_events,omitempty"`
+	EvictedExecutions     uint64 `json:"evicted_executions,omitempty"`
+	EvictedEvents         uint64 `json:"evicted_events,omitempty"`
+	EvictedModules        uint64 `json:"evicted_modules,omitempty"`
+	EvictedPendingSamples uint64 `json:"evicted_pending_samples,omitempty"`
 }
 
 // Snapshot is a point-in-time, fully-joined view of everything Timeline
 // currently holds.
+//
+// Events' Device/Queue/Attributes fields are cloned once, at EmitEvent
+// ingest time (see cloneTimelineEvent), so they never alias a backend's own
+// buffers. They are not cloned again per Snapshot call: like
+// LaunchCache.Get's return value, the events here should be treated as
+// read-only by callers, since repeated Snapshot calls return values backed
+// by the same ring storage.
 type Snapshot struct {
 	Executions  []ExecutionView    `json:"executions"`
 	Events      []GPUTimelineEvent `json:"events,omitempty"`
@@ -52,9 +65,10 @@ type Snapshot struct {
 // TimelineConfig configures Timeline's storage bounds.
 type TimelineConfig struct {
 	// LaunchCache bounds the launch cache (see LaunchCacheConfig). Its
-	// normalized Capacity also bounds Timeline's exec/event ring buffers:
-	// there is no separate capacity field for them, and exec/event volume
-	// tracks launch volume closely enough to share one dial.
+	// normalized Capacity also bounds Timeline's exec/event/module ring
+	// buffers and the pending-PC-sample map: there is no separate capacity
+	// field for them, and their volume tracks launch volume closely enough
+	// to share one dial.
 	LaunchCache LaunchCacheConfig
 	// LaunchEventJoinWindowNs is reserved for a future launch/event join
 	// (the prototype's findLaunchForEvent). Timeline does not join
@@ -76,31 +90,45 @@ type Timeline struct {
 	launchCount uint64
 
 	execs *ring[GPUKernelExec]
+
 	// pending holds PC samples keyed by correlation ID until an exec with a
-	// matching Correlation is joined at Snapshot time. Unlike execs/events
-	// this is a plain, unbounded map (per the brief's Structure section): a
-	// sample whose exec never arrives, or whose exec ages out of the ring,
-	// stays here indefinitely. Known, documented limitation - bounding it is
-	// a separate design this task's brief and tests do not call for.
-	pending map[CorrelationID][]GPUPCSample
+	// matching Correlation is joined at Snapshot time. A correlation's
+	// samples are deleted from pending the moment they are attached to an
+	// execution's view - they are consumed, not cached indefinitely. As a
+	// direct consequence, if the same still-live execution is included in a
+	// later Snapshot call, that later call sees only samples that arrived
+	// since the previous attach, not the full history: PCSamples is a
+	// once-delivered view, not an accumulating one. Samples that are never
+	// claimed (exec never arrives, or ages out of the ring first) are
+	// orphans; pendingCap/pendingOrder/pendingHead bound how many distinct
+	// correlations' worth of orphans can accumulate, evicting the oldest
+	// and counting it in Dropped.EvictedPendingSamples.
+	pending      map[CorrelationID][]GPUPCSample
+	pendingOrder []CorrelationID
+	pendingHead  int
+	pendingCap   int
+
 	events  *ring[GPUTimelineEvent]
-	modules []GPUModule
+	modules *ring[GPUModule]
 
 	dropped TimelineDropStats
 }
 
 // NewTimeline constructs a Timeline. cfg.LaunchCache is passed through to
-// NewLaunchCache unmodified (including its own zero-value defaulting).
+// NewLaunchCache unmodified (including its own zero-value defaulting); the
+// cache's own normalized capacity is reused for the exec/event/module rings
+// and the pending-sample bound rather than re-deriving it, so the default
+// can't drift between LaunchCache and Timeline.
 func NewTimeline(cfg TimelineConfig) *Timeline {
-	capacity := cfg.LaunchCache.Capacity
-	if capacity <= 0 {
-		capacity = defaultLaunchCacheCapacity
-	}
+	cache := NewLaunchCache(cfg.LaunchCache)
+	capacity := cache.cfg.Capacity
 	return &Timeline{
-		cache:   NewLaunchCache(cfg.LaunchCache),
-		execs:   newRing[GPUKernelExec](capacity),
-		events:  newRing[GPUTimelineEvent](capacity),
-		pending: make(map[CorrelationID][]GPUPCSample),
+		cache:      cache,
+		execs:      newRing[GPUKernelExec](capacity),
+		events:     newRing[GPUTimelineEvent](capacity),
+		modules:    newRing[GPUModule](capacity),
+		pending:    make(map[CorrelationID][]GPUPCSample),
+		pendingCap: capacity,
 	}
 }
 
@@ -124,48 +152,128 @@ func (t *Timeline) EmitExec(e GPUKernelExec) error {
 func (t *Timeline) EmitPCSample(p GPUPCSample) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if _, exists := t.pending[p.Correlation]; !exists {
+		t.pendingOrder = append(t.pendingOrder, p.Correlation)
+	}
 	t.pending[p.Correlation] = append(t.pending[p.Correlation], p)
+	t.evictPendingLocked()
 	return nil
+}
+
+// evictPendingLocked drops the oldest pending correlation groups once the
+// map holds more distinct correlations than pendingCap. A correlation
+// already consumed by Snapshot (its map entry deleted there; its order
+// entry left behind) is skipped rather than double-counted as an eviction -
+// presence in t.pending is a sufficient liveness check here because, unlike
+// LaunchCache, a pending entry is never replaced in place, only appended to
+// or deleted whole, so there is no stale-versus-live ambiguity to resolve.
+// Caller holds t.mu.
+func (t *Timeline) evictPendingLocked() {
+	for len(t.pending) > t.pendingCap && t.pendingHead < len(t.pendingOrder) {
+		id := t.pendingOrder[t.pendingHead]
+		t.pendingHead++
+		samples, ok := t.pending[id]
+		if !ok {
+			continue
+		}
+		delete(t.pending, id)
+		t.dropped.EvictedPendingSamples += uint64(len(samples))
+	}
+	t.compactPendingOrderLocked()
+}
+
+// compactPendingOrderLocked reclaims the dead prefix of pendingOrder once it
+// dominates the slice, the same way LaunchCache.compactLocked does, so the
+// order slice's backing array doesn't grow without bound under sustained
+// load. Caller holds t.mu.
+func (t *Timeline) compactPendingOrderLocked() {
+	if t.pendingHead < 1024 || t.pendingHead*2 < len(t.pendingOrder) {
+		return
+	}
+	rest := t.pendingOrder[t.pendingHead:]
+	t.pendingOrder = append(t.pendingOrder[:0], rest...)
+	t.pendingHead = 0
 }
 
 func (t *Timeline) EmitModule(m GPUModule) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.modules = append(t.modules, m)
+	if t.modules.push(m) {
+		t.dropped.EvictedModules++
+	}
 	return nil
 }
 
 func (t *Timeline) EmitEvent(e GPUTimelineEvent) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.events.push(e) {
+	if t.events.push(cloneTimelineEvent(e)) {
 		t.dropped.EvictedEvents++
 	}
 	return nil
 }
 
-// Snapshot builds the joined view. It copies everything Timeline itself
-// guards (execs, events, modules, pending samples, counters) while holding
-// the lock, then releases it before touching LaunchCache - which guards
-// itself - so the join work below never runs under Timeline's own mutex.
+// cloneTimelineEvent deep-copies the reference-typed fields of a
+// GPUTimelineEvent (Device, Queue, Attributes) so Timeline's stored copy
+// never aliases the caller's own memory. A high-throughput producer that
+// reuses its event buffer after Emit returns would otherwise corrupt
+// already-ingested events out from under the mutex. Events are small and
+// these fields are optional, so cloning on ingest (once) is cheap relative
+// to the alternative of documenting yet another aliasing contract.
+func cloneTimelineEvent(in GPUTimelineEvent) GPUTimelineEvent {
+	out := in
+	out.Attributes = maps.Clone(in.Attributes)
+	if in.Device != nil {
+		device := *in.Device
+		out.Device = &device
+	}
+	if in.Queue != nil {
+		queue := *in.Queue
+		out.Queue = &queue
+	}
+	return out
+}
+
+// Snapshot builds the joined view. It copies/consumes everything Timeline
+// itself guards (execs, events, modules, matched pending samples, counters)
+// while holding the lock, then releases it before touching LaunchCache -
+// which guards itself - so the join work below never runs under Timeline's
+// own mutex.
 func (t *Timeline) Snapshot() Snapshot {
 	t.mu.Lock()
 	execs := t.execs.items()
 	events := t.events.items()
-	modules := append([]GPUModule(nil), t.modules...)
-	pending := make(map[CorrelationID][]GPUPCSample, len(t.pending))
-	for id, samples := range t.pending {
-		pending[id] = append([]GPUPCSample(nil), samples...)
+	modules := t.modules.items()
+
+	// Only pop the pending samples the executions in this snapshot can
+	// actually use, rather than copying the whole map: a correlation with
+	// no live exec this round is left untouched (still eligible for a
+	// later snapshot, or eventual orphan eviction).
+	execSamples := make([][]GPUPCSample, len(execs))
+	for i, exec := range execs {
+		if samples, ok := t.pending[exec.Correlation]; ok {
+			execSamples[i] = samples
+			delete(t.pending, exec.Correlation)
+		}
 	}
+
 	launchCount := t.launchCount
 	dropped := t.dropped
 	t.mu.Unlock()
 
+	// The heuristic's candidate set is materialized once per Snapshot call
+	// (not once per miss): LaunchCache.Entries() allocates, and calling it
+	// inside the per-execution loop was exactly the quadratic-with-
+	// allocation behaviour this phase exists to remove. Grouping by queue
+	// also means each miss only scans the launches that could possibly
+	// match its queue, not the whole cache.
+	candidatesByQueue := groupLaunchesByQueue(t.cache.Entries())
+
 	views := make([]ExecutionView, 0, len(execs))
 	stats := JoinStats{LaunchCount: launchCount}
 	matched := make(map[CorrelationID]struct{})
-	for _, exec := range execs {
-		view := ExecutionView{Exec: exec, PCSamples: pending[exec.Correlation]}
+	for i, exec := range execs {
+		view := ExecutionView{Exec: exec, PCSamples: execSamples[i]}
 
 		if exec.Correlation != (CorrelationID{}) {
 			if l, ok := t.cache.Get(exec.Correlation); ok {
@@ -179,7 +287,7 @@ func (t *Timeline) Snapshot() Snapshot {
 			}
 		}
 
-		if match := t.findLaunchHeuristic(exec); match.launch != nil {
+		if match := findLaunchHeuristic(candidatesByQueue[queueKeyOf(exec.Queue)], exec); match.launch != nil {
 			view.Launch = match.launch
 			view.Join = JoinHeuristic
 			view.Heuristic = true
@@ -218,21 +326,43 @@ type launchMatch struct {
 	ambiguous bool
 }
 
+// queueKey is the subset of GPUQueueRef the heuristic join actually
+// compares on (Backend + QueueID, matching the ported filter's original
+// condition) - deliberately not the full GPUQueueRef, which also carries
+// Device and would otherwise split candidates the original rule treated as
+// the same queue.
+type queueKey struct {
+	backend GPUBackendID
+	queueID string
+}
+
+func queueKeyOf(q GPUQueueRef) queueKey {
+	return queueKey{backend: q.Backend, queueID: q.QueueID}
+}
+
+// groupLaunchesByQueue indexes entries by queueKey once, so Snapshot's
+// per-execution heuristic lookup is a map access plus a scan of only that
+// queue's candidates, not a scan of the entire cache per miss.
+func groupLaunchesByQueue(entries []GPUKernelLaunch) map[queueKey][]GPUKernelLaunch {
+	out := make(map[queueKey][]GPUKernelLaunch, len(entries))
+	for _, l := range entries {
+		k := queueKeyOf(l.Queue)
+		out[k] = append(out[k], l)
+	}
+	return out
+}
+
 // findLaunchHeuristic is the fallback path when an exec's Correlation misses
 // the cache (never arrived, or aged out). Ported from the prototype's
-// findLaunchHeuristic: same queue, a kernel-name match, and a launch that
-// precedes the exec's start - picking the most recent such launch as best,
-// and flagging Ambiguous when more than one candidate qualified. Unlike the
-// prototype, which scanned every launch ever recorded, this scans only
-// LaunchCache.Entries() - bounded by the cache's capacity, not by ingestion
-// history.
-func (t *Timeline) findLaunchHeuristic(exec GPUKernelExec) launchMatch {
+// findLaunchHeuristic: a kernel-name match and a launch that precedes the
+// exec's start - picking the most recent such launch as best, and flagging
+// Ambiguous when more than one candidate qualified. candidates is expected
+// to already be filtered to the exec's queue (see groupLaunchesByQueue);
+// this function no longer does that filtering itself.
+func findLaunchHeuristic(candidates []GPUKernelLaunch, exec GPUKernelExec) launchMatch {
 	var best *GPUKernelLaunch
 	var candidateCount int
-	for _, l := range t.cache.Entries() {
-		if l.Queue.Backend != exec.Queue.Backend || l.Queue.QueueID != exec.Queue.QueueID {
-			continue
-		}
+	for _, l := range candidates {
 		if !launchKernelNamesCompatible(l, exec) {
 			continue
 		}
@@ -270,9 +400,9 @@ func launchKernelNamesCompatible(launch GPUKernelLaunch, exec GPUKernelExec) boo
 
 // ring is a fixed-capacity FIFO: push is O(1) amortized (no shifting), and
 // overflow overwrites the oldest entry while reporting eviction to the
-// caller. It exists so the bounded exec/event buffers don't reintroduce the
-// quadratic behaviour (repeated slice-shift-on-overflow) this phase exists to
-// remove.
+// caller. It exists so the bounded exec/event/module buffers don't
+// reintroduce the quadratic behaviour (repeated slice-shift-on-overflow)
+// this phase exists to remove.
 type ring[T any] struct {
 	buf   []T
 	start int

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -1,0 +1,312 @@
+package gpu
+
+import "sync"
+
+var _ EventSink = (*Timeline)(nil)
+
+// JoinKind reports how an ExecutionView's Launch was attached, if at all.
+type JoinKind string
+
+const (
+	// JoinExact means the execution's Correlation matched a live launch in
+	// the cache directly. This is vendor-provided truth, not a guess.
+	JoinExact JoinKind = "exact"
+	// JoinHeuristic means no exact correlation match was found and the
+	// launch was instead inferred from queue, kernel name and timing. It is
+	// always paired with Heuristic=true so it can never be mistaken for
+	// JoinExact by a consumer that only checks the Launch pointer.
+	JoinHeuristic JoinKind = "heuristic"
+)
+
+// ExecutionView is one kernel execution joined (or not) back to the launch
+// that produced it, plus any PC samples attributed to it.
+type ExecutionView struct {
+	Launch    *GPUKernelLaunch `json:"launch,omitempty"`
+	Exec      GPUKernelExec    `json:"exec"`
+	PCSamples []GPUPCSample    `json:"pc_samples,omitempty"`
+	Join      JoinKind         `json:"join,omitempty"`
+	Heuristic bool             `json:"heuristic"`
+	Ambiguous bool             `json:"ambiguous,omitempty"`
+}
+
+// TimelineDropStats counts what Timeline's own bounded storage evicted.
+// LaunchCacheStats already covers launch attribution loss; this covers the
+// exec and event ring buffers layered on top of it. Modeled after SinkStats:
+// nothing bounded is allowed to evict silently.
+type TimelineDropStats struct {
+	EvictedExecutions uint64 `json:"evicted_executions,omitempty"`
+	EvictedEvents     uint64 `json:"evicted_events,omitempty"`
+}
+
+// Snapshot is a point-in-time, fully-joined view of everything Timeline
+// currently holds.
+type Snapshot struct {
+	Executions  []ExecutionView    `json:"executions"`
+	Events      []GPUTimelineEvent `json:"events,omitempty"`
+	Modules     []GPUModule        `json:"modules,omitempty"`
+	JoinStats   JoinStats          `json:"join_stats,omitempty"`
+	LaunchCache LaunchCacheStats   `json:"launch_cache,omitempty"`
+	Dropped     TimelineDropStats  `json:"dropped,omitempty"`
+}
+
+// TimelineConfig configures Timeline's storage bounds.
+type TimelineConfig struct {
+	// LaunchCache bounds the launch cache (see LaunchCacheConfig). Its
+	// normalized Capacity also bounds Timeline's exec/event ring buffers:
+	// there is no separate capacity field for them, and exec/event volume
+	// tracks launch volume closely enough to share one dial.
+	LaunchCache LaunchCacheConfig
+	// LaunchEventJoinWindowNs is reserved for a future launch/event join
+	// (the prototype's findLaunchForEvent). Timeline does not join
+	// GPUTimelineEvent to launches yet, so this field is currently inert;
+	// kept here so callers don't need to change TimelineConfig's shape later.
+	LaunchEventJoinWindowNs uint64
+}
+
+// Timeline is the indexed join point: it ingests launches, executions, PC
+// samples, modules and lifecycle events, and produces a Snapshot that joins
+// executions back to the launch that produced them. Correlation lookups go
+// through LaunchCache (O(1)/O(capacity)) rather than the earlier prototype's
+// linear scan of every launch ever seen.
+type Timeline struct {
+	mu sync.Mutex
+
+	cache *LaunchCache
+
+	launchCount uint64
+
+	execs *ring[GPUKernelExec]
+	// pending holds PC samples keyed by correlation ID until an exec with a
+	// matching Correlation is joined at Snapshot time. Unlike execs/events
+	// this is a plain, unbounded map (per the brief's Structure section): a
+	// sample whose exec never arrives, or whose exec ages out of the ring,
+	// stays here indefinitely. Known, documented limitation - bounding it is
+	// a separate design this task's brief and tests do not call for.
+	pending map[CorrelationID][]GPUPCSample
+	events  *ring[GPUTimelineEvent]
+	modules []GPUModule
+
+	dropped TimelineDropStats
+}
+
+// NewTimeline constructs a Timeline. cfg.LaunchCache is passed through to
+// NewLaunchCache unmodified (including its own zero-value defaulting).
+func NewTimeline(cfg TimelineConfig) *Timeline {
+	capacity := cfg.LaunchCache.Capacity
+	if capacity <= 0 {
+		capacity = defaultLaunchCacheCapacity
+	}
+	return &Timeline{
+		cache:   NewLaunchCache(cfg.LaunchCache),
+		execs:   newRing[GPUKernelExec](capacity),
+		events:  newRing[GPUTimelineEvent](capacity),
+		pending: make(map[CorrelationID][]GPUPCSample),
+	}
+}
+
+func (t *Timeline) EmitLaunch(l GPUKernelLaunch) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.launchCount++
+	t.cache.Put(l)
+	return nil
+}
+
+func (t *Timeline) EmitExec(e GPUKernelExec) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.execs.push(e) {
+		t.dropped.EvictedExecutions++
+	}
+	return nil
+}
+
+func (t *Timeline) EmitPCSample(p GPUPCSample) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pending[p.Correlation] = append(t.pending[p.Correlation], p)
+	return nil
+}
+
+func (t *Timeline) EmitModule(m GPUModule) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.modules = append(t.modules, m)
+	return nil
+}
+
+func (t *Timeline) EmitEvent(e GPUTimelineEvent) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.events.push(e) {
+		t.dropped.EvictedEvents++
+	}
+	return nil
+}
+
+// Snapshot builds the joined view. It copies everything Timeline itself
+// guards (execs, events, modules, pending samples, counters) while holding
+// the lock, then releases it before touching LaunchCache - which guards
+// itself - so the join work below never runs under Timeline's own mutex.
+func (t *Timeline) Snapshot() Snapshot {
+	t.mu.Lock()
+	execs := t.execs.items()
+	events := t.events.items()
+	modules := append([]GPUModule(nil), t.modules...)
+	pending := make(map[CorrelationID][]GPUPCSample, len(t.pending))
+	for id, samples := range t.pending {
+		pending[id] = append([]GPUPCSample(nil), samples...)
+	}
+	launchCount := t.launchCount
+	dropped := t.dropped
+	t.mu.Unlock()
+
+	views := make([]ExecutionView, 0, len(execs))
+	stats := JoinStats{LaunchCount: launchCount}
+	matched := make(map[CorrelationID]struct{})
+	for _, exec := range execs {
+		view := ExecutionView{Exec: exec, PCSamples: pending[exec.Correlation]}
+
+		if exec.Correlation != (CorrelationID{}) {
+			if l, ok := t.cache.Get(exec.Correlation); ok {
+				launch := l
+				view.Launch = &launch
+				view.Join = JoinExact
+				stats.ExactExecutionJoinCount++
+				matched[exec.Correlation] = struct{}{}
+				views = append(views, view)
+				continue
+			}
+		}
+
+		if match := t.findLaunchHeuristic(exec); match.launch != nil {
+			view.Launch = match.launch
+			view.Join = JoinHeuristic
+			view.Heuristic = true
+			view.Ambiguous = match.ambiguous
+			stats.HeuristicExecutionJoinCount++
+			if match.ambiguous {
+				stats.AmbiguousHeuristicMatchCount++
+			}
+			matched[match.launch.Correlation] = struct{}{}
+		} else {
+			stats.UnmatchedExecutionCount++
+		}
+		views = append(views, view)
+	}
+
+	stats.MatchedLaunchCount = uint64(len(matched))
+	if stats.LaunchCount >= stats.MatchedLaunchCount {
+		stats.UnmatchedLaunchCount = stats.LaunchCount - stats.MatchedLaunchCount
+	}
+
+	return Snapshot{
+		Executions:  views,
+		Events:      events,
+		Modules:     modules,
+		JoinStats:   stats,
+		LaunchCache: t.cache.Stats(),
+		Dropped:     dropped,
+	}
+}
+
+// launchMatch is the result of the heuristic join: the best candidate found
+// (nil on a miss - a miss must never attach a launch), and whether more than
+// one candidate matched (Ambiguous).
+type launchMatch struct {
+	launch    *GPUKernelLaunch
+	ambiguous bool
+}
+
+// findLaunchHeuristic is the fallback path when an exec's Correlation misses
+// the cache (never arrived, or aged out). Ported from the prototype's
+// findLaunchHeuristic: same queue, a kernel-name match, and a launch that
+// precedes the exec's start - picking the most recent such launch as best,
+// and flagging Ambiguous when more than one candidate qualified. Unlike the
+// prototype, which scanned every launch ever recorded, this scans only
+// LaunchCache.Entries() - bounded by the cache's capacity, not by ingestion
+// history.
+func (t *Timeline) findLaunchHeuristic(exec GPUKernelExec) launchMatch {
+	var best *GPUKernelLaunch
+	var candidateCount int
+	for _, l := range t.cache.Entries() {
+		if l.Queue.Backend != exec.Queue.Backend || l.Queue.QueueID != exec.Queue.QueueID {
+			continue
+		}
+		if !launchKernelNamesCompatible(l, exec) {
+			continue
+		}
+		if l.TimeNs > exec.StartNs {
+			continue
+		}
+		candidateCount++
+		if best == nil || l.TimeNs > best.TimeNs {
+			candidate := l
+			best = &candidate
+		}
+	}
+	if best == nil {
+		return launchMatch{}
+	}
+	return launchMatch{launch: best, ambiguous: candidateCount > 1}
+}
+
+// launchKernelNamesCompatible decides whether launch could plausibly be the
+// origin of exec, for the heuristic join's candidate filter.
+//
+// The prototype this is ported from also accepted a HIP launch's synthetic
+// "hip_kernel@..." name for any AMD exec reported under a separate
+// execution-side backend id (BackendAMDSample), gated on the launch's CPU
+// stack showing a HIP entrypoint. That launch-side/exec-side backend split
+// doesn't exist in this model (only BackendHIP, used on both sides), so
+// nothing on the exec side can distinguish "same backend, different name"
+// from "different kernel" - porting the special case as-is would accept any
+// HIP launch for any exec, looser than the original rule. Left out rather
+// than ported incorrectly; exact kernel-name match is the only rule here
+// until a future backend reintroduces that split.
+func launchKernelNamesCompatible(launch GPUKernelLaunch, exec GPUKernelExec) bool {
+	return launch.KernelName == exec.KernelName
+}
+
+// ring is a fixed-capacity FIFO: push is O(1) amortized (no shifting), and
+// overflow overwrites the oldest entry while reporting eviction to the
+// caller. It exists so the bounded exec/event buffers don't reintroduce the
+// quadratic behaviour (repeated slice-shift-on-overflow) this phase exists to
+// remove.
+type ring[T any] struct {
+	buf   []T
+	start int
+	count int
+}
+
+func newRing[T any](capacity int) *ring[T] {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &ring[T]{buf: make([]T, capacity)}
+}
+
+// push stores v, evicting the oldest entry (and reporting true) if the ring
+// was already full.
+func (r *ring[T]) push(v T) (evicted bool) {
+	capacity := len(r.buf)
+	if r.count < capacity {
+		r.buf[(r.start+r.count)%capacity] = v
+		r.count++
+		return false
+	}
+	r.buf[r.start] = v
+	r.start = (r.start + 1) % capacity
+	return true
+}
+
+// items returns the stored entries in insertion (oldest-first) order, as a
+// fresh slice safe for the caller to retain past the next push.
+func (r *ring[T]) items() []T {
+	capacity := len(r.buf)
+	out := make([]T, 0, r.count)
+	for i := 0; i < r.count; i++ {
+		out = append(out, r.buf[(r.start+i)%capacity])
+	}
+	return out
+}

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -515,5 +516,69 @@ func BenchmarkTimelineSnapshotAllMisses(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = tl.Snapshot()
+	}
+}
+
+// TestTimelineHeuristicScalesWithSingleQueueSingleKernelName is the
+// complexity regression test for round-3 review. Round 2's fix
+// (BenchmarkTimelineSnapshotAllMisses above) removed the per-miss
+// allocation but left the heuristic's *time* complexity at
+// O(misses x candidates-in-group): grouping candidates by queue alone meant
+// every launch on one queue landed in a single group, and each miss still
+// scanned that whole group linearly. A single queue is not a pathological
+// input - it is what a workload submitting on one stream looks like - and
+// Task 6's BenchmarkSnapshotAtScale (1M launches, capacity 65536) measured
+// this exact shape at ~30s per Snapshot before the binary-search fix in this
+// commit, against a sub-second gate.
+//
+// The four heuristic tests above only check correctness (right launch
+// attached, right Ambiguous flag) and cannot catch this: a
+// reverted-to-linear-scan findLaunchHeuristic still returns the right
+// answer, just slowly, at any scale small enough for those tests to finish
+// in milliseconds either way. This test pins the complexity directly, via a
+// generous wall-clock bound at a scale deliberately too large for a linear
+// scan to hide in: one queue, one kernel name (so every candidate lands in
+// the same group), 50,000 live launches, 10,000 exec misses that all share
+// that one group. That is 5*10^8 candidate comparisons for a linear scan -
+// which this exact setup measured in the tens of seconds against the
+// pre-fix code (see the round-3 report) - versus roughly
+// 10,000 * log2(50,000) ~= 170,000 comparisons for a binary search, which
+// completes in low milliseconds.
+//
+// Mutation this catches: findLaunchHeuristic reverted from sort.Search back
+// to a linear scan over the candidate group (or buildHeuristicCandidateIndex
+// grouping by queue alone again, without kernel name, or without sorting).
+func TestTimelineHeuristicScalesWithSingleQueueSingleKernelName(t *testing.T) {
+	const candidates = 50_000
+	const misses = 10_000
+
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: candidates}})
+	for i := 0; i < candidates; i++ {
+		l := launch(strconv.Itoa(i), uint64(i))
+		l.KernelName = "hot_kernel" // every launch shares one (queue, name) group
+		require.NoError(t, tl.EmitLaunch(l))
+	}
+	for i := 0; i < misses; i++ {
+		e := execFor("ghost-"+strconv.Itoa(i), uint64(i), uint64(i))
+		e.KernelName = "hot_kernel" // same group; correlation never matches -> guaranteed exact-match miss
+		require.NoError(t, tl.EmitExec(e))
+	}
+
+	done := make(chan struct{})
+	var elapsed time.Duration
+	go func() {
+		start := time.Now()
+		_ = tl.Snapshot()
+		elapsed = time.Since(start)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		assert.Less(t, elapsed, 5*time.Second,
+			"a single-queue, single-kernel-name workload must not make the heuristic join scan linearly - "+
+				"this exact shape measured tens of seconds before the binary-search fix")
+	case <-time.After(25 * time.Second):
+		t.Fatal("Snapshot did not return within 25s - the heuristic join is scanning its candidate group, not binary-searching it")
 	}
 }

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -261,6 +261,66 @@ func TestTimelinePendingOrphansAreBoundedAndCounted(t *testing.T) {
 		"evicted orphan samples must be counted, not silently dropped")
 }
 
+// TestTimelinePendingEvictionSurvivesCorrelationIDReuse is the regression
+// test for round-2 review: pendingOrder previously carried no sequence
+// discriminator, and eviction treated mere presence in t.pending as
+// liveness. Sequence of events that broke it: a correlation's samples are
+// consumed by Snapshot (its map entry deleted, its old pendingOrder position
+// left behind); the same correlation ID is then reused by a fresh
+// EmitPCSample; when the stale old position reaches the eviction head, it
+// finds the *new* generation present under that key and deletes it -
+// evicting the freshest entry while genuinely older orphans survive. The
+// trigger (correlation-ID reuse within a process run) is foreseeable for
+// this phase: 32-bit vendor correlation IDs wrap around over a long-running
+// session.
+//
+// This reproduces the coordinator's exact scenario: consume "x", add two
+// genuinely older orphans "w" and "q", reuse "x", then apply eviction
+// pressure. Mutation this catches: reverting evictPendingLocked's
+// `cur.seq != e.seq` check back to a bare presence check (`!live`) -
+// without the sequence check, "x"'s stale pre-consumption position matches
+// its reused entry by presence alone and evicts it, while "w" (genuinely
+// oldest) survives - the inverse of correct behavior.
+func TestTimelinePendingEvictionSurvivesCorrelationIDReuse(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 3}})
+	xID := CorrelationID{Backend: BackendCUPTI, Value: "x"}
+	wID := CorrelationID{Backend: BackendCUPTI, Value: "w"}
+	qID := CorrelationID{Backend: BackendCUPTI, Value: "q"}
+
+	// 1. Insert "x" and consume it via a matching exec + Snapshot: its map
+	// entry is deleted, but its pendingOrder position (seq 1) remains.
+	require.NoError(t, tl.EmitLaunch(launch("x", 1)))
+	require.NoError(t, tl.EmitExec(execFor("x", 2, 3)))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: xID, TimeNs: 1}))
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions[0].PCSamples, 1, "sanity: x's sample was attached and consumed")
+
+	// 2. Two genuinely older orphans that are never consumed.
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: wID, TimeNs: 2}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: qID, TimeNs: 3}))
+
+	// 3. Reuse "x"'s correlation ID with a fresh sample - a new generation,
+	// the freshest entry in the store, and must survive eviction.
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: xID, TimeNs: 4}))
+
+	// 4. Apply eviction pressure: pendingCap is 3 (from LaunchCache.Capacity
+	// above); pending now holds w, q, x (3 distinct live correlations) plus
+	// x's stale pre-consumption order slot at the head. One more distinct
+	// correlation pushes the live count over pendingCap and triggers
+	// eviction.
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "extra"}, TimeNs: 5,
+	}))
+
+	_, xSurvived := tl.pending[xID]
+	_, wSurvived := tl.pending[wID]
+	_, qSurvived := tl.pending[qID]
+	assert.True(t, xSurvived,
+		"the freshest re-inserted entry must survive eviction, not be mistaken for its own stale pre-consumption slot")
+	assert.False(t, wSurvived, "the genuinely oldest orphan must be the one evicted")
+	assert.True(t, qSurvived, "eviction must stop once back at capacity, not over-evict")
+}
+
 // TestTimelineEventFieldsDoNotAliasCaller is the regression test for review
 // Important 5: GPUTimelineEvent carries Device/Queue/Attributes by pointer
 // or map, and Timeline used to store the struct by value, aliasing whatever

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -836,3 +836,43 @@ func TestTimelinePendingOrphansAgeOutByHorizon(t *testing.T) {
 	assert.False(t, stillPending, "a pending correlation whose latest sample has fallen behind the horizon must be evicted")
 	assert.Greater(t, tl.dropped.EvictedPendingSamples, uint64(0), "the horizon eviction must be counted")
 }
+
+// TestTimelineEventCapacityIsIndependentOfLaunchCacheCapacity is the
+// regression test for review Important 6: every bounded store used to share
+// LaunchCache's capacity, which is wrong for GPUTimelineEvent - spec §7/§12
+// describes that traffic as plausibly 10-100x launch volume. A launch-cache
+// capacity of 4 alongside an explicit EventCapacity of 20 must bound events
+// at 20, not 4; the exec ring (which has no independent dial) must still
+// follow the launch-cache capacity. Mutation this catches: EventCapacity
+// being ignored (events ring built from the launch-cache capacity like
+// execs/modules), which would evict at 4 instead of 20.
+func TestTimelineEventCapacityIsIndependentOfLaunchCacheCapacity(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{
+		LaunchCache:   LaunchCacheConfig{Capacity: 4},
+		EventCapacity: 20,
+	})
+	for i := 0; i < 30; i++ {
+		require.NoError(t, tl.EmitEvent(GPUTimelineEvent{TimeNs: uint64(i)}))
+	}
+	for i := 0; i < 30; i++ {
+		require.NoError(t, tl.EmitExec(execFor(strconv.Itoa(i), uint64(i), uint64(i+1))))
+	}
+
+	snap := tl.Snapshot()
+	assert.Len(t, snap.Events, 20, "events must be bounded by EventCapacity, not the launch-cache capacity")
+	assert.Len(t, snap.Executions, 4, "execs have no independent dial and must still follow the launch-cache capacity")
+}
+
+// TestTimelineEventCapacityDefaultsToLaunchCacheCapacity pins the documented
+// zero-value default: TimelineConfig{} (EventCapacity left unset) must
+// behave exactly as before this field existed, so no existing caller sees a
+// change.
+func TestTimelineEventCapacityDefaultsToLaunchCacheCapacity(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 3}})
+	for i := 0; i < 10; i++ {
+		require.NoError(t, tl.EmitEvent(GPUTimelineEvent{TimeNs: uint64(i)}))
+	}
+
+	snap := tl.Snapshot()
+	assert.Len(t, snap.Events, 3, "with EventCapacity unset, events must default to the launch-cache capacity")
+}

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -876,3 +876,54 @@ func TestTimelineEventCapacityDefaultsToLaunchCacheCapacity(t *testing.T) {
 	snap := tl.Snapshot()
 	assert.Len(t, snap.Events, 3, "with EventCapacity unset, events must default to the launch-cache capacity")
 }
+
+// TestTimelineSnapshotReconcilesPCSampleFate is the regression test for
+// review Important 2's PC-sample reconciliation gauges: before
+// AttributedPCSamples/PendingSamples/PendingCorrelations existed, the
+// PC-sample path had no accounting at all for "attributed to an execution"
+// vs "still waiting for one" - an operator could see Dropped.
+// EvictedPendingSamples but had no way to tell how many samples were
+// currently in flight versus already delivered. Three correlations: "a" has
+// a matching exec (its 2 samples must be attributed), "b" and "c" do not
+// (their 3 total samples must remain pending). Mutation this catches:
+// AttributedPCSamples not counting the samples actually handed to a view,
+// or PendingSamples/PendingCorrelations not reflecting what's left in
+// t.pending after the match.
+func TestTimelineSnapshotReconcilesPCSampleFate(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+	aCorr := CorrelationID{Backend: BackendCUPTI, Value: "a"}
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: aCorr, TimeNs: 1}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: aCorr, TimeNs: 2}))
+
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: CorrelationID{Backend: BackendCUPTI, Value: "b"}, TimeNs: 1}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: CorrelationID{Backend: BackendCUPTI, Value: "c"}, TimeNs: 1}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: CorrelationID{Backend: BackendCUPTI, Value: "c"}, TimeNs: 2}))
+
+	snap := tl.Snapshot()
+	assert.Equal(t, uint64(2), snap.AttributedPCSamples, "the 2 samples attached to exec \"a\" must be counted as attributed")
+	assert.Equal(t, 3, snap.PendingSamples, "b's 1 sample plus c's 2 samples must remain pending")
+	assert.Equal(t, 2, snap.PendingCorrelations, "\"b\" and \"c\" must remain as distinct pending correlations")
+}
+
+// TestCountingSinkSnapshotWithEmbedsSinkStats is the regression test for
+// review Important 2: gpu.Snapshot omitted SinkStats entirely, so
+// admission-side losses (a full token bucket, a rejected clock domain) were
+// unreachable from a serialized profile even though JoinStats/Dropped were
+// right there. CountingSink.SnapshotWith is the fix - it must return
+// exactly what tl.Snapshot() would, plus the sink's own Stats().
+func TestCountingSinkSnapshotWithEmbedsSinkStats(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	s := NewCountingSink(tl, 1)
+
+	require.NoError(t, s.EmitLaunch(launch("a", 10)))
+	err := s.EmitLaunch(launch("b", 20)) // exhausts the anchor bucket (capacity 1)
+	require.Error(t, err)
+
+	snap := s.SnapshotWith(tl)
+	assert.Equal(t, uint64(1), snap.SinkStats.Launches.Accepted)
+	assert.Equal(t, uint64(1), snap.SinkStats.Launches.DroppedFull,
+		"admission-side losses must be reachable from the Snapshot returned by SnapshotWith")
+	assert.Equal(t, uint64(1), snap.JoinStats.LaunchCount, "the Timeline's own accounting must still be present")
+}

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -57,17 +57,44 @@ func TestTimelineAttachesPCSamplesByCorrelation(t *testing.T) {
 	assert.Equal(t, uint64(0x1a40), snap.Executions[0].PCSamples[0].PCOffset)
 }
 
+// TestTimelineDegradesWhenLaunchEvicted is the regression test for review
+// Critical 2. Before the fix, this test passed vacuously: launch() derives
+// KernelName from its correlation value ("k_a" vs "k_b"), so the surviving
+// launch "b" never shared a kernel name with the evicted "a", and the old
+// unconditional-heuristic code correctly found no candidate for reasons
+// that had nothing to do with the fix under test. The real hazard - proven
+// by the reviewer's reproduction - is a SHARED kernel name: cache capacity
+// 1, launch a (evicts to make room for) launch b, both named "hot_kernel";
+// an exec whose Correlation is "a" (so the exact lookup genuinely misses,
+// since "a" was evicted) would, under the old code, find "b" as a
+// plausible heuristic candidate (same kernel name, same queue, timestamp
+// precedes the exec) and mis-attribute the exec's CPU stack/PID/Tags to
+// "b" - a different process/container than the one that actually launched
+// the kernel. Spec §13 requires degrading to unattributed instead.
+//
+// Both launches deliberately share KernelName "hot_kernel" here so that a
+// reversion of the Critical 2 fix (dropping the
+// `exec.Correlation != (CorrelationID{})` gate in Snapshot, or restoring an
+// unconditional heuristic attempt) would make this test fail by reattaching
+// exec "a" to launch "b" - proving the fix is what prevents it, not an
+// accidental kernel-name mismatch.
 func TestTimelineDegradesWhenLaunchEvicted(t *testing.T) {
-	// A PC sample whose launch has aged out must become unattributed, never
-	// mis-attributed to a different launch.
 	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 1}})
-	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
-	require.NoError(t, tl.EmitLaunch(launch("b", 20))) // evicts "a"
-	require.NoError(t, tl.EmitExec(execFor("a", 30, 40)))
+	a := launch("a", 10)
+	a.KernelName = "hot_kernel"
+	b := launch("b", 20)
+	b.KernelName = "hot_kernel" // same kernel name and queue as "a"
+	require.NoError(t, tl.EmitLaunch(a))
+	require.NoError(t, tl.EmitLaunch(b)) // evicts "a"
+
+	exec := execFor("a", 30, 40) // Correlation "a": the exact lookup misses because "a" was evicted
+	exec.KernelName = "hot_kernel"
+	require.NoError(t, tl.EmitExec(exec))
 
 	snap := tl.Snapshot()
 	require.Len(t, snap.Executions, 1)
-	assert.Nil(t, snap.Executions[0].Launch, "an evicted launch must not be replaced by another")
+	assert.Nil(t, snap.Executions[0].Launch,
+		"an evicted launch must degrade to unattributed, not be replaced by a different launch that merely shares its kernel name")
 	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
 	assert.Equal(t, uint64(1), snap.LaunchCache.EvictedCapacity,
 		"the eviction that caused the miss must be visible in the snapshot")
@@ -357,12 +384,15 @@ func TestTimelineEventFieldsDoNotAliasCaller(t *testing.T) {
 // to an actual hit, so Join, Heuristic and Ambiguous on that path were
 // entirely unverified.
 //
-// The launch's correlation deliberately differs from the exec's, so the
-// exact lookup is guaranteed to miss and only the heuristic (same queue,
-// compatible kernel name, launch precedes exec) can produce the match.
-// Mutation this catches: the heuristic path never running at all, or
-// running but not setting Join/Heuristic, or attaching no launch, or the
-// wrong launch.
+// The exec deliberately carries the zero-value Correlation (never fixed up
+// with a real one, unlike execFor) - review Critical 2 restricts the
+// heuristic path to execs that never supplied a correlation ID at all (the
+// DRM case), since an exec with a non-zero Correlation that misses the exact
+// lookup has told us its launch aged out, and guessing there risks
+// mis-attribution. A zero-value Correlation with a matching kernel name and
+// queue is exactly the situation the heuristic exists for. Mutation this
+// catches: the heuristic path never running at all, or running but not
+// setting Join/Heuristic, or attaching no launch, or the wrong launch.
 func TestTimelineHeuristicJoinsSingleCandidate(t *testing.T) {
 	tl := NewTimeline(TimelineConfig{})
 	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
@@ -372,9 +402,9 @@ func TestTimelineHeuristicJoinsSingleCandidate(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 10},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "exec-a"},
-		KernelName:  "k_x",
-		StartNs:     20, EndNs: 30,
+		// Correlation deliberately left at its zero value - see comment above.
+		KernelName: "k_x",
+		StartNs:    20, EndNs: 30,
 	}))
 
 	snap := tl.Snapshot()
@@ -412,9 +442,10 @@ func TestTimelineHeuristicMarksAmbiguousAndPicksMostRecent(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 15},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "exec-a"},
-		KernelName:  "k_x",
-		StartNs:     20, EndNs: 30,
+		// Correlation deliberately left at its zero value - see the
+		// single-candidate test above for why (review Critical 2 gate).
+		KernelName: "k_x",
+		StartNs:    20, EndNs: 30,
 	}))
 
 	snap := tl.Snapshot()
@@ -430,7 +461,12 @@ func TestTimelineHeuristicMarksAmbiguousAndPicksMostRecent(t *testing.T) {
 // TestTimelineHeuristicRejectsLaunchAfterExecStart is the third Critical-3
 // regression test. The only candidate launch starts after the exec it might
 // otherwise match, which is causally impossible - a launch cannot produce an
-// execution that started before it did. Mutation this catches:
+// execution that started before it did. The exec's Correlation is left at
+// its zero value so the heuristic actually runs at all (review Critical 2's
+// gate; see TestTimelineHeuristicJoinsSingleCandidate) - with a non-zero
+// Correlation this test would pass vacuously, asserting Nil because the
+// heuristic was never attempted rather than because findLaunchHeuristic
+// correctly rejected the future launch. Mutation this catches:
 // `l.TimeNs > exec.StartNs` (reject future launches) flipped to `<` (reject
 // past launches, accept future ones) at the ordering check in
 // findLaunchHeuristic.
@@ -443,9 +479,8 @@ func TestTimelineHeuristicRejectsLaunchAfterExecStart(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 100},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "exec-a"},
-		KernelName:  "k_x",
-		StartNs:     20, EndNs: 30,
+		KernelName: "k_x",
+		StartNs:    20, EndNs: 30,
 	}))
 
 	snap := tl.Snapshot()
@@ -457,10 +492,14 @@ func TestTimelineHeuristicRejectsLaunchAfterExecStart(t *testing.T) {
 
 // TestTimelineHeuristicRejectsWrongQueueAndKernelName is the fourth
 // Critical-3 regression test: two decoys, one filtered by queue, one by
-// kernel name, neither should attach. Mutation this catches: the queue
-// filter (via groupLaunchesByQueue/queueKeyOf) or the kernel-name filter
-// (launchKernelNamesCompatible) being dropped from findLaunchHeuristic -
-// either omission would let one of these two decoys match.
+// kernel name, neither should attach. The exec's Correlation is left at its
+// zero value for the same reason as the test above - otherwise review
+// Critical 2's gate would skip the heuristic entirely and this test would
+// pass without findLaunchHeuristic's filters ever running. Mutation this
+// catches: the queue filter (via groupLaunchesByQueue/queueKeyOf) or the
+// kernel-name filter (launchKernelNamesCompatible) being dropped from
+// findLaunchHeuristic - either omission would let one of these two decoys
+// match.
 func TestTimelineHeuristicRejectsWrongQueueAndKernelName(t *testing.T) {
 	tl := NewTimeline(TimelineConfig{})
 	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
@@ -477,10 +516,11 @@ func TestTimelineHeuristicRejectsWrongQueueAndKernelName(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 10},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		// Queue left zero-value: "wrong-queue"'s non-zero QueueID must not match.
-		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "exec-a"},
-		KernelName:  "k_x",
-		StartNs:     20, EndNs: 30,
+		// Queue and Correlation left zero-value: "wrong-queue"'s non-zero
+		// QueueID must not match, and a zero Correlation is required for the
+		// heuristic to run at all (review Critical 2's gate).
+		KernelName: "k_x",
+		StartNs:    20, EndNs: 30,
 	}))
 
 	snap := tl.Snapshot()
@@ -497,6 +537,13 @@ func TestTimelineHeuristicRejectsWrongQueueAndKernelName(t *testing.T) {
 // Measured before the fix, this exact scenario (capacity 2000, 500 missing
 // execs): ~66.8ms/op, ~192.8MB/op, 510 allocs/op. See the fix-round report
 // for the after numbers.
+//
+// Each exec's Correlation is explicitly zeroed after execFor (which always
+// sets a non-zero one): review Critical 2 gates the heuristic path on a
+// zero-value Correlation, so a non-zero one that misses the exact lookup
+// (as every "miss-*" correlation here would) now skips the heuristic
+// entirely and this benchmark would no longer exercise - or cost - what it
+// claims to.
 func BenchmarkTimelineSnapshotAllMisses(b *testing.B) {
 	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 2000}})
 	for i := 0; i < 2000; i++ {
@@ -508,13 +555,20 @@ func BenchmarkTimelineSnapshotAllMisses(b *testing.B) {
 		// Correlation and kernel name never match any launch: every exec
 		// takes the full exact-miss + heuristic-scan path with zero result,
 		// the worst case for the candidate scan.
-		if err := tl.EmitExec(execFor("miss-"+strconv.Itoa(i), uint64(3000+i), uint64(3000+i+5))); err != nil {
+		e := execFor("miss-"+strconv.Itoa(i), uint64(3000+i), uint64(3000+i+5))
+		e.Correlation = CorrelationID{}
+		if err := tl.EmitExec(e); err != nil {
 			b.Fatal(err)
 		}
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
+		// NOTE: Snapshot consumes execs (review Critical 3), so only the
+		// first iteration of this loop actually does the O(misses) join
+		// work measured above; subsequent iterations see an empty exec
+		// ring and return quickly. Run with -benchtime=1x for a meaningful
+		// number, matching this project's convention for these benchmarks.
 		_ = tl.Snapshot()
 	}
 }
@@ -548,6 +602,13 @@ func BenchmarkTimelineSnapshotAllMisses(b *testing.B) {
 // Mutation this catches: findLaunchHeuristic reverted from sort.Search back
 // to a linear scan over the candidate group (or buildHeuristicCandidateIndex
 // grouping by queue alone again, without kernel name, or without sorting).
+//
+// Each exec's Correlation is explicitly zeroed: review Critical 2 gates the
+// heuristic path on a zero-value Correlation, and execFor always sets a
+// non-zero one. Left as execFor produces it, every exec here would miss the
+// exact lookup and then skip the heuristic entirely (Critical 2's intended
+// behavior for a non-zero, non-matching correlation), making this a
+// near-instant no-op that proves nothing about the binary-search fix.
 func TestTimelineHeuristicScalesWithSingleQueueSingleKernelName(t *testing.T) {
 	const candidates = 50_000
 	const misses = 10_000
@@ -560,7 +621,8 @@ func TestTimelineHeuristicScalesWithSingleQueueSingleKernelName(t *testing.T) {
 	}
 	for i := 0; i < misses; i++ {
 		e := execFor("ghost-"+strconv.Itoa(i), uint64(i), uint64(i))
-		e.KernelName = "hot_kernel" // same group; correlation never matches -> guaranteed exact-match miss
+		e.KernelName = "hot_kernel" // same group
+		e.Correlation = CorrelationID{}
 		require.NoError(t, tl.EmitExec(e))
 	}
 
@@ -581,4 +643,196 @@ func TestTimelineHeuristicScalesWithSingleQueueSingleKernelName(t *testing.T) {
 	case <-time.After(25 * time.Second):
 		t.Fatal("Snapshot did not return within 25s - the heuristic join is scanning its candidate group, not binary-searching it")
 	}
+}
+
+// TestTimelineSnapshotConsumesExecutions is the regression test for review
+// Critical 3: Snapshot used to only COPY t.execs (via items()), never
+// removing anything from the ring, while PC samples were already consumed
+// on attach - two different lifecycles in one call. For a polling caller (the
+// documented use case), every execution was re-reported in every Snapshot
+// until the ring rotated it out, so the same kernel time was counted once
+// per poll while its PC samples were counted exactly once. The fix drains
+// execs (via a ring swap) the same way PC samples are consumed: a second
+// consecutive Snapshot call returns no executions unless new ones arrived in
+// between. Mutation this catches: reverting Snapshot to copy (items()) the
+// live rings instead of swapping in fresh ones - the second Snapshot call
+// below would then re-report the same execution.
+func TestTimelineSnapshotConsumesExecutions(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+
+	first := tl.Snapshot()
+	require.Len(t, first.Executions, 1, "the first snapshot must report the execution that arrived before it")
+
+	second := tl.Snapshot()
+	assert.Empty(t, second.Executions, "a second snapshot with no new executions must not re-report the first one")
+
+	require.NoError(t, tl.EmitExec(execFor("a", 40, 50)))
+	third := tl.Snapshot()
+	require.Len(t, third.Executions, 1, "a snapshot after a new execution arrives must report exactly that new one")
+	assert.Equal(t, uint64(40), third.Executions[0].Exec.StartNs)
+}
+
+// TestTimelineSnapshotConsumesEventsAndModules extends the Critical 3 fix to
+// events and modules, as the ruling requires ("apply the same decision to
+// events and modules so all five stores agree"). Mutation this catches:
+// events/modules reverting to items() (copy, not drain).
+func TestTimelineSnapshotConsumesEventsAndModules(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitEvent(GPUTimelineEvent{TimeNs: 1}))
+	require.NoError(t, tl.EmitModule(GPUModule{Ref: ModuleRef{CRC: 1}, LoadedNs: 1}))
+
+	first := tl.Snapshot()
+	require.Len(t, first.Events, 1)
+	require.Len(t, first.Modules, 1)
+
+	second := tl.Snapshot()
+	assert.Empty(t, second.Events, "a second snapshot must not re-report the first snapshot's events")
+	assert.Empty(t, second.Modules, "a second snapshot must not re-report the first snapshot's modules")
+}
+
+// TestTimelineJoinStatsLaunchCountsArePerSnapshot is the regression test for
+// review Important 1: JoinStats.LaunchCount used to be t.launchCount, a
+// lifetime-cumulative counter, while MatchedLaunchCount/UnmatchedLaunchCount
+// (and every other JoinStats field) are inherently per-snapshot now that
+// Critical 3 makes execs consumed. Mixing a lifetime total with a
+// per-snapshot match count made UnmatchedLaunchCount meaningless after the
+// first snapshot. This also covers LaunchCount and MatchedLaunchCount, which
+// review Important 1 noted had zero test coverage at all.
+//
+// Mutation this catches: reverting launchesSinceSnapshot to a
+// never-reset cumulative counter - the second snapshot's LaunchCount would
+// read 4 (1+3, lifetime) instead of 3 (just the launches emitted since the
+// first snapshot).
+func TestTimelineJoinStatsLaunchCountsArePerSnapshot(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitLaunch(launch("b", 10)))
+	require.NoError(t, tl.EmitLaunch(launch("c", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30))) // matches "a" exactly
+
+	first := tl.Snapshot()
+	assert.Equal(t, uint64(3), first.JoinStats.LaunchCount, "all three launches were emitted before the first snapshot")
+	assert.Equal(t, uint64(1), first.JoinStats.MatchedLaunchCount)
+	assert.Equal(t, uint64(2), first.JoinStats.UnmatchedLaunchCount, "b and c were never referenced by any exec")
+
+	require.NoError(t, tl.EmitLaunch(launch("d", 40)))
+	require.NoError(t, tl.EmitLaunch(launch("e", 40)))
+	require.NoError(t, tl.EmitLaunch(launch("f", 40)))
+	require.NoError(t, tl.EmitExec(execFor("d", 50, 60)))
+
+	second := tl.Snapshot()
+	assert.Equal(t, uint64(3), second.JoinStats.LaunchCount,
+		"LaunchCount must reflect only launches since the previous snapshot, not the lifetime total (6)")
+	assert.Equal(t, uint64(1), second.JoinStats.MatchedLaunchCount)
+	assert.Equal(t, uint64(2), second.JoinStats.UnmatchedLaunchCount)
+}
+
+// TestTimelineHeuristicRespectsJoinWindow is the regression test for review
+// Important 3: LaunchEventJoinWindowNs was documented as inert (Timeline
+// never read it), so the heuristic accepted any candidate preceding the
+// exec no matter how old, and Ambiguous counted every such candidate -
+// permanently true for any kernel name reused across a workload's life,
+// carrying no information. With the window wired, an out-of-window
+// candidate must neither match nor count toward Ambiguous.
+//
+// Two candidates for the same (queue, kernel name) group: "far" at TimeNs=0
+// and "near" at TimeNs=95, against an exec at StartNs=100 with a window of
+// 10ns. Only "near" (5ns before the exec) is inside [90,100]; "far" (100ns
+// before) is not. Mutation this catches: joinWindowNs never being read
+// (both would still qualify, Ambiguous would read true), or the window
+// bound computed on the wrong side (rejecting "near" instead of "far").
+func TestTimelineHeuristicRespectsJoinWindow(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchEventJoinWindowNs: 10})
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "far"},
+		KernelName:  "k_x",
+		TimeNs:      0,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 0},
+	}))
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "near"},
+		KernelName:  "k_x",
+		TimeNs:      95,
+		Launch:      LaunchContext{PID: 2, TID: 2, TimeNs: 95},
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		KernelName: "k_x",
+		StartNs:    100, EndNs: 110,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	view := snap.Executions[0]
+	require.NotNil(t, view.Launch, "the in-window candidate must still be attached")
+	assert.Equal(t, "near", view.Launch.Correlation.Value, "only the in-window candidate may match")
+	assert.False(t, view.Ambiguous, "the out-of-window candidate must not count toward Ambiguous")
+}
+
+// TestTimelineHeuristicWindowZeroIsUnbounded pins the documented default:
+// TimelineConfig{} (LaunchEventJoinWindowNs left at its zero value) must
+// keep today's unbounded behavior, so every existing caller/test that never
+// sets this field sees no change. Uses the same far-candidate shape as
+// TestTimelineHeuristicRespectsJoinWindow but with no window configured -
+// "far" must now match, unlike in that test.
+func TestTimelineHeuristicWindowZeroIsUnbounded(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "far"},
+		KernelName:  "k_x",
+		TimeNs:      0,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 0},
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		KernelName: "k_x",
+		StartNs:    100, EndNs: 110,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.NotNil(t, snap.Executions[0].Launch, "with no window configured, a distant preceding candidate must still match")
+}
+
+// TestTimelinePendingSamplesPerCorrelationAreCapped is the regression test
+// for review Critical 5: evictPendingLocked only ever bounded the number of
+// distinct pending correlations (pendingCap), never the samples accumulated
+// within any single one of them - entry.samples was appended to with no cap
+// and no age-out, so one orphaned (or stale-ID-reused) correlation below the
+// cardinality bound could still grow without bound. Mutation this catches:
+// removing the `len(entry.samples) >= t.pendingSampleCap` check in
+// EmitPCSample (samples would keep accumulating past the configured cap,
+// and EvictedPendingSamples would stay 0).
+func TestTimelinePendingSamplesPerCorrelationAreCapped(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{MaxPendingSamplesPerCorrelation: 5})
+	corr := CorrelationID{Backend: BackendCUPTI, Value: "orphan"}
+	for i := 0; i < 20; i++ {
+		require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: corr, TimeNs: uint64(i + 1), PCOffset: uint64(i)}))
+	}
+
+	entry := tl.pending[corr]
+	assert.Len(t, entry.samples, 5, "one correlation's samples must never exceed the configured per-correlation cap")
+	assert.Equal(t, uint64(15), tl.dropped.EvictedPendingSamples,
+		"every sample dropped by the per-correlation cap must be counted")
+}
+
+// TestTimelinePendingOrphansAgeOutByHorizon is the second Critical 5
+// regression test: pending entries must also age out by time
+// (PendingSampleHorizonNs), not only by cardinality. Three correlations,
+// each with one sample, timestamped far enough apart that by the time the
+// third arrives, the first is well outside the 10ns horizon - even though
+// the cardinality bound (pendingCap, driven by the default launch-cache
+// capacity here) is nowhere near exceeded. Mutation this catches: removing
+// or disabling the horizon-based eviction pass in evictPendingLocked (the
+// oldest correlation would survive, and EvictedPendingSamples would stay 0).
+func TestTimelinePendingOrphansAgeOutByHorizon(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{PendingSampleHorizonNs: 10})
+	oldest := CorrelationID{Backend: BackendCUPTI, Value: "oldest"}
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: oldest, TimeNs: 0}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: CorrelationID{Backend: BackendCUPTI, Value: "mid"}, TimeNs: 5}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{Correlation: CorrelationID{Backend: BackendCUPTI, Value: "newest"}, TimeNs: 50}))
+
+	_, stillPending := tl.pending[oldest]
+	assert.False(t, stillPending, "a pending correlation whose latest sample has fallen behind the horizon must be evicted")
+	assert.Greater(t, tl.dropped.EvictedPendingSamples, uint64(0), "the horizon eviction must be counted")
 }

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -1,0 +1,170 @@
+package gpu
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func execFor(value string, startNs, endNs uint64) GPUKernelExec {
+	return GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: value},
+		KernelName:  "k_" + value,
+		StartNs:     startNs,
+		EndNs:       endNs,
+	}
+}
+
+func TestTimelineJoinsExactByCorrelationID(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.NotNil(t, snap.Executions[0].Launch)
+	assert.Equal(t, JoinExact, snap.Executions[0].Join)
+	assert.False(t, snap.Executions[0].Heuristic, "an exact join must never be marked heuristic")
+	assert.Equal(t, uint64(1), snap.JoinStats.ExactExecutionJoinCount)
+}
+
+func TestTimelineReportsUnmatchedExecution(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitExec(execFor("ghost", 20, 30)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Nil(t, snap.Executions[0].Launch, "an unmatched execution must not invent a launch")
+	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+}
+
+func TestTimelineAttachesPCSamplesByCorrelation(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitExec(execFor("a", 20, 30)))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "a"},
+		PCOffset:    0x1a40, StallReason: "long_scoreboard", Count: 5, TimeNs: 25,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.Len(t, snap.Executions[0].PCSamples, 1)
+	assert.Equal(t, uint64(0x1a40), snap.Executions[0].PCSamples[0].PCOffset)
+}
+
+func TestTimelineDegradesWhenLaunchEvicted(t *testing.T) {
+	// A PC sample whose launch has aged out must become unattributed, never
+	// mis-attributed to a different launch.
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 1}})
+	require.NoError(t, tl.EmitLaunch(launch("a", 10)))
+	require.NoError(t, tl.EmitLaunch(launch("b", 20))) // evicts "a"
+	require.NoError(t, tl.EmitExec(execFor("a", 30, 40)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Nil(t, snap.Executions[0].Launch, "an evicted launch must not be replaced by another")
+	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+	assert.Equal(t, uint64(1), snap.LaunchCache.EvictedCapacity,
+		"the eviction that caused the miss must be visible in the snapshot")
+}
+
+func TestTimelineSnapshotIsBoundedUnderLoad(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 64}})
+	for i := 0; i < 50000; i++ {
+		// Unique correlation per launch. Reusing one ID would make every Put a
+		// replacement, leaving Live at 1 and passing this assertion vacuously.
+		require.NoError(t, tl.EmitLaunch(launch(strconv.Itoa(i), uint64(i))))
+	}
+	snap := tl.Snapshot()
+	assert.Equal(t, 64, snap.LaunchCache.Live, "cache must fill to capacity and hold there")
+	assert.Greater(t, snap.LaunchCache.EvictedCapacity, uint64(0), "evictions must be counted")
+}
+
+// TestTimelineBoundsExecutionsAndCountsEviction is not one of the brief's five
+// tests. It targets the bounded exec ring the brief's Structure section calls
+// for ("append to the bounded exec slice, evicting oldest and counting when
+// over capacity") but that none of the five given tests exercise. Each exec
+// carries a unique correlation ID, so this catches an implementation that (a)
+// never evicts and grows unbounded, (b) evicts but forgets to count it, or
+// (c) evicts the wrong (non-oldest) entry.
+func TestTimelineBoundsExecutionsAndCountsEviction(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 4}})
+	for i := 0; i < 10; i++ {
+		require.NoError(t, tl.EmitExec(execFor(strconv.Itoa(i), uint64(i*10), uint64(i*10+5))))
+	}
+
+	snap := tl.Snapshot()
+	assert.Len(t, snap.Executions, 4, "exec storage must stay bounded under load")
+	assert.Equal(t, uint64(6), snap.Dropped.EvictedExecutions,
+		"every evicted execution must be counted, not silently dropped")
+	for _, ev := range snap.Executions {
+		assert.NotEqual(t, "k_0", ev.Exec.KernelName, "the oldest execution should have been evicted, not retained")
+	}
+}
+
+// TestTimelineConcurrentIngestionIsRaceFree exercises the mutex guard the
+// brief calls for directly: concurrent Emit* calls across all five EventSink
+// methods, plus concurrent Snapshot reads, on one shared Timeline. The
+// existing single-goroutine tests would pass -race even with the lock
+// removed entirely - this is the one that would actually catch it. Not a
+// correctness assertion (interleaving is nondeterministic); the point is
+// -race finding nothing while every ingress path is hit concurrently.
+func TestTimelineConcurrentIngestionIsRaceFree(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 128}})
+
+	const writers = 4
+	const opsPerGoroutine = 500
+
+	var wg sync.WaitGroup
+	wg.Add(writers*5 + 1)
+
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				id := strconv.Itoa(w) + "-" + strconv.Itoa(i)
+				require.NoError(t, tl.EmitLaunch(launch(id, uint64(i+1))))
+			}
+		}(w)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				id := strconv.Itoa(w) + "-" + strconv.Itoa(i)
+				require.NoError(t, tl.EmitExec(execFor(id, uint64(i+1), uint64(i+2))))
+			}
+		}(w)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				id := strconv.Itoa(w) + "-" + strconv.Itoa(i)
+				require.NoError(t, tl.EmitPCSample(GPUPCSample{
+					Correlation: CorrelationID{Backend: BackendCUPTI, Value: id},
+					TimeNs:      uint64(i + 1),
+				}))
+			}
+		}(w)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				require.NoError(t, tl.EmitModule(GPUModule{LoadedNs: uint64(i + 1)}))
+			}
+		}(w)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				require.NoError(t, tl.EmitEvent(GPUTimelineEvent{TimeNs: uint64(i + 1)}))
+			}
+		}(w)
+	}
+	go func() {
+		defer wg.Done()
+		for i := 0; i < opsPerGoroutine; i++ {
+			_ = tl.Snapshot()
+		}
+	}()
+	wg.Wait()
+}

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -770,6 +770,38 @@ func TestTimelineHeuristicRespectsJoinWindow(t *testing.T) {
 	assert.False(t, view.Ambiguous, "the out-of-window candidate must not count toward Ambiguous")
 }
 
+// TestTimelineHeuristicOutOfWindowDropIsCounted is the regression test for
+// the minors cleanup: JoinStats.OutOfWindowDropCount was declared but never
+// written anywhere - review Important 3 made it writable by wiring the
+// window into findLaunchHeuristic, but nothing actually wrote to it yet. A
+// single candidate exists (unlike TestTimelineHeuristicRespectsJoinWindow's
+// in-window survivor "near") and it precedes the exec but falls outside the
+// window, so the miss must be attributed specifically to the window, not to
+// "no candidate at all". Mutation this catches: OutOfWindowDropCount never
+// being incremented, or launchMatch.outOfWindow being set on a miss with no
+// preceding candidate too (which would make this indistinguishable from a
+// genuinely candidate-less miss).
+func TestTimelineHeuristicOutOfWindowDropIsCounted(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchEventJoinWindowNs: 10})
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "far"},
+		KernelName:  "k_x",
+		TimeNs:      0,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 0},
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		KernelName: "k_x",
+		StartNs:    100, EndNs: 110, // "far" (TimeNs=0) precedes this but is 100ns away, outside the 10ns window
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Nil(t, snap.Executions[0].Launch)
+	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+	assert.Equal(t, uint64(1), snap.JoinStats.OutOfWindowDropCount,
+		"a miss caused specifically by the window excluding an otherwise-preceding candidate must be counted")
+}
+
 // TestTimelineHeuristicWindowZeroIsUnbounded pins the documented default:
 // TimelineConfig{} (LaunchEventJoinWindowNs left at its zero value) must
 // keep today's unbounded behavior, so every existing caller/test that never

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -168,3 +168,292 @@ func TestTimelineConcurrentIngestionIsRaceFree(t *testing.T) {
 	}()
 	wg.Wait()
 }
+
+// TestTimelinePendingSamplesDoNotAccumulateAcrossSnapshots is the regression
+// test for review Critical 1: EmitPCSample only ever appended to t.pending,
+// and nothing ever removed an entry once its exec attached it - not even
+// samples that were successfully joined - so the map grew with all-time
+// sample count regardless of correctness. Reproduced pre-fix (with the
+// reviewer's exact repro: launch cache capacity 8, 5000 fully-matched
+// samples): t.pending held all 5000 entries.
+//
+// This deliberately uses the default (large) pending capacity rather than a
+// small one: with a small pendingCap, the orphan-eviction path added
+// alongside this fix would mask the bug on its own (evicting down to
+// pendingCap regardless of whether attach-consumption works), which is
+// exactly the kind of test that would pass whether or not the real fix is
+// present. With 1000 samples and a ~65536 pending capacity, orphan eviction
+// never fires (asserted via EvictedPendingSamples == 0 below), so the only
+// thing that can be keeping t.pending small is consumption at attach time.
+// 1000 rather than the reviewer's 5000 to keep this fast under -race, where
+// each Snapshot call's O(live launches) queue-grouping makes the whole loop
+// O(n^2) - the growth pattern that would expose the bug is identical either
+// way; only the iteration count changes.
+//
+// Each iteration emits a launch, its exec, and a PC sample correlating to
+// that same exec, then immediately snapshots - the exec is still live in the
+// ring at that point, so its sample must be attached and consumed on the
+// spot. Mutation this catches: removing the `delete(t.pending,
+// exec.Correlation)` in Snapshot (or reverting to a map-copy that doesn't
+// consume) makes len(tl.pending) grow to 1000 instead of staying near 0.
+func TestTimelinePendingSamplesDoNotAccumulateAcrossSnapshots(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	var lastDropped uint64
+	for i := 0; i < 1000; i++ {
+		id := strconv.Itoa(i)
+		require.NoError(t, tl.EmitLaunch(launch(id, uint64(i))))
+		require.NoError(t, tl.EmitExec(execFor(id, uint64(i), uint64(i+1))))
+		require.NoError(t, tl.EmitPCSample(GPUPCSample{
+			Correlation: CorrelationID{Backend: BackendCUPTI, Value: id},
+			TimeNs:      uint64(i),
+		}))
+		snap := tl.Snapshot()
+		lastDropped = snap.Dropped.EvictedPendingSamples
+	}
+	require.Equal(t, uint64(0), lastDropped,
+		"orphan eviction must not have fired - this test isolates attach-time consumption, not the capacity bound")
+	assert.LessOrEqual(t, len(tl.pending), 10,
+		"matched samples must be consumed at attach time, not retained forever")
+}
+
+// TestTimelineBoundsModulesAndCountsEviction is the regression test for
+// review Important 4: EmitModule appended to an uncapped slice with no
+// eviction and no counter. Mirrors
+// TestTimelineBoundsExecutionsAndCountsEviction. Mutation this catches:
+// module storage growing unbounded, an eviction not counted in
+// Dropped.EvictedModules, or eviction of the wrong (non-oldest) entry.
+func TestTimelineBoundsModulesAndCountsEviction(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 4}})
+	for i := 0; i < 10; i++ {
+		require.NoError(t, tl.EmitModule(GPUModule{Ref: ModuleRef{CRC: uint64(i)}, LoadedNs: uint64(i)}))
+	}
+
+	snap := tl.Snapshot()
+	assert.Len(t, snap.Modules, 4, "module storage must stay bounded under load")
+	assert.Equal(t, uint64(6), snap.Dropped.EvictedModules,
+		"every evicted module must be counted, not silently dropped")
+	for _, m := range snap.Modules {
+		assert.NotEqual(t, uint64(0), m.Ref.CRC, "the oldest module should have been evicted, not retained")
+	}
+}
+
+// TestTimelinePendingOrphansAreBoundedAndCounted is the second regression
+// test for review Critical 1: it isolates the orphan-eviction path (samples
+// whose exec never arrives) from TestTimelinePendingSamplesDoNotAccumulateAcrossSnapshots's
+// consume-on-attach path above. Every correlation ID here is unique and
+// never matched to an exec - a repeated ID would exercise append growth of
+// one group's slice, not the distinct-correlation capacity bound this test
+// targets. Mutation this catches: pending growing past pendingCap, or an
+// eviction not reaching Dropped.EvictedPendingSamples.
+func TestTimelinePendingOrphansAreBoundedAndCounted(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 4}})
+	for i := 0; i < 20; i++ {
+		id := strconv.Itoa(i)
+		require.NoError(t, tl.EmitPCSample(GPUPCSample{
+			Correlation: CorrelationID{Backend: BackendCUPTI, Value: id},
+			TimeNs:      uint64(i),
+		}))
+	}
+
+	snap := tl.Snapshot()
+	assert.LessOrEqual(t, len(tl.pending), 4, "orphaned pending samples must stay bounded")
+	assert.Greater(t, snap.Dropped.EvictedPendingSamples, uint64(0),
+		"evicted orphan samples must be counted, not silently dropped")
+}
+
+// TestTimelineEventFieldsDoNotAliasCaller is the regression test for review
+// Important 5: GPUTimelineEvent carries Device/Queue/Attributes by pointer
+// or map, and Timeline used to store the struct by value, aliasing whatever
+// the backend passed in. This simulates a backend reusing its event buffer
+// immediately after Emit returns. Mutation this catches: removing
+// cloneTimelineEvent (or cloning only some of the three fields) from
+// EmitEvent.
+func TestTimelineEventFieldsDoNotAliasCaller(t *testing.T) {
+	device := &GPUDeviceRef{DeviceID: "dev-0"}
+	attrs := map[string]string{"k": "v"}
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitEvent(GPUTimelineEvent{
+		TimeNs:     10,
+		Device:     device,
+		Attributes: attrs,
+	}))
+
+	// Simulate the backend reusing its own buffers after Emit returns.
+	device.DeviceID = "corrupted"
+	attrs["k"] = "corrupted"
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Events, 1)
+	require.NotNil(t, snap.Events[0].Device)
+	assert.Equal(t, "dev-0", snap.Events[0].Device.DeviceID,
+		"the stored event must not alias the caller's Device pointer")
+	assert.Equal(t, "v", snap.Events[0].Attributes["k"],
+		"the stored event must not alias the caller's Attributes map")
+}
+
+// TestTimelineHeuristicJoinsSingleCandidate is the first of four regression
+// tests for review Critical 3: no prior test ever drove the heuristic join
+// to an actual hit, so Join, Heuristic and Ambiguous on that path were
+// entirely unverified.
+//
+// The launch's correlation deliberately differs from the exec's, so the
+// exact lookup is guaranteed to miss and only the heuristic (same queue,
+// compatible kernel name, launch precedes exec) can produce the match.
+// Mutation this catches: the heuristic path never running at all, or
+// running but not setting Join/Heuristic, or attaching no launch, or the
+// wrong launch.
+func TestTimelineHeuristicJoinsSingleCandidate(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "launch-a"},
+		KernelName:  "k_x",
+		TimeNs:      10,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 10},
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "exec-a"},
+		KernelName:  "k_x",
+		StartNs:     20, EndNs: 30,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	ev := snap.Executions[0]
+	require.NotNil(t, ev.Launch, "the single qualifying candidate must be attached")
+	assert.Equal(t, JoinHeuristic, ev.Join)
+	assert.True(t, ev.Heuristic)
+	assert.False(t, ev.Ambiguous, "exactly one candidate must not be marked ambiguous")
+	assert.Equal(t, "launch-a", ev.Launch.Correlation.Value)
+	assert.Equal(t, uint64(1), snap.JoinStats.HeuristicExecutionJoinCount)
+}
+
+// TestTimelineHeuristicMarksAmbiguousAndPicksMostRecent is the second
+// Critical-3 regression test. Two launches both qualify (same queue,
+// compatible kernel name, both precede the exec); combined with the
+// single-candidate test above (which asserts Ambiguous == false), this pins
+// the boundary at "more than one candidate" rather than "one or more".
+// Mutation this catches: `candidateCount > 1` weakened to `>= 1` (caught by
+// the single-candidate test, not this one, since both would report
+// ambiguous here); `l.TimeNs > best.TimeNs` flipped to `<`, which would pick
+// the oldest ("older") candidate instead of the most recent ("newer").
+func TestTimelineHeuristicMarksAmbiguousAndPicksMostRecent(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "older"},
+		KernelName:  "k_x",
+		TimeNs:      10,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 10},
+	}))
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "newer"},
+		KernelName:  "k_x",
+		TimeNs:      15,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 15},
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "exec-a"},
+		KernelName:  "k_x",
+		StartNs:     20, EndNs: 30,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	ev := snap.Executions[0]
+	require.NotNil(t, ev.Launch)
+	assert.True(t, ev.Ambiguous, "two qualifying candidates must be marked ambiguous")
+	assert.Equal(t, "newer", ev.Launch.Correlation.Value,
+		"the most recent preceding launch must win, not the oldest")
+	assert.Equal(t, uint64(1), snap.JoinStats.AmbiguousHeuristicMatchCount)
+}
+
+// TestTimelineHeuristicRejectsLaunchAfterExecStart is the third Critical-3
+// regression test. The only candidate launch starts after the exec it might
+// otherwise match, which is causally impossible - a launch cannot produce an
+// execution that started before it did. Mutation this catches:
+// `l.TimeNs > exec.StartNs` (reject future launches) flipped to `<` (reject
+// past launches, accept future ones) at the ordering check in
+// findLaunchHeuristic.
+func TestTimelineHeuristicRejectsLaunchAfterExecStart(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "future"},
+		KernelName:  "k_x",
+		TimeNs:      100, // after the exec's start
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 100},
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "exec-a"},
+		KernelName:  "k_x",
+		StartNs:     20, EndNs: 30,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Nil(t, snap.Executions[0].Launch,
+		"a launch that starts after the exec cannot have produced it")
+	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+}
+
+// TestTimelineHeuristicRejectsWrongQueueAndKernelName is the fourth
+// Critical-3 regression test: two decoys, one filtered by queue, one by
+// kernel name, neither should attach. Mutation this catches: the queue
+// filter (via groupLaunchesByQueue/queueKeyOf) or the kernel-name filter
+// (launchKernelNamesCompatible) being dropped from findLaunchHeuristic -
+// either omission would let one of these two decoys match.
+func TestTimelineHeuristicRejectsWrongQueueAndKernelName(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "wrong-queue"},
+		KernelName:  "k_x",
+		TimeNs:      10,
+		Queue:       GPUQueueRef{Backend: BackendCUPTI, QueueID: "other-queue"},
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 10},
+	}))
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "wrong-name"},
+		KernelName:  "k_other",
+		TimeNs:      10,
+		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 10},
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		// Queue left zero-value: "wrong-queue"'s non-zero QueueID must not match.
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "exec-a"},
+		KernelName:  "k_x",
+		StartNs:     20, EndNs: 30,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Nil(t, snap.Executions[0].Launch,
+		"neither the wrong-queue nor the wrong-kernel-name launch should qualify")
+	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+}
+
+// BenchmarkTimelineSnapshotAllMisses is the regression benchmark for review
+// Critical 2: findLaunchHeuristic used to call LaunchCache.Entries() (a
+// fresh allocation) inside the per-execution loop, so an all-miss Snapshot
+// cost grew as O(misses x capacity) with an allocation on every miss.
+// Measured before the fix, this exact scenario (capacity 2000, 500 missing
+// execs): ~66.8ms/op, ~192.8MB/op, 510 allocs/op. See the fix-round report
+// for the after numbers.
+func BenchmarkTimelineSnapshotAllMisses(b *testing.B) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 2000}})
+	for i := 0; i < 2000; i++ {
+		if err := tl.EmitLaunch(launch(strconv.Itoa(i), uint64(i))); err != nil {
+			b.Fatal(err)
+		}
+	}
+	for i := 0; i < 500; i++ {
+		// Correlation and kernel name never match any launch: every exec
+		// takes the full exact-miss + heuristic-scan path with zero result,
+		// the worst case for the candidate scan.
+		if err := tl.EmitExec(execFor("miss-"+strconv.Itoa(i), uint64(3000+i), uint64(3000+i+5))); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = tl.Snapshot()
+	}
+}

--- a/gpu/types.go
+++ b/gpu/types.go
@@ -299,30 +299,21 @@ type GPUTimelineEvent struct {
 	Attributes  map[string]string `json:"attributes,omitempty"`
 }
 
-// WorkloadAttribution aggregates GPU activity observed for one
-// container/cgroup over a window, for cost/usage attribution.
-type WorkloadAttribution struct {
-	CgroupID            string         `json:"cgroup_id,omitempty"`
-	PodUID              string         `json:"pod_uid,omitempty"`
-	ContainerID         string         `json:"container_id,omitempty"`
-	ContainerRuntime    string         `json:"container_runtime,omitempty"`
-	FirstSeenNs         uint64         `json:"first_seen_ns,omitempty"`
-	LastSeenNs          uint64         `json:"last_seen_ns,omitempty"`
-	Backends            []GPUBackendID `json:"backends,omitempty"`
-	EventFamilies       []string       `json:"event_families,omitempty"`
-	KernelNames         []string       `json:"kernel_names,omitempty"`
-	LaunchCount         uint64         `json:"launch_count,omitempty"`
-	ExactJoinCount      uint64         `json:"exact_join_count,omitempty"`
-	HeuristicJoinCount  uint64         `json:"heuristic_join_count,omitempty"`
-	ExecutionCount      uint64         `json:"execution_count,omitempty"`
-	ExecutionDurationNs uint64         `json:"execution_duration_ns,omitempty"`
-	SampleWeight        uint64         `json:"sample_weight,omitempty"`
-	EventCount          uint64         `json:"event_count,omitempty"`
-	EventDurationNs     uint64         `json:"event_duration_ns,omitempty"`
-}
-
 // JoinStats reports how well launches, executions and events correlated
 // during a join pass, for diagnosing lossy or ambiguous joins.
+//
+// Minor cleanup (final whole-branch review): this used to also declare
+// HeuristicEventJoinCount and UnmatchedCandidateEventCount, plus a separate
+// WorkloadAttribution type with 11 more fields - all `omitempty`, none ever
+// written anywhere in this package, so a serialized Snapshot with real drops
+// elsewhere would still read as "zero event-join activity" for these,
+// indistinguishable from a producer that genuinely had none. Removed rather
+// than kept as documented-inert: they belong to the launch/event join
+// (Timeline does not join GPUTimelineEvent to launches at all yet - see
+// TimelineConfig.LaunchEventJoinWindowNs, which this phase repurposed for
+// the launch/exec heuristic instead) and to attribution aggregation, neither
+// of which exists yet. Re-add them, with a real writer in the same change,
+// when that work lands.
 type JoinStats struct {
 	LaunchCount                  uint64 `json:"launch_count,omitempty"`
 	MatchedLaunchCount           uint64 `json:"matched_launch_count,omitempty"`
@@ -331,9 +322,15 @@ type JoinStats struct {
 	HeuristicExecutionJoinCount  uint64 `json:"heuristic_execution_join_count,omitempty"`
 	AmbiguousHeuristicMatchCount uint64 `json:"ambiguous_heuristic_match_count,omitempty"`
 	UnmatchedExecutionCount      uint64 `json:"unmatched_execution_count,omitempty"`
-	HeuristicEventJoinCount      uint64 `json:"heuristic_event_join_count,omitempty"`
-	OutOfWindowDropCount         uint64 `json:"out_of_window_drop_count,omitempty"`
-	UnmatchedCandidateEventCount uint64 `json:"unmatched_candidate_event_count,omitempty"`
+	// OutOfWindowDropCount counts heuristic-join misses caused specifically
+	// by LaunchEventJoinWindowNs excluding every candidate that would
+	// otherwise have qualified (i.e. at least one candidate preceded the
+	// exec, but none within the window) - distinct from a miss with no
+	// preceding candidate at all. Became writable once review Important 3
+	// wired the window into findLaunchHeuristic; every occurrence is also
+	// counted in UnmatchedExecutionCount, the same way every heuristic hit
+	// is counted in both HeuristicExecutionJoinCount and MatchedLaunchCount.
+	OutOfWindowDropCount uint64 `json:"out_of_window_drop_count,omitempty"`
 }
 
 // EventSink receives normalized events from a backend. Every method returns an

--- a/gpu/types.go
+++ b/gpu/types.go
@@ -1,0 +1,357 @@
+// Package gpu defines the canonical, vendor-neutral GPU event model that
+// backends (CUPTI, ROCm/HIP, DRM, replay fixtures) normalize into and that
+// downstream joins/exporters consume.
+package gpu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	pp "github.com/dpsoft/perf-agent/pprof"
+)
+
+// GPUBackendID identifies the producer of a GPU event.
+type GPUBackendID string
+
+const (
+	BackendLinuxDRM GPUBackendID = "linuxdrm"
+	BackendReplay   GPUBackendID = "replay"
+	BackendHIP      GPUBackendID = "hip"
+	BackendCUPTI    GPUBackendID = "cupti"
+)
+
+// GPUCapability is a feature a Backend advertises it can produce.
+type GPUCapability uint8
+
+const (
+	CapabilityInvalid GPUCapability = iota
+	CapabilityLaunchTrace
+	CapabilityExecTimeline
+	CapabilityPCSampling
+	CapabilityLifecycleTimeline
+)
+
+var capabilityNames = []GPUCapability{
+	CapabilityLaunchTrace,
+	CapabilityExecTimeline,
+	CapabilityPCSampling,
+	CapabilityLifecycleTimeline,
+}
+
+var capabilityToName = map[GPUCapability]string{
+	CapabilityLaunchTrace:       "launch-trace",
+	CapabilityExecTimeline:      "exec-timeline",
+	CapabilityPCSampling:        "gpu-pc-sampling",
+	CapabilityLifecycleTimeline: "lifecycle-timeline",
+}
+
+var nameToCapability = map[string]GPUCapability{
+	"launch-trace":       CapabilityLaunchTrace,
+	"exec-timeline":      CapabilityExecTimeline,
+	"gpu-pc-sampling":    CapabilityPCSampling,
+	"lifecycle-timeline": CapabilityLifecycleTimeline,
+}
+
+// CapabilityNames returns the known capabilities in stable order.
+func CapabilityNames() []GPUCapability {
+	return slices.Clone(capabilityNames)
+}
+
+func (c GPUCapability) String() string {
+	if name, ok := capabilityToName[c]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown-gpu-capability-%d", uint8(c))
+}
+
+func (c GPUCapability) MarshalJSON() ([]byte, error) {
+	name, ok := capabilityToName[c]
+	if !ok {
+		return nil, fmt.Errorf("unknown gpu capability %d", c)
+	}
+	return json.Marshal(name)
+}
+
+func (c *GPUCapability) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return fmt.Errorf("decode gpu capability: %w", err)
+	}
+	value, ok := nameToCapability[name]
+	if !ok {
+		return fmt.Errorf("unknown gpu capability %q", name)
+	}
+	*c = value
+	return nil
+}
+
+// GPUDeviceRef identifies a physical or logical GPU device.
+type GPUDeviceRef struct {
+	Backend  GPUBackendID `json:"backend"`
+	DeviceID string       `json:"device_id"`
+	Name     string       `json:"name"`
+}
+
+// GPUQueueRef identifies a submission queue on a device.
+type GPUQueueRef struct {
+	Backend GPUBackendID `json:"backend"`
+	Device  GPUDeviceRef `json:"device"`
+	QueueID string       `json:"queue_id"`
+}
+
+// GPUExecutionRef identifies one kernel execution on a device/queue/context.
+type GPUExecutionRef struct {
+	Backend   GPUBackendID `json:"backend"`
+	DeviceID  string       `json:"device_id"`
+	QueueID   string       `json:"queue_id"`
+	ContextID string       `json:"context_id"`
+	ExecID    string       `json:"exec_id"`
+}
+
+// CorrelationID ties a launch to its later execution/sample events. It is
+// comparable and safe to use directly as a map key.
+type CorrelationID struct {
+	Backend GPUBackendID `json:"backend"`
+	Value   string       `json:"value"`
+}
+
+// ClockDomain identifies which clock a *_ns timestamp was measured against.
+//
+// Timestamp contract: every *_ns field emitted into the normalized GPU event
+// model is in the CPU monotonic clock domain. Backends that observe
+// GPU/device-local or host-synced clocks must convert them before emitting
+// launches, executions, PC samples, modules, or timeline events. The core
+// never converts; see ValidateSupportedClockDomain.
+type ClockDomain uint8
+
+const (
+	ClockDomainInvalid ClockDomain = iota
+	ClockDomainCPUMonotonic
+	ClockDomainSynced
+	ClockDomainGPUDevice
+)
+
+var clockDomainToName = map[ClockDomain]string{
+	ClockDomainCPUMonotonic: "cpu-monotonic",
+	ClockDomainSynced:       "synced",
+	ClockDomainGPUDevice:    "gpu-device",
+}
+
+var nameToClockDomain = map[string]ClockDomain{
+	"cpu-monotonic": ClockDomainCPUMonotonic,
+	"synced":        ClockDomainSynced,
+	"gpu-device":    ClockDomainGPUDevice,
+}
+
+func (d ClockDomain) String() string {
+	if name, ok := clockDomainToName[d]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown-clock-domain-%d", uint8(d))
+}
+
+func (d ClockDomain) MarshalJSON() ([]byte, error) {
+	name, ok := clockDomainToName[d]
+	if !ok {
+		return nil, fmt.Errorf("unknown clock domain %d", d)
+	}
+	return json.Marshal(name)
+}
+
+func (d *ClockDomain) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return fmt.Errorf("decode clock domain: %w", err)
+	}
+	value, ok := nameToClockDomain[name]
+	if !ok {
+		return fmt.Errorf("unknown clock domain %q", name)
+	}
+	*d = value
+	return nil
+}
+
+// NormalizeClockDomain maps the zero value to ClockDomainCPUMonotonic so
+// producers that omit the field default to the only supported domain.
+func NormalizeClockDomain(domain ClockDomain) ClockDomain {
+	if domain == ClockDomainInvalid {
+		return ClockDomainCPUMonotonic
+	}
+	return domain
+}
+
+// ValidateSupportedClockDomain rejects any domain other than CPU-monotonic.
+// The core never converts timestamps; producers must convert device or
+// synced clocks to CPU-monotonic before emitting.
+func ValidateSupportedClockDomain(domain ClockDomain) error {
+	switch NormalizeClockDomain(domain) {
+	case ClockDomainCPUMonotonic:
+		return nil
+	case ClockDomainSynced, ClockDomainGPUDevice:
+		return fmt.Errorf("unsupported clock domain %q", NormalizeClockDomain(domain))
+	default:
+		return fmt.Errorf("unknown clock domain %d", domain)
+	}
+}
+
+// LaunchContext carries the host-side context (CPU stack, thread, tags)
+// captured at kernel launch time.
+type LaunchContext struct {
+	PID      uint32            `json:"pid"`
+	TID      uint32            `json:"tid"`
+	TimeNs   uint64            `json:"time_ns"`
+	CPUStack []pp.Frame        `json:"cpu_stack"`
+	Tags     map[string]string `json:"tags"`
+}
+
+// GPUKernelLaunch is emitted when a kernel is submitted for execution.
+type GPUKernelLaunch struct {
+	Correlation CorrelationID `json:"correlation"`
+	Queue       GPUQueueRef   `json:"queue"`
+	KernelName  string        `json:"kernel_name"`
+	ClockDomain ClockDomain   `json:"clock_domain,omitempty"`
+	TimeNs      uint64        `json:"time_ns"`
+	Launch      LaunchContext `json:"launch"`
+}
+
+// GPUKernelExec is emitted when a launched kernel's execution window is
+// known (start/end on-device), joined back to its launch by Correlation.
+type GPUKernelExec struct {
+	Execution   GPUExecutionRef `json:"execution"`
+	Correlation CorrelationID   `json:"correlation"`
+	Queue       GPUQueueRef     `json:"queue"`
+	KernelName  string          `json:"kernel_name"`
+	ClockDomain ClockDomain     `json:"clock_domain,omitempty"`
+	StartNs     uint64          `json:"start_ns"`
+	EndNs       uint64          `json:"end_ns"`
+}
+
+// ModuleRef identifies a GPU binary (a cubin for CUPTI) by content hash. It is
+// symbolization metadata, not an event: the bytes travel out of band and are
+// resolved centrally.
+type ModuleRef struct {
+	Backend GPUBackendID `json:"backend"`
+	CRC     uint64       `json:"crc"`
+}
+
+// GPUModule records that a GPU binary was loaded. Emitted on its own lifecycle,
+// replayed to consumers that attach late.
+type GPUModule struct {
+	Ref       ModuleRef `json:"ref"`
+	SizeBytes uint64    `json:"size_bytes"`
+	LoadedNs  uint64    `json:"loaded_ns"`
+}
+
+// GPUPCSample is one program-counter sample with its stall reason, attributed to
+// a kernel launch by correlation ID. Capability-gated: only backends advertising
+// CapabilityPCSampling emit these, so no backend pays for CUPTI's richness.
+//
+// PCOffset is an offset within Module, not an absolute address — it means
+// nothing without the module, which is why the two are separate types.
+type GPUPCSample struct {
+	Correlation CorrelationID `json:"correlation"`
+	Module      ModuleRef     `json:"module"`
+	ClockDomain ClockDomain   `json:"clock_domain,omitempty"`
+	TimeNs      uint64        `json:"time_ns"`
+	PCOffset    uint64        `json:"pc_offset"`
+	StallReason string        `json:"stall_reason,omitempty"`
+	Count       uint64        `json:"count"`
+}
+
+// TimelineEventKind classifies a GPUTimelineEvent.
+type TimelineEventKind string
+
+const (
+	TimelineEventRuntime TimelineEventKind = "runtime"
+	TimelineEventSyscall TimelineEventKind = "syscall"
+	TimelineEventIOCtl   TimelineEventKind = "ioctl"
+	TimelineEventSubmit  TimelineEventKind = "submit"
+	TimelineEventWait    TimelineEventKind = "wait"
+	TimelineEventContext TimelineEventKind = "context"
+	TimelineEventQueue   TimelineEventKind = "queue"
+	TimelineEventMemory  TimelineEventKind = "memory"
+	TimelineEventDevice  TimelineEventKind = "device"
+)
+
+// GPUTimelineEvent is a generic, low-level lifecycle event (syscall, ioctl,
+// submit/wait, context/queue/memory/device activity) used to reconstruct
+// GPU activity when richer launch/exec events aren't available.
+type GPUTimelineEvent struct {
+	Backend     GPUBackendID      `json:"backend"`
+	Kind        TimelineEventKind `json:"kind"`
+	Family      string            `json:"family,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	ClockDomain ClockDomain       `json:"clock_domain,omitempty"`
+	TimeNs      uint64            `json:"time_ns"`
+	DurationNs  uint64            `json:"duration_ns,omitempty"`
+	PID         uint32            `json:"pid,omitempty"`
+	TID         uint32            `json:"tid,omitempty"`
+	Device      *GPUDeviceRef     `json:"device,omitempty"`
+	Queue       *GPUQueueRef      `json:"queue,omitempty"`
+	ContextID   string            `json:"context_id,omitempty"`
+	FD          int32             `json:"fd,omitempty"`
+	ResultCode  int64             `json:"result_code,omitempty"`
+	Driver      string            `json:"driver,omitempty"`
+	Source      string            `json:"source,omitempty"`
+	Confidence  string            `json:"confidence,omitempty"`
+	Attributes  map[string]string `json:"attributes,omitempty"`
+}
+
+// WorkloadAttribution aggregates GPU activity observed for one
+// container/cgroup over a window, for cost/usage attribution.
+type WorkloadAttribution struct {
+	CgroupID            string         `json:"cgroup_id,omitempty"`
+	PodUID              string         `json:"pod_uid,omitempty"`
+	ContainerID         string         `json:"container_id,omitempty"`
+	ContainerRuntime    string         `json:"container_runtime,omitempty"`
+	FirstSeenNs         uint64         `json:"first_seen_ns,omitempty"`
+	LastSeenNs          uint64         `json:"last_seen_ns,omitempty"`
+	Backends            []GPUBackendID `json:"backends,omitempty"`
+	EventFamilies       []string       `json:"event_families,omitempty"`
+	KernelNames         []string       `json:"kernel_names,omitempty"`
+	LaunchCount         uint64         `json:"launch_count,omitempty"`
+	ExactJoinCount      uint64         `json:"exact_join_count,omitempty"`
+	HeuristicJoinCount  uint64         `json:"heuristic_join_count,omitempty"`
+	ExecutionCount      uint64         `json:"execution_count,omitempty"`
+	ExecutionDurationNs uint64         `json:"execution_duration_ns,omitempty"`
+	SampleWeight        uint64         `json:"sample_weight,omitempty"`
+	EventCount          uint64         `json:"event_count,omitempty"`
+	EventDurationNs     uint64         `json:"event_duration_ns,omitempty"`
+}
+
+// JoinStats reports how well launches, executions and events correlated
+// during a join pass, for diagnosing lossy or ambiguous joins.
+type JoinStats struct {
+	LaunchCount                  uint64 `json:"launch_count,omitempty"`
+	MatchedLaunchCount           uint64 `json:"matched_launch_count,omitempty"`
+	UnmatchedLaunchCount         uint64 `json:"unmatched_launch_count,omitempty"`
+	ExactExecutionJoinCount      uint64 `json:"exact_execution_join_count,omitempty"`
+	HeuristicExecutionJoinCount  uint64 `json:"heuristic_execution_join_count,omitempty"`
+	AmbiguousHeuristicMatchCount uint64 `json:"ambiguous_heuristic_match_count,omitempty"`
+	UnmatchedExecutionCount      uint64 `json:"unmatched_execution_count,omitempty"`
+	HeuristicEventJoinCount      uint64 `json:"heuristic_event_join_count,omitempty"`
+	OutOfWindowDropCount         uint64 `json:"out_of_window_drop_count,omitempty"`
+	UnmatchedCandidateEventCount uint64 `json:"unmatched_candidate_event_count,omitempty"`
+}
+
+// EventSink receives normalized events from a backend. Every method returns an
+// error so a backend can be pushed back on: a sink at capacity returns
+// ErrSinkFull, and the backend is expected to drop and count rather than block.
+type EventSink interface {
+	EmitLaunch(GPUKernelLaunch) error
+	EmitExec(GPUKernelExec) error
+	EmitPCSample(GPUPCSample) error
+	EmitModule(GPUModule) error
+	EmitEvent(GPUTimelineEvent) error
+}
+
+// Backend produces normalized GPU events into an EventSink.
+type Backend interface {
+	ID() GPUBackendID
+	Capabilities() []GPUCapability
+	Start(ctx context.Context, sink EventSink) error
+	Stop(ctx context.Context) error
+	Close() error
+}

--- a/gpu/types_test.go
+++ b/gpu/types_test.go
@@ -1,0 +1,49 @@
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCorrelationIDUsableAsMapKey(t *testing.T) {
+	m := map[CorrelationID]int{}
+	a := CorrelationID{Backend: BackendCUPTI, Value: "1234"}
+	b := CorrelationID{Backend: BackendCUPTI, Value: "1234"}
+	c := CorrelationID{Backend: BackendHIP, Value: "1234"}
+
+	m[a] = 1
+	m[c] = 2
+
+	assert.Equal(t, 1, m[b], "equal correlation IDs must hash to the same bucket")
+	assert.Len(t, m, 2, "same value under a different backend is a different key")
+}
+
+func TestNormalizeClockDomainDefaultsToCPUMonotonic(t *testing.T) {
+	assert.Equal(t, ClockDomainCPUMonotonic, NormalizeClockDomain(ClockDomain(0)))
+	assert.Equal(t, ClockDomainCPUMonotonic, NormalizeClockDomain(ClockDomainCPUMonotonic))
+}
+
+func TestValidateSupportedClockDomainRejectsDeviceClocks(t *testing.T) {
+	require.NoError(t, ValidateSupportedClockDomain(ClockDomainCPUMonotonic))
+	require.NoError(t, ValidateSupportedClockDomain(ClockDomain(0)),
+		"zero value normalizes to cpu-monotonic and must be accepted")
+	assert.Error(t, ValidateSupportedClockDomain(ClockDomainGPUDevice),
+		"producers must convert device clocks before emitting")
+	assert.Error(t, ValidateSupportedClockDomain(ClockDomainSynced))
+}
+
+func TestPCSamplesAreSeparateFromExecutions(t *testing.T) {
+	// GPUPCSample must not be reachable by widening GPUKernelExec: PC data is
+	// capability-gated and only CUPTI-class backends emit it.
+	s := GPUPCSample{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "7"},
+		Module:      ModuleRef{Backend: BackendCUPTI, CRC: 0xdeadbeef},
+		PCOffset:    0x1a40,
+		StallReason: "long_scoreboard",
+		Count:       3,
+	}
+	assert.Equal(t, uint64(0x1a40), s.PCOffset)
+	assert.Equal(t, uint64(3), s.Count)
+}

--- a/gpu/types_test.go
+++ b/gpu/types_test.go
@@ -1,6 +1,8 @@
 package gpu
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,16 +36,27 @@ func TestValidateSupportedClockDomainRejectsDeviceClocks(t *testing.T) {
 	assert.Error(t, ValidateSupportedClockDomain(ClockDomainSynced))
 }
 
-func TestPCSamplesAreSeparateFromExecutions(t *testing.T) {
-	// GPUPCSample must not be reachable by widening GPUKernelExec: PC data is
-	// capability-gated and only CUPTI-class backends emit it.
-	s := GPUPCSample{
-		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "7"},
-		Module:      ModuleRef{Backend: BackendCUPTI, CRC: 0xdeadbeef},
-		PCOffset:    0x1a40,
-		StallReason: "long_scoreboard",
-		Count:       3,
+func TestPCSamplingFieldsDoNotWidenExecution(t *testing.T) {
+	// PC data is capability-gated: only backends advertising
+	// CapabilityPCSampling emit it. Keeping it off GPUKernelExec is what stops
+	// every backend paying for CUPTI's richness. Adding any of these fields to
+	// the execution type should fail here.
+	forbidden := []string{"pc", "stall", "module", "cubin", "sass"}
+
+	execType := reflect.TypeOf(GPUKernelExec{})
+	for i := range execType.NumField() {
+		name := strings.ToLower(execType.Field(i).Name)
+		for _, f := range forbidden {
+			assert.NotContains(t, name, f,
+				"GPUKernelExec must not carry PC-sampling fields; that data belongs on GPUPCSample")
+		}
 	}
-	assert.Equal(t, uint64(0x1a40), s.PCOffset)
-	assert.Equal(t, uint64(3), s.Count)
+
+	// And the fields really do live on GPUPCSample.
+	sampleType := reflect.TypeOf(GPUPCSample{})
+	_, hasPC := sampleType.FieldByName("PCOffset")
+	_, hasStall := sampleType.FieldByName("StallReason")
+	_, hasModule := sampleType.FieldByName("Module")
+	assert.True(t, hasPC && hasStall && hasModule,
+		"GPUPCSample must carry the PC, stall reason and module reference")
 }

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -1,8 +1,10 @@
 package pprof
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -89,6 +91,10 @@ type ProfileSample struct {
 	Stack       []Frame
 	Value       uint64
 	Value2      uint64
+	// Labels are per-sample pprof labels, merged over BuildersOptions.Labels.
+	// Keys present in both win here. Use for context that must not fragment
+	// stack identity (GPU stall reason, PC, queue, device, correlation ID).
+	Labels map[string]string
 }
 
 type BuildersOptions struct {
@@ -269,6 +275,9 @@ func (p *ProfileBuilder) CreateSampleOrAddValue(inputSample *ProfileSample) {
 		p.tmpLocationIDs = append(p.tmpLocationIDs, loc.ID)
 	}
 	h := xxhash.Sum64(uint64Bytes(p.tmpLocationIDs))
+	if len(inputSample.Labels) > 0 {
+		h = hashLabels(h, inputSample.Labels)
+	}
 	sample := p.sampleHashToSample[h]
 	if sample != nil {
 		p.addValue(inputSample, sample)
@@ -279,6 +288,30 @@ func (p *ProfileBuilder) CreateSampleOrAddValue(inputSample *ProfileSample) {
 	copy(sample.Location, p.tmpLocations)
 	p.sampleHashToSample[h] = sample
 	p.Profile.Sample = append(p.Profile.Sample, sample)
+}
+
+// hashLabels folds per-sample labels into the sample dedup hash so that two
+// samples sharing a stack but carrying different labels are kept apart rather
+// than silently merged. Keys are sorted, so the result does not depend on Go's
+// randomized map iteration order.
+func hashLabels(seed uint64, labels map[string]string) uint64 {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	d := xxhash.New()
+	var seedBuf [8]byte
+	binary.LittleEndian.PutUint64(seedBuf[:], seed)
+	_, _ = d.Write(seedBuf[:])
+	for _, k := range keys {
+		_, _ = d.WriteString(k)
+		_, _ = d.WriteString("\x00")
+		_, _ = d.WriteString(labels[k])
+		_, _ = d.WriteString("\x00")
+	}
+	return d.Sum64()
 }
 
 func (p *ProfileBuilder) addLocation(frame Frame, pid uint32) *profile.Location {
@@ -446,9 +479,12 @@ func (p *ProfileBuilder) newSample(inputSample *ProfileSample) *profile.Sample {
 		sample.Value = []int64{0, 0}
 	}
 	sample.Location = make([]*profile.Location, len(inputSample.Stack))
-	if len(p.opt.Labels) > 0 {
-		sample.Label = make(map[string][]string, len(p.opt.Labels))
+	if len(p.opt.Labels) > 0 || len(inputSample.Labels) > 0 {
+		sample.Label = make(map[string][]string, len(p.opt.Labels)+len(inputSample.Labels))
 		for k, v := range p.opt.Labels {
+			sample.Label[k] = []string{v}
+		}
+		for k, v := range inputSample.Labels {
 			sample.Label[k] = []string{v}
 		}
 	}

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -37,6 +37,13 @@ var SampleTypeCpu = SampleType(0)
 var SampleTypeMem = SampleType(1)
 var SampleTypeOffCpu = SampleType(2)
 
+// SampleTypeGpu is for GPU execution/PC-sample time, already expressed in
+// nanoseconds by the caller (see gpu/projection.go). Like SampleTypeOffCpu,
+// it uses Period 1 so BuilderForSample's addValue does not rescale it by the
+// CPU sampling period - a GPU sample's Value is a duration, not a sample
+// count to be multiplied out.
+var SampleTypeGpu = SampleType(3)
+
 type SampleAggregation bool
 
 var (
@@ -156,6 +163,10 @@ func (b *ProfileBuilders) BuilderForSample(sample *ProfileSample) *ProfileBuilde
 		sampleType = []*profile.ValueType{{Type: "offcpu", Unit: "nanoseconds"}}
 		periodType = &profile.ValueType{Type: "offcpu", Unit: "nanoseconds"}
 		period = 1 // Direct nanosecond values, not sampled
+	case SampleTypeGpu:
+		sampleType = []*profile.ValueType{{Type: "gpu", Unit: "nanoseconds"}}
+		periodType = &profile.ValueType{Type: "gpu", Unit: "nanoseconds"}
+		period = 1 // Direct nanosecond values, not sampled - see SampleTypeGpu's doc comment
 	default:
 		sampleType = []*profile.ValueType{{Type: "alloc_objects", Unit: "count"}, {Type: "alloc_space", Unit: "bytes"}}
 		periodType = &profile.ValueType{Type: "space", Unit: "bytes"}
@@ -473,7 +484,7 @@ func uint64Bytes(s []uint64) []byte {
 }
 func (p *ProfileBuilder) newSample(inputSample *ProfileSample) *profile.Sample {
 	sample := new(profile.Sample)
-	if inputSample.SampleType == SampleTypeCpu || inputSample.SampleType == SampleTypeOffCpu {
+	if inputSample.SampleType == SampleTypeCpu || inputSample.SampleType == SampleTypeOffCpu || inputSample.SampleType == SampleTypeGpu {
 		sample.Value = []int64{0}
 	} else {
 		sample.Value = []int64{0, 0}
@@ -497,6 +508,11 @@ func (p *ProfileBuilder) addValue(inputSample *ProfileSample, sample *profile.Sa
 		sample.Value[0] += int64(inputSample.Value) * p.Profile.Period
 	case SampleTypeOffCpu:
 		// Off-CPU values are already in nanoseconds, no scaling needed
+		sample.Value[0] += int64(inputSample.Value)
+	case SampleTypeGpu:
+		// GPU values are already in nanoseconds, no scaling needed - see
+		// SampleTypeGpu's doc comment for why this must not go through the
+		// SampleTypeCpu path and be multiplied by the CPU sampling period.
 		sample.Value[0] += int64(inputSample.Value)
 	default:
 		sample.Value[0] += int64(inputSample.Value)

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -33,6 +33,7 @@ func TestSampleTypes(t *testing.T) {
 	}{
 		{"CPU", SampleTypeCpu, "cpu", "nanoseconds"},
 		{"OffCPU", SampleTypeOffCpu, "offcpu", "nanoseconds"},
+		{"GPU", SampleTypeGpu, "gpu", "nanoseconds"},
 		{"Memory", SampleTypeMem, "alloc_objects", "count"},
 	}
 
@@ -155,6 +156,34 @@ func TestOffCpuValueNotScaled(t *testing.T) {
 
 	for _, b := range builders.Builders {
 		assert.Equal(t, int64(1000000), b.Profile.Sample[0].Value[0])
+	}
+}
+
+// TestGpuValueNotScaledByCpuPeriod is the regression test for review
+// Critical 4: a GPU sample's Value is already a nanosecond duration (an
+// execution's StartNs/EndNs interval, or a proportional share of it), not a
+// count of periodic samples. Before SampleTypeGpu existed, GPU samples went
+// through SampleTypeCpu and BuilderForSample.addValue multiplied every
+// value by the CPU sampling period (~10.1ms at 99Hz) - a 70us kernel
+// rendered as 707.1 seconds. SampleRate is deliberately set low (1, an
+// extreme CPU period) so a reverted addValue case (falling through to
+// SampleTypeCpu's multiplication) would produce a value wildly different
+// from 70000, not one that happens to look close by coincidence.
+func TestGpuValueNotScaledByCpuPeriod(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 1})
+
+	builders.AddSample(&ProfileSample{
+		SampleType:  SampleTypeGpu,
+		Aggregation: SampleAggregated,
+		Stack:       FramesFromNames([]string{"main"}),
+		Value:       70000, // a 70us kernel, expressed in nanoseconds
+	})
+
+	require.Len(t, builders.Builders, 1)
+	for _, b := range builders.Builders {
+		assert.Equal(t, int64(1), b.Profile.Period, "SampleTypeGpu must use period 1, like SampleTypeOffCpu")
+		assert.Equal(t, int64(70000), b.Profile.Sample[0].Value[0],
+			"a 70us kernel must render as ~70000ns, not be multiplied by the CPU sampling period")
 	}
 }
 

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -624,3 +624,95 @@ func TestNewProfileBuilders_StaticLabelsOnSample(t *testing.T) {
 		}
 	}
 }
+
+func TestProfileSampleLabels(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames([]string{"main"}),
+		Value:      100,
+		Labels:     map[string]string{"gpu_kernel": "flash_attn_fwd"},
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 1)
+		assert.Equal(t, []string{"flash_attn_fwd"}, b.Profile.Sample[0].Label["gpu_kernel"])
+	}
+}
+
+func TestProfileSampleLabelsMergeWithBuilderLabels(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{
+		SampleRate: 99,
+		Labels:     map[string]string{"pod_uid": "pod-a", "gpu_kernel": "from_builder"},
+	})
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames([]string{"main"}),
+		Value:      100,
+		Labels:     map[string]string{"gpu_kernel": "from_sample"},
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 1)
+		labels := b.Profile.Sample[0].Label
+		assert.Equal(t, []string{"pod-a"}, labels["pod_uid"],
+			"builder-level labels with no per-sample override must survive")
+		assert.Equal(t, []string{"from_sample"}, labels["gpu_kernel"],
+			"per-sample labels must win over builder-level labels of the same key")
+	}
+}
+
+func TestSameStackDifferentLabelsNotMerged(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	stack := []string{"main", "compute"}
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      10,
+		Labels:     map[string]string{"gpu_stall": "long_scoreboard"},
+	})
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      20,
+		Labels:     map[string]string{"gpu_stall": "barrier"},
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 2,
+			"samples with identical stacks but different labels must not be merged")
+	}
+}
+
+func TestSameStackSameLabelsStillMerged(t *testing.T) {
+	builders := NewProfileBuilders(BuildersOptions{SampleRate: 99})
+	stack := []string{"main", "compute"}
+	labels := map[string]string{"gpu_stall": "barrier"}
+
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      10,
+		Labels:     labels,
+	})
+	builders.AddSample(&ProfileSample{
+		SampleType: SampleTypeCpu,
+		Stack:      FramesFromNames(stack),
+		Value:      20,
+		Labels:     labels,
+	})
+
+	for _, b := range builders.Builders {
+		require.Len(t, b.Profile.Sample, 1,
+			"identical stack and identical labels must still aggregate")
+	}
+}
+
+func TestLabelHashIsOrderIndependent(t *testing.T) {
+	a := hashLabels(1234, map[string]string{"x": "1", "y": "2"})
+	b := hashLabels(1234, map[string]string{"y": "2", "x": "1"})
+	assert.Equal(t, a, b, "label hash must not depend on map iteration order")
+}


### PR DESCRIPTION
Builds the `gpu/` core so it survives a fast producer — bounded memory, indexed joins, accounted losses — **before** any vendor shim exists to stress it.

Supersedes the exploration in #10, which stays open as reference. This branch deliberately carries **contracts, not code** from it: the canonical model and join ladder are ported with revisions; the storage beneath them is new.

**Spec:** `docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md` · **Plan:** `docs/superpowers/plans/2026-08-17-gpu-v2-phase2-continuous-core.md`

## Why

The prototype appended to five unbounded slices and rescanned every launch for every execution — invisible against fixtures, fatal at CUPTI rates. Phase 2 replaces the engine while keeping the skeleton.

## Exit gate

`BenchmarkSnapshotAtScale` — 1M launches, 750k PC samples, 65,536-entry cache:

| | ns/op | allocs/op |
|---|---:|---:|
| start of phase | 25,159,622,216 | — |
| **now** | **~36–46 M** | **16,537** |

~450× faster, and identical at any `-benchtime` (see "the gate that lied" below).

## What is in it

- **`types.go`** — canonical model. `GPUSample` split into a lean type plus capability-gated `GPUPCSample`; `GPUModule`/`ModuleRef` for symbolization metadata; `EventSink` returns `error`.
- **`launchcache.go`** — bounded FIFO indexed by correlation ID, sequence-numbered lazy deletion, capacity + horizon eviction, anomaly clamp, every drop counted.
- **`sink.go`** — admission control, clock-domain enforcement, refillable token buckets in **two priority classes** so launches (correlation anchors) survive overload that drops samples.
- **`timeline.go`** — the join ladder. Exact correlation first; heuristic **only** for correlation-less execs, over a `(queue, kernel-name)` index with binary search. Heuristic and ambiguous joins always marked.
- **`projection.go`** — frames carry the CPU stack, `[gpu:launch]`, and the kernel. Everything that must not fragment stack identity — stall, PC, queue, device, correlation, pod/container — goes to per-sample labels.
- **`conformance_test.go`** — replaces 53 checked-in goldens with invariants any producer must satisfy, parameterised over `drive func(EventSink) error` so replay, HIP and CUPTI run the same suite.

## Notable fixes found by review

- **A guessed join reached pprof as vendor truth.** The timeline marked heuristic joins correctly; the projection read none of it. Now every sample carries `gpu_join=exact|heuristic|unmatched`, unconditionally — an absent label must not read as "exact".
- **Evicted launches mis-attributed.** With a shared kernel name (one kernel in a loop), an exec whose launch aged out attached to a *different* launch. Spec §13 requires degrading to unattributed. The test guarding this was vacuous — it passed only because the fixture derived kernel names from correlation IDs.
- **A 70 µs kernel rendered as 707 seconds.** Nanoseconds and sample counts shared one value dimension, both scaled by the CPU sampling period. Fixed with a period-1 `gpu` sample type and proportional weight distribution.
- **Executions were re-reported on every poll** while PC samples were consumed — two opposite lifecycles in one snapshot.
- **Pending PC samples were unbounded per correlation**, and the gate emitted none so it could not see it.

### The gate that lied

Consuming executions on snapshot made `BenchmarkSnapshotAtScale` self-invalidating: it built its timeline once outside the loop, so every iteration after the first measured an empty structure. At default `-benchtime` it reported **3.2 ms and 52 allocations** and passed. It now rebuilds inside the loop with the timer stopped, and reports the same allocation count at any invocation.

## Scope

- **No vendor backends, no eBPF, no CGO GPU code.** Deliberate — the core is proven before a real producer exists.
- **`gpu/` is not wired into the agent.** No CLI flags, no behaviour change to CPU/off-CPU/PMU profiling.
- **`pprof/pprof.go` changes are strictly additive** — a new `SampleTypeGpu`; the CPU and off-CPU arms are byte-identical.
- Contains the `ProfileSample.Labels` commit from #28, merged locally to unblock the projection. Expect it to arrive twice if #28 lands first; git resolves it as a no-op.

## Known Phase 3 backlog

Recorded rather than fixed, highest value first:

1. **Correlation-less launches all collapse onto one cache key**, so the heuristic path is structurally untestable against a real DRM producer. Needs synthetic per-launch correlations.
2. Late PC samples for a drained execution present as "pending" rather than lost; the horizon that would age them out defaults to off.
3. `Snapshot` mixes cumulative counters, per-snapshot deltas and gauges, so a polling caller cannot reconcile from one snapshot alone.
4. Non-zero defaults for `LaunchEventJoinWindowNs` and `PendingSampleHorizonNs`.
5. The bounded-FIFO-with-lazy-deletion pattern is implemented twice and grew this cycle; the same stale-position bug appeared in both. Extract before a third consumer arrives.
6. `uint64` overflow in `distributeExecutionWeight` on a malformed execution interval.

## Testing

`go test ./... -count=1` — all 25 packages pass. `go test ./gpu/ -race` clean.