### PR TITLE
gpu: extract the shared bounded FIFO before a third copy exists

### DIFF
--- a/gpu/boundedfifo.go
+++ b/gpu/boundedfifo.go
@@ -1,0 +1,139 @@
+package gpu
+
+// orderedFIFO tracks bounded FIFO insertion order for a sequence-numbered
+// key space with lazy deletion. It is the single implementation of the
+// mechanism LaunchCache and Timeline's pending-sample store each grew a
+// hand-written, near-identical copy of: a FIFO of keys where a later insert
+// (a replace, or a reappearance after consumption/eviction) may reuse an
+// earlier key, and where eviction must walk from the oldest position, skip
+// any position a later insert has superseded, and stop at the first
+// genuinely live one - without ever mistaking mere presence-in-the-map for
+// liveness. That last part is exactly the bug both LaunchCache and
+// Timeline.pending independently hit and had to fix separately: a key
+// deleted (consumed) and then reused leaves its old order position behind
+// with no map entry (or, worse, a map entry belonging to its own next
+// generation); a naive presence check can't tell that stale position apart
+// from the key's brand new, live generation, and evicts the wrong one.
+//
+// orderedFIFO deliberately does not own value storage. The owner -
+// LaunchCache or Timeline - keeps its own map from key to whatever it
+// stores (the value, plus the sequence number orderedFIFO handed out for
+// that entry, plus - for an owner that needs O(1) horizon eviction rather
+// than rescanning its value on every check - a timestamp anchor), and
+// answers orderedFIFO's isLive callback by checking that map directly. This
+// keeps each owner's aliasing contract and field shapes entirely its own;
+// orderedFIFO only ever sees keys and sequence numbers. It matters
+// concretely for Timeline: its existing tests reach into its pending map
+// directly (map indexing, len, ranging over samples), so that map has to
+// stay a real, owner-held map rather than storage hidden inside a generic
+// type.
+//
+// NOT internally synchronized. Every method requires the caller to already
+// hold its own lock; both LaunchCache and Timeline call orderedFIFO only
+// while holding their own mutex, and never share one orderedFIFO across
+// goroutines without that lock.
+type orderedFIFO[K comparable] struct {
+	order []seqPos[K]
+	head  int
+	seq   uint64
+}
+
+// seqPos names one FIFO position: the key inserted and the sequence number
+// it was inserted (or reinserted) with. A position is live only as long as
+// the owner's map still holds an entry for key stamped with exactly this
+// seq; a later insert for the same key bumps the sequence and appends a new
+// position, leaving this one to be recognized as superseded and skipped.
+type seqPos[K comparable] struct {
+	key K
+	seq uint64
+}
+
+// newOrderedFIFO constructs an orderedFIFO. capacityHint preallocates the
+// order slice when positive (an owner with a normalized capacity bound,
+// e.g. LaunchCache); zero leaves it nil, growing organically, matching a
+// store with no capacity hint of its own to preallocate against (e.g.
+// Timeline.pending, which is bounded by cardinality but was never
+// preallocated for it before this refactor and should not start being so
+// now).
+func newOrderedFIFO[K comparable](capacityHint int) *orderedFIFO[K] {
+	f := &orderedFIFO[K]{}
+	if capacityHint > 0 {
+		f.order = make([]seqPos[K], 0, capacityHint)
+	}
+	return f
+}
+
+// insert bumps the sequence counter and records a new order position for
+// key at that sequence, returning it so the owner can stamp it onto the
+// value it stores. Call this every time a key's stored value is being
+// fully replaced (LaunchCache.Put's contract), or only on the
+// absent-to-present transition for a store where a live entry instead
+// accumulates in place across many calls (Timeline.pending's contract) -
+// see the divergence documented on LaunchCache.Put vs Timeline.EmitPCSample,
+// which is deliberate and must not be "fixed" into uniformity.
+func (f *orderedFIFO[K]) insert(key K) uint64 {
+	f.seq++
+	f.order = append(f.order, seqPos[K]{key: key, seq: f.seq})
+	return f.seq
+}
+
+// evictOldestLive walks forward from the current head, permanently skipping
+// (never reporting, never counting as an eviction) any position isLive
+// resolves as superseded, and pops the first position isLive confirms is
+// still live: the head advances past it and its key is returned. isLive is
+// called with the position's own (key, seq) and must answer against the
+// owner's own map: true only if the owner still holds an entry for key
+// stamped with exactly that seq. ok is false once every remaining position
+// has been exhausted with nothing live left to evict. Compaction runs as a
+// side effect - the caller never has to think about it, or repeat the
+// magic-number compaction threshold.
+func (f *orderedFIFO[K]) evictOldestLive(isLive func(key K, seq uint64) bool) (key K, ok bool) {
+	for f.head < len(f.order) {
+		pos := f.order[f.head]
+		f.head++
+		if isLive(pos.key, pos.seq) {
+			f.compact()
+			return pos.key, true
+		}
+	}
+	f.compact()
+	var zero K
+	return zero, false
+}
+
+// peekOldestLive is evictOldestLive's non-destructive counterpart: it still
+// permanently advances past superseded positions (that cleanup is correct
+// to do regardless of what the caller decides next), but leaves the oldest
+// live position's slot at head instead of consuming it, so a caller
+// enforcing a horizon can resolve the returned key against its own map
+// (e.g. read its anchor timestamp) and decide whether to evict at all
+// before calling evictOldestLive to actually pop it.
+func (f *orderedFIFO[K]) peekOldestLive(isLive func(key K, seq uint64) bool) (key K, ok bool) {
+	for f.head < len(f.order) {
+		pos := f.order[f.head]
+		if isLive(pos.key, pos.seq) {
+			f.compact()
+			return pos.key, true
+		}
+		f.head++
+	}
+	f.compact()
+	var zero K
+	return zero, false
+}
+
+// compact reclaims the dead prefix of order once it dominates the slice, so
+// a long-running owner's order slice does not grow without bound under
+// sustained churn. It is not tight: compaction only fires once head >= 1024
+// && head*2 >= len(order), so in steady state under sustained load order
+// oscillates between roughly the live count and roughly 2x it. That is
+// bounded, but len(order) should never be read as a proxy for live count -
+// use the owner's own map length instead.
+func (f *orderedFIFO[K]) compact() {
+	if f.head < 1024 || f.head*2 < len(f.order) {
+		return
+	}
+	rest := f.order[f.head:]
+	f.order = append(f.order[:0], rest...)
+	f.head = 0
+}

--- a/gpu/boundedfifo_test.go
+++ b/gpu/boundedfifo_test.go
@@ -1,0 +1,178 @@
+package gpu
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// orderedFIFOIsLive builds an isLive callback bound to a plain map the test
+// owns directly - the same shape LaunchCache.isLiveLocked and
+// Timeline.isPendingLiveLocked use in production, minus the mutex, since
+// these tests exercise orderedFIFO single-threaded except where noted.
+func orderedFIFOIsLive(byKey map[string]uint64) func(string, uint64) bool {
+	return func(key string, seq uint64) bool {
+		s, ok := byKey[key]
+		return ok && s == seq
+	}
+}
+
+// TestOrderedFIFOStalePositionSurvivesCorrelationIDReuse is the direct,
+// generalized regression test for both prior bugs (LaunchCache's and
+// Timeline.pending's): a key is consumed (its map entry removed, its order
+// position left behind), the same key is then reused (a fresh insert, a new
+// generation), and genuinely older keys are added in between. Eviction
+// pressure must take the genuinely oldest *live* entry, not mistake the
+// reused key's stale pre-consumption position for its live one.
+//
+// Mutation this catches: isLive's `s == seq` check weakened to a bare
+// presence check (`ok` alone). With that mutation, the stale position left
+// behind by "x"'s consumption matches "x"'s reused entry by presence alone
+// (since "x" is in byKey again, just under a new seq), so the first
+// evictOldestLive call would return "x" - evicting the freshest entry -
+// instead of "w", the genuinely oldest live one.
+func TestOrderedFIFOStalePositionSurvivesCorrelationIDReuse(t *testing.T) {
+	f := newOrderedFIFO[string](0)
+	byKey := map[string]uint64{}
+	insert := func(k string) { byKey[k] = f.insert(k) }
+	isLive := orderedFIFOIsLive(byKey)
+
+	insert("x")        // seq 1
+	delete(byKey, "x") // "x" consumed: map entry gone, order position (x,1) left stale
+	insert("w")        // seq 2 - genuinely older than the reused "x" below
+	insert("q")        // seq 3 - also genuinely older
+	insert("x")        // seq 4 - "x" reused: a fresh, live generation
+
+	key, ok := f.evictOldestLive(isLive)
+	require.True(t, ok)
+	assert.Equal(t, "w", key,
+		"the genuinely oldest live entry must be evicted, not the reused key's stale pre-consumption position")
+	delete(byKey, key)
+
+	assert.Equal(t, uint64(4), byKey["x"], "the reused, freshest entry must survive untouched")
+	_, qStillLive := byKey["q"]
+	assert.True(t, qStillLive, "eviction must stop after taking exactly the oldest live entry")
+}
+
+// TestOrderedFIFOSupersededPositionsSkippedWithoutCounting verifies that a
+// position superseded by a later insert for the same key is walked past
+// silently: it advances the internal head (so it is never revisited) but is
+// never itself returned as an eviction, so a caller counting losses from
+// evictOldestLive's return values never over-counts.
+//
+// Mutation this catches: evictOldestLive treating every position as live
+// regardless of what isLive reports (i.e. the superseded-skip check being
+// dropped) would report 3 evictions here - ["a", "a", "b"], the dead
+// pre-replace position counted alongside the two genuinely live entries -
+// instead of exactly ["a", "b"].
+func TestOrderedFIFOSupersededPositionsSkippedWithoutCounting(t *testing.T) {
+	f := newOrderedFIFO[string](0)
+	byKey := map[string]uint64{}
+	insert := func(k string) { byKey[k] = f.insert(k) }
+	isLive := orderedFIFOIsLive(byKey)
+
+	insert("a") // seq 1
+	insert("a") // seq 2 - replaces "a": order position (a,1) is now superseded
+	insert("b") // seq 3
+
+	var evicted []string
+	for {
+		key, ok := f.evictOldestLive(isLive)
+		if !ok {
+			break
+		}
+		delete(byKey, key)
+		evicted = append(evicted, key)
+	}
+
+	assert.Equal(t, []string{"a", "b"}, evicted,
+		"exactly the two genuinely live entries must be evicted, in FIFO order")
+	assert.Equal(t, 3, f.head,
+		"the superseded position must still be walked past (consumed from the order slice) even though it was never reported")
+}
+
+// TestOrderedFIFOCompactionBoundsOrderSlice is the generalized version of
+// TestLaunchCacheMemoryIsBounded, aimed directly at the order slice rather
+// than the owner's map: under sustained insert/evict churn far exceeding
+// capacity, the order slice's backing array must stay bounded by
+// compaction, not grow linearly with total operations performed over the
+// structure's lifetime.
+//
+// Mutation this catches: removing the compact() call from evictOldestLive
+// (or breaking its head>=1024 && head*2>=len(order) condition) would let
+// order grow to roughly the full 100000-operation count instead of staying
+// within a small bounded multiple of capacity.
+func TestOrderedFIFOCompactionBoundsOrderSlice(t *testing.T) {
+	const capacity = 16
+	const iterations = 100000
+
+	f := newOrderedFIFO[string](capacity)
+	byKey := map[string]uint64{}
+	isLive := orderedFIFOIsLive(byKey)
+
+	for i := 0; i < iterations; i++ {
+		k := strconv.Itoa(i) // unique key per iteration: exercises capacity eviction, not replace
+		byKey[k] = f.insert(k)
+		for len(byKey) > capacity {
+			key, ok := f.evictOldestLive(isLive)
+			if !ok {
+				break
+			}
+			delete(byKey, key)
+		}
+	}
+
+	assert.LessOrEqual(t, len(byKey), capacity, "the owner's map must stay bounded by capacity")
+	assert.Less(t, len(f.order), 5000,
+		"the order slice must stay bounded by compaction, not grow with the total number of operations performed")
+}
+
+// TestOrderedFIFOConcurrencyContract exercises orderedFIFO exactly as its
+// doc comment requires: NOT internally synchronized, with the caller
+// providing its own lock around every call. Run with -race, this is the
+// assertion that the documented contract - external locking is sufficient,
+// and mandatory - actually holds. It does not, on its own, prove LaunchCache
+// or Timeline honor that contract correctly; TestLaunchCacheConcurrentPutGetIsRaceFree
+// and TestTimelineConcurrentIngestionIsRaceFree (both pre-existing, both
+// still race-clean after this refactor) are what verify that; see this
+// package's boundedfifo.go doc comment for the explicit contract statement
+// both owners are required to match.
+func TestOrderedFIFOConcurrencyContract(t *testing.T) {
+	const capacity = 64
+	const writers = 4
+	const opsPerWriter = 2000
+
+	f := newOrderedFIFO[string](capacity)
+	byKey := make(map[string]uint64)
+	isLive := orderedFIFOIsLive(byKey)
+	var mu sync.Mutex
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < opsPerWriter; i++ {
+				k := strconv.Itoa(w) + "-" + strconv.Itoa(i)
+				mu.Lock()
+				byKey[k] = f.insert(k)
+				for len(byKey) > capacity {
+					key, ok := f.evictOldestLive(isLive)
+					if !ok {
+						break
+					}
+					delete(byKey, key)
+				}
+				mu.Unlock()
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.LessOrEqual(t, len(byKey), capacity, "concurrent, externally-locked use must still stay bounded")
+}

--- a/gpu/launchcache.go
+++ b/gpu/launchcache.go
@@ -53,19 +53,14 @@ const defaultMaxAdvanceNs = 60 * 1e9 // 60s
 
 // cacheEntry is a stored launch tagged with the Put sequence number that
 // produced it, so a stale order position (superseded by a later replace) can
-// be told apart from the entry currently live for that correlation ID.
+// be told apart from the entry currently live for that correlation ID. The
+// horizon anchor is the launch's own TimeNs (cacheEntry.launch.TimeNs) - a
+// single scalar, already O(1) to read - so unlike Timeline.pending (whose
+// value is a slice needing its own tracked anchor; see pendingSamples),
+// cacheEntry does not need a separate anchor field.
 type cacheEntry struct {
 	launch GPUKernelLaunch
 	seq    uint64
-}
-
-// orderEntry names one FIFO position: the correlation ID inserted and the
-// sequence number it was inserted (or replaced) with. Comparing seq against
-// the current cacheEntry.seq for the same id is how eviction tells a live
-// position from one a later Put has superseded.
-type orderEntry struct {
-	id  CorrelationID
-	seq uint64
 }
 
 // LaunchCache is a bounded FIFO of recent launches indexed by correlation ID.
@@ -82,9 +77,7 @@ type LaunchCache struct {
 	mu       sync.Mutex
 	cfg      LaunchCacheConfig
 	byCorr   map[CorrelationID]cacheEntry
-	order    []orderEntry // insertion order; entries before head are dead
-	head     int
-	seq      uint64
+	order    *orderedFIFO[CorrelationID]
 	newestNs uint64
 	stats    LaunchCacheStats
 }
@@ -99,8 +92,16 @@ func NewLaunchCache(cfg LaunchCacheConfig) *LaunchCache {
 	return &LaunchCache{
 		cfg:    cfg,
 		byCorr: make(map[CorrelationID]cacheEntry, cfg.Capacity),
-		order:  make([]orderEntry, 0, cfg.Capacity),
+		order:  newOrderedFIFO[CorrelationID](cfg.Capacity),
 	}
+}
+
+// isLiveLocked answers orderedFIFO's isLive callback: a position is live
+// only if byCorr still holds an entry for id stamped with exactly seq. The
+// caller must hold c.mu.
+func (c *LaunchCache) isLiveLocked(id CorrelationID, seq uint64) bool {
+	e, ok := c.byCorr[id]
+	return ok && e.seq == seq
 }
 
 // Put inserts or replaces the launch for its correlation ID. A repeated
@@ -112,13 +113,11 @@ func (c *LaunchCache) Put(l GPUKernelLaunch) {
 
 	c.observeTimestampLocked(l.TimeNs)
 
-	c.seq++
-	seq := c.seq
+	seq := c.order.insert(l.Correlation)
 	if _, exists := c.byCorr[l.Correlation]; exists {
 		c.stats.Replaced++
 	}
 	c.byCorr[l.Correlation] = cacheEntry{launch: l, seq: seq}
-	c.order = append(c.order, orderEntry{id: l.Correlation, seq: seq})
 	c.evictLocked()
 }
 
@@ -189,62 +188,26 @@ func (c *LaunchCache) Stats() LaunchCacheStats {
 // caller must hold c.mu.
 func (c *LaunchCache) evictLocked() {
 	if c.cfg.HorizonNs > 0 {
-		for c.head < len(c.order) {
-			e := c.order[c.head]
-			cur, superseded := c.currentIfLiveLocked(e)
-			if superseded {
-				c.head++
-				continue
-			}
-			if c.newestNs <= cur.TimeNs || c.newestNs-cur.TimeNs <= c.cfg.HorizonNs {
+		for {
+			id, ok := c.order.peekOldestLive(c.isLiveLocked)
+			if !ok {
 				break
 			}
-			delete(c.byCorr, e.id)
-			c.head++
+			cur := c.byCorr[id] // guaranteed present: peekOldestLive just confirmed liveness
+			if c.newestNs <= cur.launch.TimeNs || c.newestNs-cur.launch.TimeNs <= c.cfg.HorizonNs {
+				break
+			}
+			c.order.evictOldestLive(c.isLiveLocked)
+			delete(c.byCorr, id)
 			c.stats.EvictedHorizon++
 		}
 	}
-	for len(c.byCorr) > c.cfg.Capacity && c.head < len(c.order) {
-		e := c.order[c.head]
-		c.head++
-		if _, superseded := c.currentIfLiveLocked(e); superseded {
-			continue
+	for len(c.byCorr) > c.cfg.Capacity {
+		id, ok := c.order.evictOldestLive(c.isLiveLocked)
+		if !ok {
+			break
 		}
-		delete(c.byCorr, e.id)
+		delete(c.byCorr, id)
 		c.stats.EvictedCapacity++
 	}
-	c.compactLocked()
-}
-
-// currentIfLiveLocked resolves an order position to the launch currently
-// live for its correlation ID, and reports whether that position is
-// superseded rather than real. A position is superseded in two cases: the id
-// has since been evicted outright (superseded && zero value; this should be
-// unreachable given eviction always consumes the order position it deletes
-// through, but is kept as a defensive guard), or — the case this exists to
-// fix — a later Put replaced the entry, so e.seq no longer matches the
-// sequence number the map holds for that id. Only a non-superseded position
-// is a real, currently-live entry eligible for eviction. The caller must
-// hold c.mu.
-func (c *LaunchCache) currentIfLiveLocked(e orderEntry) (GPUKernelLaunch, bool) {
-	cur, live := c.byCorr[e.id]
-	if !live || cur.seq != e.seq {
-		return GPUKernelLaunch{}, true
-	}
-	return cur.launch, false
-}
-
-// compactLocked reclaims the dead prefix of order once it dominates the
-// slice, so a long-running agent's order slice does not grow without bound.
-// It is not tight: compaction only fires once head >= 1024 && head*2 >=
-// len(order), so in steady state under sustained load order oscillates
-// between roughly capacity and roughly 2x capacity. That is bounded, but
-// len(order) should not be read as a proxy for live count.
-func (c *LaunchCache) compactLocked() {
-	if c.head < 1024 || c.head*2 < len(c.order) {
-		return
-	}
-	rest := c.order[c.head:]
-	c.order = append(c.order[:0], rest...)
-	c.head = 0
 }

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -195,10 +195,10 @@ type Timeline struct {
 	// Dropped.EvictedPendingSamples.
 	//
 	// Both pending's entries and pendingOrder's positions carry a sequence
-	// number, the same way LaunchCache pairs cacheEntry.seq with
-	// orderEntry.seq (see currentIfLiveLocked there). This exists to solve
-	// the identical hazard: a correlation ID consumed by Snapshot leaves its
-	// old pendingOrder position behind with no map entry; if that same ID is
+	// number, the same way LaunchCache pairs cacheEntry.seq with orderedFIFO
+	// (see LaunchCache.isLiveLocked). This exists to solve the identical
+	// hazard: a correlation ID consumed by Snapshot leaves its old
+	// pendingOrder position behind with no map entry; if that same ID is
 	// then reused by a later EmitPCSample, presence-only eviction cannot
 	// tell that stale position apart from the ID's new, live generation, and
 	// would delete the freshly re-inserted entry instead of the position it
@@ -208,11 +208,16 @@ type Timeline struct {
 	// entry - unlike LaunchCache.Put, which always replaces the whole value,
 	// pending accumulates samples across many EmitPCSample calls for the
 	// same still-live generation, so an in-place append must not look like a
-	// new generation.
+	// new generation. This divergence in bump cadence (vs. LaunchCache's
+	// every-call bump) is deliberate; see EmitPCSample.
+	//
+	// pending itself stays a plain, owner-held map (not hidden inside a
+	// generic type) because existing tests reach into it directly
+	// (len(tl.pending), tl.pending[id], tl.pending[id].samples); only the
+	// order/sequence/compaction bookkeeping is shared, via orderedFIFO, with
+	// LaunchCache.
 	pending      map[CorrelationID]pendingSamples
-	pendingOrder []pendingOrderEntry
-	pendingHead  int
-	pendingSeq   uint64
+	pendingOrder *orderedFIFO[CorrelationID]
 	pendingCap   int
 
 	// pendingSampleCap bounds how many samples a single pending correlation's
@@ -250,20 +255,17 @@ type Timeline struct {
 
 // pendingSamples is a pending correlation's accumulated samples, tagged with
 // the sequence number of its current (live) generation - see the pending
-// field's doc comment.
+// field's doc comment. anchorNs is the largest PC-sample TimeNs appended to
+// samples so far (a running max, updated incrementally by EmitPCSample),
+// mirroring cacheEntry's use of its own launch.TimeNs as an O(1) horizon
+// anchor - before this refactor, the equivalent value was recomputed by
+// latestSampleTimeNs scanning every sample in the entry (up to
+// pendingSampleCap of them) on every evictPendingLocked call while the
+// horizon was enabled; anchorNs makes that O(1) instead.
 type pendingSamples struct {
-	samples []GPUPCSample
-	seq     uint64
-}
-
-// pendingOrderEntry names one FIFO position: the correlation ID inserted and
-// the sequence number it was inserted with. Comparing seq against the
-// current pendingSamples.seq for the same id is how eviction tells a live
-// position from one a later re-insertion (after consumption or eviction) has
-// superseded. Mirrors LaunchCache's orderEntry.
-type pendingOrderEntry struct {
-	id  CorrelationID
-	seq uint64
+	samples  []GPUPCSample
+	seq      uint64
+	anchorNs uint64
 }
 
 // defaultMaxPendingSamplesPerCorrelation bounds a single pending
@@ -302,10 +304,19 @@ func NewTimeline(cfg TimelineConfig) *Timeline {
 		events:           newRing[GPUTimelineEvent](eventCapacity),
 		modules:          newRing[GPUModule](capacity),
 		pending:          make(map[CorrelationID]pendingSamples),
+		pendingOrder:     newOrderedFIFO[CorrelationID](0),
 		pendingCap:       capacity,
 		pendingSampleCap: sampleCap,
 		pendingHorizonNs: cfg.PendingSampleHorizonNs,
 	}
+}
+
+// isPendingLiveLocked answers orderedFIFO's isLive callback for pendingOrder:
+// a position is live only if t.pending still holds an entry for id stamped
+// with exactly seq. The caller must hold t.mu.
+func (t *Timeline) isPendingLiveLocked(id CorrelationID, seq uint64) bool {
+	cur, ok := t.pending[id]
+	return ok && cur.seq == seq
 }
 
 func (t *Timeline) EmitLaunch(l GPUKernelLaunch) error {
@@ -338,10 +349,12 @@ func (t *Timeline) EmitPCSample(p GPUPCSample) error {
 		// or evicted. Either way it is a new generation and gets a new
 		// sequence number plus a new order position - see the pending
 		// field's doc comment for why this must not also happen on every
-		// append to an already-live entry.
-		t.pendingSeq++
-		entry.seq = t.pendingSeq
-		t.pendingOrder = append(t.pendingOrder, pendingOrderEntry{id: p.Correlation, seq: entry.seq})
+		// append to an already-live entry. This is the divergence from
+		// LaunchCache.Put (which bumps on every call): pending accumulates
+		// samples into one live generation across many EmitPCSample calls,
+		// so re-stamping per append would falsely orphan the entry's own
+		// live order position.
+		entry.seq = t.pendingOrder.insert(p.Correlation)
 	}
 
 	if len(entry.samples) >= t.pendingSampleCap {
@@ -350,8 +363,8 @@ func (t *Timeline) EmitPCSample(p GPUPCSample) error {
 		// samples within any single one of them. Without this check, one
 		// orphaned (or stale-ID-reused) correlation below that bound could
 		// still accumulate samples forever. The entry (and its order
-		// position/generation) is left exactly as it was; only the new
-		// sample is dropped and counted.
+		// position/generation/anchor) is left exactly as it was; only the
+		// new sample is dropped and counted.
 		t.dropped.EvictedPendingSamples++
 		t.pending[p.Correlation] = entry
 		t.evictPendingLocked()
@@ -359,6 +372,9 @@ func (t *Timeline) EmitPCSample(p GPUPCSample) error {
 	}
 
 	entry.samples = append(entry.samples, p)
+	if p.TimeNs > entry.anchorNs {
+		entry.anchorNs = p.TimeNs
+	}
 	t.pending[p.Correlation] = entry
 	t.pendingSampleTotal++
 	t.evictPendingLocked()
@@ -380,72 +396,43 @@ func (t *Timeline) observePendingTimestampLocked(timeNs uint64) {
 	t.pendingNewestNs = timeNs
 }
 
-// latestSampleTimeNs returns the largest TimeNs among samples, for aging a
-// pending entry against pendingNewestNs.
-func latestSampleTimeNs(samples []GPUPCSample) uint64 {
-	var latest uint64
-	for _, s := range samples {
-		if s.TimeNs > latest {
-			latest = s.TimeNs
-		}
-	}
-	return latest
-}
-
 // evictPendingLocked drops pending correlation groups past the horizon
 // first (if pendingHorizonNs > 0), then the oldest ones once the map holds
 // more distinct correlations than pendingCap. An order position whose
 // sequence no longer matches the map's current entry for that id - because
 // Snapshot already consumed it, or a later re-insertion superseded it - is
 // skipped rather than double-counted or, worse, mistaken for the live
-// generation and evicted in its place. This mirrors
-// LaunchCache.evictLocked/currentIfLiveLocked exactly, for the same reason:
-// presence in the map is not a sufficient liveness check when a key can be
-// deleted and then reused. Caller holds t.mu.
+// generation and evicted in its place. This mirrors LaunchCache.evictLocked
+// exactly, for the same reason: presence in the map is not a sufficient
+// liveness check when a key can be deleted and then reused - both now
+// delegate that walk to orderedFIFO. Caller holds t.mu.
 func (t *Timeline) evictPendingLocked() {
 	if t.pendingHorizonNs > 0 {
-		for t.pendingHead < len(t.pendingOrder) {
-			e := t.pendingOrder[t.pendingHead]
-			cur, live := t.pending[e.id]
-			if !live || cur.seq != e.seq {
-				t.pendingHead++
-				continue
-			}
-			latest := latestSampleTimeNs(cur.samples)
-			if t.pendingNewestNs <= latest || t.pendingNewestNs-latest <= t.pendingHorizonNs {
+		for {
+			id, ok := t.pendingOrder.peekOldestLive(t.isPendingLiveLocked)
+			if !ok {
 				break
 			}
-			delete(t.pending, e.id)
-			t.pendingHead++
+			cur := t.pending[id] // guaranteed present: peekOldestLive just confirmed liveness
+			if t.pendingNewestNs <= cur.anchorNs || t.pendingNewestNs-cur.anchorNs <= t.pendingHorizonNs {
+				break
+			}
+			t.pendingOrder.evictOldestLive(t.isPendingLiveLocked)
+			delete(t.pending, id)
 			t.pendingSampleTotal -= uint64(len(cur.samples))
 			t.dropped.EvictedPendingSamples += uint64(len(cur.samples))
 		}
 	}
-	for len(t.pending) > t.pendingCap && t.pendingHead < len(t.pendingOrder) {
-		e := t.pendingOrder[t.pendingHead]
-		t.pendingHead++
-		cur, live := t.pending[e.id]
-		if !live || cur.seq != e.seq {
-			continue
+	for len(t.pending) > t.pendingCap {
+		id, ok := t.pendingOrder.evictOldestLive(t.isPendingLiveLocked)
+		if !ok {
+			break
 		}
-		delete(t.pending, e.id)
+		cur := t.pending[id]
+		delete(t.pending, id)
 		t.pendingSampleTotal -= uint64(len(cur.samples))
 		t.dropped.EvictedPendingSamples += uint64(len(cur.samples))
 	}
-	t.compactPendingOrderLocked()
-}
-
-// compactPendingOrderLocked reclaims the dead prefix of pendingOrder once it
-// dominates the slice, the same way LaunchCache.compactLocked does, so the
-// order slice's backing array doesn't grow without bound under sustained
-// load. Caller holds t.mu.
-func (t *Timeline) compactPendingOrderLocked() {
-	if t.pendingHead < 1024 || t.pendingHead*2 < len(t.pendingOrder) {
-		return
-	}
-	rest := t.pendingOrder[t.pendingHead:]
-	t.pendingOrder = append(t.pendingOrder[:0], rest...)
-	t.pendingHead = 0
 }
 
 func (t *Timeline) EmitModule(m GPUModule) error {


### PR DESCRIPTION
Stacked on #30 — review that first. Pure refactor: no behaviour change, and **no existing test was edited**.

## Why now

`gpu/` contained a bounded FIFO with sequence-numbered lazy deletion **twice**: as `LaunchCache`, and inline in `Timeline.pending`. The same stale-position bug appeared in both and was found in both — separately, by two different reviewers, each time by diligence rather than by a test that generalises. The duplication *grew* during Phase 2s final fix wave.

Three more consumers of this shape are scheduled: eBPF batch reassembly, an in-flight correlation table, and a cubin-by-CRC store. This lands before a third hand-written copy exists.

## What was actually duplicated

Identical `orderEntry`, identical `head`/`seq`/`newestNs`, identical `observeTimestamp`, and compaction that was character-for-character the same **including the magic `1024`**.

After this: `orderEntry`, `pendingOrderEntry`, `compactLocked` and `compactPendingOrderLocked` are gone from both owners, and `1024` appears in exactly one place.

## The design, and a deliberate deviation

`orderedFIFO[K comparable]` owns **ordering only** — insert, `evictOldestLive`, `peekOldestLive`, compaction — and asks the owner `isLive(key, seq) bool` via callback. Each owner keeps its own map.

This is not the `boundedFIFO[K,V]` shape originally suggested. Value storage, eviction cost (1 launch vs `len(samples)`) and eviction policy (capacity+horizon vs cardinality+horizon) were always required to stay owner-specific, so a type owning the map too would have needed hooks for all three and converged on roughly this boundary anyway. A future consumer writes a few lines of glue — a map, an `isLive`, a cost read — and inherits the entire bug surface for free.

## Preserved deliberately

The sequence-bump cadence differs between owners and **must**: `LaunchCache.Put` bumps on every call (replace semantics), while `EmitPCSample` bumps only on the absent→present transition, because pending accumulates samples into one live generation and re-stamping per append would falsely orphan the entrys own live order position. Flattening these into uniformity would look like cleanup and would reintroduce the bug. Verified surviving.

## One improvement folded in

`LaunchCache` did horizon eviction in O(1) via `cur.TimeNs`; `Timeline` scanned `latestSampleTimeNs(cur.samples)` on **every** `EmitPCSample` when the horizon was enabled — up to 4,096 comparisons with a large orphan at the head. `pendingSamples` now carries an `anchorNs`, so both are O(1). The gate benchmark never sets the horizon, so this cost was invisible to it.

## Tests

Four new tests against the shared type, each encoding a bug found the hard way rather than restating the implementation:

- stale position survives correlation-ID reuse (the bug found twice)
- superseded positions are skipped **without** being counted as evictions
- compaction bounds the order slice under sustained churn
- the concurrency contract — `orderedFIFO` is explicitly **not** internally synchronised; both owners call it under their own lock

All pre-existing tests pass unchanged. `go test ./gpu/ ./pprof/` green, `-race` clean. `BenchmarkSnapshotAtScale` unchanged: identical allocation profile, timing within noise.

## Left alone

`observeTimestampLocked` / `observePendingTimestampLocked` remain separate. Different mechanism (a scalar anchor plus clamp, not an order/seq FIFO), pre-existing, and out of scope. Review noted a real asymmetry worth its own follow-up: `LaunchCache`s is configurable via `cfg.MaxAdvanceNs` while `Timeline`s hardcodes `defaultMaxAdvanceNs` with no equivalent knob.

**Net +89 lines** — the shared file documents the mechanism and the historical bug once, replacing ~35 lines of logic in each owner.