### PR TITLE
gpu: refuse to attribute GPU time to the profiler's own stack

### DIFF
--- a/.superpowers/sdd/attrib-guard-report.md
+++ b/.superpowers/sdd/attrib-guard-report.md
@@ -1,0 +1,198 @@
+# GPU attribution guard: a stack that never left the profiler is not an attribution
+
+Branch `fix/gpu-profiler-only-stacks`, worktree `.worktrees/gpu-attrib-guard`.
+
+## The rule
+
+A resolved launch capture is attached to its launch **only if at least one of
+its frames is provably outside the profiler's own injected module** — unless
+the shim is itself the program, in which case there is no profiler/application
+boundary and every stack is a legitimate attribution.
+
+A capture that fails the test is withheld. The launch still ships, stackless,
+and its execution's measured GPU time projects as `[gpu:launch unsampled]` —
+the same unattributed population as a launch the sampler never picked. Nothing
+is scaled, no execution borrows a sibling's call path, and the attributed and
+unattributed populations still sum to the exact measured total. The only thing
+lost is a claim the profiler could not support.
+
+This is what the RTX 3090 / CUPTI run produced without the guard: the
+frame-pointer walk died inside libcupti, the single surviving frame was
+`(anonymous namespace)::on_callback`, and 100% of the attributed GPU time was
+nested under a function that has never launched a kernel.
+
+## Telling the two deployment shapes apart
+
+`gpuprobe.shimScope` classifies the shim **once, at consumer construction,
+from the shim's own ELF header**:
+
+* `ET_EXEC`, or `ET_DYN` carrying a `PT_INTERP` segment → a file the kernel can
+  exec → **self-contained producer** (`shim/stub`, which the phase gate runs).
+  Guard OFF: `main → perfagent_stub_run` is entirely "inside the shim" and is a
+  perfectly good attribution, because profiler and application are the same
+  binary.
+* anything else → a shared object → **injected adapter** (the CUDA case).
+  Guard ON: application code lives in other modules by construction, so a stack
+  confined to the shim provably never reached the application.
+
+### Why this and not `/proc/<pid>/exe`
+
+Comparing `stat("/proc/<pid>/exe")` against the shim by device+inode answers
+the same question and is immune to path spelling, but it answers it *later*,
+*per pid*, *on the hot capture path*; it needs `PTRACE_MODE_READ` on a process
+that may already have exited (the short-lived-CUDA-process case is exactly the
+one Phase 4b is chartered to fix); and it needs a bounded per-pid memo table to
+stay cheap under a system-wide attach. The ELF answer is a static, deterministic
+property of the file the consumer already opened to attach its probes, costs one
+`elf.Open` per consumer, and needs no privilege at all. Its one blind spot is
+covered below, and it fails towards silence.
+
+### What fools it
+
+* **A static-PIE self-contained producer** (`ET_DYN`, no `PT_INTERP`) is read as
+  an injected library, so its legitimate inside-only stacks are rejected.
+  Information loss, counted, honest. This is the `/proc/<pid>/exe` route's one
+  real advantage, given up deliberately. (`shim/stub` is dynamically linked, so
+  the gate is unaffected; `TestShimShapeIsClassifiedFromTheELF` pins the
+  classification of a program and of a real mapped `.so`.)
+* **Module identity is a path comparison** — the configured spelling, its
+  absolute form, its symlink-resolved form, plus a basename fallback. The
+  basename fallback exists because a target in another mount namespace reports
+  the shim under *its own* rootfs, which matches none of the three spellings;
+  without it the shim's own frames would read as "outside" and the guard would
+  accept a profiler-only stack, the one direction that must not happen. The cost
+  is that an application module sharing the shim's file name reads as "inside",
+  which can only cause a rejection. `BuildID` would be a stronger identity, but
+  `pprof.Frame.BuildID` is filled by the pprof builder from `/proc/<pid>/maps`
+  long after this check runs; the frames the consumer holds carry only what the
+  symbolizer set. When Phase 4b snapshots maps, this comparison should move to
+  the build ID.
+* **A frame with no module proves nothing** and is never read as "outside".
+  Reading "unknown" as "outside" would be a false accept. So a stack of nothing
+  but unnamed modules is rejected too — and counted apart, see below.
+* **An empty `ShimPath` disables the guard.** With no idea which module is the
+  profiler's there is no evidence in either direction, and rejecting everything
+  on no evidence is destruction rather than honesty. `Attach` always sets it (it
+  parses that file's USDT notes and opens it as an executable), so this is a
+  unit-test shape, not a live one.
+* **An unreadable/unparseable shim ELF** leaves the shape unknown; the guard
+  stays ON and treats it as injected — the lossy direction.
+
+Every failure mode above errs towards rejecting a genuine attribution
+(information loss, counted) rather than accepting a profiler-only one (the bug).
+
+## Where the check lives, and why
+
+In `gpuprobe`, in `Consumer.attachSampledStackLocked`, immediately after
+`resolveStackLocked` succeeds and before the capture can be parked or attached —
+so it covers **both** arrival orders (stack-first parks nothing; batch-first
+releases the held launch without lending it the refused stack).
+
+`gpu/` is unchanged in behaviour, deliberately. The judgement needs two things
+`gpu/` does not have and should not acquire: which module is the profiler's, and
+which deployment shape it is running in — vendor/deployment knowledge that this
+codebase has kept out of `gpu/` on purpose. `gpu/projection.go`'s `sampledStack`
+already treats "launch carried no stack" as the single definition of
+unattributed; the consumer withholding a stack simply lands there. The only
+`gpu/` change is a comment on `sampledStack` recording that "carried no stack"
+now also covers a refused capture, and why the decision is made elsewhere.
+
+## Accounting
+
+Two new fields on `gpuprobe.Stats`:
+
+* **`StacksProfilerOnly`** — resolved captures refused because the walk never
+  left the profiler's own injected shim. Attribution loss, not record loss.
+* **`StacksProfilerOnlyUncertain`** — the *subset* of the above refused without
+  proof (no frame provably outside, but at least one frame's module unknown).
+  Deliberately a subset, not an additive bucket, so the reconciliation stays a
+  partition. It separates the two ways the guard can be wrong: proven refusals
+  are the bug it was built for; a rising uncertain count means symbolization is
+  failing to name modules and the guard is paying for it in lost attribution.
+
+The documented at-rest identity becomes:
+
+    StacksResolved = StacksAttached + StacksEvicted + StacksProfilerOnly + PendingStacks
+
+`TestSampledStackAccountingReconciles` asserts it, plus
+`StacksProfilerOnlyUncertain <= StacksProfilerOnly`. `cmd/gpu-stub-profile`
+prints `Stats` with `%+v`, so both counters surface with no change there.
+
+## Phase gate
+
+Not weakened, and strengthened by one assertion: `gate_test.go` now also asserts
+`stats.StacksProfilerOnly == 0`, on the grounds that the stub IS the shim, so a
+refusal there means the injected-adapter guard misread a self-contained
+producer. The existing "exactly 63 sampled launches carry a non-empty CPUStack
+containing `perfagent_stub_run`" assertion is untouched and is unaffected by the
+guard, which is off for a program-shaped shim.
+
+## Tests added (`gpuprobe/shimscope_test.go`)
+
+* `TestShimShapeIsClassifiedFromTheELF` — `/proc/self/exe` classifies as a
+  program (guard off); a real shared object mapped into this very process
+  (found by parsing `/proc/self/maps`) classifies as a library (guard on).
+* `TestNoShimPathLeavesTheGuardOff`.
+* `TestVerdictNeedsPositiveEvidenceOfLeavingTheShim` — table over the injected
+  shape: the exact RTX 3090 single-callback stack; a stack that reached the
+  application; the same shim under another mount namespace's path; unknown
+  modules alone and mixed with real evidence.
+* `TestInjectedShimOnlyStackIsWithheldAndCounted` — end to end through
+  `applyBatch`: launch ships, `CPUStack` empty, `SamplePeriod` zero,
+  `StacksProfilerOnly == 1`, `StacksResolved == 1`, nothing parked.
+* `TestInjectedShimStackThatReachesTheApplicationIsKept` — same shim, one
+  application frame: attached untouched, counter zero.
+* `TestSelfContainedShimStackIsAnAttribution` — the stub shape, synthesized:
+  every frame in the shim, and it is attached.
+* `TestUnprovenRejectionIsCountedSeparately`.
+* `TestRefusedStackIsNeverAttachedInEitherArrivalOrder` — batch-first order.
+
+None of them skips on this machine (verified with `-v`).
+
+## Verification
+
+```
+$ go build ./... && go vet ./...
+(no output: clean)
+
+$ go test ./gpu/ ./gpuprobe/ ./internal/... -count=1
+ok  	github.com/dpsoft/perf-agent/gpu	3.484s
+ok  	github.com/dpsoft/perf-agent/gpuprobe	0.050s
+ok  	github.com/dpsoft/perf-agent/internal/bpfstack	0.003s
+ok  	github.com/dpsoft/perf-agent/internal/gpuabi	0.003s
+ok  	github.com/dpsoft/perf-agent/internal/k8slabels	0.003s
+ok  	github.com/dpsoft/perf-agent/internal/nspid	0.003s
+ok  	github.com/dpsoft/perf-agent/internal/perfdata	0.227s
+ok  	github.com/dpsoft/perf-agent/internal/perfevent	0.002s
+ok  	github.com/dpsoft/perf-agent/internal/usdt	0.114s
+
+$ go test ./gpuprobe/ -race -count=1
+ok  	github.com/dpsoft/perf-agent/gpuprobe	1.178s
+
+$ gofmt -l gpu gpuprobe
+(no output: clean)
+
+$ ~/go/bin/golangci-lint run --timeout=5m
+0 issues.
+```
+
+## What I could not verify
+
+* `CapEff: 0` on this machine, so **the phase gate itself was not run**
+  (`TestStubDrivesThePipelineToPprofWithoutAGPU` needs `CAP_BPF` + `CAP_PERFMON`
+  and skips). The argument that it still passes is: `shim/perfagent-gpu-stub` is
+  a dynamically linked program, so `newShimScope` returns an unguarded scope and
+  `verdict` returns `stackAttributable` unconditionally — the guard cannot touch
+  a single stub stack. `TestSelfContainedShimStackIsAnAttribution` exercises that
+  path end to end with `/proc/self/exe` standing in for the stub.
+* **No real CUPTI/GPU hardware here**, so the injected-adapter shape is exercised
+  against synthesized frames and a real system `.so` rather than against
+  `libperfagent_cupti.so` on an RTX 3090. What a live run will confirm is the one
+  assumption behind the guard: that blazesym populates `Frame.Module` with the
+  adapter's path for the callback frame. If it does not, the run lands in
+  `StacksProfilerOnlyUncertain` instead of `StacksProfilerOnly` — still refused,
+  still honest, still counted, just without proof.
+* The privileged gate binary was rebuilt once at the end
+  (`/home/diego/gpuprobe.test`, blazesym statically linked, `readelf -d | grep -c
+  blazesym` = 0). **Rebuilding stripped its file capabilities; a human must
+  `setcap` it again** before the gate can run.

--- a/.superpowers/sdd/attrib-guard-report.md
+++ b/.superpowers/sdd/attrib-guard-report.md
@@ -86,7 +86,8 @@ Every failure mode above errs towards rejecting a genuine attribution
 In `gpuprobe`, in `Consumer.attachSampledStackLocked`, immediately after
 `resolveStackLocked` succeeds and before the capture can be parked or attached —
 so it covers **both** arrival orders (stack-first parks nothing; batch-first
-releases the held launch without lending it the refused stack).
+does not lend the held launch the refused stack — it does not release that
+launch either, which waits for the next batch, the queue's bound, or `Flush`).
 
 `gpu/` is unchanged in behaviour, deliberately. The judgement needs two things
 `gpu/` does not have and should not acquire: which module is the profiler's, and
@@ -196,3 +197,138 @@ $ ~/go/bin/golangci-lint run --timeout=5m
   (`/home/diego/gpuprobe.test`, blazesym statically linked, `readelf -d | grep -c
   blazesym` = 0). **Rebuilding stripped its file capabilities; a human must
   `setcap` it again** before the gate can run.
+
+---
+
+# Review round 2: two false-accept fixes
+
+Both findings were in the dangerous direction (accepting a profiler-only
+stack), and both are fixed. Nothing else moved: the accounting identity, the
+over-reject-on-unknown-module behaviour, the placement in
+`attachSampledStackLocked` and `gpu/` are all untouched.
+
+## Fix 1: `PT_INTERP` is not what makes a file a program
+
+The review is right, and the counterexample is on this machine:
+
+```
+$ readelf -lh /lib64/libc.so.6 | grep -E "Type:|INTERP"
+  Type:                              DYN (Shared object file)
+  INTERP         0x00000000001bf000 ...
+$ readelf -d /lib64/libc.so.6 | grep -i soname
+ 0x000000000000000e (SONAME)             Library soname: [libc.so.6]
+```
+
+`libc.so.6` is a shared object that carries an interpreter — it is runnable,
+it prints its own version banner. Under the old test it classified as a
+program, so a shim `.so` linked the same way would have switched the guard
+**off** entirely, silently, in exactly the deployment the guard exists for.
+
+The new discriminator, in order, with "library" as the default at every exit:
+
+1. **`ET_EXEC`** → program. Nothing else is ever `ET_EXEC`. (`shim/perfagent-gpu-stub`
+   is `EXEC`, so the gate's shim is decided here, by the strongest signal.)
+2. **`DT_SONAME` present** → library, overriding everything below it. A file
+   that declares the name other objects link against is a library whatever
+   else it carries. This is the check that catches `libc.so.6`, and it is
+   deliberately consulted *before* the program signals so a mislabelled file
+   fails towards "library", which leaves the guard on.
+3. **`DF_1_PIE` in `DT_FLAGS_1`** → program. The linker sets it on
+   position-independent *executables* and on nothing else — the most direct
+   statement of intent an `ET_DYN` file can make. Verified present on this
+   machine's PIE (`readelf -d /proc/self/exe` → `Flags: NOW PIE`) and absent
+   on `libc.so.6` (`Flags: NOW`).
+4. **`PT_INTERP`** → program, as the fallback for a toolchain old enough to
+   emit no `DF_1_PIE`. Only ever reached after `DT_SONAME` has been ruled
+   out, which is what makes it safe here and unsafe on its own.
+
+Residual hole, now documented on `shimScope`: an injected shim `.so`
+deliberately linked with an explicit `--dynamic-linker` **and** with no
+soname, on a toolchain emitting no `DF_1_PIE`, would still read as a program.
+That is three unusual choices at once; the standard `-shared -Wl,-soname`
+shim is caught by rule 2 alone, and a `-shared` shim with no soname (what
+`shim/Makefile` builds) is caught by having neither 3 nor 4.
+
+### The counterexample is asserted, not skipped
+
+`mappedLibrary`'s `isELFProgram` filter is gone — it was stepping around
+precisely the file that disproved the classifier.
+`TestAnInterpreterCarryingSharedObjectIsStillALibrary` now walks every shared
+object mapped into the test process, and for each one that carries `PT_INTERP`
+asserts it classifies as a **library** and that a shim spelled that way is
+guarded. It ends with `require.Positive(t, checked, ...)`, so if no such
+object is mapped the test **fails** rather than passing vacuously. On this
+machine it checks `/usr/lib64/libc.so.6`. `TestShimShapeIsClassifiedFromTheELF`
+likewise now asserts over every mapped `.so` rather than the first acceptable
+one.
+
+Mutation-checked: deleting the `DT_SONAME` branch fails
+`TestAnInterpreterCarryingSharedObjectIsStillALibrary` with
+`/usr/lib64/libc.so.6 is a shared object that happens to carry PT_INTERP` and
+also fails `TestShimShapeIsClassifiedFromTheELF`.
+
+## Fix 2: the `(deleted)` suffix
+
+`shimScope.isShimModule` now strips a trailing `" (deleted)"` before matching,
+against both the path spellings and the basename (`deletedSuffix`). Without
+it, a shim replaced under a running profiled process reports as
+`.../libperfagent-gpu-nvidia.so (deleted)`, matches nothing, and the shim's
+own frame reads as *outside* the shim — a false accept, arriving during an
+upgrade, which is the least observable moment there is.
+
+I did check blazesym: `src/maps.rs`, `parse_path_name`, strips the suffix
+itself (`path.strip_suffix(b" (deleted)")`) when it parses a maps line, so
+with `symbolize.LocalSymbolizer` this is belt and braces. It is handled here
+anyway because `Config.Symbolizer` is an interface — nothing obliges another
+implementation to normalize the path, and the trade is one `TrimSuffix`
+against a silent false attribution.
+
+Two table cases pin it (plain and combined with the mount-namespace basename
+fallback); mutation-checked by making the strip a no-op, which fails both.
+
+## Also done (the two optional items)
+
+* `TestSampledStackAccountingReconciles` now runs with a real `ShimPath` and a
+  module-aware symbolizer, so **every** term of the second identity is
+  non-zero at once: one attached, one evicted, one refused as profiler-only,
+  one still parked (each asserted individually, then the identity). Before,
+  the `StacksProfilerOnly` term was zero by construction.
+* Report wording corrected: the batch-first refusal does **not** release the
+  held launch. The guard returns before `deferred.take`, so the launch waits
+  exactly as it would for a capture that failed to resolve — for the next
+  batch, the queue's own bound, or `Flush`. Bounded and lossless, but a wait,
+  not a release. The same correction is now in the test's own comment.
+
+## Re-verification
+
+```
+$ go build ./... && go vet ./...
+(no output: clean)
+
+$ go test ./gpu/ ./gpuprobe/ ./internal/... -count=1
+ok  	github.com/dpsoft/perf-agent/gpu	3.454s
+ok  	github.com/dpsoft/perf-agent/gpuprobe	0.062s
+ok  	github.com/dpsoft/perf-agent/internal/bpfstack	0.004s
+ok  	github.com/dpsoft/perf-agent/internal/gpuabi	0.004s
+ok  	github.com/dpsoft/perf-agent/internal/k8slabels	0.004s
+ok  	github.com/dpsoft/perf-agent/internal/nspid	0.002s
+ok  	github.com/dpsoft/perf-agent/internal/perfdata	0.187s
+ok  	github.com/dpsoft/perf-agent/internal/perfevent	0.003s
+ok  	github.com/dpsoft/perf-agent/internal/usdt	0.199s
+
+$ go test ./gpuprobe/ -race -count=1
+ok  	github.com/dpsoft/perf-agent/gpuprobe	1.172s
+
+$ gofmt -l gpu gpuprobe
+(no output: clean)
+
+$ ~/go/bin/golangci-lint run --timeout=5m
+0 issues.
+```
+
+Still not verifiable here: the phase gate itself (`CapEff: 0`). The stub is
+`ET_EXEC`, so it is classified a program by rule 1 — the strongest and least
+ambiguous of the four — and the guard cannot touch a stub stack.
+`/home/diego/gpuprobe.test` was rebuilt once at the end with the static
+blazesym recipe; **its file capabilities are stripped and a human must
+`setcap` it again**.

--- a/gpu/projection.go
+++ b/gpu/projection.go
@@ -105,6 +105,16 @@ func ProjectExecutions(snap Snapshot) []pp.ProfileSample {
 // unattributed as an execution that joined no launch at all, and both must
 // project the same way. Deciding this from SamplePeriod instead would claim
 // attribution for a sampled launch whose capture failed.
+//
+// "Carried no stack" also covers a capture the consumer refused
+// to attach because it never left the profiler's own injected module - a
+// frame-pointer walk that died inside the vendor libraries and came back
+// holding nothing but the adapter's own callback (gpuprobe.shimScope,
+// counted as gpuprobe.Stats.StacksProfilerOnly). That judgement needs to
+// know which module is the profiler's and which deployment shape it is in,
+// which is vendor- and deployment-specific knowledge this package
+// deliberately does not hold. It is made where that knowledge lives, and
+// arrives here as what it is: a launch with no stack.
 func sampledStack(view ExecutionView) ([]pp.Frame, bool) {
 	if view.Launch == nil || len(view.Launch.Launch.CPUStack) == 0 {
 		return nil, false

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -269,7 +269,8 @@ type Stats struct {
 	//
 	//	SampledLaunches = StacksMissing + StacksUncorrelated +
 	//	                  StackLookupFailed + SymbolizeFailed + StacksResolved
-	//	StacksResolved  = StacksAttached + StacksEvicted + PendingStacks
+	//	StacksResolved  = StacksAttached + StacksEvicted +
+	//	                  StacksProfilerOnly + PendingStacks
 	//
 	// (the second identity holds at rest; PendingStacks is a gauge). Both
 	// are asserted by TestSampledStackAccountingReconciles.
@@ -348,6 +349,37 @@ type Stats struct {
 	// small for the in-flight window. It is attribution loss, not record
 	// loss: the launches themselves are unaffected.
 	StacksEvicted uint64
+	// StacksProfilerOnly counts resolved captures the consumer refused to
+	// attach because the walk never left the profiler's own injected shim:
+	// every frame it produced lies inside the .so carrying the probes, so
+	// the stack says where the profiler was, not where the application was.
+	//
+	// This is attribution loss, not record loss - the launch is delivered
+	// without a stack and its execution's measured GPU time projects as
+	// [gpu:launch unsampled], the same bucket as a launch the sampler never
+	// picked. The counter exists because the alternative is what a real
+	// CUPTI run produced: 100% of the attributed GPU time nested under the
+	// adapter's own callback frame, stated as confidently as a true
+	// attribution. A profiler that cannot see the application must say so.
+	//
+	// Zero by construction for a self-contained producer such as shim/stub,
+	// where the shim IS the program and there is no boundary to cross. See
+	// shimScope for how the two deployment shapes are told apart.
+	StacksProfilerOnly uint64
+	// StacksProfilerOnlyUncertain is the SUBSET of StacksProfilerOnly
+	// rejected without proof: no frame was provably outside the shim, but at
+	// least one frame's module was unknown (the symbolizer named the frame
+	// after its own address, or resolved it without a module), so the stack
+	// might have reached the application and been unnameable rather than
+	// never having got there.
+	//
+	// It is a subset, deliberately not additive with StacksProfilerOnly, so
+	// the reconciliation identity above stays a partition. It separates the
+	// two ways this guard can be wrong: the certain rejections are the bug
+	// it was built for, while a rising uncertain count means symbolization
+	// is failing to name modules and the guard is paying for it in lost
+	// attribution.
+	StacksProfilerOnlyUncertain uint64
 	// KernelNamesLearned counts gpu_kernel_name_v1 records interned. The
 	// producer replays its whole table on late attach, so a name may be
 	// learned more than once for the same kernel; this counts records, not
@@ -513,6 +545,12 @@ type Consumer struct {
 	deferred    *deferredLaunches
 	names       *kernelNameTable
 	unnamed     *pendingNames
+	// shim is the attribution guard's view of what the consumer attached
+	// to: whether the shim is an injected library or the program itself,
+	// and which module paths are the shim's own. Immutable after
+	// newConsumer; see shimScope.
+	shim shimScope
+
 	// sawKernelName records whether this producer emits kernel names at
 	// all. Holding an event for a name that is never coming would delay
 	// every event a producer without the name probe ever sends, so nothing
@@ -531,6 +569,7 @@ type Consumer struct {
 func newConsumer(cfg Config) *Consumer {
 	return &Consumer{
 		cfg:         cfg,
+		shim:        newShimScope(cfg.ShimPath),
 		seqByStream: map[seqKey]uint64{},
 		pending:     newPendingStacks(cfg.SampledStackCapacity),
 		deferred:    newDeferredLaunches(cfg.DeferredLaunchCapacity),
@@ -972,6 +1011,22 @@ func (c *Consumer) attachSampledStackLocked(pid uint32, stackID int32, sl gpuabi
 		return // counted inside resolveStackLocked
 	}
 	c.stats.StacksResolved++
+
+	// A stack that never left the profiler's own injected module is not an
+	// attribution, and attaching it would hand this launch's measured GPU
+	// time to a call path inside the profiler. Withhold it: the launch ships
+	// stackless and projects as unattributed, exactly as if the sampler had
+	// never picked it. See shimScope for the rule and its failure modes.
+	switch c.shim.verdict(frames) {
+	case stackProfilerOnlyUncertain:
+		c.stats.StacksProfilerOnlyUncertain++
+		c.stats.StacksProfilerOnly++
+		return
+	case stackProfilerOnly:
+		c.stats.StacksProfilerOnly++
+		return
+	case stackAttributable:
+	}
 
 	// Keyed on (pid, correlation), never correlation alone: see launchKey.
 	// pid is the batch header's, i.e. the process that fired the probe, which

--- a/gpuprobe/consumer_test.go
+++ b/gpuprobe/consumer_test.go
@@ -1536,23 +1536,42 @@ func TestEmptyStackEntryIsCountedAsALookupFailure(t *testing.T) {
 // from a consumer quietly losing captures, which is the whole point of §6.1
 // accounting.
 func TestSampledStackAccountingReconciles(t *testing.T) {
+	// A real shim path, and a symbolizer that places frames in modules, so
+	// the StacksProfilerOnly term is actually exercised: with an empty
+	// ShimPath the guard is off and that term is zero by construction, which
+	// would make the identity below pass without ever having been tested
+	// against a refusal.
+	shim := mappedLibrary(t)
 	sink := &recordingSink{}
-	c, sm, _ := stackConsumer(t, sink, Config{SampledStackCapacity: 1})
+	sym := &moduleSymbolizer{modules: map[uint64]string{
+		0x1000: "/app/train", 0x2000: "/app/train", 0x3000: "/app/train",
+		0x4000: shim, // never left the profiler: refused
+	}}
+	c, sm, _ := stackConsumer(t, sink, Config{SampledStackCapacity: 1, ShimPath: shim, Symbolizer: sym})
 
 	sm.put(1, 0x1000) // resolves, then parks
 	sm.put(2, 0x2000) // resolves, parks, evicting the first
 	sm.put(3, 0x3000) // resolves and attaches to a held launch
+	sm.put(4, 0x4000) // resolves, then is refused as profiler-only
 	apply(t, c, sampledBatchWith(4242, 1, 1, 8))
 	apply(t, c, sampledBatchWith(4242, 2, 2, 8))
 	apply(t, c, launchBatchWith(4242, 3))
 	apply(t, c, sampledBatchWith(4242, 3, 3, 8))
+	apply(t, c, sampledBatchWith(4242, 8, 4, 8))
 	apply(t, c, sampledBatchWith(4242, 4, -1, 8))  // capture failed
 	apply(t, c, sampledBatchWith(4242, 0, 5, 8))   // no correlation
 	apply(t, c, sampledBatchWith(4242, 6, 404, 8)) // no such entry
 	c.Flush()
 
 	st := c.Stats()
-	assert.Equal(t, uint64(6), st.SampledLaunches)
+	assert.Equal(t, uint64(7), st.SampledLaunches)
+	// Every term of the second identity is non-zero here, which is the point
+	// of the arrangement above: one attached, one evicted, one refused, one
+	// still parked.
+	assert.Equal(t, uint64(1), st.StacksAttached)
+	assert.Equal(t, uint64(1), st.StacksEvicted)
+	assert.Equal(t, uint64(1), st.StacksProfilerOnly)
+	assert.Equal(t, 1, st.PendingStacks)
 	assert.Equal(t, st.SampledLaunches,
 		st.StacksMissing+st.StacksUncorrelated+st.StackLookupFailed+st.SymbolizeFailed+st.StacksResolved,
 		"every sampled launch must land in exactly one bucket")

--- a/gpuprobe/consumer_test.go
+++ b/gpuprobe/consumer_test.go
@@ -1557,8 +1557,10 @@ func TestSampledStackAccountingReconciles(t *testing.T) {
 		st.StacksMissing+st.StacksUncorrelated+st.StackLookupFailed+st.SymbolizeFailed+st.StacksResolved,
 		"every sampled launch must land in exactly one bucket")
 	assert.Equal(t, st.StacksResolved,
-		st.StacksAttached+st.StacksEvicted+uint64(st.PendingStacks),
-		"every resolved stack is attached, evicted, or still waiting - nothing else")
+		st.StacksAttached+st.StacksEvicted+st.StacksProfilerOnly+uint64(st.PendingStacks),
+		"every resolved stack is attached, evicted, refused as profiler-only, or still waiting - nothing else")
+	assert.LessOrEqual(t, st.StacksProfilerOnlyUncertain, st.StacksProfilerOnly,
+		"the uncertain count is a subset of the refusals, never a bucket of its own")
 }
 
 // Run must release what it is holding on the way out, so a caller can

--- a/gpuprobe/gate_test.go
+++ b/gpuprobe/gate_test.go
@@ -233,6 +233,8 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	assert.Zero(t, stats.StackDeleteFailed, "every stackmap entry read must also be deletable")
 	assert.Zero(t, stats.StacksUncorrelated,
 		"the stub never emits correlation 0 on a sampled launch")
+	assert.Zero(t, stats.StacksProfilerOnly,
+		"the stub IS the shim, so main -> perfagent_stub_run is a real attribution; a refusal here means the injected-adapter guard misread a self-contained producer")
 	assert.Zero(t, stats.SymbolizeFailed,
 		"a real Symbolizer is configured; every captured stack must resolve to at least one frame")
 	// The counter that would have caught this branch's symbolization failure

--- a/gpuprobe/shimscope.go
+++ b/gpuprobe/shimscope.go
@@ -3,6 +3,7 @@ package gpuprobe
 import (
 	"debug/elf"
 	"path/filepath"
+	"strings"
 
 	pp "github.com/dpsoft/perf-agent/pprof"
 )
@@ -48,9 +49,11 @@ import (
 //     application are the same binary. There is no boundary to cross.
 //
 // shimScope tells the two apart from the shim's ELF alone, once, when the
-// consumer is built: a file that carries a PT_INTERP segment (or is ET_EXEC)
-// is a program the kernel can exec, i.e. shape two; anything else is a
-// shared object, i.e. shape one. That is a static, deterministic property of
+// consumer is built: ET_EXEC, or an ET_DYN that declares no DT_SONAME and
+// marks itself DF_1_PIE (or, on an older toolchain, carries PT_INTERP), is a
+// program the kernel can exec, i.e. shape two; anything else is a shared
+// object, i.e. shape one. See isELFProgram for why PT_INTERP alone is not
+// that test - libc.so.6 has one. That is a static, deterministic property of
 // the file the consumer attached to. The obvious alternative - readlink or
 // stat /proc/<pid>/exe per launching pid and compare it to the shim - was
 // rejected: it answers the same question later, per pid, on the hot path,
@@ -65,9 +68,18 @@ import (
 // Rejecting a genuine stack loses information; accepting a profiler-only one
 // is the bug this exists to prevent.
 //
-//   - A static-PIE self-contained producer (ET_DYN, no PT_INTERP) is
-//     classified as an injected library, so its legitimate inside-only
-//     stacks are rejected. Information loss, counted, honest.
+//   - A static-PIE self-contained producer (ET_DYN, no PT_INTERP, and no
+//     DF_1_PIE from a toolchain that omits it) is classified as an injected
+//     library, so its legitimate inside-only stacks are rejected.
+//     Information loss, counted, honest.
+//   - The reverse - an injected shim .so deliberately linked with an
+//     interpreter AND with no DT_SONAME, on a toolchain emitting no
+//     DF_1_PIE - would read as a program and disable the guard. That is the
+//     dangerous direction, and it is why DT_SONAME is checked first and why
+//     PT_INTERP is only ever a last-resort fallback. It requires linking
+//     -shared with an explicit --dynamic-linker and suppressing the soname,
+//     which no sane build does; the standard `-shared -Wl,-soname` shim is
+//     classified as a library by rule 2 alone.
 //   - A frame whose module the symbolizer could not name proves nothing, so
 //     it is never read as "outside". A stack of nothing but unnamed modules
 //     is therefore rejected too - and counted separately, in
@@ -81,6 +93,10 @@ import (
 //     "outside" - a false accept, the direction that must not happen. The
 //     cost is that an application module that happens to share the shim's
 //     basename reads as "inside", which can only cause a rejection.
+//   - A mapping the kernel marks " (deleted)" - the shim was replaced while
+//     a profiled process had it mapped - is normalized before matching. See
+//     deletedSuffix: without that, the shim's own frame reads as outside the
+//     shim, which is a false accept.
 //   - An empty ShimPath disables the guard entirely: with no idea which
 //     module is the profiler's, there is no evidence either way, and
 //     rejecting everything on no evidence is destruction, not honesty.
@@ -147,10 +163,38 @@ func newShimScope(shimPath string) shimScope {
 	return s
 }
 
-// isELFProgram reports whether path is a file the kernel can exec directly:
-// ET_EXEC, or an ET_DYN carrying PT_INTERP (a position-independent
-// executable). A shared object is neither. An unreadable or unparseable file
-// reports false, which leaves the guard on - the lossy direction.
+// isELFProgram reports whether path is a program - something the kernel
+// execs as a process image - rather than a shared object something else
+// loads into a process it did not create.
+//
+// PT_INTERP is NOT that test, which is the trap this function was rewritten
+// to avoid. Glibc's own libc.so.6 carries a PT_INTERP segment (it is
+// runnable: `/lib64/libc.so.6` prints its version banner), and so does the
+// dynamic loader. A shim .so linked with an explicit interpreter would
+// therefore have classified as a program and switched the whole guard OFF -
+// silently, in exactly the deployment the guard exists for. Unreachable
+// today only because shim/Makefile links with a plain -shared.
+//
+// The signals, in the order they are consulted:
+//
+//  1. ET_EXEC. A non-PIE executable. Nothing else is ever ET_EXEC.
+//  2. DT_SONAME. A file that declares the name other objects should link
+//     against is a library, whatever else it carries. This is what tells
+//     libc.so.6 (SONAME libc.so.6, PT_INTERP present) apart from a PIE, and
+//     it is consulted BEFORE the two program signals so it can override
+//     them: a mislabelled library must fail towards "library", because that
+//     leaves the guard on.
+//  3. DF_1_PIE in DT_FLAGS_1. Set by the linker on position-independent
+//     EXECUTABLES only, and by nothing else - the most direct statement of
+//     intent an ET_DYN file can make. Present on binutils/lld output for
+//     roughly the last decade.
+//  4. PT_INTERP, as the fallback for an older toolchain that emits no
+//     DF_1_PIE. Only ever reached once DT_SONAME has been ruled out, which
+//     is what makes it safe here and unsafe on its own.
+//
+// Anything else - including an unreadable or unparseable file - is reported
+// as a library, which leaves the guard ON. That is the lossy direction, and
+// the deliberate one.
 func isELFProgram(path string) bool {
 	f, err := elf.Open(path)
 	if err != nil {
@@ -162,6 +206,18 @@ func isELFProgram(path string) bool {
 	}
 	if f.Type != elf.ET_DYN {
 		return false
+	}
+	// DynString returns an error for a file with no dynamic section at all
+	// (a static-PIE); no SONAME either way, so the error is not special.
+	if soname, err := f.DynString(elf.DT_SONAME); err == nil && len(soname) > 0 {
+		return false
+	}
+	if flags, err := f.DynValue(elf.DT_FLAGS_1); err == nil {
+		for _, v := range flags {
+			if v&uint64(elf.DF_1_PIE) != 0 {
+				return true
+			}
+		}
 	}
 	for _, p := range f.Progs {
 		if p.Type == elf.PT_INTERP {
@@ -202,8 +258,30 @@ func (s shimScope) verdict(frames []pp.Frame) stackVerdict {
 // first, then file name - see the failure modes on shimScope for why the
 // basename fallback is there and which way it errs.
 func (s shimScope) isShimModule(module string) bool {
+	module = strings.TrimSuffix(module, deletedSuffix)
 	if _, ok := s.paths[module]; ok {
 		return true
 	}
 	return filepath.Base(module) == s.base
 }
+
+// deletedSuffix is what the kernel appends to a mapping's path in
+// /proc/<pid>/maps once the file behind it has been unlinked - which happens
+// to the shim itself whenever it is upgraded or reinstalled under a running
+// profiled process.
+//
+// It has to be stripped before matching, because an unstripped
+// ".../libperfagent-gpu-nvidia.so (deleted)" matches none of the shim's
+// spellings and not its basename either, so the shim's OWN frame would read
+// as "outside the shim" and a profiler-only stack would be accepted. That is
+// the false-accept direction, the one thing this guard must never do, and it
+// would happen only during an upgrade - the least observable moment
+// possible.
+//
+// blazesym strips the suffix itself when it parses a maps line (src/maps.rs,
+// parse_path_name), so with the LocalSymbolizer this is belt and braces. It
+// is done here anyway because Config.Symbolizer is an interface: nothing
+// obliges another implementation to normalize the path, and the cost of
+// being wrong is a silent false attribution against the cost of one
+// TrimSuffix.
+const deletedSuffix = " (deleted)"

--- a/gpuprobe/shimscope.go
+++ b/gpuprobe/shimscope.go
@@ -1,0 +1,209 @@
+package gpuprobe
+
+import (
+	"debug/elf"
+	"path/filepath"
+
+	pp "github.com/dpsoft/perf-agent/pprof"
+)
+
+// A stack that never left the profiler is not an attribution.
+//
+// The launch sampler captures the launching thread's CPU stack with
+// bpf_get_stackid, which is a frame-pointer walk: it stops at the first
+// frame it cannot follow. When the shim is an adapter injected into someone
+// else's process, the call chain from the probe outwards is
+//
+//	probe -> our callback -> libcupti -> libcudart -> the application
+//
+// and the walk dies in the vendor libraries, which are built without frame
+// pointers. What comes back is one frame - the adapter's own callback - and
+// projecting it hands every GPU kernel's measured time to a call path inside
+// the profiler itself. That is not a weak attribution, it is a false one:
+// the observed CUPTI run on an RTX 3090 reported 100% of the attributed GPU
+// time under "(anonymous namespace)::on_callback", a function that has never
+// launched a kernel in its life. A DWARF unwinder that can walk NVIDIA's
+// libraries is the real fix (Phase 4b); until then the honest answer is to
+// say nothing, and to say how often we had to.
+//
+// A stack rejected here is withheld from the launch, so the launch reaches
+// the sink stackless and projects as [gpu:launch unsampled] - the same
+// unattributed population as a launch the sampler never picked. No duration
+// is scaled, no execution borrows another's call path, and the attributed
+// and unattributed populations still sum to the measured total.
+//
+// # Why "every frame is inside the shim" is not the test
+//
+// There are two deployment shapes, and the naive test would be wrong for one
+// of them:
+//
+//   - Injected adapter (the CUDA case). The shim is a shared object loaded
+//     into a process it did not create. Application code lives in other
+//     modules by construction, so a stack confined to the shim provably
+//     never reached the application.
+//   - Self-contained producer (shim/stub, which the phase gate runs). The
+//     shim IS the program. Its whole legitimate stack - main ->
+//     perfagent_stub_run -> the probe - is "inside the shim", and it is a
+//     perfectly good attribution, because here the profiler and the
+//     application are the same binary. There is no boundary to cross.
+//
+// shimScope tells the two apart from the shim's ELF alone, once, when the
+// consumer is built: a file that carries a PT_INTERP segment (or is ET_EXEC)
+// is a program the kernel can exec, i.e. shape two; anything else is a
+// shared object, i.e. shape one. That is a static, deterministic property of
+// the file the consumer attached to. The obvious alternative - readlink or
+// stat /proc/<pid>/exe per launching pid and compare it to the shim - was
+// rejected: it answers the same question later, per pid, on the hot path,
+// needs PTRACE_MODE_READ on a process that may already have exited, and
+// needs bounded per-pid memoization to stay cheap. Its one advantage is
+// covering a static-PIE producer (ET_DYN with no PT_INTERP), which this
+// classifier calls a library - see the failure modes below.
+//
+// # Failure modes, and which way they fail
+//
+// The guard is built to fail towards silence rather than towards invention.
+// Rejecting a genuine stack loses information; accepting a profiler-only one
+// is the bug this exists to prevent.
+//
+//   - A static-PIE self-contained producer (ET_DYN, no PT_INTERP) is
+//     classified as an injected library, so its legitimate inside-only
+//     stacks are rejected. Information loss, counted, honest.
+//   - A frame whose module the symbolizer could not name proves nothing, so
+//     it is never read as "outside". A stack of nothing but unnamed modules
+//     is therefore rejected too - and counted separately, in
+//     Stats.StacksProfilerOnlyUncertain, because that is a rejection without
+//     proof.
+//   - Module paths are compared by spelling (as configured, absolute, and
+//     symlink-resolved) plus basename. Basename matching is the deliberate
+//     loose end: a target in another mount namespace reports its own
+//     rootfs's path for the shim, which matches none of the three spellings,
+//     and without the basename fallback the shim's own frames would read as
+//     "outside" - a false accept, the direction that must not happen. The
+//     cost is that an application module that happens to share the shim's
+//     basename reads as "inside", which can only cause a rejection.
+//   - An empty ShimPath disables the guard entirely: with no idea which
+//     module is the profiler's, there is no evidence either way, and
+//     rejecting everything on no evidence is destruction, not honesty.
+//     Attach always sets it (it parses that file's USDT notes and opens it
+//     as an executable), so this is a unit-test shape, not a live one.
+//   - A shim whose ELF cannot be read leaves the shape unknown; the guard
+//     stays ON and treats it as injected, which is the lossy direction.
+//
+// BuildID would be a stronger module identity than a path, but pprof.Frame's
+// BuildID is filled in by the pprof builder from /proc/<pid>/maps long after
+// this check runs - the frames the consumer holds carry only what the
+// symbolizer set, which is Name/Module/File/Line/Address. When Phase 4b's
+// map-snapshot work puts a build ID on the frame, this comparison should
+// move to it.
+type shimScope struct {
+	// guarded is false when there is nothing to police: no shim path
+	// configured, or the shim is the program itself.
+	guarded bool
+	// paths holds the accepted spellings of the shim's own module.
+	paths map[string]struct{}
+	// base is the shim's file name, the cross-mount-namespace fallback.
+	base string
+}
+
+// stackVerdict is what shimScope makes of one resolved capture.
+type stackVerdict int
+
+const (
+	// stackAttributable: a frame provably outside the shim, or no boundary
+	// to police in the first place.
+	stackAttributable stackVerdict = iota
+	// stackProfilerOnly: every frame's module is known, and every one of
+	// them is the shim. The walk never reached the application.
+	stackProfilerOnly
+	// stackProfilerOnlyUncertain: no frame is provably outside the shim, but
+	// at least one frame's module is unknown, so "never reached the
+	// application" is the honest assumption rather than a proven fact.
+	stackProfilerOnlyUncertain
+)
+
+// newShimScope classifies the shim the consumer attached to. It reads the
+// file once, at construction; nothing on the capture path touches the
+// filesystem.
+func newShimScope(shimPath string) shimScope {
+	if shimPath == "" {
+		return shimScope{}
+	}
+	if isELFProgram(shimPath) {
+		// The shim is the program. Profiler and application are the same
+		// binary, so "inside the shim" says nothing about attribution.
+		return shimScope{}
+	}
+	s := shimScope{
+		guarded: true,
+		paths:   map[string]struct{}{shimPath: {}},
+		base:    filepath.Base(shimPath),
+	}
+	if abs, err := filepath.Abs(shimPath); err == nil {
+		s.paths[abs] = struct{}{}
+		if real, err := filepath.EvalSymlinks(abs); err == nil {
+			s.paths[real] = struct{}{}
+		}
+	}
+	return s
+}
+
+// isELFProgram reports whether path is a file the kernel can exec directly:
+// ET_EXEC, or an ET_DYN carrying PT_INTERP (a position-independent
+// executable). A shared object is neither. An unreadable or unparseable file
+// reports false, which leaves the guard on - the lossy direction.
+func isELFProgram(path string) bool {
+	f, err := elf.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	if f.Type == elf.ET_EXEC {
+		return true
+	}
+	if f.Type != elf.ET_DYN {
+		return false
+	}
+	for _, p := range f.Progs {
+		if p.Type == elf.PT_INTERP {
+			return true
+		}
+	}
+	return false
+}
+
+// verdict judges one resolved capture. See stackVerdict.
+//
+// It requires POSITIVE evidence that the walk left the shim: one frame in a
+// module that is known and is not the shim's. A frame with no module is
+// evidence of nothing and never counts as an escape, because reading
+// "unknown" as "outside" is exactly the false accept this guard exists to
+// prevent.
+func (s shimScope) verdict(frames []pp.Frame) stackVerdict {
+	if !s.guarded {
+		return stackAttributable
+	}
+	unknown := false
+	for _, f := range frames {
+		if f.Module == "" {
+			unknown = true
+			continue
+		}
+		if !s.isShimModule(f.Module) {
+			return stackAttributable
+		}
+	}
+	if unknown {
+		return stackProfilerOnlyUncertain
+	}
+	return stackProfilerOnly
+}
+
+// isShimModule reports whether a frame's module is the shim's own. Spelling
+// first, then file name - see the failure modes on shimScope for why the
+// basename fallback is there and which way it errs.
+func (s shimScope) isShimModule(module string) bool {
+	if _, ok := s.paths[module]; ok {
+		return true
+	}
+	return filepath.Base(module) == s.base
+}

--- a/gpuprobe/shimscope_test.go
+++ b/gpuprobe/shimscope_test.go
@@ -2,6 +2,7 @@ package gpuprobe
 
 import (
 	"bufio"
+	"debug/elf"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,17 +39,23 @@ func (s *moduleSymbolizer) SymbolizeProcess(_ uint32, ips []uint64) ([]symbolize
 
 func (s *moduleSymbolizer) Close() error { return nil }
 
-// mappedLibrary returns the path of a shared object mapped into this very
-// process, so the deployment-shape tests run against a real ELF rather than
-// a fixture that only claims to be one. A CGO-linked test binary always maps
-// at least libc; a fully static one maps nothing, and the test says so
-// rather than pretending to have checked.
-func mappedLibrary(t *testing.T) string {
+// mappedSharedObjects returns the paths of the shared objects mapped into
+// this very process, so the deployment-shape tests run against real ELF
+// files rather than fixtures that only claim to be one. A CGO-linked test
+// binary always maps at least libc and the dynamic loader.
+//
+// Note what this does NOT do: filter by isELFProgram. An earlier version
+// skipped any mapped library the classifier called a program, which stepped
+// silently around the one file that proves the classifier wrong - see
+// TestAnInterpreterCarryingSharedObjectIsStillALibrary.
+func mappedSharedObjects(t *testing.T) []string {
 	t.Helper()
 	f, err := os.Open("/proc/self/maps")
 	require.NoError(t, err)
 	defer func() { _ = f.Close() }()
 
+	var out []string
+	seen := map[string]bool{}
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		fields := strings.Fields(sc.Text())
@@ -60,13 +67,65 @@ func mappedLibrary(t *testing.T) string {
 		if !strings.HasSuffix(base, ".so") && !strings.Contains(base, ".so.") {
 			continue
 		}
-		if isELFProgram(path) {
+		if !seen[path] {
+			seen[path] = true
+			out = append(out, path)
+		}
+	}
+	require.NotEmpty(t, out,
+		"no shared object mapped into this process; the test binary must be dynamically linked (it is CGO-linked against blazesym)")
+	return out
+}
+
+// mappedLibrary returns one real shared object to stand in for an injected
+// shim.
+func mappedLibrary(t *testing.T) string {
+	t.Helper()
+	return mappedSharedObjects(t)[0]
+}
+
+// hasPTInterp reports whether an ELF carries an interpreter segment.
+func hasPTInterp(t *testing.T, path string) bool {
+	t.Helper()
+	f, err := elf.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	for _, p := range f.Progs {
+		if p.Type == elf.PT_INTERP {
+			return true
+		}
+	}
+	return false
+}
+
+// The counterexample that broke the first version of isELFProgram, pinned.
+//
+// Glibc's libc.so.6 is a shared object that carries a PT_INTERP segment - it
+// is runnable, it prints its own version banner. "Has PT_INTERP" therefore
+// classified it as a program, and a shim .so linked the same way would have
+// switched the guard OFF entirely, in exactly the deployment the guard
+// exists for. DT_SONAME is what actually separates the two, and it is
+// consulted first.
+//
+// This asserts on the real file mapped into this process rather than
+// skipping past it, because a test that skips its own counterexample is not
+// testing.
+func TestAnInterpreterCarryingSharedObjectIsStillALibrary(t *testing.T) {
+	checked := 0
+	for _, so := range mappedSharedObjects(t) {
+		if !hasPTInterp(t, so) {
 			continue
 		}
-		return path
+		checked++
+		assert.False(t, isELFProgram(so),
+			"%s is a shared object that happens to carry PT_INTERP; classifying it as a program would disable the guard", so)
+		assert.True(t, newShimScope(so).guarded,
+			"a shim spelled like %s must still be guarded as an injected library", so)
 	}
-	t.Skip("no shared object mapped into this process; needs a dynamically linked test binary")
-	return ""
+	require.Positive(t, checked,
+		"no PT_INTERP-carrying shared object is mapped into this process, so the counterexample went unchecked; on glibc libc.so.6 is one")
 }
 
 // The two deployment shapes, told apart from the shim's ELF alone.
@@ -81,10 +140,11 @@ func TestShimShapeIsClassifiedFromTheELF(t *testing.T) {
 	assert.False(t, newShimScope("/proc/self/exe").guarded,
 		"a shim that IS the program is the self-contained shape (shim/stub): profiler and application are the same binary, so there is no boundary to police")
 
-	lib := mappedLibrary(t)
-	assert.False(t, isELFProgram(lib), "%s is a shared object, not a program", lib)
-	assert.True(t, newShimScope(lib).guarded,
-		"a shim that is a shared object is the injected shape (the CUPTI adapter): application code lives in other modules by construction")
+	for _, so := range mappedSharedObjects(t) {
+		assert.False(t, isELFProgram(so), "%s is a shared object, not a program", so)
+		assert.True(t, newShimScope(so).guarded,
+			"a shim that is a shared object is the injected shape (the CUPTI adapter): application code lives in other modules by construction")
+	}
 }
 
 // An empty ShimPath is not evidence of anything, so it cannot justify
@@ -132,6 +192,19 @@ func TestVerdictNeedsPositiveEvidenceOfLeavingTheShim(t *testing.T) {
 		// happen.
 		name:   "same shim under another mount namespace's path",
 		frames: []pp.Frame{{Name: "on_callback", Module: "/rootfs/opt/perfagent/libperfagent_cupti.so"}},
+		want:   stackProfilerOnly,
+	}, {
+		// The shim was upgraded under a running process, so the kernel
+		// reports its mapping as deleted. Unstripped, that path matches
+		// neither the spellings nor the basename and the shim's own frame
+		// reads as "outside" - a false accept, during an upgrade, which is
+		// the least observable moment there is.
+		name:   "the shim was replaced while the process had it mapped",
+		frames: []pp.Frame{{Name: "on_callback", Module: shim + " (deleted)"}},
+		want:   stackProfilerOnly,
+	}, {
+		name:   "deleted mapping under another mount namespace's path",
+		frames: []pp.Frame{{Name: "on_callback", Module: "/rootfs" + shim + " (deleted)"}},
 		want:   stackProfilerOnly,
 	}, {
 		name: "a frame with no module proves nothing",
@@ -259,6 +332,12 @@ func TestUnprovenRejectionIsCountedSeparately(t *testing.T) {
 // The guard runs before the stack is parked, so a refused capture never
 // occupies the bounded side table and never gets attached by the other
 // arrival order either.
+//
+// Note what the refusal does NOT do: release the launch it was held for. The
+// guard returns before deferred.take, so the held launch waits exactly as it
+// would for a capture that failed to resolve - for the next batch, for the
+// queue's own bound, or for Flush, which is what releases it here. Bounded
+// and lossless, but it is a wait, not a release.
 func TestRefusedStackIsNeverAttachedInEitherArrivalOrder(t *testing.T) {
 	lib := mappedLibrary(t)
 	sink := &recordingSink{}
@@ -267,7 +346,7 @@ func TestRefusedStackIsNeverAttachedInEitherArrivalOrder(t *testing.T) {
 	sm.put(5, 0x1000)
 
 	// Batched twin first: the launch is held, and the capture that follows
-	// must release it without lending it the refused stack.
+	// must not lend it the refused stack. Flush is what lets it go.
 	apply(t, c, launchBatchWith(4242, 7))
 	apply(t, c, sampledBatchWith(4242, 7, 5, 8))
 	c.Flush()

--- a/gpuprobe/shimscope_test.go
+++ b/gpuprobe/shimscope_test.go
@@ -1,0 +1,281 @@
+package gpuprobe
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pp "github.com/dpsoft/perf-agent/pprof"
+	"github.com/dpsoft/perf-agent/symbolize"
+)
+
+// moduleSymbolizer is fakeSymbolizer with modules: it names each IP
+// "fn_<hex>" exactly the same way, and puts each IP's frame in the module
+// modules[ip]. A missing entry means a frame the symbolizer could not place
+// in any module, which is the "unknown" case the guard must not read as
+// "outside the shim".
+type moduleSymbolizer struct {
+	modules map[uint64]string
+}
+
+func (s *moduleSymbolizer) SymbolizeProcess(_ uint32, ips []uint64) ([]symbolize.Frame, error) {
+	out := make([]symbolize.Frame, 0, len(ips))
+	for _, ip := range ips {
+		out = append(out, symbolize.Frame{
+			Address: ip,
+			Name:    fmt.Sprintf("fn_%x", ip),
+			Module:  s.modules[ip],
+		})
+	}
+	return out, nil
+}
+
+func (s *moduleSymbolizer) Close() error { return nil }
+
+// mappedLibrary returns the path of a shared object mapped into this very
+// process, so the deployment-shape tests run against a real ELF rather than
+// a fixture that only claims to be one. A CGO-linked test binary always maps
+// at least libc; a fully static one maps nothing, and the test says so
+// rather than pretending to have checked.
+func mappedLibrary(t *testing.T) string {
+	t.Helper()
+	f, err := os.Open("/proc/self/maps")
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 6 || !strings.HasPrefix(fields[5], "/") {
+			continue
+		}
+		path := fields[5]
+		base := filepath.Base(path)
+		if !strings.HasSuffix(base, ".so") && !strings.Contains(base, ".so.") {
+			continue
+		}
+		if isELFProgram(path) {
+			continue
+		}
+		return path
+	}
+	t.Skip("no shared object mapped into this process; needs a dynamically linked test binary")
+	return ""
+}
+
+// The two deployment shapes, told apart from the shim's ELF alone.
+//
+// This is the whole basis of the guard: "every frame is inside the shim" is
+// a fatal verdict for an injected adapter and a completely normal stack for
+// a self-contained producer, so the classifier has to be right about which
+// one it is looking at before it judges a single frame.
+func TestShimShapeIsClassifiedFromTheELF(t *testing.T) {
+	assert.True(t, isELFProgram("/proc/self/exe"),
+		"this test binary is a program: ET_EXEC, or a PIE carrying PT_INTERP")
+	assert.False(t, newShimScope("/proc/self/exe").guarded,
+		"a shim that IS the program is the self-contained shape (shim/stub): profiler and application are the same binary, so there is no boundary to police")
+
+	lib := mappedLibrary(t)
+	assert.False(t, isELFProgram(lib), "%s is a shared object, not a program", lib)
+	assert.True(t, newShimScope(lib).guarded,
+		"a shim that is a shared object is the injected shape (the CUPTI adapter): application code lives in other modules by construction")
+}
+
+// An empty ShimPath is not evidence of anything, so it cannot justify
+// rejecting a stack. Attach always sets one - it parses that file's USDT
+// notes - so this is the unit-test shape.
+func TestNoShimPathLeavesTheGuardOff(t *testing.T) {
+	s := newShimScope("")
+	assert.False(t, s.guarded)
+	assert.Equal(t, stackAttributable, s.verdict([]pp.Frame{{Name: "anything"}}),
+		"with no idea which module is the profiler's there is no evidence either way; rejecting everything on no evidence is destruction, not honesty")
+}
+
+func TestVerdictNeedsPositiveEvidenceOfLeavingTheShim(t *testing.T) {
+	const shim = "/opt/perfagent/libperfagent_cupti.so"
+	injected := shimScope{
+		guarded: true,
+		paths:   map[string]struct{}{shim: {}},
+		base:    filepath.Base(shim),
+	}
+
+	tests := []struct {
+		name   string
+		frames []pp.Frame
+		want   stackVerdict
+	}{{
+		// The RTX 3090 run, exactly: the frame-pointer walk died in
+		// libcupti and the only frame that came back was the adapter's own
+		// callback.
+		name:   "only the adapter's own callback",
+		frames: []pp.Frame{{Name: "(anonymous namespace)::on_callback", Module: shim}},
+		want:   stackProfilerOnly,
+	}, {
+		name: "the walk reached the application",
+		frames: []pp.Frame{
+			{Name: "main", Module: "/app/train"},
+			{Name: "cudaLaunchKernel", Module: "/usr/lib/libcudart.so.12"},
+			{Name: "(anonymous namespace)::on_callback", Module: shim},
+		},
+		want: stackAttributable,
+	}, {
+		// The target runs in a container, so its maps report the shim under
+		// the container's own rootfs. Without the basename fallback that
+		// path reads as "outside the shim" and the guard accepts a stack
+		// that never left the profiler - the one direction that must not
+		// happen.
+		name:   "same shim under another mount namespace's path",
+		frames: []pp.Frame{{Name: "on_callback", Module: "/rootfs/opt/perfagent/libperfagent_cupti.so"}},
+		want:   stackProfilerOnly,
+	}, {
+		name: "a frame with no module proves nothing",
+		frames: []pp.Frame{
+			{Name: "0x7f1c00401234"},
+			{Name: "on_callback", Module: shim},
+		},
+		want: stackProfilerOnlyUncertain,
+	}, {
+		name:   "no module anywhere",
+		frames: []pp.Frame{{Name: "0x7f1c00401234"}, {Name: "0x7f1c00405678"}},
+		want:   stackProfilerOnlyUncertain,
+	}, {
+		name: "an unknown module does not weaken real evidence",
+		frames: []pp.Frame{
+			{Name: "0x7f1c00401234"},
+			{Name: "main", Module: "/app/train"},
+			{Name: "on_callback", Module: shim},
+		},
+		want: stackAttributable,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, injected.verdict(tc.frames))
+		})
+	}
+}
+
+// The injected shape end to end: a capture that resolves to frames wholly
+// inside the adapter must not reach the launch. The launch itself is
+// untouched - it ships, stackless, and its GPU time projects as
+// unattributed.
+func TestInjectedShimOnlyStackIsWithheldAndCounted(t *testing.T) {
+	lib := mappedLibrary(t)
+	sink := &recordingSink{}
+	sym := &moduleSymbolizer{modules: map[uint64]string{0x1000: lib, 0x2000: lib}}
+	c, sm, _ := stackConsumer(t, sink, Config{ShimPath: lib, Symbolizer: sym})
+	sm.put(5, 0x2000, 0x1000)
+
+	apply(t, c, sampledBatchWith(4242, 7, 5, 8))
+	apply(t, c, launchBatchWith(4242, 7))
+	c.Flush()
+
+	require.Len(t, sink.launches, 1, "the launch is never dropped for this: only its stack is withheld")
+	assert.Empty(t, sink.launches[0].Launch.CPUStack,
+		"a stack that never left the profiler must not be presented as an attribution")
+	assert.Zero(t, sink.launches[0].Launch.SamplePeriod,
+		"no stack, no period: gpu_sample_period rides only on the attributed population")
+
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.StacksProfilerOnly, "no loss is silent")
+	assert.Zero(t, st.StacksProfilerOnlyUncertain, "every frame's module was known, so the rejection is proven")
+	assert.Zero(t, st.StacksAttached)
+	assert.Equal(t, uint64(1), st.StacksResolved, "the capture did resolve; it was refused afterwards")
+	assert.Zero(t, st.PendingStacks, "a refused stack is not parked waiting for a twin that cannot use it")
+}
+
+// The same injected shim, but the walk got out into the application. That is
+// a real attribution and must be attached untouched.
+func TestInjectedShimStackThatReachesTheApplicationIsKept(t *testing.T) {
+	lib := mappedLibrary(t)
+	sink := &recordingSink{}
+	sym := &moduleSymbolizer{modules: map[uint64]string{0x1000: "/app/train", 0x2000: lib}}
+	c, sm, _ := stackConsumer(t, sink, Config{ShimPath: lib, Symbolizer: sym})
+	sm.put(5, 0x2000, 0x1000)
+
+	apply(t, c, sampledBatchWith(4242, 7, 5, 8))
+	apply(t, c, launchBatchWith(4242, 7))
+	c.Flush()
+
+	require.Len(t, sink.launches, 1)
+	assert.Equal(t, []string{"fn_1000", "fn_2000"}, frameNames(sink.launches[0].Launch.CPUStack),
+		"one frame outside the shim is proof the walk reached the application")
+	assert.Equal(t, uint32(8), sink.launches[0].Launch.SamplePeriod)
+	assert.Zero(t, c.Stats().StacksProfilerOnly)
+	assert.Equal(t, uint64(1), c.Stats().StacksAttached)
+}
+
+// The self-contained shape end to end, which is what the phase gate runs:
+// shim/stub IS the program, its whole stack is "inside the shim", and that
+// is a perfectly good attribution. A guard that rejected this would be
+// testing the wrong thing.
+func TestSelfContainedShimStackIsAnAttribution(t *testing.T) {
+	self, err := os.Executable()
+	require.NoError(t, err)
+	sink := &recordingSink{}
+	sym := &moduleSymbolizer{modules: map[uint64]string{0x1000: self, 0x2000: self}}
+	c, sm, _ := stackConsumer(t, sink, Config{ShimPath: self, Symbolizer: sym})
+	sm.put(5, 0x2000, 0x1000)
+
+	apply(t, c, sampledBatchWith(4242, 7, 5, 8))
+	apply(t, c, launchBatchWith(4242, 7))
+	c.Flush()
+
+	require.Len(t, sink.launches, 1)
+	assert.Equal(t, []string{"fn_1000", "fn_2000"}, frameNames(sink.launches[0].Launch.CPUStack),
+		"main -> perfagent_stub_run is entirely inside the shim and is still the application's own call path")
+	assert.Zero(t, c.Stats().StacksProfilerOnly,
+		"zero by construction for a self-contained producer: there is no boundary to fail to cross")
+	assert.Equal(t, uint64(1), c.Stats().StacksAttached)
+}
+
+// A rejection with no proof behind it is still a rejection - the honest
+// direction - but it is counted apart from the proven ones, because the two
+// have different causes and different fixes.
+func TestUnprovenRejectionIsCountedSeparately(t *testing.T) {
+	lib := mappedLibrary(t)
+	sink := &recordingSink{}
+	sym := &moduleSymbolizer{} // no module for any IP
+	c, sm, _ := stackConsumer(t, sink, Config{ShimPath: lib, Symbolizer: sym})
+	sm.put(5, 0x2000, 0x1000)
+
+	apply(t, c, sampledBatchWith(4242, 7, 5, 8))
+	apply(t, c, launchBatchWith(4242, 7))
+	c.Flush()
+
+	require.Len(t, sink.launches, 1)
+	assert.Empty(t, sink.launches[0].Launch.CPUStack)
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.StacksProfilerOnly, "the uncertain count is a subset, not a separate bucket")
+	assert.Equal(t, uint64(1), st.StacksProfilerOnlyUncertain)
+}
+
+// The guard runs before the stack is parked, so a refused capture never
+// occupies the bounded side table and never gets attached by the other
+// arrival order either.
+func TestRefusedStackIsNeverAttachedInEitherArrivalOrder(t *testing.T) {
+	lib := mappedLibrary(t)
+	sink := &recordingSink{}
+	sym := &moduleSymbolizer{modules: map[uint64]string{0x1000: lib}}
+	c, sm, _ := stackConsumer(t, sink, Config{ShimPath: lib, Symbolizer: sym})
+	sm.put(5, 0x1000)
+
+	// Batched twin first: the launch is held, and the capture that follows
+	// must release it without lending it the refused stack.
+	apply(t, c, launchBatchWith(4242, 7))
+	apply(t, c, sampledBatchWith(4242, 7, 5, 8))
+	c.Flush()
+
+	require.Len(t, sink.launches, 1)
+	assert.Empty(t, sink.launches[0].Launch.CPUStack)
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.StacksProfilerOnly)
+	assert.Zero(t, st.PendingStacks)
+	assert.Zero(t, st.StacksAttached)
+}


### PR DESCRIPTION
Run against a real CUDA workload on an RTX 3090, the profiler produced this:

```
[gpu:kernel:_Z14perfagent_axpyfPKfPfi]                     3089.52us  51.60%
[gpu:kernel:_Z15perfagent_scalePffi]                       2898.07us  48.40%
(anonymous namespace)::on_callback(void*, CUpti_CallbackDomain, ...)  772.77us  12.91%
[gpu:launch]                                                772.77us  12.91%
```

The only CPU frame is **the adapter's own CUPTI callback**. The chain is `probe → our callback → libcupti → libcudart cudaLaunchKernel → application`, and the frame-pointer walk stops at the first vendor frame it cannot follow, so the application's call path never appears.

That is worse than no attribution — GPU time is attributed to the profiler, confidently and specifically. This codebase refuses that class of error everywhere else: it never scales a duration, never lets an unsampled execution borrow a stack, always marks a heuristic join as heuristic.

**This PR makes the profiler withhold an attribution it cannot justify.** The real fix — a DWARF unwinder that walks through NVIDIA's libraries — is Phase 4b. A refused capture ships stackless and projects under `[gpu:launch unsampled]`, exactly like a launch that was never sampled.

## The hard part: two deployment shapes

"Every frame is inside the shim" is not a sufficient test.

- **Injected adapter** — the shim is a `.so` in someone else's process. An all-shim stack never reached the application → refuse.
- **Self-contained producer** (`shim/stub/`, which the phase gate runs) — the shim *is* the program. Its legitimate stack is `main → perfagent_stub_run`, entirely inside the shim → accept. The gate asserts it.

Classified once at construction from the shim's own ELF, layered to fail safe: `ET_EXEC` → program; else `DT_SONAME` present → library (checked first, so a mislabelled file errs toward the guard staying **on**); else `DF_1_PIE` → program; `PT_INTERP` only as a last-resort fallback.

That ordering matters: `PT_INTERP` alone is *not* exclusive to executables — glibc's own `libc.so.6` carries one. An earlier revision keyed on it and would have silently disabled the guard for any shim linked that way. `TestAnInterpreterCarryingSharedObjectIsStillALibrary` now walks every mapped shared object and asserts each `PT_INTERP`-carrying one classifies as a library, failing if it finds none to check.

## Direction of error

Deliberately asymmetric. Over-rejecting loses information but stays honest; accepting a profiler-only stack is the original bug. So: an unknown module never reads as "outside"; a basename collision over-rejects; a static-PIE producer is misread as injected and over-rejects. The `(deleted)` map suffix is stripped before matching — blazesym already does this, but `Config.Symbolizer` is an interface.

Documented residual: a `.so` linked with an explicit `--dynamic-linker` *and* no soname *and* no `DF_1_PIE` would still read as a program.

## Accounting

`Stats.StacksProfilerOnly`, with `StacksProfilerOnlyUncertain` as a documented subset for refusals made without proof. The identity `StacksResolved = StacksAttached + StacksEvicted + StacksProfilerOnly + PendingStacks` holds on every path and is exercised with all four terms non-zero simultaneously.

## Verification

`gpu/projection.go` is comment-only — the honesty invariants are untouched. Full suite green, `-race` clean, `golangci-lint` 0 issues, and the phase gate passes under `cap_bpf,cap_perfmon` in 0.82s with the stub's stacks still attributed, confirming the guard does not fire on the self-contained shape.