### PR TITLE
gpu: the NVIDIA CUPTI adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,10 @@ pmu.txt
 perf-agent
 # GPU shim stub executable (the .so/.a/.o forms are covered above)
 shim/perfagent-gpu-stub
+# The CUDA test workload the NVIDIA adapter is proven against: built by
+# `make -C shim nvidia-workload`, needs the CUDA toolkit, and has no extension
+# for the *.so / *.o rules above to catch.
+shim/nvidia/testdata/cuda_workload
 bench/cmd/scenario/scenario
 bench/cmd/report/report
 

--- a/.superpowers/sdd/cupti-adapter-report.md
+++ b/.superpowers/sdd/cupti-adapter-report.md
@@ -259,3 +259,40 @@ If the profile comes out empty, the first thing to check is whether the semaphor
 5. **`kernel_id` is an FNV-1a hash of the mangled name**, so two kernels whose names collide would merge in the profile. 64-bit FNV over a few dozen distinct names makes that vanishingly unlikely, and the alternative (a pointer-keyed cache) would not survive CUPTI handing back a different copy of the same string.
 6. **Names are emitted mangled.** Demangling would need `__cxa_demangle` and a malloc on the launch path; it belongs on the consumer side.
 7. `cudaGraph` launches are not covered — only the `cudaLaunchKernel` family. A graph-heavy workload would produce execs with no matching launch. `CUpti_ActivityKernel12::graphNodeId` is the hook if that becomes real.
+
+## Controller note — first real-GPU flame graph, and its limit (2026-08-20)
+
+Ran on the RTX 3090, 2000 iters x 2 kernels, period 8:
+
+    [gpu:kernel:_Z14perfagent_axpyfPKfPfi]  3089.52us  51.60%
+    [gpu:kernel:_Z15perfagent_scalePffi]    2898.07us  48.40%
+    [gpu:launch]                             772.77us  12.91%
+    [gpu:launch unsampled]                  5214.82us  87.09%
+
+WORKS: real mangled CUDA kernel names interned and resolved (KnownKernelNames:2);
+exact duration conservation (772.77 + 5214.82 = 5987.59us, nothing scaled); attributed
+share 12.91% == 1/8, matching the configured sampling period on real hardware.
+KernelStacksMissing:0, PendingLaunches:0, PendingNamedEvents:0.
+
+DOES NOT WORK: the only CPU frame is the adapter's OWN callback,
+`(anonymous namespace)::on_callback(...)`. The application's call path above it is
+absent. The chain from the probe to the app is
+probe -> our callback -> libcupti -> libcudart cudaLaunchKernel -> application,
+and the frame-pointer walk (bpf_get_stackid, BPF_F_USER_STACK) stops at the first
+frame it cannot follow. Net effect: GPU time is attributed to THE PROFILER, which is
+confidently wrong — the one failure mode this design avoids everywhere else.
+
+I attempted a quick objdump count of frame-pointer prologues in libcupti/libcudart to
+confirm the cause; the command was malformed (counted `push %rbp` anywhere against
+exported-symbol counts) and proves nothing. The cause is NOT yet established. Candidates
+to test properly: FP absence in the vendor libraries; the walk depth limit; or
+symbolization dropping frames it could not resolve.
+
+CONSEQUENCE FOR PLANNING: Phase 4a deliberately deferred the DWARF unwind driver
+(unwind_common.h's third consumer) on the grounds that frame-pointer stacks were a
+reasonable first cut. This run shows FP stacks are not merely a reduced-fidelity first
+cut for the CUDA path — they yield an actively misleading attribution, because the
+frames that survive are the profiler's own. Phase 4b is therefore REQUIRED for this
+feature to be truthful, not an enhancement. Until it lands, the honest presentation is
+to treat a stack whose deepest frames are all shim/vendor as unattributed rather than
+projecting it under [gpu:launch].

--- a/.superpowers/sdd/cupti-adapter-report.md
+++ b/.superpowers/sdd/cupti-adapter-report.md
@@ -1,0 +1,261 @@
+# NVIDIA CUPTI adapter — build and GPU verification report
+
+Branch `feat/gpu-v2-cupti-adapter`, worktree `.worktrees/gpu-v2-cupti`.
+Hardware: NVIDIA GeForce RTX 3090, driver 610.57.04, CUDA 13.3, CUPTI 2026.2.1.
+Date: 2026-08-20.
+
+## What was built
+
+| Path | What it is |
+|---|---|
+| `shim/nvidia/cupti_adapter.cc` | The adapter. Injected by the CUDA driver via `CUDA_INJECTION64_PATH`; turns CUPTI callbacks and activity records into the frozen USDT records of `shim/core/usdt_abi.h`. |
+| `shim/nvidia/export.map` | Linker version script. `-fvisibility=hidden` alone does **not** give a single-symbol library (see below). |
+| `shim/nvidia/testdata/cuda_workload.cu` | Two-kernel CUDA workload with a self-checking result and the stub's stdin-EOF linger protocol. |
+| `shim/Makefile` | New targets `nvidia`, `nvidia-workload`; `clean` extended. |
+| `cmd/gpu-cuda-profile/main.go` | Sibling of `cmd/gpu-stub-profile`: attaches the consumer to the adapter `.so` and runs the CUDA workload under it. |
+| `.gitignore` | Ignores the built `shim/nvidia/testdata/cuda_workload`. |
+
+`shim/core/` and `shim/stub/` are unmodified apart from the new Makefile targets.
+
+## How it maps onto core/
+
+Exactly the wiring `shim/stub/stub.cc` uses, with CUPTI as the event source:
+
+- `Batch<gpu_launch_v1,32>` and `Batch<gpu_exec_v1,32>` — batched, flushed on the drain tick.
+- `Sampler` — one-in-N over **every** launch; period from `PERFAGENT_GPU_SAMPLE_PERIOD` (default 8).
+- `gpu_launch_sampled_v1` — emitted **unbatched, one record per probe fire**, never through a `Batch`.
+- `KernelNameTable` — `intern()` on first sight from *both* the launch callback and the activity record; replayed once on the unattached→attached edge.
+- `ClockFit` — `(cuptiGetTimestamp, CLOCK_MONOTONIC)` pair resampled every drain tick, under a mutex (activity buffers are decoded on a CUPTI worker thread while the drain thread resamples).
+- `Drainer` — 100 ms (`PERFAGENT_GPU_DRAIN_MS`), calling `cuptiActivityFlushAll(0)`; CUPTI hands buffers over only when full, so this timer is what bounds delivery.
+
+### Decisions taken from the spike, not re-derived
+
+1. `InitializeInjection` carries `__attribute__((visibility("default")))` — `extern "C"` alone is hidden by `-fvisibility=hidden` and the driver then fails silently.
+2. Subscribed domains: `CUPTI_CB_DOMAIN_RUNTIME_API` + `CUPTI_CB_DOMAIN_RESOURCE` only. No `DRIVER_API`.
+3. `cuptiGetTimestamp` is `CLOCK_REALTIME`; conversion to CPU-monotonic is an offset through `ClockFit`. Every `*_ns` on the wire is CPU-monotonic.
+4. `correlationId` is a wrapping uint32; the wire correlation is `(epoch+1) << 32 | id`, so it is never zero. Epochs advance only on the launch path (which sees ids in issue order); the activity path reads the same atomic word and steps the epoch *back* for an id that is implausibly far ahead of the last launched id — a record left over from before the most recent wrap. A backwards jump only counts as a wrap when it exceeds 2^31, so multi-threaded launch reordering does not manufacture epochs.
+5. Own drain timer at 100 ms; `cuptiActivityFlushPeriod` is not used.
+6. `queue_id` is zero on launches (the ABI's "unknown") and comes from `CUpti_ActivityKernel12::streamId` on execs; `device_id` from `deviceId`.
+
+### Launch cbids
+
+CUDA 13 routes `cudaLaunchKernel` through `__cudaLaunchKernel`. All six ids are matched:
+`cudaLaunchKernel_v7000`, `_ptsz_v7000`, `cudaLaunchKernelExC_v11060`, `_ptsz_v11060`,
+`__cudaLaunchKernel_v13000`, `_ptsz_v13000`. On this toolkit the older ids alone would have seen nothing.
+
+### Semaphore gating
+
+`on_launch` takes the launch ordinal and the sampling decision unconditionally (two relaxed atomics — that is what keeps `launch_seq` and the one-in-N period reproducible across an attach that happens mid-run) and then returns immediately if neither `gpu_launch_v1` nor `gpu_launch_sampled_v1` is armed. The name hash, the intern table's mutex and `Batch`'s mutex are all past that gate. Skipped launches are counted in `launch_unattached`; the exec path does the same with `exec_unattached`.
+
+### Every drop is counted
+
+`launch_unattached`, `launch_batch_dropped` (`Batch::dropped()`), `exec_unattached`, `exec_batch_dropped`, `exec_no_clock` (fit not yet seeded), `exec_no_time` (CUPTI reported `start==end==0`), `cupti_dropped` (`cuptiActivityGetNumDroppedRecords`), `buffer_alloc_failed` (an activity buffer CUPTI asked for and we could not allocate), plus `clock_steps` from `ClockFit`. All printed by the `atexit` handler when `PERFAGENT_GPU_LOG` is set.
+
+### Logging
+
+Silent unless `PERFAGENT_GPU_LOG` is set (the library is injected into somebody else's process). `stderr` or `-` means stderr; anything else is a file path opened append/cloexec.
+
+## Commands and output
+
+### Build
+
+```
+$ make -C shim nvidia
+g++ -std=c++17 -O2 -Wall -Wextra -fPIC -fvisibility=hidden -I core -pthread -I core \
+  -I /usr/local/cuda-13.3/targets/x86_64-linux/include -shared -o libperfagent-gpu-nvidia.so \
+  nvidia/cupti_adapter.cc core/batch.cc core/clock.cc core/drain.cc core/sampler.cc \
+  -Wl,--version-script=nvidia/export.map \
+  -L /usr/local/cuda-13.3/targets/x86_64-linux/lib -lcupti \
+  -Wl,-rpath,/usr/local/cuda-13.3/targets/x86_64-linux/lib
+```
+
+No warnings (`-Wall -Wextra`).
+
+```
+$ make -C shim nvidia-workload
+/usr/local/cuda-13.3/bin/nvcc -O2 -g -lineinfo -arch=sm_86 \
+  -Xcompiler -fno-omit-frame-pointer -Xcompiler -rdynamic -o nvidia/testdata/cuda_workload \
+  nvidia/testdata/cuda_workload.cu
+```
+
+`-fno-omit-frame-pointer` and no strip are deliberate: the sampled launch stacks are symbolized against this binary.
+
+### The four probes
+
+```
+$ readelf -n shim/libperfagent-gpu-nvidia.so | grep -E "Provider|Name:|Arguments"
+    Provider: perfagent
+    Name: gpu_launch_v1
+    Arguments: 8@%rdi 8@%rsi 8@%rdx
+    Provider: perfagent
+    Name: gpu_exec_v1
+    Arguments: 8@%rdi 8@%rsi 8@%rdx
+    Provider: perfagent
+    Name: gpu_kernel_name_v1
+    Arguments: 8@%rdi 8@%rsi 8@%rdx
+    Provider: perfagent
+    Name: gpu_launch_sampled_v1
+    Arguments: 8@%rdi 8@%rsi 8@%rdx
+```
+
+Parsed by the consumer's own parser (`internal/usdt.ParseFile`), which is the code path `gpuprobe.Attach` uses:
+
+```
+perfagent:gpu_launch_v1         offset=0x7b0   sem=true semoff=0x6150 args="8@%rdi 8@%rsi 8@%rdx"
+perfagent:gpu_exec_v1           offset=0x7d0   sem=true semoff=0x6152 args="8@%rdi 8@%rsi 8@%rdx"
+perfagent:gpu_kernel_name_v1    offset=0x918   sem=true semoff=0x6156 args="8@%rdi 8@%rsi 8@%rdx"
+perfagent:gpu_launch_sampled_v1 offset=0x228d  sem=true semoff=0x6154 args="8@%rdi 8@%rsi 8@%rdx"
+```
+
+All four have semaphores, so `Attach` will not reject any of them.
+
+### Exports
+
+```
+$ nm -D --defined-only shim/libperfagent-gpu-nvidia.so
+0000000000000fb0 T InitializeInjection
+```
+
+Before the version script was added this listed 16 symbols: `std::thread::_State_impl` for `Drainer`'s lambda, `std::function`'s manager thunks, and their typeinfo/vtables — vague-linkage instantiations that `-fvisibility=hidden` cannot touch because libstdc++ declares `namespace std` with `_GLIBCXX_VISIBILITY(default)`. Several carried `perfagent::Drainer` in their mangled names, i.e. `core/` was leaking into the host process's dynamic symbol table. `nvidia/export.map` is what fixes it.
+
+### The workload links no CUPTI
+
+```
+$ ldd shim/nvidia/testdata/cuda_workload | grep -i "cupti\|cuda"
+(no output)
+```
+
+So the injection really is the driver's doing, not a link-time dependency.
+
+### Unattached run — the requested gate
+
+```
+$ cd shim && CUDA_INJECTION64_PATH=$PWD/libperfagent-gpu-nvidia.so \
+    PERFAGENT_GPU_LOG=stderr PERFAGENT_GPU_SAMPLE_PERIOD=8 \
+    ./nvidia/testdata/cuda_workload 2000 200 0
+perfagent-cupti: initialized pid=353853 sample_period=8 drain_ms=100 clock_offset_ns=1787179217714814364
+workload: iters=2000 launches=4000 elapsed_ms=541.3 abs_err=0.000000 y[0]=2.000000
+perfagent-cupti: exit pid=353853 launches=4000 sampled=500 period=8 launch_unattached=4000 \
+  launch_batch_dropped=0 activity_kernels=4000 activity_other=0 buffers=6 buffer_alloc_failed=0 \
+  exec_unattached=4000 exec_batch_dropped=0 exec_no_clock=0 exec_no_time=0 cupti_dropped=0 \
+  names=0 clock_steps=0 clock_offset_ns=1787179217714814264
+perfagent-cupti: resource cbid=1 count=1
+perfagent-cupti: resource cbid=5 count=1
+perfagent-cupti: resource cbid=6 count=1
+perfagent-cupti: resource cbid=8 count=4000
+exit=0
+```
+
+Reading it:
+
+- `InitializeInjection` ran in a real CUDA process (the `initialized` line), and the clock fit seeded.
+- 4000 launches observed = 2000 iterations x 2 kernels. Exact.
+- 500 sampled = 4000 / 8. Exact, deterministic.
+- **Everything dropped, nothing emitted**: `launch_unattached=4000`, `exec_unattached=4000`, `names=0` (interning is behind the name semaphore too). No probe ever fired.
+- 4000 activity kernel records — one per launch, none lost by CUPTI.
+- The workload still computed the right answer: `abs_err=0.000000`, exit 0.
+- `clock_steps=0`; the offset moved 100 ns over the run (pure NTP slew, three orders of magnitude below the 1 ms step threshold).
+
+Baseline for comparison, without injection: `elapsed_ms=528.2 abs_err=0.000000 y[0]=2.000000`, exit 0.
+
+### Sampling period varies from the environment
+
+```
+$ PERFAGENT_GPU_SAMPLE_PERIOD=4 ... ./nvidia/testdata/cuda_workload 20000 0 0
+launches=40000 sampled=10000 period=4 launch_unattached=40000 activity_kernels=40000
+  buffers=3 exec_unattached=40000 cupti_dropped=0 clock_steps=0    (elapsed_ms=115.0)
+
+$ PERFAGENT_GPU_SAMPLE_PERIOD=1 ... ./nvidia/testdata/cuda_workload 500 0 0
+launches=1000 sampled=1000 period=1 launch_unattached=1000 activity_kernels=1000
+  buffers=1 exec_unattached=1000 cupti_dropped=0 clock_steps=0     (elapsed_ms=4.0)
+```
+
+40000/4 = 10000 and 1000/1 = 1000, both exact. At 40000 launches in 115 ms — 348k launches/s — CUPTI dropped nothing.
+
+### Unattached injection overhead
+
+20000 iterations, no sleep, three runs each:
+
+| | run 1 | run 2 | run 3 |
+|---|---|---|---|
+| no injection | 82.7 ms | 81.5 ms | 77.7 ms |
+| injected, no consumer | 109.9 ms | 111.7 ms | 111.3 ms |
+
++37% at ~480k launches/s. Almost none of that is the adapter: past the semaphore gate its unattached path is two relaxed atomics and a branch. It is the cost of having CUPTI instrumented at all — the activity record CUPTI writes for every kernel, plus a `CUPTI_CBID_RESOURCE_MODULE_PROFILED` resource callback that fires **once per launch** (cbid 8 above: 4000 for 4000 launches, 40000 for 40000). That callback is a consequence of the RESOURCE domain subscription the spike settled on. It costs one relaxed atomic on our side; the callback dispatch itself is CUPTI's.
+
+### Go side
+
+```
+$ go build ./...            # BUILD OK
+$ go vet ./...              # clean
+$ go test ./gpu/... ./gpuprobe/... ./internal/...
+ok  github.com/dpsoft/perf-agent/gpu       3.569s
+ok  github.com/dpsoft/perf-agent/gpuprobe  0.824s
+ok  github.com/dpsoft/perf-agent/internal/bpfstack   0.006s
+ok  github.com/dpsoft/perf-agent/internal/gpuabi     0.007s
+ok  github.com/dpsoft/perf-agent/internal/k8slabels  0.007s
+ok  github.com/dpsoft/perf-agent/internal/nspid      0.005s
+ok  github.com/dpsoft/perf-agent/internal/perfdata   0.234s
+ok  github.com/dpsoft/perf-agent/internal/perfevent  0.003s
+ok  github.com/dpsoft/perf-agent/internal/usdt       0.158s
+$ make -C shim test         # batch/clock/drain/sampler/probe_args/usdt_abi all OK
+```
+
+## What could NOT be verified here
+
+This shell has `CapEff: 0000000000000000`, so no BPF program could be loaded and **no probe was ever armed**. Everything below is unproven and needs the privileged run:
+
+1. That a probe fires at all. The semaphore has never been non-zero in any run above, so no `PERFAGENT_USDT_PROBE3` has executed in this library. The probe *mechanics* are proven by `shim/core/probe_args_test.cc` and by the stub's end-to-end gate, and the notes are byte-identical in structure, but this `.so` has not been observed emitting.
+2. That the uprobe refcount arms probes in a process that maps the `.so` **after** attach. `cmd/gpu-cuda-profile` attaches system-wide (PID 0) because the CUDA process does not exist yet; the kernel is expected to bump the semaphore when the driver maps the library. Not exercised.
+3. That the launch/exec correlation join produces matched pairs in `gpu.Timeline`. The epoch prefix and the activity-side epoch step-back are unit-reasoned, not observed against a consumer.
+4. That `CUpti_ActivityKernel12`'s `start`/`end`, converted through `ClockFit`, land after the launch's `time_ns` on the same monotonic scale. The conversion runs, but nothing has read the result.
+5. That sampled launch stacks symbolize to named frames of `cuda_workload` (and how far into `libcudart`/`libcuda` they reach). `-fno-omit-frame-pointer` was applied to the workload's host code only; the CUDA runtime is not built with it, so the stack may be shallow.
+6. `golangci-lint` is not installed on this machine, so the repo's lint gate was not run. `go vet ./...` is clean.
+7. The correlation wrap path. 2^32 ids is ~2.2 h at the spike's rate; no run here came near it.
+
+## The privileged end-to-end run
+
+```bash
+cd /home/diego/github/perf-agent/.worktrees/gpu-v2-cupti
+
+# 1. The adapter and the workload (no privileges needed)
+make -C shim nvidia nvidia-workload
+
+# 2. The consumer binary is already built at /home/diego/gpu-cuda-profile
+#    (static blazesym; `ldd` shows only libc/libgcc). To rebuild:
+#      mkdir -p /tmp/bzstatic && cp /home/diego/github/blazesym/target/release/libblazesym_c.a /tmp/bzstatic/
+#      export CGO_CFLAGS="-I /usr/include/bpf -I /usr/include/pcap -I /home/diego/github/blazesym/capi/include"
+#      CGO_LDFLAGS="-L/tmp/bzstatic -lblazesym_c" go build -o /home/diego/gpu-cuda-profile ./cmd/gpu-cuda-profile
+
+# 3. Capabilities. Not /tmp — it is nosuid and file caps do not survive exec there.
+sudo setcap cap_bpf,cap_perfmon+ep /home/diego/gpu-cuda-profile
+
+# 4. Run it. No sudo.
+/home/diego/gpu-cuda-profile \
+  -shim   /home/diego/github/perf-agent/.worktrees/gpu-v2-cupti/shim/libperfagent-gpu-nvidia.so \
+  -workload /home/diego/github/perf-agent/.worktrees/gpu-v2-cupti/shim/nvidia/testdata/cuda_workload \
+  -iters 2000 -sleep-us 200 -period 8 \
+  -out /home/diego/gpu-cuda.pb.gz
+
+# 5. Read it
+go tool pprof -http=: /home/diego/gpu-cuda.pb.gz
+```
+
+What a good run looks like:
+
+- The adapter's own `exit` line should now show `launch_unattached=0`, `exec_unattached=0`, `names=2` (`perfagent_axpy` and `perfagent_scale`, mangled), and `launch_batch_dropped`/`exec_batch_dropped` near zero.
+- `launches=4000 sampled=500 period=8`.
+- The command's final line prints `expected_sampled=500` next to `stats=...`; `SampledLaunches` should equal it, and `StacksResolved` should be most of it.
+- Non-zero `KernelDropped`, `SequenceGaps` or `Malformed` in `stats` is a real finding, not noise.
+
+If the profile comes out empty, the first thing to check is whether the semaphore was ever armed: run the workload by hand with `PERFAGENT_GPU_LOG=stderr` while the command is attached, and see whether `launch_unattached` is still equal to `launches`.
+
+## Concerns
+
+1. **Nothing in this library has ever emitted a record.** Every claim above is about the unattached path. The armed path is unexercised code.
+2. **`CUPTI_CBID_RESOURCE_MODULE_PROFILED` fires once per launch.** It is the only per-launch cost the RESOURCE subscription imposes, and this adapter reads none of the resource events. If the overhead matters, the subscription is the thing to revisit — but the spike settled on this set, so I did not change it.
+3. **The activity-side epoch step-back is a heuristic**, correct only while the lag between a launch and its activity record is far shorter than a wrap (100 ms drain vs ~2.2 h). That holds by three orders of magnitude, but it is an assumption, not a proof.
+4. **`aligned_alloc` in `buffer_requested` can return null** under memory pressure. The adapter then returns a null pointer with size 0 and counts the refusal in `buffer_alloc_failed`. CUPTI's behaviour on a declined request is **not documented** — whether it retries, drops silently, or counts the records in `cuptiActivityGetNumDroppedRecords` is unknown, and unexercised here. The refusal itself is at least never silent.
+5. **`kernel_id` is an FNV-1a hash of the mangled name**, so two kernels whose names collide would merge in the profile. 64-bit FNV over a few dozen distinct names makes that vanishingly unlikely, and the alternative (a pointer-keyed cache) would not survive CUPTI handing back a different copy of the same string.
+6. **Names are emitted mangled.** Demangling would need `__cxa_demangle` and a malloc on the launch path; it belongs on the consumer side.
+7. `cudaGraph` launches are not covered — only the `cudaLaunchKernel` family. A graph-heavy workload would produce execs with no matching launch. `CUpti_ActivityKernel12::graphNodeId` is the hook if that becomes real.

--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -1,0 +1,167 @@
+// Attaches to the NVIDIA CUPTI adapter, runs a real CUDA workload under it,
+// and writes gpu-cuda.pb.gz through the existing pprof builder.
+//
+// This is cmd/gpu-stub-profile with the synthetic producer replaced by an
+// actual GPU. The adapter is not executed: it is a shared object the CUDA
+// driver loads into the workload through CUDA_INJECTION64_PATH, so this
+// command attaches its uprobes to the .so by path (system-wide, since the
+// process it will be mapped into does not exist yet) and then starts the
+// workload with that environment variable set.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/dpsoft/perf-agent/gpu"
+	"github.com/dpsoft/perf-agent/gpuprobe"
+	"github.com/dpsoft/perf-agent/pprof"
+	"github.com/dpsoft/perf-agent/symbolize"
+)
+
+func main() {
+	var (
+		shim     = flag.String("shim", "./shim/libperfagent-gpu-nvidia.so", "the CUPTI adapter .so carrying the perfagent USDT probes")
+		workload = flag.String("workload", "./shim/nvidia/testdata/cuda_workload", "CUDA program to run under the adapter")
+		iters    = flag.Int("iters", 2000, "workload iterations; it launches two kernels per iteration")
+		sleepUs  = flag.Int("sleep-us", 200, "workload sleep between iterations, in microseconds")
+		period   = flag.Int("period", 8, "one-in-N launch sampling period (PERFAGENT_GPU_SAMPLE_PERIOD)")
+		linger   = flag.Int("linger-ms", 30000, "how long the workload may wait to be released after it finishes")
+		out      = flag.String("out", "gpu-cuda.pb.gz", "output pprof profile")
+	)
+	flag.Parse()
+
+	shimPath, err := filepath.Abs(*shim)
+	if err != nil {
+		log.Fatalf("shim path: %v", err)
+	}
+	// The driver dlopens this by the exact string in CUDA_INJECTION64_PATH,
+	// and the uprobes are attached to the path resolved here. If the two ever
+	// disagreed the probes would sit on a file nothing maps and the run would
+	// silently produce an empty profile, so both come from one variable.
+	if _, err := os.Stat(shimPath); err != nil {
+		log.Fatalf("adapter %s: %v (build it with: make -C shim nvidia)", shimPath, err)
+	}
+
+	timeline := gpu.NewTimeline(gpu.TimelineConfig{})
+	// Without a symbolizer the sampled launch stacks still arrive and are
+	// still accounted for, but every one of them degrades to no stack — the
+	// profile would then be honest and useless, all GPU time unattributed.
+	sym, err := symbolize.NewLocalSymbolizer()
+	if err != nil {
+		log.Fatalf("symbolizer: %v", err)
+	}
+	defer func() { _ = sym.Close() }()
+
+	c, err := gpuprobe.Attach(gpuprobe.Config{
+		ShimPath: shimPath,
+		// PID 0: the process that will map the adapter has not been started
+		// yet, so the attachment has to be system-wide. The semaphore the
+		// uprobe refcount maintains is what arms the probes in it once the
+		// driver maps the .so.
+		PID:        0,
+		Backend:    gpu.BackendCUPTI,
+		Sink:       timeline,
+		Symbolizer: sym,
+	})
+	if err != nil {
+		log.Fatalf("attach: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := c.Run(ctx); err != nil {
+			log.Printf("consumer: %v", err)
+		}
+	}()
+
+	// The sampler is deterministic one-in-N over every launch, and the
+	// workload launches exactly two kernels per iteration, so the expected
+	// count is exact rather than approximate.
+	launches := *iters * 2
+	wantSampled := (launches + *period - 1) / *period
+
+	cmd := exec.Command(*workload,
+		fmt.Sprint(*iters), fmt.Sprint(*sleepUs), fmt.Sprint(*linger))
+	cmd.Env = append(os.Environ(),
+		"CUDA_INJECTION64_PATH="+shimPath,
+		fmt.Sprintf("PERFAGENT_GPU_SAMPLE_PERIOD=%d", *period),
+		"PERFAGENT_GPU_LOG=stderr",
+	)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	// Same release protocol as the stub: the workload's CPU stacks are
+	// symbolized against /proc/<pid>/maps, which the kernel destroys the
+	// instant it exits, so we hold its stdin open until the consumer has
+	// counted what it needs.
+	release, err := cmd.StdinPipe()
+	if err != nil {
+		log.Fatalf("workload stdin: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		log.Fatalf("workload: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Duration(*linger) * time.Millisecond)
+	for c.Stats().SampledLaunches < uint64(wantSampled) {
+		if time.Now().After(deadline) {
+			log.Printf("WARNING: only %d/%d sampled launches observed before the workload was released; "+
+				"stacks that arrive after it exits cannot be symbolized",
+				c.Stats().SampledLaunches, wantSampled)
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if err := release.Close(); err != nil {
+		log.Fatalf("release workload: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		log.Fatalf("workload: %v", err)
+	}
+	// The adapter's atexit handler runs cuptiActivityFlushAll and flushes
+	// both batches before the process leaves, so everything is in the ringbuf
+	// by now. This sleep is for the consumer goroutine to drain the tail of
+	// batched launches and executions — none of which carries a stack, so
+	// none of it needs the workload alive.
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	<-done
+	// Release any launch still held for a sampled twin before the snapshot.
+	c.Flush()
+
+	snap := timeline.Snapshot()
+	samples := gpu.ProjectExecutions(snap)
+	if len(samples) == 0 {
+		log.Fatal("no samples projected; the pipeline produced nothing")
+	}
+
+	builders := pprof.NewProfileBuilders(pprof.BuildersOptions{SampleRate: 1})
+	for i := range samples {
+		builders.AddSample(&samples[i])
+	}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, b := range builders.Builders {
+		if _, err := b.Write(f); err != nil {
+			log.Fatalf("write profile: %v", err)
+		}
+		break
+	}
+	if err := f.Close(); err != nil {
+		log.Fatalf("close %s: %v", *out, err)
+	}
+	st := c.Stats()
+	log.Printf("wrote %s: %d samples, launches=%d expected_sampled=%d stats=%+v",
+		*out, len(samples), launches, wantSampled, st)
+}

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -2,6 +2,8 @@
 #   all         libperfagent-gpu-core.a
 #   test        fast unit tests: batch, clock, drain, and the C11 ABI header
 #   test-tsan   the concurrency case under ThreadSanitizer (clang++ only)
+#   nvidia      libperfagent-gpu-nvidia.so, the CUPTI adapter (needs the CUDA toolkit)
+#   nvidia-workload  the CUDA test workload the adapter is proven against
 #   clean
 CXX ?= c++
 CC ?= cc
@@ -10,10 +12,19 @@ CC ?= cc
 TSAN_CXX ?= clang++
 CXXFLAGS ?= -std=c++17 -O2 -Wall -Wextra -fPIC -fvisibility=hidden -I core
 
+# The CUDA toolkit is not a build dependency of perf-agent: only the `nvidia`
+# targets need it, and they are not reachable from `all` or `test`.
+CUDA_HOME ?= /usr/local/cuda-13.3
+CUDA_INC := $(CUDA_HOME)/targets/x86_64-linux/include
+CUDA_LIB := $(CUDA_HOME)/targets/x86_64-linux/lib
+NVCC ?= $(CUDA_HOME)/bin/nvcc
+# sm_86 is the RTX 3090 this adapter was proven on.
+CUDA_ARCH ?= sm_86
+
 CORE_SRC := core/batch.cc core/clock.cc core/drain.cc core/sampler.cc
 CORE_OBJ := $(CORE_SRC:.cc=.o)
 
-.PHONY: all test test-tsan clean
+.PHONY: all test test-tsan nvidia nvidia-workload clean
 all: libperfagent-gpu-core.a
 
 libperfagent-gpu-core.a: $(CORE_OBJ)
@@ -27,6 +38,29 @@ perfagent-gpu-stub: stub/stub.cc $(CORE_SRC)
 
 libperfagent-gpu-stub.so: stub/stub.cc $(CORE_SRC)
 	$(CXX) $(CXXFLAGS) -pthread -I core -shared -o $@ stub/stub.cc $(CORE_SRC)
+
+# The CUPTI adapter. The CUDA driver dlopens this through CUDA_INJECTION64_PATH
+# into a process that links no CUPTI of its own, so the rpath is load-bearing:
+# libcupti.so is not on the default loader path and the injected process has no
+# reason to have it there.
+#
+# -fvisibility=hidden comes from CXXFLAGS and is what keeps core/ from leaking
+# symbols into somebody else's address space; InitializeInjection carries an
+# explicit default-visibility attribute to survive it (see cupti_adapter.cc).
+nvidia: libperfagent-gpu-nvidia.so
+libperfagent-gpu-nvidia.so: nvidia/cupti_adapter.cc nvidia/export.map $(CORE_SRC)
+	$(CXX) $(CXXFLAGS) -pthread -I core -I $(CUDA_INC) -shared -o $@ \
+		nvidia/cupti_adapter.cc $(CORE_SRC) \
+		-Wl,--version-script=nvidia/export.map \
+		-L $(CUDA_LIB) -lcupti -Wl,-rpath,$(CUDA_LIB)
+
+# Not stripped, and built with -g: a sampled launch's CPU stack is symbolized
+# against this binary's own symbols, so a stripped workload would prove the
+# pipeline runs and name nothing in it.
+nvidia-workload: nvidia/testdata/cuda_workload
+nvidia/testdata/cuda_workload: nvidia/testdata/cuda_workload.cu
+	$(NVCC) -O2 -g -lineinfo -arch=$(CUDA_ARCH) \
+		-Xcompiler -fno-omit-frame-pointer -Xcompiler -rdynamic -o $@ $<
 
 # core/probe_args_test.cc is the one test here built with -O2, and that is not
 # a detail: it checks that the record a probe points at has actually been
@@ -58,4 +92,5 @@ test-tsan: core/batch_test.cc core/batch.cc core/batch.h core/sampler_test.cc co
 		-o /tmp/sampler_test_tsan core/sampler_test.cc core/sampler.cc && /tmp/sampler_test_tsan
 
 clean:
-	rm -f $(CORE_OBJ) libperfagent-gpu-core.a perfagent-gpu-stub libperfagent-gpu-stub.so
+	rm -f $(CORE_OBJ) libperfagent-gpu-core.a perfagent-gpu-stub libperfagent-gpu-stub.so \
+		libperfagent-gpu-nvidia.so nvidia/testdata/cuda_workload

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -1,0 +1,520 @@
+// The NVIDIA CUPTI adapter: a vendor plug for shim/core's runtime.
+//
+// It is loaded into an ordinary CUDA process by the driver, through
+// CUDA_INJECTION64_PATH, and turns CUPTI's callbacks and activity records
+// into the frozen USDT records in core/usdt_abi.h. Every design point below
+// was measured on an RTX 3090 in the Phase 3 spike; the comments say which.
+//
+// The shape mirrors shim/stub/stub.cc, which wires the same core pieces --
+// Batch, Sampler, KernelNameTable, ClockFit, Drainer -- to synthetic events.
+// If this file emits what the stub emits, the consumer, the BPF program, the
+// stack capture and the projection all work unchanged.
+#include "batch.h"
+#include "clock.h"
+#include "drain.h"
+#include "kernelnames.h"
+#include "sampler.h"
+#include "usdt_abi.h"
+#include "usdt_probe.h"
+
+#include <cupti.h>
+
+#include <atomic>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <mutex>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+// One line per probe: semaphore, enabled/emit thunks, and the frozen wire
+// size the consumer's BPF attach cookie assumes. See PERFAGENT_USDT_EMITTER.
+PERFAGENT_USDT_EMITTER(gpu_launch_v1, 48);
+PERFAGENT_USDT_EMITTER(gpu_exec_v1, 48);
+// gpu_launch_sampled_v1 fires UNBATCHED -- one probe per sampled launch,
+// never through Batch<T,N>. The eBPF consumer captures the calling thread's
+// stack the instant the probe fires, so a batch would staple one stack onto
+// N unrelated launches.
+PERFAGENT_USDT_EMITTER(gpu_launch_sampled_v1, 56);
+PERFAGENT_USDT_EMITTER(gpu_kernel_name_v1, 272);
+
+namespace {
+
+// ---------------------------------------------------------------- logging
+
+// Silent unless PERFAGENT_GPU_LOG names a destination: this library is
+// injected into somebody else's process and must not write to their stderr
+// uninvited. "stderr" or "-" means stderr; anything else is a file path.
+FILE *g_log = nullptr;
+
+void logf(const char *fmt, ...) {
+    if (!g_log) return;
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(g_log, fmt, ap);
+    va_end(ap);
+    fflush(g_log);
+}
+
+void open_log() {
+    const char *dest = getenv("PERFAGENT_GPU_LOG");
+    if (!dest || !*dest) return;
+    if (!strcmp(dest, "stderr") || !strcmp(dest, "-")) { g_log = stderr; return; }
+    g_log = fopen(dest, "ae");
+}
+
+// ------------------------------------------------------------------ clock
+
+uint64_t mono_ns() {
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return (uint64_t)t.tv_sec * 1000000000ULL + (uint64_t)t.tv_nsec;
+}
+
+uint32_t current_tid() { return (uint32_t)syscall(SYS_gettid); }
+
+// cuptiGetTimestamp is CLOCK_REALTIME, not a device clock: 2000/2000 spike
+// trials were bracketed by realtime reads, 0/2000 by monotonic, and the
+// offset sat exactly 37s off TAI. Activity record start/end share that
+// domain. So the conversion to the CPU-monotonic clock every *_ns field on
+// the wire uses is a pure offset -- and the hazard is a realtime STEP, which
+// ClockFit already detects and counts.
+//
+// ClockFit itself is not thread safe (a plain int64 plus a flag) and the
+// activity buffers are decoded on a CUPTI worker thread while the drain
+// thread resamples, so the mutex is required rather than defensive.
+perfagent::ClockFit g_clock;
+std::mutex g_clock_mu;
+
+void resample_clock() {
+    uint64_t vendor = 0;
+    if (cuptiGetTimestamp(&vendor) != CUPTI_SUCCESS) return;
+    const uint64_t mono = mono_ns();
+    std::lock_guard<std::mutex> g(g_clock_mu);
+    g_clock.resample(vendor, mono);
+}
+
+// Returns false when the fit has never been seeded, rather than silently
+// converting to a nonsense zero-based timestamp.
+bool vendor_to_mono(uint64_t vendor_ns, uint64_t *out) {
+    std::lock_guard<std::mutex> g(g_clock_mu);
+    if (!g_clock.valid()) return false;
+    *out = g_clock.to_monotonic(vendor_ns);
+    return true;
+}
+
+// ------------------------------------------------------------ correlation
+
+// CUPTI's correlationId is a process-wide uint32 counter that WRAPS: at the
+// 542k launches/s measured in the spike, 2^32 is exhausted in about 2.2
+// hours, and §6.1 requires a unique, non-zero correlation. So the wire
+// correlation is (epoch+1) << 32 | id -- epochs are 1-based, which is what
+// makes the result non-zero even for id 0.
+//
+// State is one atomic word, (epoch << 32 | last_id), so an epoch and the id
+// that justified it can never be read torn apart.
+std::atomic<uint64_t> g_corr{0};
+
+// A backwards jump only counts as a wrap if it is enormous. Launches from
+// several threads land here slightly out of order, and a naive `id < last`
+// would promote every one of those reorderings into a new epoch.
+constexpr uint32_t kWrapGuard = 1u << 31;
+
+uint64_t make_corr(uint32_t epoch, uint32_t id) {
+    return ((uint64_t)(epoch + 1) << 32) | (uint64_t)id;
+}
+
+// Called on the launch path, which sees ids in (near) issue order and is
+// therefore the only place the epoch may advance.
+uint64_t correlate_launch(uint32_t id) {
+    uint64_t cur = g_corr.load(std::memory_order_relaxed);
+    for (;;) {
+        const uint32_t last = (uint32_t)cur;
+        const uint32_t epoch = (uint32_t)(cur >> 32);
+        uint32_t next_epoch = epoch;
+        uint64_t next = cur;
+        if (last > id && (uint32_t)(last - id) > kWrapGuard) {
+            next_epoch = epoch + 1;                       // the counter wrapped
+            next = ((uint64_t)next_epoch << 32) | id;
+        } else if (id > last) {
+            next = ((uint64_t)epoch << 32) | id;          // ordinary advance
+        } else {
+            return make_corr(epoch, id);                  // a small reordering
+        }
+        if (g_corr.compare_exchange_weak(cur, next, std::memory_order_relaxed))
+            return make_corr(next_epoch, id);
+    }
+}
+
+// Called on the activity path, which sees ids that were issued in the past
+// and must never move the epoch itself. An id far AHEAD of the last launched
+// id can only be a record left over from before the most recent wrap.
+uint64_t correlate_activity(uint32_t id) {
+    const uint64_t cur = g_corr.load(std::memory_order_relaxed);
+    const uint32_t last = (uint32_t)cur;
+    uint32_t epoch = (uint32_t)(cur >> 32);
+    if (id > last && (uint32_t)(id - last) > kWrapGuard && epoch > 0) epoch--;
+    return make_corr(epoch, id);
+}
+
+// ----------------------------------------------------------- kernel names
+
+// FNV-1a. kernel_id has to be derived from the name alone, because the launch
+// callback and the activity record reach it by different routes and must
+// agree; a pointer-keyed cache would not survive CUPTI handing back a
+// different copy of the same string.
+uint64_t hash_name(const char *s) {
+    uint64_t h = 1469598103934665603ULL;
+    if (!s) s = "<unknown>";
+    for (; *s; s++) {
+        h ^= (unsigned char)*s;
+        h *= 1099511628211ULL;
+    }
+    return h ? h : 1;   // zero is reserved for "no kernel"
+}
+
+// ------------------------------------------------------------------ state
+
+perfagent::Batch<gpu_launch_v1, 32> *g_lb = nullptr;
+perfagent::Batch<gpu_exec_v1, 32> *g_eb = nullptr;
+perfagent::Sampler *g_sampler = nullptr;
+perfagent::KernelNameTable *g_names = nullptr;
+perfagent::Drainer *g_drainer = nullptr;
+CUpti_SubscriberHandle g_subscriber = nullptr;
+
+std::atomic<unsigned long> g_sampled_seq{0};
+std::atomic<unsigned long> g_name_seq{0};
+std::atomic<uint64_t> g_launch_ordinal{0};
+
+// Every discard has a counter. Nothing here is allowed to be silent (§6.1).
+std::atomic<uint64_t> g_launch_unattached{0};   // no consumer at launch time
+std::atomic<uint64_t> g_exec_unattached{0};     // no consumer at activity time
+std::atomic<uint64_t> g_exec_no_clock{0};       // fit not seeded yet
+std::atomic<uint64_t> g_exec_no_time{0};        // CUPTI reported start==end==0
+std::atomic<uint64_t> g_activity_records{0};    // kernel records decoded
+std::atomic<uint64_t> g_activity_other{0};      // records of kinds we ignore
+std::atomic<uint64_t> g_cupti_dropped{0};       // CUPTI's own overflow count
+// Resource callbacks are counted per cbid rather than in one lump: the
+// subscription set is RUNTIME_API + RESOURCE (§spike finding 2) and this
+// adapter reads none of the resource events yet, so the histogram is the only
+// way to see what that subscription actually costs.
+constexpr unsigned kResourceCbidMax = 32;
+std::atomic<uint64_t> g_resource_events[kResourceCbidMax];
+std::atomic<uint64_t> g_buffers{0};
+// A buffer CUPTI asked for and we could not allocate. CUPTI's behaviour on a
+// declined request is not documented, so whatever it does with the records
+// for that window, the refusal itself is on the record here.
+std::atomic<uint64_t> g_buffer_alloc_failed{0};
+
+bool g_names_was_attached = false;
+
+// ------------------------------------------------------------ launch path
+
+// The runtime entry points that submit a kernel. CUDA 13 routes
+// cudaLaunchKernel through __cudaLaunchKernel, so the older ids alone would
+// see nothing on this toolkit; both spellings, and both the default and the
+// per-thread-default-stream variants, are listed.
+bool is_launch_cbid(CUpti_CallbackId cbid) {
+    switch (cbid) {
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000:
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_ptsz_v7000:
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060:
+        case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060:
+        case CUPTI_RUNTIME_TRACE_CBID___cudaLaunchKernel_v13000:
+        case CUPTI_RUNTIME_TRACE_CBID___cudaLaunchKernel_ptsz_v13000:
+            return true;
+        default:
+            return false;
+    }
+}
+
+void emit_name_if_new(uint64_t kernel_id, const char *name) {
+    if (!gpu_kernel_name_v1_enabled()) return;
+    gpu_kernel_name_v1 rec{};
+    if (g_names->intern(kernel_id, name ? name : "<unknown>", &rec) &&
+        gpu_kernel_name_v1_enabled()) {
+        gpu_kernel_name_v1_emit(&rec, 1, g_name_seq.fetch_add(1, std::memory_order_relaxed));
+    }
+}
+
+void on_launch(const CUpti_CallbackData *cb) {
+    // The ordinal and the sampling decision are taken on EVERY launch,
+    // attached or not: two relaxed atomics, and keeping them unconditional is
+    // what makes launch_seq and the one-in-N period reproducible across an
+    // attach that happens mid-run.
+    const uint64_t ordinal = g_launch_ordinal.fetch_add(1, std::memory_order_relaxed);
+    const bool sample = g_sampler->should_sample();
+
+    // The semaphore gate. Everything past this point -- hashing the kernel
+    // name, the intern table's mutex, Batch's mutex -- is work an unprofiled
+    // application must not pay, so the whole path is skipped and the launches
+    // it skipped are counted instead.
+    if (!gpu_launch_v1_enabled() && !gpu_launch_sampled_v1_enabled()) {
+        g_launch_unattached.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    const uint64_t kernel_id = hash_name(cb->symbolName);
+    emit_name_if_new(kernel_id, cb->symbolName);
+
+    const uint64_t now = mono_ns();
+
+    gpu_launch_v1 l{};
+    l.correlation = correlate_launch(cb->correlationId);
+    l.kernel_id = kernel_id;
+    // queue_id stays zero -- the ABI's "unknown". The launch side cannot
+    // derive a stream id that matches the activity record's, and guessing one
+    // would produce a queue that never appears again (§6.3 finding 1).
+    l.queue_id = 0;
+    l.context_id = cb->contextUid;
+    l.time_ns = now;
+    l.tid = current_tid();
+    g_lb->add(l);
+
+    // Unbatched, one record per fire: this probe is the whole reason the
+    // consumer can attribute GPU time to a CPU stack.
+    if (sample && gpu_launch_sampled_v1_enabled()) {
+        gpu_launch_sampled_v1 s{};
+        s.correlation = l.correlation;
+        s.kernel_id = kernel_id;
+        s.queue_id = 0;
+        s.context_id = cb->contextUid;
+        s.time_ns = now;
+        s.tid = l.tid;
+        s.sample_period = g_sampler->period();
+        s.launch_seq = ordinal;
+        gpu_launch_sampled_v1_emit(&s, 1, g_sampled_seq.fetch_add(1, std::memory_order_relaxed));
+    }
+}
+
+void CUPTIAPI on_callback(void *, CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
+                          const void *cbdata) {
+    if (domain == CUPTI_CB_DOMAIN_RESOURCE) {
+        if (cbid < kResourceCbidMax)
+            g_resource_events[cbid].fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    if (domain != CUPTI_CB_DOMAIN_RUNTIME_API) return;
+    const CUpti_CallbackData *cb = (const CUpti_CallbackData *)cbdata;
+    if (cb->callbackSite != CUPTI_API_ENTER) return;
+    if (!is_launch_cbid(cbid)) return;
+    on_launch(cb);
+}
+
+// -------------------------------------------------------------- exec path
+
+// 4 MiB: large enough that a busy process fills one every few tens of ms
+// rather than every millisecond, small enough that the drain timer's forced
+// handover of a partly filled buffer costs nothing.
+constexpr size_t kBufferSize = 4u * 1024 * 1024;
+constexpr size_t kBufferAlign = 8;
+
+void CUPTIAPI buffer_requested(uint8_t **buffer, size_t *size, size_t *max_records) {
+    void *p = aligned_alloc(kBufferAlign, kBufferSize);
+    if (!p) g_buffer_alloc_failed.fetch_add(1, std::memory_order_relaxed);
+    *buffer = (uint8_t *)p;
+    *size = p ? kBufferSize : 0;
+    *max_records = 0;   // pack as many records as fit
+}
+
+void handle_kernel(const CUpti_ActivityKernel12 *k) {
+    g_activity_records.fetch_add(1, std::memory_order_relaxed);
+
+    if (!gpu_exec_v1_enabled()) {
+        g_exec_unattached.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    // CUPTI documents start == end == 0 as "no timestamp could be collected".
+    if (k->start == 0 && k->end == 0) {
+        g_exec_no_time.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    uint64_t start = 0, end = 0;
+    if (!vendor_to_mono(k->start, &start) || !vendor_to_mono(k->end, &end)) {
+        g_exec_no_clock.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    const uint64_t kernel_id = hash_name(k->name);
+    // Intern from this side too: a kernel whose launch happened before the
+    // consumer attached has no name on the wire yet, and the activity record
+    // carries the same string the launch callback would have.
+    emit_name_if_new(kernel_id, k->name);
+
+    gpu_exec_v1 e{};
+    e.correlation = correlate_activity(k->correlationId);
+    e.kernel_id = kernel_id;
+    // The activity record is authoritative for queue and device: this is the
+    // only place a stream id that means anything is available (§6.3 finding 1).
+    e.queue_id = k->streamId;
+    e.device_id = k->deviceId;
+    e.start_ns = start;
+    e.end_ns = end;
+    g_eb->add(e);
+}
+
+void CUPTIAPI buffer_completed(CUcontext, uint32_t, uint8_t *buffer, size_t,
+                               size_t valid_size) {
+    g_buffers.fetch_add(1, std::memory_order_relaxed);
+    if (buffer && valid_size) {
+        CUpti_Activity *record = nullptr;
+        for (;;) {
+            const CUptiResult st = cuptiActivityGetNextRecord(buffer, valid_size, &record);
+            if (st == CUPTI_ERROR_MAX_LIMIT_REACHED) break;
+            if (st != CUPTI_SUCCESS) break;
+            if (record->kind == CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL ||
+                record->kind == CUPTI_ACTIVITY_KIND_KERNEL) {
+                handle_kernel((const CUpti_ActivityKernel12 *)record);
+            } else {
+                g_activity_other.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    }
+    // CUPTI's own overflow. Counted, never silent.
+    size_t dropped = 0;
+    if (cuptiActivityGetNumDroppedRecords(nullptr, 0, &dropped) == CUPTI_SUCCESS && dropped)
+        g_cupti_dropped.fetch_add(dropped, std::memory_order_relaxed);
+    free(buffer);   // free(nullptr) is a no-op, and a declined request lands here too
+}
+
+// ----------------------------------------------------------------- report
+
+void report(const char *why) {
+    logf("perfagent-cupti: %s pid=%d launches=%llu sampled=%llu period=%u "
+         "launch_unattached=%llu launch_batch_dropped=%llu "
+         "activity_kernels=%llu activity_other=%llu buffers=%llu buffer_alloc_failed=%llu "
+         "exec_unattached=%llu exec_batch_dropped=%llu exec_no_clock=%llu "
+         "exec_no_time=%llu cupti_dropped=%llu names=%zu "
+         "clock_steps=%llu clock_offset_ns=%lld\n",
+         why, (int)getpid(),
+         (unsigned long long)g_sampler->observed(),
+         (unsigned long long)g_sampler->sampled(), g_sampler->period(),
+         (unsigned long long)g_launch_unattached.load(),
+         (unsigned long long)g_lb->dropped(),
+         (unsigned long long)g_activity_records.load(),
+         (unsigned long long)g_activity_other.load(),
+         (unsigned long long)g_buffers.load(),
+         (unsigned long long)g_buffer_alloc_failed.load(),
+         (unsigned long long)g_exec_unattached.load(),
+         (unsigned long long)g_eb->dropped(),
+         (unsigned long long)g_exec_no_clock.load(),
+         (unsigned long long)g_exec_no_time.load(),
+         (unsigned long long)g_cupti_dropped.load(),
+         g_names->size(),
+         (unsigned long long)g_clock.steps(),
+         (long long)g_clock.offset_ns());
+    for (unsigned i = 0; i < kResourceCbidMax; i++) {
+        const uint64_t n = g_resource_events[i].load();
+        if (n) logf("perfagent-cupti: resource cbid=%u count=%llu\n", i,
+                    (unsigned long long)n);
+    }
+}
+
+// ------------------------------------------------------------------ drain
+
+// CUPTI hands a buffer back only when it is FULL. On an idle GPU that is up
+// to 15 seconds of nothing, and cuptiActivityFlushPeriod does not help --- it
+// flushes full buffers only. The timer is ours (§10); it bounded delivery to
+// ~100ms in the spike at no measurable cost.
+void on_tick() {
+    // Resample first, so the conversion the flush is about to feed through
+    // ClockFit is the freshest offset available.
+    resample_clock();
+    cuptiActivityFlushAll(0);
+    g_lb->flush();
+    g_eb->flush();
+
+    // Late attach: replay the interned names exactly once, on the
+    // unattached -> attached edge, so an already-attached consumer is not
+    // re-sent the whole table every 100ms (§6.1's replay contract).
+    const bool now_attached = gpu_kernel_name_v1_enabled();
+    if (now_attached && !g_names_was_attached) {
+        g_names->replay([](const gpu_kernel_name_v1 &r) {
+            if (gpu_kernel_name_v1_enabled())
+                gpu_kernel_name_v1_emit(&r, 1, g_name_seq.fetch_add(1, std::memory_order_relaxed));
+        });
+    }
+    g_names_was_attached = now_attached;
+}
+
+// The documented CUPTI shutdown hook. Without it the records still sitting in
+// a partly filled CUPTI buffer at exit are lost, and so is whatever is in the
+// batches.
+void at_exit_handler() {
+    cuptiActivityFlushAll(1);
+    if (g_lb) g_lb->flush();
+    if (g_eb) g_eb->flush();
+    report("exit");
+}
+
+unsigned env_uint(const char *name, unsigned dflt) {
+    const char *v = getenv(name);
+    if (!v || !*v) return dflt;
+    const long n = strtol(v, nullptr, 10);
+    if (n <= 0) return dflt;
+    return (unsigned)n;
+}
+
+bool check(CUptiResult r, const char *what) {
+    if (r == CUPTI_SUCCESS) return true;
+    const char *msg = "?";
+    cuptiGetResultString(r, &msg);
+    logf("perfagent-cupti: %s failed: %s\n", what, msg);
+    return false;
+}
+
+}  // namespace
+
+// The one exported symbol. `extern "C"` alone is NOT enough: this library is
+// built with -fvisibility=hidden, which hides an extern "C" function just as
+// thoroughly as a C++ one, and the CUDA driver then fails to find the entry
+// point and moves on WITHOUT SAYING ANYTHING. That silence cost real time in
+// the spike; the attribute is the fix.
+extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) {
+    static std::atomic<bool> done{false};
+    bool expected = false;
+    if (!done.compare_exchange_strong(expected, true)) return 1;
+
+    open_log();
+
+    // Leaked on purpose, never deleted: CUPTI worker threads keep calling
+    // buffer_completed during process teardown, and a destroyed Batch or
+    // Sampler under them is a use-after-free in somebody else's process.
+    g_lb = new perfagent::Batch<gpu_launch_v1, 32>(gpu_launch_v1_emit, gpu_launch_v1_enabled);
+    g_eb = new perfagent::Batch<gpu_exec_v1, 32>(gpu_exec_v1_emit, gpu_exec_v1_enabled);
+    g_sampler = new perfagent::Sampler(env_uint("PERFAGENT_GPU_SAMPLE_PERIOD", 8));
+    g_names = new perfagent::KernelNameTable();
+    g_drainer = new perfagent::Drainer();
+
+    if (!check(cuptiSubscribe(&g_subscriber, (CUpti_CallbackFunc)on_callback, nullptr),
+               "cuptiSubscribe"))
+        return 0;
+    // RUNTIME_API and RESOURCE only. Adding DRIVER_API more than doubled
+    // correlation-id consumption in the spike (2.242 vs 1.004 ids per launch),
+    // which halves the time to a uint32 wrap, and buys this ABI nothing.
+    check(cuptiEnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_RUNTIME_API),
+          "enable RUNTIME_API");
+    check(cuptiEnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_RESOURCE),
+          "enable RESOURCE");
+
+    check(cuptiActivityRegisterCallbacks(buffer_requested, buffer_completed),
+          "cuptiActivityRegisterCallbacks");
+    check(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL),
+          "enable CONCURRENT_KERNEL");
+
+    // Seed the fit before any activity record can be converted.
+    resample_clock();
+
+    const unsigned drain_ms = env_uint("PERFAGENT_GPU_DRAIN_MS", 100);
+    g_drainer->on_tick(on_tick);
+    g_drainer->start(drain_ms);
+
+    atexit(at_exit_handler);
+
+    logf("perfagent-cupti: initialized pid=%d sample_period=%u drain_ms=%u "
+         "clock_offset_ns=%lld\n",
+         (int)getpid(), g_sampler->period(), drain_ms, (long long)g_clock.offset_ns());
+    return 1;
+}

--- a/shim/nvidia/export.map
+++ b/shim/nvidia/export.map
@@ -1,0 +1,16 @@
+/* The injected library must export exactly one symbol.
+ *
+ * -fvisibility=hidden alone does not achieve that: libstdc++ declares
+ * namespace std with _GLIBCXX_VISIBILITY(default), so the vague-linkage
+ * instantiations this file drags in -- std::thread's _State_impl for
+ * Drainer's lambda, std::function's manager thunks, their typeinfo and
+ * vtables -- come out as exported weak symbols with "perfagent::Drainer" in
+ * their mangled names. Localizing them keeps core/ out of the dynamic symbol
+ * table of whatever process the driver injects us into (spec §6.1).
+ */
+{
+    global:
+        InitializeInjection;
+    local:
+        *;
+};

--- a/shim/nvidia/testdata/cuda_workload.cu
+++ b/shim/nvidia/testdata/cuda_workload.cu
@@ -1,0 +1,134 @@
+// The CUDA workload the NVIDIA adapter is proven against.
+//
+// Two distinct kernels, launched in a loop from two named host functions, so
+// that a sampled launch's captured CPU stack has something to resolve to and
+// the kernel-name table has more than one entry to intern. The result is
+// checked on the host: the point of the unattached run is that the workload
+// still computes the right answer with the adapter injected.
+#include <cuda_runtime.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <poll.h>
+#include <unistd.h>
+
+#define CHECK(call)                                                            \
+    do {                                                                       \
+        const cudaError_t _e = (call);                                         \
+        if (_e != cudaSuccess) {                                               \
+            fprintf(stderr, "workload: %s failed: %s\n", #call,                \
+                    cudaGetErrorString(_e));                                   \
+            exit(2);                                                           \
+        }                                                                      \
+    } while (0)
+
+static const int kN = 1 << 16;
+
+__global__ void perfagent_axpy(float a, const float *x, float *y, int n) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) y[i] = a * x[i] + y[i];
+}
+
+__global__ void perfagent_scale(float *y, float s, int n) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) y[i] = y[i] * s;
+}
+
+// noinline so the sampled stack has a frame that names which kernel was
+// being submitted, rather than one inlined blob of the loop body.
+static __attribute__((noinline)) void launch_axpy(const float *x, float *y) {
+    perfagent_axpy<<<(kN + 255) / 256, 256>>>(2.0f, x, y, kN);
+}
+
+static __attribute__((noinline)) void launch_scale(float *y) {
+    perfagent_scale<<<(kN + 255) / 256, 256>>>(y, 0.5f, kN);
+}
+
+static uint64_t mono_ns() {
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return (uint64_t)t.tv_sec * 1000000000ULL + (uint64_t)t.tv_nsec;
+}
+
+// Same contract as the stub's linger (shim/stub/stub.cc): a sampled launch's
+// CPU stack is symbolized against /proc/<pid>/maps of THIS process, which the
+// kernel destroys the instant it exits. The consumer releases us by closing
+// our stdin; linger_ms is the backstop for a run by hand from a terminal,
+// where stdin never reaches EOF.
+static void linger(unsigned linger_ms) {
+    if (!linger_ms) return;
+    struct pollfd p{};
+    p.fd = STDIN_FILENO;
+    p.events = POLLIN;
+    const uint64_t deadline = mono_ns() + (uint64_t)linger_ms * 1000000ULL;
+    for (;;) {
+        const uint64_t now = mono_ns();
+        if (now >= deadline) return;
+        const int left = (int)((deadline - now) / 1000000ULL) + 1;
+        const int rc = poll(&p, 1, left);
+        if (rc < 0) {
+            if (errno == EINTR) continue;
+            return;
+        }
+        if (rc == 0) return;
+        char buf[256];
+        const ssize_t got = read(STDIN_FILENO, buf, sizeof(buf));
+        if (got <= 0) return;
+    }
+}
+
+int main(int argc, char **argv) {
+    const unsigned iters = argc > 1 ? (unsigned)atoi(argv[1]) : 2000;
+    const unsigned sleep_us = argc > 2 ? (unsigned)atoi(argv[2]) : 200;
+    const unsigned linger_ms = argc > 3 ? (unsigned)atoi(argv[3]) : 0;
+
+    float *x = nullptr, *y = nullptr;
+    CHECK(cudaMalloc(&x, kN * sizeof(float)));
+    CHECK(cudaMalloc(&y, kN * sizeof(float)));
+
+    float *hx = (float *)malloc(kN * sizeof(float));
+    float *hy = (float *)malloc(kN * sizeof(float));
+    for (int i = 0; i < kN; i++) { hx[i] = 1.0f; hy[i] = 0.0f; }
+    CHECK(cudaMemcpy(x, hx, kN * sizeof(float), cudaMemcpyHostToDevice));
+    CHECK(cudaMemcpy(y, hy, kN * sizeof(float), cudaMemcpyHostToDevice));
+
+    const uint64_t t0 = mono_ns();
+    for (unsigned i = 0; i < iters; i++) {
+        launch_axpy(x, y);      // y = 2x + y
+        launch_scale(y);        // y = y/2
+        if ((i % 64) == 63) CHECK(cudaDeviceSynchronize());
+        if (sleep_us) usleep(sleep_us);
+    }
+    CHECK(cudaDeviceSynchronize());
+    const uint64_t t1 = mono_ns();
+    CHECK(cudaGetLastError());
+
+    CHECK(cudaMemcpy(hy, y, kN * sizeof(float), cudaMemcpyDeviceToHost));
+    // Each iteration is y = (2x + y)/2 with x == 1, whose fixed point is
+    // y == 2 -- reached to float precision within ~25 iterations. That single
+    // number checks BOTH kernels: drop the axpy and y decays to 0, drop the
+    // scale and y grows to 2*iters. It is the workload's proof that the
+    // injected adapter did not perturb the computation.
+    const double want = 2.0;
+    double err = 0.0;
+    for (int i = 0; i < kN; i++) {
+        const double d = (double)hy[i] - want;
+        err += d < 0 ? -d : d;
+    }
+    printf("workload: iters=%u launches=%u elapsed_ms=%.1f abs_err=%.6f y[0]=%.6f\n",
+           iters, iters * 2, (double)(t1 - t0) / 1e6, err, (double)hy[0]);
+    fflush(stdout);
+
+    linger(linger_ms);
+
+    CHECK(cudaFree(x));
+    CHECK(cudaFree(y));
+    free(hx);
+    free(hy);
+    // Not cudaDeviceReset(): it tears the context down before the adapter's
+    // atexit flush runs, and the last activity records go with it.
+    return err < 1e-3 ? 0 : 1;
+}


### PR DESCRIPTION
Replaces the synthetic stub with real GPU events. This is the component §6.1 predicted would be *thin* — and it is: `shim/core/` already supplies batching, the sampler, clock pairing, the drain timer, kernel-name interning, the ABI and the probe macros, so the adapter is CUPTI plumbing onto pieces that already work.

Everything downstream is unchanged and already on `main`.

## Proven on an RTX 3090

```
[gpu:kernel:_Z14perfagent_axpyfPKfPfi]   3089.52us  51.60%
[gpu:kernel:_Z15perfagent_scalePffi]     2898.07us  48.40%
[gpu:launch]                              772.77us  12.91%
[gpu:launch unsampled]                   5214.82us  87.09%
```

Real mangled CUDA kernel names, interned and resolved. Duration conservation exact: 772.77 + 5214.82 = 5987.59 µs, nothing scaled. Attributed share **12.91% ≈ 1/8**, matching the configured sampling period — so the sampler, the join and the projection all agree on real hardware.

Unattached, it emits nothing and counts every discard: `launches=4000 sampled=500 activity_kernels=4000 launch_unattached=4000 exec_unattached=4000 cupti_dropped=0 clock_steps=0`, with the workload's numerical result unaffected. Sampling is exact at every period tested (500/4000 at 8, 10000/40000 at 4, 1000/1000 at 1).

## Built on what the spike measured

No re-derivation — the four spike answers are applied directly: `InitializeInjection` needs explicit default visibility (`extern "C"` alone does not survive `-fvisibility=hidden`); subscribe `RUNTIME` + `RESOURCE` only, since `DRIVER` more than doubles correlation-ID consumption; `cuptiGetTimestamp` is `CLOCK_REALTIME`, so conversion runs through `ClockFit`; correlation IDs wrap, so they carry a 32-bit epoch; and CUPTI hands over a buffer only when full, so `core/`'s `Drainer` calls `cuptiActivityFlushAll` on a timer.

## Known limit — read before using the output

**The CPU stack truncates at the vendor-library boundary.** The chain is `probe → our callback → libcupti → libcudart cudaLaunchKernel → application`, and the frame-pointer walk stops at the first frame it cannot follow, so the only frame that survives is the adapter's own callback.

`main` already carries the guard that refuses such a stack rather than attributing GPU time to the profiler (#39), so the output is **honest but unattributed** on the CUDA path: kernels, durations and names are real; CPU call paths are not yet recovered. Phase 4b's DWARF driver — the third consumer of `unwind_common.h` — is what actually reaches the application.

## One finding worth carrying to future adapters

`-fvisibility=hidden` alone did **not** stop symbol leakage: 15 libstdc++ vague-linkage symbols were still exported, several naming `perfagent::Drainer`. §6.1 requires `core/` not to leak into the host process, so the adapter uses an explicit version script (`shim/nvidia/export.map`) exporting only `InitializeInjection`. Any future adapter, ROCm included, needs the same.