### PR TITLE
symbolize: require CAP_CHECKPOINT_RESTORE instead of degrading around it

### DIFF
--- a/.superpowers/sdd/simplify-symbolize-report.md
+++ b/.superpowers/sdd/simplify-symbolize-report.md
@@ -1,0 +1,239 @@
+# Simplifying the symbolization path: require the capability we already document
+
+Branch `refactor/require-checkpoint-restore`, off `origin/main` (`8b7628c5`).
+
+## What was deleted
+
+`symbolize/local.go` went from **357 → 241 lines** (`git diff --numstat`: `100 insertions, 216 deletions`).
+Removed outright:
+
+| Thing | What it was |
+|---|---|
+| `noMapFiles atomic.Bool` | the process-lifetime latch |
+| `disableMapFiles(reason)` | the compare-and-swap that made the log fire exactly once |
+| `canFollowMapFiles()` + `capSysAdmin` / `capCheckpointRestore` consts | the startup `/proc/self/status` `CapEff` bitmask probe |
+| `isPermissionDenied()` | the **string match** on blazesym's `"permission denied"` text |
+| `errSkippedMapFiles` | the stand-in error for a skipped first attempt |
+| `symbolizeMapFiles()` + `mapFilesAttempt` field | the test seam that existed only to inject the two failure kinds the classifier had to tell apart |
+| the `no_map_files` retry in `SymbolizeProcess` | the second resolution path, with its `retryOpts` copy |
+| `LocalStats.MapFilesDisabled`, `.MapFilesDisabledReason`, `.MapFilesPermissionDenied`, `.MapFilesTransientFailure`, `.FallbackRescued` | five fields, and the `atomic.Value` holding the reason string |
+
+`symbolize/local_test.go`: **342 → 266 lines** (`105 / 181`). Gone with the machinery:
+`TestOnlyAPermissionFailureLatchesTheMapFilesFallback` (three subtests, all about
+latch classification) and `TestIsPermissionDenied` (the string-matcher's pin).
+
+Net across the branch: **414 deletions, 245 insertions — 169 lines removed**, of which
+the two Go files account for 397/205.
+
+## What replaced it, and why
+
+`map_files` is now the single resolution path. `NewLocalSymbolizer` calls
+`checkMapFilesAccess()` once and **returns an error** if the process cannot follow a
+magic symlink.
+
+The probe is an actual `open()` of a real `/proc/self/map_files/<start>-<end>` entry,
+not a `CapEff` read. This is strictly better than what it replaces on three counts,
+each verified on this machine (`CapEff: 0`):
+
+1. **It exercises the exact kernel gate.** `proc_map_files_get_link()` is what blazesym
+   trips. A bitmask read guesses at which capability the running kernel consults; this
+   asks it.
+2. **It is not fooled by user namespaces or by Permitted-not-Effective.** The kernel
+   check is `checkpoint_restore_ns_capable(&init_user_ns)`; a capability held only in a
+   nested userns shows up in `CapEff` and does not help.
+3. **It yields a typed errno**, `errors.Is(err, os.ErrPermission)`. That is what removes
+   the dependency on blazesym's error *text* — the C API collapses the errno into an
+   enum, so the string was the only evidence the old code had.
+
+One trap found while building it, and handled in the code: `readlink()` on a `map_files`
+entry **succeeds without the capability** (`proc_pid_readlink` → `map_files_get_link`, no
+`capable()` check); only `open()` goes through `proc_map_files_get_link`. Measured here:
+
+```
+name=56416ac4d000-56416ac4e000 target=/usr/bin/python3.14
+  readlink='/usr/bin/python3.14' err=None
+  open err=PermissionError(1, 'Operation not permitted')
+```
+
+A second trap: the entry name must be `%x-%x` with **no leading zeros**. `/proc/pid/maps`
+pads to word width, and the kernel's `dname_to_vma_addr()` rejects a leading zero with
+`-EINVAL`, which surfaces as `ENOENT` and would have been misread as "mapping vanished".
+The code reformats rather than reusing the maps text.
+
+Only a definite `EPERM` is a verdict. An unreadable `/proc/self/maps`, a process with no
+file-backed mapping, or a mapping unmapped between the read and the `open` returns `nil`:
+a probe that could not decide must never be the reason a profiler refuses to start.
+
+### Hard error, not a log plus a `Stats` flag
+
+The brief left this open. Hard error, for two reasons.
+
+**Nobody reads `LocalStats`.** Before this change, `Stats()` and every `LocalStats` field
+were referenced from exactly two files: `local.go` and `local_test.go`. Not one consumer
+in the repository — not `perfagent/agent.go`, not `profile/`, not `offcpu/`, not
+`gpuprobe/` — ever loaded the flag. A "prominent one-time log plus a `Stats` flag" is
+therefore silent degradation with extra steps: the log scrolls past at startup and is
+gone by the time a sixty-second run writes a `.pb.gz` full of `0x7f...`.
+
+**The output is not degraded, it is useless.** A profile whose every user frame is a bare
+address costs a full run to discover and cannot be read without `addr2line` and the exact
+binaries. Refusing in 5 ms with the `setcap` line is a strictly better trade, and it is
+what this codebase does everywhere else rather than hand back something that looks like a
+result.
+
+### What was kept
+
+`LocalStats.RawAddrBatches` — genuine per-process resolution failures. A pid that exited
+before its `/proc` entry could be read still yields hex-named frames rather than dropping
+the batch (stack shape and addresses are worth keeping) and still returns `err == nil`, so
+`Frame.Reason == FailureMissingSymbols` remains the signal `gpuprobe.Stats.StacksUnresolved`
+consumes. That path is now *counted*, which it was on the old code too, and is real signal.
+
+## How a missing capability surfaces
+
+`NewLocalSymbolizer` returns, wrapping the sentinel `symbolize.ErrMapFilesUnavailable`:
+
+```
+symbolize: cannot follow /proc/<pid>/map_files/ (open /proc/self/map_files/400000-57c000:
+operation not permitted): every user-space frame would resolve to a bare hex address.
+Grant CAP_CHECKPOINT_RESTORE - sudo setcap
+cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep <binary> - or run as root
+```
+
+Every caller already propagates or fails on it: `perfagent/agent.go:246`
+(`chooseSymbolizer` returns it up), `bench/cmd/scenario/main.go` (`log.Fatalf`),
+`cmd/gpu-stub-profile`, `gpuprobe/gate_test.go` (`require.NoError`).
+`symbolize/debuginfod/symbolizer.go:76` deliberately tolerates it — the local symbolizer
+is only its NULL-return fallback there — and that stays as it was.
+
+## Tests
+
+- **`TestLocalSymbolizerRefusesWithoutMapFilesAndResolvesWithIt`** — the new contract,
+  pinned in both directions, **with no skip in either branch**. Without the capability it
+  asserts the constructor refuses with `ErrMapFilesUnavailable` *and* that the message
+  carries the remedy (`CAP_CHECKPOINT_RESTORE`, `cap_checkpoint_restore+ep`, `hex address`).
+  With it, it symbolizes a live libc mapping in this very process and asserts a real name,
+  `Reason == FailureNone`, no `0x` prefix. libc, not the Go test binary: `go test` strips
+  the symbol table from the binary it runs, `go test -c` does not, so libc's `.dynsym` is
+  the target that cannot go missing. This is the test that runs green on `CapEff: 0` today
+  and becomes the real-resolution assertion the moment the capability is granted.
+- **`TestSymbolizeProcessCountsGenuineResolutionFailures`** — new: pid 0 yields one
+  hex-named `FailureMissingSymbols` frame, `err == nil`, `RawAddrBatches == 1`.
+- **`TestLocalSymbolizerSymbolizeSelf`** and **`TestLocalSymbolizerCloseIdempotent`** —
+  kept, now gated by `requireMapFilesAccess(t)`.
+
+On the skip that was removed earlier for masking a bug: `requireMapFilesAccess` gates on
+`checkMapFilesAccess()`, the same probe the constructor uses, which **can only cause a
+false skip, never a false pass** — if the probe wrongly reported access, the constructor
+would proceed and the assertions would run for real and fail. The skip it replaces was
+different in kind: it hid a failure that was present *with* the capability set the gate
+mandated, because the product claimed to work there and did not. That claim is now gone
+from the code and from the docs.
+
+## The gate
+
+`gpuprobe/gate_test.go`: the ad-hoc `hasBPFAndPerfmon` was refactored into a generic
+`hasCaps(want ...cap.Value)`, on top of which:
+
+- `hasBPFAndPerfmon()` — `BPF, PERFMON`. Unchanged semantics; still what
+  `attach_test.go:66` inverts to exercise the unprivileged BPF-load failure.
+- `hasGateCaps()` — `BPF, PERFMON, CHECKPOINT_RESTORE`. Used by
+  `TestStubDrivesThePipelineToPprofWithoutAGPU`.
+
+Skip message now names the capability, the reason, and the fix. The gate's assertions are
+untouched — including `StacksUnresolved == 0` and the per-stack
+`strings.Contains(f.Name, "perfagent_stub_run")` check, which is precisely the assertion
+that the removed fallback used to satisfy through `/proc/<pid>/maps` symbolic paths and
+must now satisfy through `map_files`.
+
+**The gate needs the extra capability at runtime. A human must grant it:**
+
+```bash
+sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep /home/diego/gpuprobe.test
+```
+
+Without it the gate now **skips** with that message rather than passing with hex frames.
+
+## Docs corrected
+
+| File | Change |
+|---|---|
+| `README.md` | New paragraph under the capability table: `cap_checkpoint_restore` (or `cap_sys_admin`) is **required, not optional**; perf-agent checks at startup and refuses rather than write a profile of hex. |
+| `docs/superpowers/plans/2026-08-20-gpu-v2-phase4a-sampled-stacks.md` | Privileged-test setcap line → `cap_bpf,cap_perfmon,cap_checkpoint_restore` (3 occurrences: prose, Step 2, Step 3). Phase-gate item 5 → `getcap` shows the three caps and no `cap_sys_admin`. The "Deferred" note that described the `no_map_files` retry and latch as the fix rewritten to record that it was removed and why. |
+| `docs/superpowers/plans/2026-08-19-gpu-v2-phase3-usdt-transport.md` | Two setcap lines updated; gate item 5 updated, keeping its point that `cap_sys_admin` must not appear and noting `cap_checkpoint_restore` is for symbolization, not the attach. |
+
+Checked and **left alone** because they were already correct:
+`docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md` §11 (already states
+`CAP_CHECKPOINT_RESTORE` (5.9) covers `/proc/<pid>/map_files`), `SECURITY.md`,
+`perfagent/agent.go`'s capability comment, `bench/README.md`, `examples/*/README.md`,
+`docs/superpowers/plans/2026-08-16-gpu-v2-phase1-enablers.md`.
+`CLAUDE.md` already lists `CAP_CHECKPOINT_RESTORE` in the required set and needs no
+correction (it is untracked and is never committed).
+
+`CAP_SYS_ADMIN` was not touched anywhere: the `uprobe_multi` attach path is exactly as it
+was.
+
+## Command output
+
+```
+$ go build ./...
+OK
+$ go vet ./...
+OK
+$ go test ./symbolize/... ./gpuprobe/ ./gpu/ ./internal/... -count=1
+ok  	github.com/dpsoft/perf-agent/symbolize	0.004s
+ok  	github.com/dpsoft/perf-agent/symbolize/debuginfod	0.383s
+ok  	github.com/dpsoft/perf-agent/symbolize/debuginfod/cache	0.024s
+ok  	github.com/dpsoft/perf-agent/gpuprobe	0.897s
+ok  	github.com/dpsoft/perf-agent/gpu	3.436s
+ok  	github.com/dpsoft/perf-agent/internal/bpfstack	0.016s
+ok  	github.com/dpsoft/perf-agent/internal/gpuabi	0.016s
+ok  	github.com/dpsoft/perf-agent/internal/k8slabels	0.016s
+ok  	github.com/dpsoft/perf-agent/internal/nspid	0.015s
+ok  	github.com/dpsoft/perf-agent/internal/perfdata	0.150s
+ok  	github.com/dpsoft/perf-agent/internal/perfevent	0.013s
+ok  	github.com/dpsoft/perf-agent/internal/usdt	0.102s
+
+$ go test ./gpuprobe/ -race -count=1
+ok  	github.com/dpsoft/perf-agent/gpuprobe	1.140s
+
+$ gofmt -l symbolize gpuprobe gpu
+symbolize/debuginfod/elftest_helpers_test.go
+symbolize/debuginfod/stats.go
+symbolize/hist.go
+
+$ ~/go/bin/golangci-lint run --timeout=5m
+0 issues.
+```
+
+The three `gofmt` names are **pre-existing and untouched by this branch** — verified by
+running `gofmt -l` over `git show origin/main:<path>` for each; all three report unformatted
+on `origin/main` too. They are struct-field alignment differences produced by this
+machine's `go1.26.5` `gofmt` against a tree formatted with an older one. No file this
+branch changes is listed.
+
+Verbose run of the changed tests on `CapEff: 0`:
+
+```
+=== RUN   TestLocalSymbolizerRefusesWithoutMapFilesAndResolvesWithIt
+--- PASS: TestLocalSymbolizerRefusesWithoutMapFilesAndResolvesWithIt (0.00s)
+=== RUN   TestSymbolizeProcessCountsGenuineResolutionFailures
+    local_test.go:96: needs CAP_CHECKPOINT_RESTORE: symbolize: cannot follow
+    /proc/<pid>/map_files/ (open /proc/self/map_files/400000-57c000: operation not
+    permitted): every user-space frame would resolve to a bare hex address. Grant
+    CAP_CHECKPOINT_RESTORE - sudo setcap
+    cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep <binary> - or run as root
+--- SKIP: TestSymbolizeProcessCountsGenuineResolutionFailures (0.00s)
+=== RUN   TestLocalSymbolizerSymbolizeSelf
+--- SKIP: TestLocalSymbolizerSymbolizeSelf (0.00s)
+=== RUN   TestLocalSymbolizerCloseIdempotent
+--- SKIP: TestLocalSymbolizerCloseIdempotent (0.00s)
+PASS
+```
+
+## Not verifiable here
+
+This environment has `CapEff: 0`, so the *positive* branch — construction succeeding and
+libc resolving to a real name through `map_files` — and the GPU phase gate itself were not
+run. Both need the `setcap` line above. The negative branch, the probe's typed `EPERM`, and
+the `readlink`-vs-`open` asymmetry the probe depends on were all measured directly.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ See [`docs/perf-data-output.md`](docs/perf-data-output.md) for the per-tool walk
 | `cap_checkpoint_restore` | Follow `/proc/<pid>/map_files/` symlinks during symbolization |
 | `cap_sys_admin` | Only on kernels older than 5.8/5.9 — see below |
 
+`cap_checkpoint_restore` (or `cap_sys_admin`) is **required, not optional**.
+blazesym reaches the file behind every mapping through
+`/proc/<pid>/map_files/`, and the kernel refuses to follow those magic
+symlinks without one of the two — so without it every user-space frame in a
+profile is a bare hex address. perf-agent checks this at startup and refuses
+to run rather than write a profile that looks like a result and is not.
+
 `cap_sys_admin` is kept for backward compatibility. Two capabilities were added
 to the kernel to carve out the roles perf-agent used it for — but they did not
 arrive in the same release:

--- a/docs/superpowers/plans/2026-08-19-gpu-v2-phase3-usdt-transport.md
+++ b/docs/superpowers/plans/2026-08-19-gpu-v2-phase3-usdt-transport.md
@@ -1976,7 +1976,7 @@ Expected: FAIL or SKIP. If it skips, setcap the test binary:
 
 ```bash
 go test -c ./gpuprobe/ -o /home/diego/gpuprobe.test
-sudo setcap cap_bpf,cap_perfmon+ep /home/diego/gpuprobe.test
+sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep /home/diego/gpuprobe.test
 /home/diego/gpuprobe.test -test.run TestStubDrives -test.v
 ```
 
@@ -2074,7 +2074,7 @@ func main() {
 
 ```bash
 go build -o /home/diego/gpu-stub-profile ./cmd/gpu-stub-profile
-sudo setcap cap_bpf,cap_perfmon+ep /home/diego/gpu-stub-profile
+sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep /home/diego/gpu-stub-profile
 /home/diego/gpu-stub-profile && go tool pprof -top gpu-stub.pb.gz | head -20
 ```
 
@@ -2106,7 +2106,7 @@ Phase 3 is done when all of the following hold:
    came out 100% `[gpu:launch]` with no kernel frames, exactly as the deferral
    implies. Symbolized kernel frames are Phase 4's gate, not this one.
 4. The stub, unattached, reports every record dropped and emits nothing.
-5. `getcap` on the test binary shows `cap_bpf,cap_perfmon` only — **no `cap_sys_admin`**. If the attach needs it, the consumer is using the wrong mechanism.
+5. `getcap` on the test binary shows `cap_bpf,cap_perfmon,cap_checkpoint_restore` — **no `cap_sys_admin`**. If the attach needs it, the consumer is using the wrong mechanism. (`cap_checkpoint_restore` is for symbolization, not the attach: blazesym follows `/proc/<pid>/map_files/` and `symbolize.NewLocalSymbolizer` refuses without it.)
 6. **The ABI review has been done on paper** against the rocprofiler bridge's taxonomy on branch `gpu-profiling-spec` (§6.1, §14). Walk `examples/rocprofiler_sdk_preload_bridge.cpp` and confirm each of `gpu_launch_v1`, `gpu_exec_v1`, `gpu_module_load_v1` and `gpu_kernel_name_v1` can be populated from what rocprofiler delivers, or record why not. Do not skip this because NVIDIA ships first — it is the whole reason `core/` is worth having.
 
 ## Deferred to Phase 4, deliberately

--- a/docs/superpowers/plans/2026-08-20-gpu-v2-phase4a-sampled-stacks.md
+++ b/docs/superpowers/plans/2026-08-20-gpu-v2-phase4a-sampled-stacks.md
@@ -36,12 +36,12 @@ export LD_LIBRARY_PATH=/home/diego/github/blazesym/target/release
 
 Run `go test` and `go generate` directly. Do not run `make test-unit`.
 
-Privileged tests need `cap_bpf,cap_perfmon`. Build such binaries **outside `/tmp`** (it is `nosuid`, so file capabilities do not survive exec) and link blazesym statically (a setcap'd binary runs in secure-execution mode and ignores `LD_LIBRARY_PATH`):
+Privileged tests need `cap_bpf,cap_perfmon,cap_checkpoint_restore` — the last one because blazesym resolves every mapping through `/proc/<pid>/map_files/`, and `symbolize.NewLocalSymbolizer` refuses to construct without it rather than hand back a profile of bare hex addresses. Build such binaries **outside `/tmp`** (it is `nosuid`, so file capabilities do not survive exec) and link blazesym statically (a setcap'd binary runs in secure-execution mode and ignores `LD_LIBRARY_PATH`):
 
 ```bash
 go test -c ./gpuprobe/ -o /home/diego/gpuprobe.test \
   -ldflags '-linkmode external -extldflags "-Wl,-Bstatic -lblazesym_c -Wl,-Bdynamic"'
-sudo setcap cap_bpf,cap_perfmon+ep /home/diego/gpuprobe.test
+sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep /home/diego/gpuprobe.test
 ```
 **Rebuilding strips the capability bit.** Do all source work first, rebuild once, then re-`setcap`.
 
@@ -860,7 +860,7 @@ Keep every Phase 3 assertion. Add, against a stub run with `sample_period = 8` a
 ```bash
 go test -c ./gpuprobe/ -o /home/diego/gpuprobe.test \
   -ldflags '-linkmode external -extldflags "-Wl,-Bstatic -lblazesym_c -Wl,-Bdynamic"'
-sudo setcap cap_bpf,cap_perfmon+ep /home/diego/gpuprobe.test
+sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep /home/diego/gpuprobe.test
 cd gpuprobe && /home/diego/gpuprobe.test -test.run TestStubDrives -test.v -test.timeout=120s
 ```
 
@@ -868,7 +868,7 @@ cd gpuprobe && /home/diego/gpuprobe.test -test.run TestStubDrives -test.v -test.
 
 ```bash
 go build -o /home/diego/gpu-stub-profile ./cmd/gpu-stub-profile
-sudo setcap cap_bpf,cap_perfmon+ep /home/diego/gpu-stub-profile
+sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep /home/diego/gpu-stub-profile
 /home/diego/gpu-stub-profile && go tool pprof -top gpu-stub.pb.gz | head -25
 ```
 
@@ -889,7 +889,7 @@ git -c user.name="diego" -c user.email="diegolparra@gmail.com" commit -m "test(g
 2. The gate test passes with the sampled-stack and kernel-name assertions, on a machine with no GPU.
 3. `gpu-stub-profile` writes a pprof containing real CPU frames above `[gpu:launch]` above `[gpu:kernel:<name>]`, plus a distinct `[gpu:launch unsampled]` subtree.
 4. Attributed and unattributed GPU time sum to the exact measured total; no duration is scaled.
-5. `getcap` on the test binary shows `cap_bpf,cap_perfmon` and **no `cap_sys_admin`**.
+5. `getcap` on the test binary shows `cap_bpf,cap_perfmon,cap_checkpoint_restore` and **no `cap_sys_admin`**.
 6. `golangci-lint run --timeout=5m` (v2.11.4, CI's pin) reports 0 issues.
 7. The unattached stub still emits nothing and counts every record dropped.
 
@@ -899,7 +899,7 @@ git -c user.name="diego" -c user.email="diegolparra@gmail.com" commit -m "test(g
 
   The fix is to stop symbolizing against live `/proc`: capture the maps eagerly — on first sight of a pid, or from a `sched_process_exit` probe — and resolve against that snapshot, the way `profile/` will have to for short-lived targets too. It is deliberately not attempted here: it needs a per-pid maps cache with its own eviction policy and a build-id keyed module store, which is a Phase 4b feature, not a patch to this one. The gate sidesteps it by holding the stub open (its `linger_ms` argument) until the consumer has counted every sampled launch, so the gate proves the *symbolization path* works without also depending on the unsolved lifetime problem.
 
-  Related, and already fixed here rather than deferred: blazesym's process source resolves each mapping through `/proc/<pid>/map_files/`, whose magic symlinks the kernel refuses to open without `CAP_CHECKPOINT_RESTORE` (or `CAP_SYS_ADMIN`). A perf-agent setcap'd with only `cap_bpf,cap_perfmon` — which is what the phase gate above mandates — therefore got `permission denied` for **every** batch and degraded every frame to a bare address. `symbolize.LocalSymbolizer.SymbolizeProcess` now retries once with `no_map_files`, reading the symbolic paths out of `/proc/<pid>/maps` instead, and latches the doomed first attempt off once the retry has rescued a batch. This affects `profile/` and `offcpu/` identically; it was invisible there for the same reason it was invisible here — blazesym's error is swallowed into hex-named frames and never reaches a counter.
+  Related, and settled rather than deferred: blazesym's process source resolves each mapping through `/proc/<pid>/map_files/`, whose magic symlinks the kernel refuses to open without `CAP_CHECKPOINT_RESTORE` (or `CAP_SYS_ADMIN`). A binary setcap'd with only `cap_bpf,cap_perfmon` — which is what this phase gate originally mandated — therefore got `permission denied` for **every** batch and degraded every frame to a bare address. The first fix retried with `no_map_files`, reading the symbolic paths out of `/proc/<pid>/maps`, and latched the doomed first attempt off; that has since been **removed**. `CAP_CHECKPOINT_RESTORE` is already in perf-agent's documented required set (`README.md`, `SECURITY.md`, `perfagent/agent.go`) and `unwind/procmap`, `unwind/dwarfagent` and `symbolize/debuginfod` already depend on it, so the retry existed only to tolerate an unsupported capability configuration — at the cost of a permanent latch, a startup probe, and a string match on blazesym's error text. `symbolize.NewLocalSymbolizer` now probes the kernel gate once, by `open()`ing a real `map_files` entry for itself, and returns `symbolize.ErrMapFilesUnavailable` naming the missing capability and the `setcap` line. The gate's own capability check was widened to match, so a run that would produce hex frames now skips loudly instead of passing green. This affects `profile/` and `offcpu/` identically.
 
 - **The DWARF unwind driver.** Frame-pointer stacks via `bpf_get_stackid` cover binaries built with frame pointers; the third `unwind_common.h` driver covers the rest. The wire format does not change — `stack_id` becomes a walker handle instead — so this is additive.
 - The CUPTI adapter itself, and everything needing a GPU.

--- a/gpuprobe/gate_test.go
+++ b/gpuprobe/gate_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/dpsoft/perf-agent/symbolize"
 )
 
-// hasBPFAndPerfmon mirrors perfagent/agent.go's hasCapSysPtrace: check
-// Permitted as well as Effective, because a setcap'd binary has not promoted
-// Permitted yet, and never gate on Getuid alone.
-func hasBPFAndPerfmon() bool {
+// hasCaps mirrors perfagent/agent.go's hasCapSysPtrace: check Permitted as
+// well as Effective, because a setcap'd binary has not promoted Permitted
+// yet, and never gate on Getuid alone.
+func hasCaps(want ...cap.Value) bool {
 	if os.Geteuid() == 0 {
 		return true
 	}
@@ -34,10 +34,10 @@ func hasBPFAndPerfmon() bool {
 	if set == nil {
 		return false
 	}
-	for _, want := range []cap.Value{cap.BPF, cap.PERFMON} {
+	for _, w := range want {
 		ok := false
 		for _, flag := range []cap.Flag{cap.Permitted, cap.Effective} {
-			if have, err := set.GetFlag(flag, want); err == nil && have {
+			if have, err := set.GetFlag(flag, w); err == nil && have {
 				ok = true
 				break
 			}
@@ -49,11 +49,27 @@ func hasBPFAndPerfmon() bool {
 	return true
 }
 
+// hasBPFAndPerfmon is the attach-side capability question: can this binary
+// load the BPF object and attach the uprobes at all.
+func hasBPFAndPerfmon() bool { return hasCaps(cap.BPF, cap.PERFMON) }
+
+// hasGateCaps is the whole-pipeline question, and it is strictly larger.
+// CAP_CHECKPOINT_RESTORE is what lets blazesym follow /proc/<pid>/map_files/;
+// without it symbolize.NewLocalSymbolizer refuses outright, and before it
+// refused, this gate ran green while all 63 sampled stacks resolved to bare
+// hex addresses. Gating on the capability the code actually needs is what
+// turns that into a visible skip instead of a passing run with useless
+// output.
+func hasGateCaps() bool { return hasCaps(cap.BPF, cap.PERFMON, cap.CHECKPOINT_RESTORE) }
+
 // The Phase 3 gate: the stub drives the full pipeline to pprof samples on a
 // machine with no GPU.
 func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
-	if !hasBPFAndPerfmon() {
-		t.Skip("needs CAP_BPF and CAP_PERFMON; setcap the test binary")
+	if !hasGateCaps() {
+		t.Skip("needs CAP_BPF, CAP_PERFMON and CAP_CHECKPOINT_RESTORE " +
+			"(the last one so blazesym can follow /proc/<pid>/map_files/; without it " +
+			"symbolize.NewLocalSymbolizer refuses and every frame would be a bare address); " +
+			"sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep <test binary>")
 	}
 	built := filepath.Join("..", "shim", "perfagent-gpu-stub")
 	requireBuilt(t, built)

--- a/symbolize/local.go
+++ b/symbolize/local.go
@@ -4,9 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"log"
 	"os"
-	"strconv"
 	"strings"
 	"sync/atomic"
 
@@ -16,9 +14,10 @@ import (
 // ErrClosed is returned from operations on a closed Symbolizer.
 var ErrClosed = errors.New("symbolize: closed")
 
-// errSkippedMapFiles stands in for the first attempt's error once the
-// map_files path has been latched off. It never escapes SymbolizeProcess.
-var errSkippedMapFiles = errors.New("symbolize: map_files disabled")
+// ErrMapFilesUnavailable is returned from NewLocalSymbolizer when this process
+// cannot follow /proc/<pid>/map_files/ magic symlinks. Wrapped, so callers can
+// test for it with errors.Is.
+var ErrMapFilesUnavailable = errors.New("symbolize: cannot follow /proc/<pid>/map_files/")
 
 // LocalSymbolizer wraps blazesym's Process source with no off-box hooks —
 // preserves perf-agent's pre-debuginfod behavior. Used when no debuginfod
@@ -26,166 +25,117 @@ var errSkippedMapFiles = errors.New("symbolize: map_files disabled")
 type LocalSymbolizer struct {
 	bz     *blazesym.Symbolizer
 	closed atomic.Bool
-	// noMapFiles latches once /proc/<pid>/map_files/ has been proven
-	// unusable for this process - either because the startup capability
-	// probe said so, or because a symbolization actually failed with
-	// permission denied (see SymbolizeProcess).
-	//
-	// It is NOT a plain performance latch, which is what it was first
-	// written as, and what made it wrong: it downgrades every later
-	// symbolization, for every process, to symbolic /proc/<pid>/maps paths,
-	// which under overlayfs can be re-pointed between the mmap and the read
-	// and then resolve to the WRONG symbols rather than to none. Paying that
-	// for the life of the symbolizer because one pid vanished mid-batch, or
-	// because a frame landed in a JIT region, is not a trade worth making
-	// silently. So only a permission failure - the one cause that cannot
-	// improve on its own - may set it.
-	noMapFiles atomic.Bool
-	stats      localCounters
-	// mapFilesAttempt overrides the first, inode-accurate attempt. It is a
-	// field only so a test can inject the two failure kinds SymbolizeProcess
-	// has to tell apart - blazesym itself offers no way to ask for one -
-	// while the retry underneath stays real. Nil in production.
-	mapFilesAttempt func(ips []uint64, pid uint32, opts []blazesym.ProcessSourceOption) ([]blazesym.Sym, error)
-}
-
-// symbolizeMapFiles runs the first attempt, through the test seam if one is
-// installed.
-func (s *LocalSymbolizer) symbolizeMapFiles(ips []uint64, pid uint32, opts []blazesym.ProcessSourceOption) ([]blazesym.Sym, error) {
-	if s.mapFilesAttempt != nil {
-		return s.mapFilesAttempt(ips, pid, opts)
-	}
-	return s.bz.SymbolizeProcessAbsAddrs(ips, pid, opts...)
+	stats  localCounters
 }
 
 // localCounters are the process-side symbolization counters. Kept separate
 // from Counters, which is the kernel symbolizer's and is already wired into
 // the /metrics endpoint with a fixed field set.
 type localCounters struct {
-	mapFilesPermissionDenied atomic.Uint64
-	mapFilesTransientFailure atomic.Uint64
-	fallbackRescued          atomic.Uint64
-	rawAddrBatches           atomic.Uint64
-	disabledReason           atomic.Value // string
+	rawAddrBatches atomic.Uint64
 }
 
-// LocalStats is a point-in-time view of what SymbolizeProcess has had to
-// degrade to. The map_files transition used to be invisible - no counter, no
-// log - which meant a profiler could silently spend an entire run resolving
-// through re-pointable symbolic paths and nothing would say so.
+// LocalStats is a point-in-time view of what SymbolizeProcess could not
+// resolve.
 type LocalStats struct {
-	// MapFilesDisabled reports whether the inode-accurate
-	// /proc/<pid>/map_files/ path has been latched off.
-	MapFilesDisabled bool
-	// MapFilesDisabledReason says why, and is empty while it is still on.
-	MapFilesDisabledReason string
-	// MapFilesPermissionDenied counts first attempts that failed with
-	// permission denied. Only these latch.
-	MapFilesPermissionDenied uint64
-	// MapFilesTransientFailure counts first attempts that failed for any
-	// other reason - a deleted mapping, a JIT region, a pid that exited
-	// mid-batch. These deliberately do NOT latch: the next batch gets the
-	// inode-accurate path back.
-	MapFilesTransientFailure uint64
-	// FallbackRescued counts batches the no_map_files retry saved.
-	FallbackRescued uint64
-	// RawAddrBatches counts batches where the retry failed too and every
-	// frame came back as a bare hex address.
+	// RawAddrBatches counts batches blazesym refused outright — the usual
+	// cause being a pid that exited before its /proc entry could be read —
+	// and where every frame therefore came back as a bare hex address.
 	RawAddrBatches uint64
 }
 
 // Stats returns the current process-side symbolization counters.
 func (s *LocalSymbolizer) Stats() LocalStats {
-	reason, _ := s.stats.disabledReason.Load().(string)
-	return LocalStats{
-		MapFilesDisabled:         s.noMapFiles.Load(),
-		MapFilesDisabledReason:   reason,
-		MapFilesPermissionDenied: s.stats.mapFilesPermissionDenied.Load(),
-		MapFilesTransientFailure: s.stats.mapFilesTransientFailure.Load(),
-		FallbackRescued:          s.stats.fallbackRescued.Load(),
-		RawAddrBatches:           s.stats.rawAddrBatches.Load(),
-	}
+	return LocalStats{RawAddrBatches: s.stats.rawAddrBatches.Load()}
 }
 
-// disableMapFiles latches the fallback on and says so exactly once. The
-// compare-and-swap is what makes it once: a second caller finds the latch
-// already set and returns without logging again.
-func (s *LocalSymbolizer) disableMapFiles(reason string) {
-	if !s.noMapFiles.CompareAndSwap(false, true) {
-		return
-	}
-	s.stats.disabledReason.Store(reason)
-	log.Printf("symbolize: /proc/<pid>/map_files/ unusable (%s); "+
-		"falling back to /proc/<pid>/maps symbolic paths for all "+
-		"processes - symbols stay resolvable but are no longer "+
-		"inode-accurate", reason)
-}
-
-// capCheckpointRestore and capSysAdmin are the two capabilities the kernel's
-// proc_map_files_get_link() accepts; without either, following a map_files
-// magic symlink is EPERM no matter which process is targeted.
-const (
-	capSysAdmin          = 21
-	capCheckpointRestore = 40
-)
-
-// canFollowMapFiles reports whether this process holds a capability that lets
-// it follow /proc/<pid>/map_files/ links. Probed once, at construction, so
-// the common setcap'd case (cap_bpf,cap_perfmon and nothing else - the
-// configuration that produced hex-named frames in every shipped profile/ and
-// offcpu/ run) skips the doomed first attempt from the very first batch
-// instead of discovering it by failing.
+// checkMapFilesAccess reports whether this process may follow a
+// /proc/<pid>/map_files/ magic symlink, which is the single path blazesym's
+// process source uses to reach the file behind a mapping. The kernel's
+// proc_map_files_get_link() rejects the open with EPERM unless the caller
+// holds CAP_CHECKPOINT_RESTORE (or CAP_SYS_ADMIN); perf-agent documents both
+// in its required set, and unwind/procmap, unwind/dwarfagent and
+// symbolize/debuginfod already depend on it directly.
 //
-// An unreadable or unparsable /proc/self/status returns true: the cost of
-// guessing "capable" wrongly is one failed attempt per batch until a real
-// permission error latches it, whereas guessing "incapable" wrongly would
-// give up inode accuracy that the process actually has.
-func canFollowMapFiles() bool {
-	f, err := os.Open("/proc/self/status")
+// The check is an actual open() of a real map_files entry, not a read of
+// CapEff out of /proc/self/status. It exercises the exact kernel gate that
+// symbolization will hit, so it cannot be wrong about which capability the
+// running kernel consults, about a capability held only in a non-initial user
+// namespace (checkpoint_restore_ns_capable() checks &init_user_ns), or about
+// Permitted-but-not-Effective. It also yields a typed errno, which is what
+// lets this refuse without string-matching blazesym's error text.
+//
+// Only a definite EPERM is a verdict. An unreadable /proc/self/maps, a
+// process with no file-backed mapping, or a mapping that was unmapped between
+// the read and the open returns nil: a probe that could not decide must never
+// be the reason a profiler refuses to start.
+func checkMapFilesAccess() error {
+	f, err := os.Open("/proc/self/maps")
 	if err != nil {
-		return true
+		return nil
 	}
 	defer func() { _ = f.Close() }()
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
-		line := sc.Text()
-		hex, ok := strings.CutPrefix(line, "CapEff:")
-		if !ok {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 6 || !strings.HasPrefix(fields[5], "/") {
 			continue
 		}
-		caps, err := strconv.ParseUint(strings.TrimSpace(hex), 16, 64)
-		if err != nil {
-			return true
+		var start, end uint64
+		if _, err := fmt.Sscanf(fields[0], "%x-%x", &start, &end); err != nil {
+			continue
 		}
-		return caps&(1<<capSysAdmin) != 0 || caps&(1<<capCheckpointRestore) != 0
+		// Reformatted with %x rather than reused from /proc/self/maps: maps
+		// pads each address to the word width, and the kernel's
+		// dname_to_vma_addr() rejects a leading zero with -EINVAL, which
+		// would surface as ENOENT and be mistaken for a vanished mapping.
+		name := fmt.Sprintf("/proc/self/map_files/%x-%x", start, end)
+		fh, err := os.Open(name)
+		if err == nil {
+			_ = fh.Close()
+			return nil
+		}
+		if errors.Is(err, os.ErrPermission) {
+			return fmt.Errorf("%w (%v): every user-space frame would resolve to a bare "+
+				"hex address. Grant CAP_CHECKPOINT_RESTORE - "+
+				"sudo setcap cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep <binary> - "+
+				"or run as root", ErrMapFilesUnavailable, err)
+		}
+		// Any other error is not an answer about capabilities: the mapping
+		// was unmapped between the read and the open. Try the next one.
 	}
-	return true
-}
-
-// isPermissionDenied reports whether err is the one failure that can never
-// improve on its own.
-//
-// The typed check comes first and covers anything that carries an errno
-// (syscall.EPERM and syscall.EACCES both satisfy errors.Is(_, os.ErrPermission)).
-// blazesym is not that: its C API collapses the errno into an enum, blaze_err_str
-// renders BLAZE_ERR_PERMISSION_DENIED as the bare string "permission denied",
-// and the Go binding wraps that with errors.New - so by the time the error
-// reaches here there is nothing typed left to match, and the string is the
-// only evidence. Matching it is narrow and it is checked by a test; the
-// alternative is latching on every failure, which is the bug being fixed.
-func isPermissionDenied(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, os.ErrPermission) {
-		return true
-	}
-	return strings.Contains(strings.ToLower(err.Error()), "permission denied")
+	return nil
 }
 
 // NewLocalSymbolizer constructs a LocalSymbolizer with code-info and
 // inlined-fns enabled (matches today's behavior at the three call sites).
+//
+// It refuses, rather than degrading, when /proc/<pid>/map_files/ is closed to
+// this process. That is a deliberate trade. There used to be a second
+// resolution path here - a retry with blazesym's no_map_files option, which
+// reads the symbolic paths out of /proc/<pid>/maps and needs no capability -
+// plus a latch, a once-only log, a startup CapEff probe and a string match on
+// blazesym's "permission denied" text to drive them. All of it existed to
+// tolerate one unsupported configuration: a binary setcap'd with only
+// cap_bpf,cap_perfmon, which is narrower than the set perf-agent's own README,
+// SECURITY.md and agent.go document as required.
+//
+// Keeping map_files as the single path costs nothing a supported deployment
+// has, and buys two things. Inode accuracy: a symbolic path out of
+// /proc/<pid>/maps can be re-pointed at different contents between the mmap
+// and the read - under overlayfs that resolves to the WRONG symbols rather
+// than to none - while a map_files link cannot. And a failure that is
+// impossible to miss: the alternative considered here was a prominent
+// one-time log plus a flag on LocalStats, which is silent degradation wearing
+// a hat, because no caller in this repository reads LocalStats and a log line
+// emitted at startup is gone by the time a sixty-second run writes a
+// profile.pb.gz full of hex. A profiler whose every user frame is "0x7f..."
+// is not degraded, it is useless, and this codebase refuses everywhere else
+// rather than hand back output that looks like a result.
 func NewLocalSymbolizer() (*LocalSymbolizer, error) {
+	if err := checkMapFilesAccess(); err != nil {
+		return nil, err
+	}
 	bz, err := blazesym.NewSymbolizer(
 		blazesym.SymbolizerWithCodeInfo(true),
 		blazesym.SymbolizerWithInlinedFns(true),
@@ -193,55 +143,23 @@ func NewLocalSymbolizer() (*LocalSymbolizer, error) {
 	if err != nil {
 		return nil, err
 	}
-	s := &LocalSymbolizer{bz: bz}
-	if !canFollowMapFiles() {
-		s.disableMapFiles("no CAP_CHECKPOINT_RESTORE or CAP_SYS_ADMIN")
-	}
-	return s, nil
+	return &LocalSymbolizer{bz: bz}, nil
 }
 
 // SymbolizeProcess returns one Frame per IP. blazesym's Inlined chain is
 // expanded into the Frame.Inlined slice in caller-most-to-callee order.
 //
-// blazesym's process source resolves each mapping through
-// /proc/<pid>/map_files/<range>, which is inode-accurate: it cannot be
-// fooled by a binary that was replaced or deleted since it was mapped.
-// Following those magic symlinks is privileged — the kernel's
-// proc_map_files_get_link() rejects the open with EPERM unless the caller
-// holds CAP_CHECKPOINT_RESTORE (or CAP_SYS_ADMIN) — so on a perf-agent that
-// was setcap'd with only cap_bpf,cap_perfmon the ENTIRE batch fails with
-// "permission denied" and every frame degrades to a bare address. Nothing
-// about that failure is visible in the returned error, because the fallback
-// below deliberately does not propagate it.
-//
-// So: on any error, retry once with no_map_files, which reads the symbolic
-// paths out of /proc/<pid>/maps instead. That is what every other profiler
-// does and needs no capability at all; it is second choice only because a
-// symbolic path can be re-pointed at different contents between the mmap and
-// the read - under overlayfs that yields WRONG symbols, not merely
-// unresolved ones.
-//
-// The retry always runs. What is conditional is the LATCH that turns the
-// first attempt off for every later batch and every later process: that
-// happens only when map_files is closed to us for good, which means either
-// the startup capability probe said so (canFollowMapFiles) or a first
-// attempt actually failed with permission denied. A transient failure - a
-// mapping deleted between the walk and the read, a JIT region with no file
-// behind it, a pid that exited mid-batch - is rescued by the retry and then
-// forgotten, because the next batch may well be fine and inode accuracy is
-// worth one doomed attempt to get back. Latching on any failure at all,
-// which is what this used to do, permanently traded accuracy for one bad
-// moment, silently. Both paths are counted, and the latch logs once (see
-// Stats and disableMapFiles).
-//
-// If the retry fails too — the usual reason being that the process exited and
-// /proc/<pid>/maps is gone, "entity not found" — returns raw hex-named Frames
-// instead of dropping the batch. That preserves stack shape and addresses so
-// operators can decode with addr2line and the pprof's user mapping still has
-// somewhere to attach. Those frames carry Reason == FailureMissingSymbols;
-// callers that need to know symbolization resolved nothing must inspect
-// Frame.Reason, because err is nil on this path (see
-// gpuprobe.Stats.StacksUnresolved for a consumer that does).
+// If blazesym fails the batch — with the capability check in
+// NewLocalSymbolizer standing, the realistic reason is that the process
+// exited and /proc/<pid>/maps is gone, "entity not found" — returns raw
+// hex-named Frames instead of dropping the batch. That preserves stack shape
+// and addresses so operators can decode with addr2line and the pprof's user
+// mapping still has somewhere to attach. Those frames carry Reason ==
+// FailureMissingSymbols; callers that need to know symbolization resolved
+// nothing must inspect Frame.Reason, because err is nil on this path (see
+// gpuprobe.Stats.StacksUnresolved for a consumer that does). The batch is
+// counted in LocalStats.RawAddrBatches: a per-process failure is real signal
+// about that process and must not be silent.
 func (s *LocalSymbolizer) SymbolizeProcess(pid uint32, ips []uint64) ([]Frame, error) {
 	if s.closed.Load() {
 		return nil, ErrClosed
@@ -249,47 +167,13 @@ func (s *LocalSymbolizer) SymbolizeProcess(pid uint32, ips []uint64) ([]Frame, e
 	if len(ips) == 0 {
 		return nil, nil
 	}
-	opts := []blazesym.ProcessSourceOption{
+	syms, err := s.bz.SymbolizeProcessAbsAddrs(ips, pid,
 		blazesym.ProcessSourceWithPerfMap(true),
 		blazesym.ProcessSourceWithDebugSyms(true),
-	}
-	var syms []blazesym.Sym
-	var err error
-	skipped := s.noMapFiles.Load()
-	if !skipped {
-		syms, err = s.symbolizeMapFiles(ips, pid, opts)
-	} else {
-		err = errSkippedMapFiles
-	}
+	)
 	if err != nil {
-		denied := !skipped && isPermissionDenied(err)
-		if !skipped {
-			if denied {
-				s.stats.mapFilesPermissionDenied.Add(1)
-			} else {
-				s.stats.mapFilesTransientFailure.Add(1)
-			}
-		}
-		// A fresh slice, not append(opts, ...): opts must not gain the
-		// no_map_files option as a side effect if this function ever grows a
-		// second use of it.
-		retryOpts := make([]blazesym.ProcessSourceOption, 0, len(opts)+1)
-		retryOpts = append(retryOpts, opts...)
-		retryOpts = append(retryOpts, blazesym.ProcessSourceWithoutMapFiles(true))
-		var retryErr error
-		syms, retryErr = s.bz.SymbolizeProcessAbsAddrs(ips, pid, retryOpts...)
-		if retryErr != nil {
-			s.stats.rawAddrBatches.Add(1)
-			return rawUserAddrFrames(ips), nil
-		}
-		if !skipped {
-			s.stats.fallbackRescued.Add(1)
-		}
-		// Only a permission failure means map_files will still be closed on
-		// the next batch. Anything else gets the inode-accurate path back.
-		if denied {
-			s.disableMapFiles("blazesym reported permission denied")
-		}
+		s.stats.rawAddrBatches.Add(1)
+		return rawUserAddrFrames(ips), nil
 	}
 	out := make([]Frame, 0, len(syms))
 	for i, sym := range syms {

--- a/symbolize/local_test.go
+++ b/symbolize/local_test.go
@@ -8,33 +8,118 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"syscall"
 	"testing"
-
-	blazesym "github.com/libbpf/blazesym/go"
 )
 
-// Symbolizing a live process must produce real names WITHOUT any capability.
-// It did not: blazesym's process source resolves each mapping through
-// /proc/<pid>/map_files/, whose magic symlinks the kernel refuses to open
-// unless the caller holds CAP_CHECKPOINT_RESTORE (or CAP_SYS_ADMIN), so every
-// batch failed with "permission denied" and SymbolizeProcess quietly handed
-// back hex-named frames. This test used to SKIP on exactly that condition,
-// which is why nothing caught it — the GPU phase-4a gate, run from a binary
-// setcap'd with only cap_bpf,cap_perfmon, symbolized 63 stacks into nothing
-// but addresses. The capability skip is gone on purpose: the no_map_files
-// retry in SymbolizeProcess is what makes this pass unprivileged.
+// requireMapFilesAccess skips when this process cannot follow
+// /proc/<pid>/map_files/, which is the capability perf-agent documents as
+// required and NewLocalSymbolizer now refuses to start without.
 //
-// The remaining skip is an environment fact, not a permission one: `go test`
-// links the test binary it RUNS with the symbol table stripped (`go test -c`
-// does not), so under a plain `go test ./symbolize/` there is genuinely
-// nothing here to resolve. TestLocalSymbolizerResolvesRealNamesUnprivileged
-// below covers the same ground with a target that always has symbols, and it
-// never skips.
+// Gating on checkMapFilesAccess - the same probe the constructor uses - can
+// only ever cause a false SKIP, never a false pass: if the probe wrongly
+// reports access, the constructor proceeds and the assertions below run for
+// real against a process that cannot resolve anything, and fail. The skip
+// this replaces was different in kind. It hid a bug that was present *with*
+// the capability set the gate mandated, because the product claimed to work
+// there and did not.
+func requireMapFilesAccess(t *testing.T) {
+	t.Helper()
+	if err := checkMapFilesAccess(); err != nil {
+		t.Skipf("needs CAP_CHECKPOINT_RESTORE: %v", err)
+	}
+}
+
+// The contract NewLocalSymbolizer now carries, pinned in both directions with
+// no skip in either: without the capability it must refuse loudly and name
+// the fix, and with it, symbolizing a live process must produce a real name
+// rather than a hex address.
+//
+// The target is a shared library mapped into this very process. Unlike the Go
+// test binary (`go test` strips the symbol table from the binary it runs;
+// `go test -c` does not), libc always carries a dynamic symbol table, so a
+// bare address here means symbolization failed and nothing else. That is the
+// exact shape the map_files EPERM produced: 63 GPU stacks in the phase gate
+// symbolized into nothing but addresses, silently, because a no_map_files
+// retry stood underneath and swallowed the error.
+func TestLocalSymbolizerRefusesWithoutMapFilesAndResolvesWithIt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses /proc/self/maps")
+	}
+	probeErr := checkMapFilesAccess()
+
+	s, err := NewLocalSymbolizer()
+	if probeErr != nil {
+		if s != nil {
+			_ = s.Close()
+		}
+		if !errors.Is(err, ErrMapFilesUnavailable) {
+			t.Fatalf("without map_files access the constructor must refuse with ErrMapFilesUnavailable, got %v", err)
+		}
+		// The error is the only thing an operator sees, so it has to carry
+		// the remedy, not just the diagnosis.
+		for _, want := range []string{"CAP_CHECKPOINT_RESTORE", "cap_checkpoint_restore+ep", "hex address"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("the refusal must be actionable: %q missing from %q", want, err.Error())
+			}
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("NewLocalSymbolizer: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	addr, want := mappedLibcFuncAddr(t)
+	frames, err := s.SymbolizeProcess(uint32(os.Getpid()), []uint64{addr})
+	if err != nil {
+		t.Fatalf("SymbolizeProcess: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("got %d frames, want 1", len(frames))
+	}
+	// Not an equality check against `want`: aliases (memcpy/__memcpy_avx_unaligned
+	// and friends) mean blazesym may legitimately name it something else. The
+	// property under test is that it resolved a NAME rather than an address.
+	if frames[0].Reason != FailureNone || strings.HasPrefix(frames[0].Name, "0x") {
+		t.Fatalf("0x%x (%s in libc) did not resolve: Name=%q Reason=%s",
+			addr, want, frames[0].Name, frames[0].Reason)
+	}
+	if st := s.Stats(); st.RawAddrBatches != 0 {
+		t.Fatalf("a resolved batch must not be counted as a raw-address batch: %+v", st)
+	}
+}
+
+// A batch for a pid that does not exist is a genuine per-process failure, not
+// a capability one: it must still yield hex frames rather than an error (the
+// stack shape is worth keeping), and it must be counted.
+func TestSymbolizeProcessCountsGenuineResolutionFailures(t *testing.T) {
+	requireMapFilesAccess(t)
+	s, err := NewLocalSymbolizer()
+	if err != nil {
+		t.Fatalf("NewLocalSymbolizer: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// PID 0 is never a live process, so blazesym cannot read its /proc entry.
+	frames, err := s.SymbolizeProcess(0, []uint64{0xdeadbeef})
+	if err != nil {
+		t.Fatalf("a dead pid must not fail the batch: %v", err)
+	}
+	if len(frames) != 1 || frames[0].Reason != FailureMissingSymbols || frames[0].Name != "0xdeadbeef" {
+		t.Fatalf("want one hex-named unresolved frame, got %+v", frames)
+	}
+	if st := s.Stats(); st.RawAddrBatches != 1 {
+		t.Fatalf("a per-process failure must be counted, not silent: %+v", st)
+	}
+}
+
+// The second real-resolution target: this test binary itself. Kept alongside
+// the libc one because it exercises .symtab rather than .dynsym.
 func TestLocalSymbolizerSymbolizeSelf(t *testing.T) {
 	if testing.Short() {
 		t.Skip("uses /proc/self/maps")
 	}
+	requireMapFilesAccess(t)
 	if !hasSymtab(t, "/proc/self/exe") {
 		t.Skip("this test binary was linked without a symbol table (go test strips the binary it runs; go test -c does not)")
 	}
@@ -69,6 +154,7 @@ func TestLocalSymbolizerSymbolizeSelf(t *testing.T) {
 }
 
 func TestLocalSymbolizerCloseIdempotent(t *testing.T) {
+	requireMapFilesAccess(t)
 	s, err := NewLocalSymbolizer()
 	if err != nil {
 		t.Fatalf("NewLocalSymbolizer: %v", err)
@@ -86,43 +172,6 @@ func TestLocalSymbolizerCloseIdempotent(t *testing.T) {
 func getOsGetpidAddr() uintptr {
 	// Reflect on os.Getpid's PC. It's a real function we can guarantee is mapped.
 	return reflect.ValueOf(os.Getpid).Pointer()
-}
-
-// The regression guard for the map_files EPERM, with a target that cannot
-// go missing: a shared library mapped into this very process. Unlike the Go
-// test binary above, libc always carries a dynamic symbol table, so a bare
-// address here means symbolization failed and nothing else.
-//
-// No capability gate, by design. This test is the assertion that perf-agent
-// resolves user symbols when running with cap_bpf,cap_perfmon and nothing
-// more, which is the capability set its own phase gates mandate.
-func TestLocalSymbolizerResolvesRealNamesUnprivileged(t *testing.T) {
-	if testing.Short() {
-		t.Skip("uses /proc/self/maps")
-	}
-	addr, want := mappedLibcFuncAddr(t)
-
-	s, err := NewLocalSymbolizer()
-	if err != nil {
-		t.Fatalf("NewLocalSymbolizer: %v", err)
-	}
-	defer func() { _ = s.Close() }()
-
-	frames, err := s.SymbolizeProcess(uint32(os.Getpid()), []uint64{addr})
-	if err != nil {
-		t.Fatalf("SymbolizeProcess: %v", err)
-	}
-	if len(frames) != 1 {
-		t.Fatalf("got %d frames, want 1", len(frames))
-	}
-	// Not an equality check against `want`: aliases (memcpy/__memcpy_avx_unaligned
-	// and friends) mean blazesym may legitimately name it something else. The
-	// property under test is that it resolved a NAME rather than an address.
-	if frames[0].Reason != FailureNone || strings.HasPrefix(frames[0].Name, "0x") {
-		t.Fatalf("0x%x (%s in libc) did not resolve: Name=%q Reason=%s\n"+
-			"this is the map_files/CAP_CHECKPOINT_RESTORE failure if it says missing_symbols",
-			addr, want, frames[0].Name, frames[0].Reason)
-	}
 }
 
 // hasSymtab reports whether the ELF at path carries a .symtab section.
@@ -214,129 +263,4 @@ func libcExecMapping(t *testing.T) (uint64, uint64, string) {
 	}
 	t.Skip("no executable libc mapping in this process (static binary?)")
 	return 0, 0, ""
-}
-
-// The map_files fallback used to latch on ANY first-attempt failure, and
-// then stay latched, for every process, for the life of the symbolizer -
-// with no counter and no log. That is a permanent, invisible loss of
-// inode-accurate resolution bought with one transient failure: a mapping
-// deleted between the walk and the read, a JIT region, a pid that vanished
-// mid-batch. And it is not merely a loss of precision: a symbolic path can
-// be re-pointed between the mmap and the read (overlayfs), which resolves to
-// the WRONG symbols rather than to none.
-//
-// Only a permission failure may latch, because only a permission failure
-// cannot improve on its own.
-func TestOnlyAPermissionFailureLatchesTheMapFilesFallback(t *testing.T) {
-	if testing.Short() {
-		t.Skip("uses /proc/self/maps")
-	}
-	addr, _ := mappedLibcFuncAddr(t)
-	self := uint32(os.Getpid())
-
-	// Both cases inject only the FIRST attempt's failure; the no_map_files
-	// retry underneath is the real one, against this live process, so the
-	// rescue being asserted is a real rescue.
-	newForcedFailure := func(t *testing.T, injected error) *LocalSymbolizer {
-		t.Helper()
-		s, err := NewLocalSymbolizer()
-		if err != nil {
-			t.Fatalf("NewLocalSymbolizer: %v", err)
-		}
-		t.Cleanup(func() { _ = s.Close() })
-		// Undo whatever the startup capability probe decided: this test is
-		// about the runtime decision, and it must read the same on a root
-		// host and on a cap_bpf-only one.
-		s.noMapFiles.Store(false)
-		s.stats.disabledReason.Store("")
-		s.mapFilesAttempt = func([]uint64, uint32, []blazesym.ProcessSourceOption) ([]blazesym.Sym, error) {
-			return nil, injected
-		}
-		return s
-	}
-
-	t.Run("transient failure does not latch", func(t *testing.T) {
-		s := newForcedFailure(t, errors.New("failed to read /proc/1234/maps: entity not found"))
-		frames, err := s.SymbolizeProcess(self, []uint64{addr})
-		if err != nil {
-			t.Fatalf("SymbolizeProcess: %v", err)
-		}
-		if len(frames) != 1 || frames[0].Reason != FailureNone {
-			t.Fatalf("the retry must still rescue the batch: %+v", frames)
-		}
-		st := s.Stats()
-		if st.MapFilesDisabled {
-			t.Fatalf("a transient failure must not cost inode accuracy for the rest of the run (reason %q)",
-				st.MapFilesDisabledReason)
-		}
-		if st.MapFilesTransientFailure != 1 || st.MapFilesPermissionDenied != 0 {
-			t.Fatalf("misclassified: %+v", st)
-		}
-		if st.FallbackRescued != 1 {
-			t.Fatalf("the rescue must be counted, not silent: %+v", st)
-		}
-	})
-
-	t.Run("permission failure latches", func(t *testing.T) {
-		// Exactly what blazesym produces: BLAZE_ERR_PERMISSION_DENIED is
-		// rendered by blaze_err_str as this bare string and wrapped with
-		// errors.New, so no errno survives to match on.
-		s := newForcedFailure(t, errors.New("permission denied"))
-		if _, err := s.SymbolizeProcess(self, []uint64{addr}); err != nil {
-			t.Fatalf("SymbolizeProcess: %v", err)
-		}
-		st := s.Stats()
-		if !st.MapFilesDisabled {
-			t.Fatal("a permission failure cannot improve on its own; it must latch")
-		}
-		if st.MapFilesDisabledReason == "" {
-			t.Fatal("the transition must never be silent: it needs a reason")
-		}
-		if st.MapFilesPermissionDenied != 1 || st.MapFilesTransientFailure != 0 {
-			t.Fatalf("misclassified: %+v", st)
-		}
-		// Latched means latched: the second batch skips the first attempt
-		// outright, so neither classification counter moves again.
-		if _, err := s.SymbolizeProcess(self, []uint64{addr}); err != nil {
-			t.Fatalf("second SymbolizeProcess: %v", err)
-		}
-		if st2 := s.Stats(); st2.MapFilesPermissionDenied != 1 || st2.MapFilesTransientFailure != 0 {
-			t.Fatalf("a skipped first attempt is not a failure: %+v", st2)
-		}
-	})
-
-	t.Run("errno-typed permission errors are recognized too", func(t *testing.T) {
-		s := newForcedFailure(t, fmt.Errorf("open: %w", syscall.EACCES))
-		if _, err := s.SymbolizeProcess(self, []uint64{addr}); err != nil {
-			t.Fatalf("SymbolizeProcess: %v", err)
-		}
-		if !s.Stats().MapFilesDisabled {
-			t.Fatal("EACCES is a permission failure")
-		}
-	})
-}
-
-// The classifier is the whole difference between the fixed behavior and the
-// bug, so it is pinned directly.
-func TestIsPermissionDenied(t *testing.T) {
-	cases := []struct {
-		err  error
-		want bool
-	}{
-		{nil, false},
-		{errors.New("permission denied"), true},
-		{errors.New("Permission denied (os error 13)"), true},
-		{fmt.Errorf("wrapped: %w", syscall.EPERM), true},
-		{fmt.Errorf("wrapped: %w", syscall.EACCES), true},
-		{os.ErrPermission, true},
-		{errors.New("entity not found"), false},
-		{errors.New("invalid data"), false},
-		{fmt.Errorf("wrapped: %w", syscall.ENOENT), false},
-		{errSkippedMapFiles, false},
-	}
-	for _, c := range cases {
-		if got := isPermissionDenied(c.err); got != c.want {
-			t.Errorf("isPermissionDenied(%v) = %v, want %v", c.err, got, c.want)
-		}
-	}
 }


### PR DESCRIPTION
**169 lines removed.** `symbolize/local.go` goes 357 → 241.

## What this deletes, and why it existed

blazesym resolves mappings through `/proc/<pid>/map_files/`, whose magic symlinks the kernel refuses without `CAP_CHECKPOINT_RESTORE`. When a *test* binary was setcap'd with only `cap_bpf,cap_perfmon`, symbolization silently resolved nothing — every user frame came back as a bare hex address while reporting zero failures.

The fix at the time added a fallback path: retry with `no_map_files`, latch that setting, log once via compare-and-swap, probe capabilities at startup, and detect permission errors by **string-matching blazesym's message** because the C API drops errno. Plus five `LocalStats` fields to manage it.

All of that existed to tolerate a capability configuration **this project does not support**. `CAP_CHECKPOINT_RESTORE` is already in the documented required set (`CLAUDE.md`, spec §11, which states it covers `/proc/<pid>/map_files`), and three other code paths already depend on it directly — `unwind/procmap/parse.go`, `unwind/dwarfagent/miss_drainer.go`, `symbolize/debuginfod/buildid.go`.

A test-harness constraint had been absorbed into the product.

Gone: the latch, the CAS log, the startup capability probe, the string match, the `no_map_files` retry, the test seam, and five stats fields. Kept: `RawAddrBatches`, which reports genuine per-process resolution failures — real signal.

## Failing loudly instead

`NewLocalSymbolizer` now refuses with a typed error rather than degrading:

```
symbolize: cannot follow /proc/<pid>/map_files/ (open …: operation not permitted):
every user-space frame would resolve to a bare hex address.
Grant CAP_CHECKPOINT_RESTORE - sudo setcap … - or run as root
```

A hard error rather than a logged flag, because nothing in the repo read `LocalStats` — a log plus a flag would have been silent degradation with extra steps. Detection is an actual `open()` of a real `map_files` entry: the exact kernel gate, a typed errno, immune to user-namespace quirks and to Permitted-not-yet-Effective. Only a definite `EPERM` is treated as a verdict.

## Fixing the cause, not just the symptom

Test provisioning is corrected so the same pressure does not return: the gate's capability check and every documented `setcap` line now require `cap_bpf,cap_perfmon,cap_checkpoint_restore` — the set the product actually needs. A run that would emit hex frames now **skips with a reason** rather than passing green with degraded output.

For the phase gate, a human runs:
```
sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep /home/diego/gpuprobe.test
```

## Note on `CAP_SYS_ADMIN`

Not used, and not needed. It grants `map_files` too, but `CAP_CHECKPOINT_RESTORE` is narrower and already required. The one place `CAP_SYS_ADMIN` would apply — `perf_uprobe` instead of `uprobe_multi` — costs *more* code (one link per probe rather than one link with cookies) and buys only the removal of the Linux 6.6 floor. That is a deployment-reach decision, not a simplification.

## Verification

`go build`, `go vet`, all listed packages, `-race`, `golangci-lint` 0 issues. Three pre-existing `gofmt` offenders (`symbolize/hist.go`, `symbolize/debuginfod/stats.go`, and a test helper) are untouched by this branch — a go1.26 alignment change already on `main`.

Also spotted and deliberately left alone: `perfagent/agent.go:327` calls `caps.SetFlag` without a following `caps.SetProc()`, so that raise is a no-op. Harmless for `+ep` binaries, unrelated to this change.

⚠️ `main` is currently red on `TestKernelStackResolution` (`no user-side function in profile`), which predates this branch and touches none of this code — reruns in flight to confirm flakiness.