### PR TITLE
[control, do not merge] arm64 integration flake isolation for #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,3 +436,5 @@ If you find a security issue, please do **not** open a public issue. See [SECURI
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE).
+
+<!-- ci control run for issue #42; delete with the branch -->


### PR DESCRIPTION
Not for merge. Delete after CI reports.

Identical to `1851e622` (the base of #46) apart from one comment line in README.md. Purpose: put base code through the same arm64 runner while #46 fails `TestKernelStackResolution` there twice in a row, with two different symptoms.

- fails here too → the flake is #42's, and #46 is clean
- passes here → the change in #46 is implicated and #46 does not merge

See https://github.com/dpsoft/perf-agent/issues/42#issuecomment-5376996485