### PR TITLE
gpu: key launch/execution joins on (pid, correlation)

### DIFF
--- a/.superpowers/sdd/issue-36-report.md
+++ b/.superpowers/sdd/issue-36-report.md
@@ -1,0 +1,467 @@
+# Issue #36 — `LaunchCache` and `Timeline.pending` were PID-blind, and sampled stacks made that dangerous
+
+Branch `fix/gpu-join-pid`, worktree `.worktrees/gpu-join-pid`, cut from `origin/main`
+(`35d5d496`). One commit. Not pushed, no PR.
+
+---
+
+## 1. The design decision, and why
+
+### 1.1 What was wrong
+
+`gpu.LaunchCache.byCorr` and `gpu.Timeline.pending` are both `map[CorrelationID]…`,
+and `CorrelationID` was `{Backend, Value}` — no process. The probes are attached with
+`uprobe_multi` against the shim **file**, so every process that maps it feeds one
+`Consumer` and one `Timeline`, and `Config.PID == 0` (system-wide) is the documented
+default. Vendor correlation counters restart from a low value in every process
+(CUPTI's `correlationId` is a process-wide counter; spec §6.3 finding 4), so two
+profiled processes collide within the first handful of launches.
+
+Since Phase 4a a launch carries a symbolized CPU stack resolved against
+`/proc/<pid>/maps` of the process that produced it. So a mis-join did not merely swap
+metadata — it attributed one process's measured GPU time to a call path in a
+different address space, and reported it as `JoinExact`, i.e. vendor-provided truth.
+
+The consumer's own side tables were fixed to `launchKey{pid, corr}` in `63e9f610`.
+The timeline underneath them was not.
+
+### 1.2 What I did
+
+Put the process **inside** `CorrelationID`:
+
+```go
+type CorrelationID struct {
+	Backend GPUBackendID `json:"backend"`
+	PID     uint32       `json:"pid,omitempty"`
+	Value   string       `json:"value"`
+}
+```
+
+I implemented the issue's suggested shape rather than an alternative, and I agree with
+its reasoning: the alternative — a `PID` field on `GPUKernelExec`/`GPUPCSample` plus a
+`pid` argument on every join — puts the burden on each *join site* to remember, which
+is exactly the failure this bug is. Inside the id, the compiler enforces it at every
+*construction* site, and there is nothing left to remember at the four map lookups.
+`GPUKernelExec` and `GPUPCSample` still carry no `PID` field of their own; their
+correlation is where their process identity lives, and that is documented on both
+types.
+
+Consequences, all in the diff:
+
+- **`LaunchCache` and `Timeline.pending` needed no code change at all.** Their keys are
+  `CorrelationID`; widening the type widened the key. That is the whole point of the
+  shape, and it is why the fix is small.
+- **`Consumer.correlationOf` now takes the pid**: `correlationOf(pid uint32, v uint64)`.
+  It is the single construction point on the producing side, and it cannot be called
+  without naming a process. Both call sites pass `b.PID`, the batch header's — the
+  process that fired the probe, already on the wire, already the field
+  `LaunchContext.PID` is filled from.
+- **`gpuprobe.launchKey` is deleted.** With the pid in the id, `launchKey{pid, corr}`
+  was two copies of the same fact that could drift apart — a redundant key that
+  silently misses when its halves disagree is a new failure mode, not defence in
+  depth. `pendingStacks` and `deferredLaunches` now key on `gpu.CorrelationID`
+  directly, and `attachSampledStackLocked` builds its key through the same
+  `correlationOf` as the batched twin, so the two keys are equal by construction
+  rather than by two hand-written literals agreeing. `launchKey`'s doc comment (which
+  was the best statement of this hazard anywhere in the tree) is preserved, partly on
+  `CorrelationID` and partly above `pendingStacks`.
+
+### 1.3 The one genuinely new hazard, and the guard for it
+
+Adding a field to `CorrelationID` breaks `correlation != CorrelationID{}` as the test
+for *"did this record carry a correlation at all"*. That test is load-bearing:
+`Timeline.Snapshot` uses it to route a correlation-less execution to the heuristic
+join and an execution whose correlation merely **missed** the cache to unattributed
+(review Critical 2, spec §13). A producer that knows the pid but got no vendor
+correlation would now build a non-zero `CorrelationID` with an empty `Value` and be
+read as carrying a real, joinable id.
+
+So the predicate is now explicit:
+
+```go
+func (c CorrelationID) Present() bool { return c.Value != "" }
+```
+
+and **all four** sites that ask the presence question use it: `Timeline.Snapshot`,
+`Consumer.admitLaunchLocked`, `projectionLabels` (`gpu/projection.go:214`, which had
+been asking it inline as `Correlation.Value != ""` — correct, but the duplicated
+literal this change exists to remove), and the conformance harness's
+`assertHeuristicOnlyForCorrelationlessExecs`.
+`TestCorrelationCarryingOnlyAProcessIsNotPresent` pins it, including end-to-end
+through `Timeline`: an exec with a pid and no value must reach the heuristic path.
+
+`correlationOf` deliberately still returns the **whole** zero value for wire value 0,
+not one carrying only the pid, so the old `== CorrelationID{}` reading and the
+`Present()` reading agree on exactly those records.
+
+---
+
+## 2. Pre-fix failure output of the regression tests
+
+Written first, run against the unfixed keying.
+
+**Reproduction recipe.** Both transcripts below are from a scratch worktree checked
+out at `origin/main` (`35d5d496`) — genuine pre-fix code, not this branch with a
+patch reverted:
+
+```
+git worktree add /tmp/prefix-check origin/main --detach
+```
+
+then copy in `gpu/crossprocess_test.go` and append the `execBatchWith` helper plus
+`TestSameCorrelationInTwoProcessesJoinsInTheTimeline` to
+`gpuprobe/consumer_test.go`. Two edits are needed to make the new tests compile
+against a `CorrelationID` that has no `PID` field:
+
+- `corrFor` drops the field (`_ = pid`) — which is not a contrivance, it is precisely
+  what `main`'s type forces on every caller, and is the bug;
+- `TestCorrelationCarryingOnlyAProcessIsNotPresent` is omitted, since it exercises
+  `Present()`, an API this change introduces rather than a behaviour it repairs.
+
+Everything else — test bodies, assertions, messages — is byte-identical to what is
+committed here.
+
+**An earlier draft of §2.2 quoted a run made by reverting `correlationOf` on this
+branch. That transcript was wrong and has been replaced.** Because this branch also
+deletes `gpuprobe.launchKey`, reverting `correlationOf` alone reverts the consumer's
+side tables *as well as* the timeline's key, producing a state strictly worse than
+`main` (both processes lose their stacks) rather than the pre-fix keying. The bug's
+direction was right, but the output was not reproducible as written. What follows is
+what `origin/main` actually prints.
+
+### 2.1 `./gpu/` at `origin/main` — four failures, one pass
+
+```
+=== RUN   TestLaunchCacheKeepsTwoProcessesSameCorrelationApart
+    crossprocess_test.go:86: Not equal: expected: 2   actual: 1
+        	Messages:   	two processes, two launches: one must not overwrite the other
+--- FAIL: TestLaunchCacheKeepsTwoProcessesSameCorrelationApart (0.00s)
+=== RUN   TestTimelineJoinsExecutionToItsOwnProcessLaunch
+    crossprocess_test.go:123: Not equal: expected: 0x1092   actual: 0x14e9
+        	Messages:   	pid 4242's execution joined a launch from pid 5353
+    crossprocess_test.go:125: Not equal: expected: []string{"a_work"}   actual: []string{"b_work"}
+        	Messages:   	pid 4242's GPU time must be attributed to the call path pid 4242 ran
+    crossprocess_test.go:132: Not equal: expected: 0x2   actual: 0x1
+        	Messages:   	two distinct launches were matched, not one launch matched twice
+    crossprocess_test.go:134: Should be zero, but was 1
+--- FAIL: TestTimelineJoinsExecutionToItsOwnProcessLaunch (0.01s)
+=== RUN   TestTimelinePendingPCSamplesStayWithTheirProcess
+    crossprocess_test.go:158: "[{{cupti 7} { 0} unknown-clock-domain-0 25 2730  1} {{cupti 7} { 0} unknown-clock-domain-0 26 3003  1}]" should have 1 item(s), but has 2
+        	Messages:   	the execution starting at 20 must get exactly its own process's sample
+--- FAIL: TestTimelinePendingPCSamplesStayWithTheirProcess (0.00s)
+=== RUN   TestSingleProcessJoinsAreUnaffected
+--- PASS: TestSingleProcessJoinsAreUnaffected (0.00s)
+=== RUN   TestExecutionWithNoLaunchInItsOwnProcessIsUnattributed
+    crossprocess_test.go:217: Expected nil, but got: &gpu.GPUKernelLaunch{
+        	  Correlation:gpu.CorrelationID{Backend:"cupti", Value:"7"}, KernelName:"hot_kernel", TimeNs:0xa,
+        	  Launch:gpu.LaunchContext{PID:0x1092, TID:0x1092, TimeNs:0xa,
+        	    CPUStack:[]pprof.Frame{pprof.Frame{Name:"a_work", …}}}}
+        	Messages:   	pid 5353's execution must not borrow pid 4242's launch, or its call stack
+    crossprocess_test.go:221: Not equal: expected: 0x1   actual: 0x0
+        	Messages:   	the miss must be counted, not absorbed silently
+    crossprocess_test.go:223: Should be zero, but was 1
+        	Messages:   	a cross-process match must never be reported as vendor-provided truth
+--- FAIL: TestExecutionWithNoLaunchInItsOwnProcessIsUnattributed (0.02s)
+FAIL
+FAIL	github.com/dpsoft/perf-agent/gpu	0.042s
+```
+
+`0x1092` is 4242 and `0x14e9` is 5353. In the second test both executions joined pid
+5353's launch and took pid 5353's stack, because pid 5353's `Put` had *replaced* pid
+4242's entry. The third is the same collision in `Timeline.pending`: both samples
+landed in one bucket and were handed wholesale to whichever execution drained first.
+
+The fourth is the sharpest of the four, and the earlier draft of this report
+undercounted the evidence by omitting it. With **only pid 4242 having launched at
+all**, pid 5353's execution was handed pid 4242's launch object — including
+`CPUStack:[{Name:"a_work"}]`, a symbol resolved against `/proc/4242/maps` — and it was
+reported as `ExactExecutionJoinCount == 1` with `UnmatchedExecutionCount == 0`. Every
+honesty signal read clean while the output was fabricated.
+
+`TestSingleProcessJoinsAreUnaffected` passing here is the point of it: it is the
+control, and the fix must not move it (§4).
+
+### 2.2 `./gpuprobe/` at `origin/main` — the end-to-end run
+
+`TestSameCorrelationInTwoProcessesJoinsInTheTimeline` drives two pids' sampled, launch
+and exec batches through a real `Consumer` into a real `gpu.Timeline`:
+
+```
+--- FAIL: TestSameCorrelationInTwoProcessesJoinsInTheTimeline (0.01s)
+    consumer_test.go:2568: Not equal: expected: 0x1092   actual: 0x14e9
+        	Messages:   	pid 4242's execution joined a launch from pid 5353
+    consumer_test.go:2570: Not equal: expected: []string{"fn_1000"}   actual: []string{"fn_2000"}
+        	Messages:   	pid 4242's GPU time must carry the call path captured in pid 4242, not the other process's
+    consumer_test.go:2574: Not equal: expected: 0x2   actual: 0x1
+        	Messages:   	two distinct launches were matched, not one matched twice
+    consumer_test.go:2577: Should be zero, but was 1
+FAIL
+FAIL	github.com/dpsoft/perf-agent/gpuprobe	0.010s
+```
+
+This is the clearest statement of the defect, and worth reading closely for **what
+does not fail**. The assertion on pid 5353's stack passes: `main`'s consumer-side
+`launchKey{pid, corr}` (commit `63e9f610`) did its job, so pid 5353's launch reached
+the sink carrying its own `fn_2000`. The corruption is entirely in the layer below —
+pid 4242's execution was shown running `fn_2000`, a symbol from pid 5353's address
+space, because the timeline's `LaunchCache` had already discarded pid 4242's launch as
+a "replacement". That is exactly the issue's framing: the same bug one layer down,
+with the layer above already fixed and unable to help.
+
+### 2.3 The full set of new tests
+
+| test | file | what it pins |
+|---|---|---|
+| `TestLaunchCacheKeepsTwoProcessesSameCorrelationApart` | `gpu/crossprocess_test.go` | the storage half: two entries, `Replaced == 0`, each `Get` returns its own process's launch |
+| `TestTimelineJoinsExecutionToItsOwnProcessLaunch` | `gpu/crossprocess_test.go` | the join half: both exact, each carries its own process's stack, `MatchedLaunchCount == 2` |
+| `TestTimelinePendingPCSamplesStayWithTheirProcess` | `gpu/crossprocess_test.go` | `Timeline.pending`: each execution gets exactly its own process's PC sample |
+| `TestExecutionWithNoLaunchInItsOwnProcessIsUnattributed` | `gpu/crossprocess_test.go` | the honest miss: a cross-process value now misses, degrades to unattributed, and is **counted** — never repaired by the heuristic |
+| `TestCorrelationCarryingOnlyAProcessIsNotPresent` | `gpu/crossprocess_test.go` | `Present()`, incl. through `Timeline`: pid + empty value ⇒ heuristic path, marked as a guess |
+| `TestSingleProcessJoinsAreUnaffected` | `gpu/crossprocess_test.go` | non-regression, see §4 |
+| `TestSameCorrelationInTwoProcessesJoinsInTheTimeline` | `gpuprobe/consumer_test.go` | consumer → timeline end to end |
+
+All are pure unit tests: no privileges, no BPF attach, no GPU.
+
+### 2.4 Overlap with `gpuprobe/sampledstacks_test.go` — asked for explicitly
+
+**There is no overlap, and the file's own name is slightly misleading about where its
+cross-process coverage lives.** `sampledstacks_test.go` holds three tests, all about
+the `pendingStacks` order-slice bound (`TestParkedStackOrderStaysBounded…`,
+`TestOrderReclamationPreservesEvictionOrder`); none of them involves two processes.
+The consumer-side cross-process tests the issue refers to are in
+**`gpuprobe/consumer_test.go`**: `TestSameCorrelationInTwoProcessesKeepsItsOwnStack`
+(:1684) and `TestHeldLaunchDoesNotTakeAnotherProcessesStack` (:1716).
+
+Those two are the model I followed, and their coverage stops one layer above this bug:
+they assert what the **`Consumer` emitted to its sink** (each launch keeps its own
+stack), and both already passed on `main`. Neither builds a `Timeline`, so neither can
+see a launch that survives the consumer intact and is then handed to the wrong
+execution downstream. They still earn their place — they cover `pendingStacks`/
+`deferredLaunches`, which this change rekeyed — and they pass unchanged, which is
+useful evidence that collapsing `launchKey` into `gpu.CorrelationID` preserved their
+behaviour exactly. The new end-to-end test is deliberately the same scenario carried
+one layer further, into the join.
+
+---
+
+## 3. Serialization — every site and its fate
+
+I searched the whole tree for `json.Marshal`/`Unmarshal`/`NewEncoder`/`NewDecoder`
+and for every importer of `github.com/dpsoft/perf-agent/gpu`.
+
+| site | what it serializes | fate |
+|---|---|---|
+| `gpu/types.go` `GPUCapability.MarshalJSON` / `UnmarshalJSON` | a capability name string | untouched. Does not involve `CorrelationID`. |
+| `gpu/types.go` `ClockDomain.MarshalJSON` / `UnmarshalJSON` | a clock-domain name string | untouched. Same. |
+| `bench/internal/schema/schema.go` | the benchmark `Document` (compile timings) | untouched. Does not import `gpu`. |
+| `unwind/ehcompile/ehcompile_test.go` | a CFI-row golden fixture | untouched. Does not import `gpu`. |
+
+**No code anywhere in the repository marshals or unmarshals `CorrelationID`,
+`GPUKernelLaunch`, `GPUKernelExec`, `GPUPCSample` or `Snapshot`.** The `json:` tags on
+those types are a declared contract for a serialized snapshot that nothing produces or
+consumes yet. There are no JSON fixtures in the tree (`find -name '*.json'` returns
+only `.claude/settings.json`), and no replay backend exists — `BackendReplay` is a
+declared constant with no implementation.
+
+The `Snapshot` *fields* are likewise unchanged in shape — no field added, removed or
+retyped — though two of them will read differently on a multi-process run now that
+launches no longer collide into one entry: `LaunchCacheStats.Replaced` falls and
+`EvictedCapacity` rises. See §5.2.
+
+**So no wire or on-disk format changes.** For completeness, if that contract is
+exercised later: `pid` is added as `"pid,omitempty"`, which is additive in both
+directions — a pre-change document decodes with `PID == 0`, and a post-change document
+read by a pre-change decoder ignores the unknown key. A document written before this
+change and replayed after it would join as it always did, because all its correlations
+share `PID == 0`.
+
+Two adjacent boundaries I checked and did **not** change:
+
+- **The USDT wire ABI** (`internal/gpuabi`, `shim/core/usdt_abi.h`, the `.bpf.c`
+  producer) is untouched. The pid is not a new field on the wire: it already travels
+  in the batch header (`batch_hdr` offset 16) and was already being read into
+  `LaunchContext.PID`. This change only stops discarding it on the execution and
+  correlation path. No `make generate`, no bytecode change.
+- **The pprof label `gpu_correlation`** still formats as `backend:value`, with no pid.
+  Its emit condition now goes through `Correlation.Present()` rather than an inline
+  `Value != ""`, which is the same predicate and the same output.
+  Adding the pid there would change profile output for a diagnostic label, which is
+  outside this issue. The consequence is worth recording: in system-wide mode two
+  processes' executions can still show the *same* `gpu_correlation` string. That is an
+  ambiguous label, not a misattribution — each sample now carries its own process's
+  stack and tags — but if `gpu_correlation` is ever used to group across a
+  system-wide profile it will over-group, and the fix would be to add the pid to the
+  label (or a `gpu_pid` label) in its own change.
+
+---
+
+## 4. Single-process non-regression evidence
+
+Asked for as proof, not assumption. Three independent pieces:
+
+1. **`TestSingleProcessJoinsAreUnaffected`** (`gpu/crossprocess_test.go`) drives 200
+   launches and 200 executions through one pid and asserts every one joins exactly,
+   pairs with its *own* correlation value and its own stack, and that
+   `UnmatchedExecutionCount`, `HeuristicExecutionJoinCount`, `UnmatchedLaunchCount`
+   and `LaunchCache.Replaced` are all zero. **It passes both before and after the
+   change** — see the `--- PASS` line in §2.1, in the same run where the other three
+   failed. That is the point: it is the control, and the fix must not move it.
+2. **The argument it encodes.** With `Config.PID != 0` only one process's probes are
+   attached, so every correlation reaching the cache carries the same constant `PID`.
+   A map keyed on `{Backend, PID, Value}` with `PID` constant partitions identically
+   to one keyed on `{Backend, Value}` — same hits, same misses, same eviction order
+   (order is by `orderedFIFO` insertion sequence, which the key type does not affect).
+3. **The pre-existing suite is itself a single-process corpus.** Every test in
+   `gpu/timeline_test.go`, `gpu/launchcache_test.go`, `gpu/projection_test.go` and
+   `gpu/conformance_test.go` builds correlations with no pid, i.e. `PID == 0`
+   throughout — the degenerate single-process case. All pass unchanged, including the
+   conformance harness's five join invariants and its loss-accounting reconciliation.
+   The only pre-existing assertions I edited are the two that named the *old shape*
+   rather than the behaviour (`assertHeuristicOnlyForCorrelationlessExecs`'s
+   `== CorrelationID{}` → `Present()`, and two `TestApplyBatchNormalizes*` correlation
+   assertions, both **strengthened** to require the batch pid rather than relaxed).
+
+---
+
+## 5. Metric integrity and capacity — what these counters read when joins fail
+
+### 5.1 Join counters
+
+The project's stated pattern (six defects that were counters reading green exactly
+when things were worst) applies squarely here, so:
+
+**This change adds no counter and removes none.** It changes *which* counter a
+cross-process pair lands in, and that is the substance of the fix.
+
+- **Before:** a cross-process pair was an `ExactExecutionJoinCount` — reported as
+  vendor-provided truth. §2.1 shows this: with two executions and two launches, the
+  pre-fix run reported `ExactExecutionJoinCount == 2` and both were wrong.
+  `HeuristicExecutionJoinCount` was 0 and `AmbiguousHeuristicMatchCount` was 0, so
+  every "is the join honest" signal read clean.
+- **After:** an execution whose correlation exists only in another process misses the
+  cache and lands in `UnmatchedExecutionCount`, and the view carries
+  `gpu_join="unmatched"` with `Launch == nil`.
+  `TestExecutionWithNoLaunchInItsOwnProcessIsUnattributed` asserts exactly that,
+  including that `ExactExecutionJoinCount` stays 0 and the heuristic does not run.
+
+The one signal that *was* available pre-fix is worth naming, because it is why this
+went unnoticed: `MatchedLaunchCount` counts **distinct** launches matched, so the
+pre-fix run reported `MatchedLaunchCount == 1` and `UnmatchedLaunchCount == 1` for two
+executions. That is a real signal — but it is indistinguishable from the ordinary,
+benign case of a launch whose execution simply had not arrived in this snapshot
+window, which happens constantly. It could not have raised an alarm on its own. The
+new tests assert `MatchedLaunchCount == 2` precisely so that signal is pinned.
+
+There is no counter for "this execution missed because its correlation belongs to
+another process", and I did not add one: the cache cannot distinguish that from "the
+launch aged out" without retaining evicted keys, so such a counter could only be
+guessed at — the exact anti-pattern the note warns about.
+
+### 5.2 Capacity — a real consequence of this change
+
+**This change makes the bounded stores fill faster in system-wide mode, and the report
+should say so plainly.**
+
+Both bounds are global and unscaled: `LaunchCache` defaults to 65536 entries
+(`defaultLaunchCacheCapacity`, `gpu/launchcache.go:46`), and `Timeline.pendingCap`
+reuses that same normalized capacity for the pending-PC-sample map's cardinality.
+Neither is per-process, and neither is derived from how many processes are being
+profiled.
+
+Pre-fix, two processes' colliding launches **collapsed into one entry** — the second
+`Put` overwrote the first and was tallied as `Replaced`. Post-fix they correctly
+occupy two. So an N-process run now reaches capacity roughly N× sooner than it did,
+and evicts entries that previously survived. Concretely: the storage that used to look
+adequate was partly an illusion created by the very collision this change fixes.
+
+Three reasons this is a consequence to record rather than a regression to fix:
+
+1. **What survived before was the wrong entry.** A cache that fits more launches by
+   silently discarding one process's launch in favour of another's is not "holding
+   more", it is holding the wrong things and mis-joining them. Correct eviction under
+   pressure is strictly better than incorrect retention.
+2. **Nothing is silent.** Every eviction path is already counted and reaches the
+   serialized `Snapshot`: `LaunchCacheStats.EvictedCapacity` and `EvictedHorizon` for
+   launches, `TimelineDropStats.EvictedPendingSamples` for pending samples. The
+   pressure shows up as a rising eviction count, not as a mystery drop in attribution.
+   The counter that *falls* is `Replaced`, which pre-fix was quietly absorbing
+   cross-process collisions and reading as benign correlation reuse.
+3. **An evicted launch degrades honestly.** Its execution misses the cache and lands in
+   `UnmatchedExecutionCount` with `Launch == nil` and `gpu_join="unmatched"` — the
+   review Critical 2 path, which is exactly the behaviour
+   `TestTimelineDegradesWhenLaunchEvicted` and
+   `TestConformanceEvictedLaunchDegradesToUnattributed` already pin.
+
+**There is no per-process fairness, and that is the part worth watching on a real
+multi-process run.** Eviction is global FIFO by insertion sequence, so a busy process
+can push a quiet process's launches out of the cache before their executions arrive.
+The quiet process then loses attribution it would have kept if it were profiled alone.
+This is not new — the FIFO was always global — but this change is what makes multiple
+processes actually *occupy* the cache simultaneously, so it is the change that makes
+the unfairness reachable. Sizing `LaunchCacheConfig.Capacity` for the expected process
+count, or making eviction process-aware, would be the remedy; both are design
+decisions well outside a keying bugfix, and neither is needed until a real
+multi-process run shows `EvictedCapacity` climbing.
+
+---
+
+## 6. Known residual, deliberately not fixed
+
+**The heuristic join is still process-blind, and cannot be fixed here.**
+`candidateGroupKey` groups launches by `(queue, kernel name)` with no pid. It cannot
+carry one: the heuristic runs only for an execution that supplied **no correlation at
+all**, and the correlation is now the only place an execution's process identity
+lives — so a correlation-less execution has no pid to group by. Closing it needs a
+process field on `GPUKernelExec` itself, which no producer in the tree would populate:
+the one shipping backend (`gpuprobe`) supplies a correlation on every launch and
+execution, as spec §6 requires without exception, so nothing reaches that path today,
+and `BackendLinuxDRM` has no implementation. A field nobody writes is the other half
+of the metric-integrity anti-pattern, so I documented the gap at
+`candidateGroupKey` rather than adding one.
+
+Out of scope and untouched, as instructed: **#49** (CFI tables not yet registered),
+**#42** (CI flakiness).
+
+---
+
+## 7. Verification run
+
+Re-run in full after the review amendments (including the `projection.go` change):
+
+```
+go build ./...                                                    ok
+go vet ./...                                                      ok
+go test ./gpu/ ./gpuprobe/ ./internal/... ./unwind/... -count=1    all ok
+go test ./gpu/ ./gpuprobe/ -race -count=1                          ok  (gpu 5.370s, gpuprobe 1.193s)
+~/go/bin/golangci-lint run --timeout=5m                            0 issues.
+```
+
+Plus the pre-fix runs of §2.1 and §2.2, against a scratch worktree at `origin/main`.
+
+---
+
+## 8. Cannot verify
+
+- **Anything requiring privilege.** `CapEff: 0` in this environment: no BPF program
+  load, no `uprobe_multi` attach, no ringbuf. `gpuprobe/gate_test.go` and
+  `gpuprobe/attach_test.go`'s attach paths skip on the capability gate; they compile
+  and their non-privileged assertions pass, but the attach itself never ran here.
+- **The live two-process RTX 3090 run.** The scenario this issue is really about —
+  two real CUDA processes mapping the shim, each with its own correlation sequence,
+  producing a profile in which each process's GPU time sits under its own call paths —
+  has only been exercised against synthetic batches. The end-to-end test in §2.2 goes
+  through the real `Consumer.applyBatch` and the real `Timeline`, but its input is
+  hand-built wire bytes, not a shim. The one thing I would specifically watch on that
+  run: `JoinStats.UnmatchedExecutionCount` should stay at its pre-change level. If it
+  *rises* on a single-process run, something is populating the launch's and the
+  execution's correlation pid from different sources; §4 argues it cannot, but that
+  is an argument, not a measurement.
+- **PC-sample behaviour with real CUPTI.** `Timeline.pending` is now process-keyed,
+  but the shipping collection mode supplies **no** correlation on PC samples (spec
+  §6.3 finding 3), so on the real hardware every PC sample still lands on the
+  not-`Present()` key regardless of process. The PC-sample test in §2.3 exercises the
+  correlated path, which today only a hypothetical kernel-serialized collector would
+  produce. This change does not make PC-sample attribution worse, and does not make it
+  work either.
+- **Nothing was skipped or weakened to get a green local run.** No assertion was
+  relaxed; the two pre-existing assertions I edited were both strengthened (§4, item 3).

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -291,12 +291,18 @@ func assertHeuristicAlwaysMarked(t *testing.T, snap Snapshot) {
 // Correlation (a backend, like DRM, that never supplies one) may take the
 // heuristic path at all. See TestConformanceEvictedLaunchDegradesToUnattributed
 // below for the specific reproduction this generalizes.
+//
+// The test is Present(), not equality with the zero CorrelationID: since
+// issue #36 a correlation also carries the producing process, so a record
+// with a pid and no vendor value is not the zero value yet still supplied no
+// correlation.
 func assertHeuristicOnlyForCorrelationlessExecs(t *testing.T, snap Snapshot) {
 	t.Helper()
 	for _, view := range snap.Executions {
 		if view.Join == JoinHeuristic {
-			assert.Equal(t, CorrelationID{}, view.Exec.Correlation,
-				"a heuristic join must only ever attach to an exec that never supplied a correlation ID at all")
+			assert.False(t, view.Exec.Correlation.Present(),
+				"a heuristic join must only ever attach to an exec that never supplied a correlation ID at all, got %+v",
+				view.Exec.Correlation)
 		}
 	}
 }

--- a/gpu/crossprocess_test.go
+++ b/gpu/crossprocess_test.go
@@ -1,0 +1,256 @@
+package gpu
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pp "github.com/dpsoft/perf-agent/pprof"
+)
+
+// The probes are attached against the shim *file*, so every process that maps
+// it feeds the same Timeline, and system-wide (Config.PID == 0) is the
+// documented default. Vendor correlation counters restart from a low value in
+// every process, so two profiled processes collide on correlation within the
+// first handful of launches. These tests pin the consequence: an execution
+// must join the launch its OWN process produced, never a namesake from
+// another one.
+//
+// The stakes are the launch's symbolized CPU stack (Phase 4a), resolved
+// against /proc/<pid>/maps of the process that produced it. A mis-join does
+// not merely swap metadata; it attributes one process's measured GPU time to
+// a call path in a different process's address space - a flame graph that is
+// confidently, specifically wrong. Spec §4 exists to forbid exactly that.
+//
+// Every assertion below is stated in terms the OLD, pid-blind types could
+// express too - a launch's LaunchContext.PID and an execution's own StartNs -
+// so the tests compile unchanged against the pre-fix keying and fail on the
+// join, not on a missing field.
+
+// corrFor builds the correlation that a process's launch and its later
+// execution both carry. The pid is part of the identity, not context the
+// caller may leave off: it is what makes "correlation 7" in pid 4242 a
+// different key from "correlation 7" in pid 5353.
+func corrFor(pid uint32, value string) CorrelationID {
+	return CorrelationID{Backend: BackendCUPTI, PID: pid, Value: value}
+}
+
+// launchIn is deliberately identical across processes except for pid and the
+// captured stack: same kernel name, same queue, adjacent timestamps. Only the
+// process identity can tell the two joins apart.
+func launchIn(pid uint32, value string, timeNs uint64, fn string) GPUKernelLaunch {
+	return GPUKernelLaunch{
+		Correlation: corrFor(pid, value),
+		KernelName:  "hot_kernel",
+		TimeNs:      timeNs,
+		Launch: LaunchContext{
+			PID:      pid,
+			TID:      pid,
+			TimeNs:   timeNs,
+			CPUStack: pp.FramesFromNames([]string{fn}),
+		},
+	}
+}
+
+func execIn(pid uint32, value string, startNs, endNs uint64) GPUKernelExec {
+	return GPUKernelExec{
+		Correlation: corrFor(pid, value),
+		KernelName:  "hot_kernel",
+		StartNs:     startNs,
+		EndNs:       endNs,
+	}
+}
+
+func stackNames(l *GPUKernelLaunch) []string {
+	if l == nil {
+		return nil
+	}
+	out := make([]string, 0, len(l.Launch.CPUStack))
+	for _, f := range l.Launch.CPUStack {
+		out = append(out, f.Name)
+	}
+	return out
+}
+
+// TestLaunchCacheKeepsTwoProcessesSameCorrelationApart is the storage half:
+// the cache must hold both launches, not treat the second as a replacement
+// of the first.
+func TestLaunchCacheKeepsTwoProcessesSameCorrelationApart(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 8})
+	c.Put(launchIn(4242, "7", 10, "a_work"))
+	c.Put(launchIn(5353, "7", 11, "b_work"))
+
+	require.Equal(t, 2, c.Len(), "two processes, two launches: one must not overwrite the other")
+	assert.Zero(t, c.Stats().Replaced, "neither launch is a replacement of the other")
+
+	got, ok := c.Get(corrFor(4242, "7"))
+	require.True(t, ok, "pid 4242's launch must still be retrievable")
+	assert.Equal(t, uint32(4242), got.Launch.PID)
+	assert.Equal(t, []string{"a_work"}, stackNames(&got))
+
+	got, ok = c.Get(corrFor(5353, "7"))
+	require.True(t, ok, "pid 5353's launch must still be retrievable")
+	assert.Equal(t, uint32(5353), got.Launch.PID)
+	assert.Equal(t, []string{"b_work"}, stackNames(&got))
+}
+
+// TestTimelineJoinsExecutionToItsOwnProcessLaunch is the join half, and the
+// one that matters: both executions must take the exact path, and each must
+// carry the stack its own process captured.
+//
+// Executions are told apart by StartNs rather than by anything on the
+// correlation, so the assertion is about the join and nothing else.
+func TestTimelineJoinsExecutionToItsOwnProcessLaunch(t *testing.T) {
+	wantPID := map[uint64]uint32{20: 4242, 21: 5353}
+	wantStack := map[uint64]string{20: "a_work", 21: "b_work"}
+
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launchIn(4242, "7", 10, "a_work")))
+	require.NoError(t, tl.EmitLaunch(launchIn(5353, "7", 11, "b_work")))
+	require.NoError(t, tl.EmitExec(execIn(4242, "7", 20, 30)))
+	require.NoError(t, tl.EmitExec(execIn(5353, "7", 21, 31)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 2)
+	for _, view := range snap.Executions {
+		pid := wantPID[view.Exec.StartNs]
+		require.NotNilf(t, view.Launch, "pid %d's execution lost its launch entirely", pid)
+		assert.Equalf(t, JoinExact, view.Join,
+			"pid %d supplied a correlation that exists in its own process; the join must be exact", pid)
+		assert.Equalf(t, pid, view.Launch.Launch.PID,
+			"pid %d's execution joined a launch from pid %d", pid, view.Launch.Launch.PID)
+		assert.Equalf(t, []string{wantStack[view.Exec.StartNs]}, stackNames(view.Launch),
+			"pid %d's GPU time must be attributed to the call path pid %d ran", pid, pid)
+	}
+
+	assert.Equal(t, uint64(2), snap.JoinStats.ExactExecutionJoinCount)
+	assert.Zero(t, snap.JoinStats.UnmatchedExecutionCount)
+	assert.Zero(t, snap.JoinStats.HeuristicExecutionJoinCount)
+	assert.Equal(t, uint64(2), snap.JoinStats.MatchedLaunchCount,
+		"two distinct launches were matched, not one launch matched twice")
+	assert.Zero(t, snap.JoinStats.UnmatchedLaunchCount)
+}
+
+// TestTimelinePendingPCSamplesStayWithTheirProcess covers Timeline.pending,
+// the second table keyed on correlation alone. A PC sample carrying pid
+// 5353's correlation must never be handed to pid 4242's execution.
+func TestTimelinePendingPCSamplesStayWithTheirProcess(t *testing.T) {
+	wantPC := map[uint64]uint64{20: 0xAAA, 21: 0xBBB}
+
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launchIn(4242, "7", 10, "a_work")))
+	require.NoError(t, tl.EmitLaunch(launchIn(5353, "7", 11, "b_work")))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation: corrFor(4242, "7"), PCOffset: 0xAAA, Count: 1, TimeNs: 25,
+	}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation: corrFor(5353, "7"), PCOffset: 0xBBB, Count: 1, TimeNs: 26,
+	}))
+	require.NoError(t, tl.EmitExec(execIn(4242, "7", 20, 30)))
+	require.NoError(t, tl.EmitExec(execIn(5353, "7", 21, 31)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 2)
+	for _, view := range snap.Executions {
+		require.Lenf(t, view.PCSamples, 1,
+			"the execution starting at %d must get exactly its own process's sample", view.Exec.StartNs)
+		assert.Equalf(t, wantPC[view.Exec.StartNs], view.PCSamples[0].PCOffset,
+			"the execution starting at %d was handed another process's PC sample", view.Exec.StartNs)
+	}
+	assert.Equal(t, uint64(2), snap.AttributedPCSamples)
+	assert.Zero(t, snap.PendingSamples, "both samples were claimed by their own execution")
+}
+
+// TestSingleProcessJoinsAreUnaffected is the non-regression half. With
+// Config.PID != 0 only one process ever reaches the timeline, so
+// process-qualifying the key must be a no-op there: every correlation still
+// joins exactly, nothing is unmatched, nothing degrades to the heuristic, and
+// no launch is treated as a replacement of another.
+func TestSingleProcessJoinsAreUnaffected(t *testing.T) {
+	const pid = 4242
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 512}})
+	for i := range 200 {
+		v := strconv.Itoa(i)
+		require.NoError(t, tl.EmitLaunch(launchIn(pid, v, uint64(i*10)+1, "work_"+v)))
+	}
+	for i := range 200 {
+		v := strconv.Itoa(i)
+		require.NoError(t, tl.EmitExec(execIn(pid, v, uint64(i*10)+2, uint64(i*10)+3)))
+	}
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 200)
+	for _, view := range snap.Executions {
+		require.NotNil(t, view.Launch)
+		assert.Equal(t, JoinExact, view.Join)
+		assert.Equal(t, view.Exec.Correlation.Value, view.Launch.Correlation.Value,
+			"a single-process join must still pair an execution with its own correlation")
+		assert.Equal(t, []string{"work_" + view.Exec.Correlation.Value}, stackNames(view.Launch))
+	}
+	assert.Equal(t, uint64(200), snap.JoinStats.ExactExecutionJoinCount)
+	assert.Zero(t, snap.JoinStats.UnmatchedExecutionCount)
+	assert.Zero(t, snap.JoinStats.HeuristicExecutionJoinCount)
+	assert.Zero(t, snap.JoinStats.UnmatchedLaunchCount)
+	assert.Zero(t, snap.LaunchCache.Replaced, "no correlation repeats within one process here")
+}
+
+// TestExecutionWithNoLaunchInItsOwnProcessIsUnattributed is the honest-miss
+// half. Once the key names the process, an execution whose correlation value
+// exists only in ANOTHER process legitimately misses the cache - and the miss
+// must degrade to unattributed and be counted, never be repaired by the
+// heuristic into the other process's launch (spec §13, review Critical 2).
+//
+// The two processes share a kernel name and queue and the surviving launch
+// precedes the execution, so the heuristic would find it a "plausible"
+// candidate if it were ever allowed to run here.
+func TestExecutionWithNoLaunchInItsOwnProcessIsUnattributed(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launchIn(4242, "7", 10, "a_work")))
+	require.NoError(t, tl.EmitExec(execIn(5353, "7", 20, 30)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	view := snap.Executions[0]
+	assert.Nil(t, view.Launch,
+		"pid 5353's execution must not borrow pid 4242's launch, or its call stack")
+	assert.False(t, view.Heuristic,
+		"a correlation was supplied and missed; guessing is not the remedy")
+	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount,
+		"the miss must be counted, not absorbed silently")
+	assert.Zero(t, snap.JoinStats.ExactExecutionJoinCount,
+		"a cross-process match must never be reported as vendor-provided truth")
+	assert.Zero(t, snap.JoinStats.HeuristicExecutionJoinCount)
+}
+
+// A record that carried no vendor correlation is still tagged with the
+// process that produced it, so "did this record carry a correlation" cannot
+// be asked by comparing against the zero CorrelationID. Present is the test,
+// and Timeline must use it: an exec with a pid and no value has to reach the
+// heuristic path, not be looked up as if "" were a real id.
+func TestCorrelationCarryingOnlyAProcessIsNotPresent(t *testing.T) {
+	assert.False(t, CorrelationID{}.Present())
+	assert.False(t, CorrelationID{Backend: BackendLinuxDRM, PID: 4242}.Present(),
+		"a pid is not a correlation")
+	assert.True(t, corrFor(4242, "7").Present())
+
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		KernelName: "hot_kernel",
+		TimeNs:     10,
+		Launch:     LaunchContext{PID: 4242, TimeNs: 10},
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendLinuxDRM, PID: 4242},
+		KernelName:  "hot_kernel",
+		StartNs:     20,
+		EndNs:       30,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Equal(t, JoinHeuristic, snap.Executions[0].Join,
+		"an exec with a pid but no correlation value supplied no correlation at all")
+	assert.True(t, snap.Executions[0].Heuristic, "a guess must always be marked as one")
+}

--- a/gpu/launchcache.go
+++ b/gpu/launchcache.go
@@ -64,6 +64,10 @@ type cacheEntry struct {
 }
 
 // LaunchCache is a bounded FIFO of recent launches indexed by correlation ID.
+// The correlation carries the producing process (see CorrelationID), so the
+// index is process-qualified: two processes reusing the same vendor value -
+// the norm system-wide, since vendor counters restart per process - occupy
+// two entries and neither can be handed out for the other's execution.
 // Put and Get are O(1) amortized. It replaces the unbounded slice plus linear
 // scan the earlier prototype used, which was quadratic at snapshot time.
 //

--- a/gpu/projection.go
+++ b/gpu/projection.go
@@ -182,7 +182,7 @@ func projectionPID(view ExecutionView) uint32 {
 // all. This label reports what was actually observed on the execution, not
 // what was inferred by the join; a heuristic match has no vendor-provided
 // correlation for this execution to report, so the label reflects that
-// honestly (present-if-nonzero, exactly as for an exact join) rather than
+// honestly (CorrelationID.Present(), exactly as for an exact join) rather than
 // borrowing the launch's Correlation and presenting an inference as an
 // observation.
 //
@@ -211,7 +211,7 @@ func projectionLabels(view ExecutionView) map[string]string {
 	if view.Exec.Queue.Device.DeviceID != "" {
 		labels["gpu_device"] = view.Exec.Queue.Device.DeviceID
 	}
-	if view.Exec.Correlation.Value != "" {
+	if view.Exec.Correlation.Present() {
 		labels["gpu_correlation"] = fmt.Sprintf("%s:%s", view.Exec.Correlation.Backend, view.Exec.Correlation.Value)
 	}
 	switch view.Join {

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -174,8 +174,10 @@ type Timeline struct {
 
 	execs *ring[GPUKernelExec]
 
-	// pending holds PC samples keyed by correlation ID until an exec with a
-	// matching Correlation is joined at Snapshot time. A correlation's
+	// pending holds PC samples keyed by correlation ID - which carries the
+	// producing process, so two processes reusing the same vendor value never
+	// share a bucket (see CorrelationID) - until an exec with a matching
+	// Correlation is joined at Snapshot time. A correlation's
 	// samples are deleted from pending the moment they are attached to an
 	// execution's view - they are consumed, not cached indefinitely. Since
 	// review Critical 3 made Snapshot drain execs the same way (an exec is
@@ -541,7 +543,7 @@ func (t *Timeline) Snapshot() Snapshot {
 
 	// The heuristic's candidate set is built lazily - only once the loop
 	// below hits its first exec that actually needs it (see the
-	// exec.Correlation zero-value branch), not unconditionally on every
+	// exec.Correlation.Present() branch), not unconditionally on every
 	// Snapshot call - review Important 4. LaunchCache.Entries() and the
 	// per-group sort are O(capacity); a CUPTI-style workload where every
 	// join is exact never touches this at all. Grouping by (queue, kernel
@@ -559,7 +561,7 @@ func (t *Timeline) Snapshot() Snapshot {
 	for i, exec := range execs {
 		view := ExecutionView{Exec: exec, PCSamples: execSamples[i]}
 
-		if exec.Correlation != (CorrelationID{}) {
+		if exec.Correlation.Present() {
 			if l, ok := t.cache.Get(exec.Correlation); ok {
 				launch := l
 				view.Launch = &launch
@@ -578,6 +580,12 @@ func (t *Timeline) Snapshot() Snapshot {
 			// different, still-live launch's PID and Tags to this
 			// execution merely because it shares a kernel name and queue -
 			// spec §13 requires degrading to unattributed instead.
+			//
+			// Since the correlation carries the producing process (issue
+			// #36), a launch from ANOTHER process with the same vendor
+			// value is now one of the things that legitimately misses here,
+			// and lands in UnmatchedExecutionCount rather than being
+			// reported as an exact join to the wrong process's call stack.
 			stats.UnmatchedExecutionCount++
 			views = append(views, view)
 			continue
@@ -651,6 +659,18 @@ func queueKeyOf(q GPUQueueRef) queueKey {
 	return queueKey{backend: q.Backend, queueID: q.QueueID}
 }
 
+// candidateGroupKey deliberately carries no process. It cannot: the heuristic
+// runs only for an execution that supplied no correlation at all, and since
+// issue #36 the correlation is the only place an execution's process
+// identity lives, so a correlation-less execution has no pid to group by.
+// A correlation-less backend in system-wide mode can therefore still match an
+// execution to another process's launch on (queue, kernel name, time) alone.
+// Closing that needs a process field on GPUKernelExec itself, which no
+// producer in the tree would populate today: the one shipping backend
+// (gpuprobe) supplies a correlation on every launch and execution, as spec §6
+// requires without exception, so nothing reaches this path. Left as a known,
+// documented gap rather than a field nobody writes.
+//
 // candidateGroupKey is the exact equivalence launchKernelNamesCompatible
 // defines (queue match plus kernel-name equality) turned into a map key.
 // Grouping candidates by this key and looking a miss up by its own
@@ -694,7 +714,7 @@ func buildHeuristicCandidateIndex(entries []GPUKernelLaunch) map[candidateGroupK
 }
 
 // findLaunchHeuristic is the fallback path when an exec never carried a
-// correlation ID at all (see the exec.Correlation zero-value branch in
+// correlation ID at all (see the exec.Correlation.Present() branch in
 // Snapshot). Ported decision from the prototype's findLaunchHeuristic: a
 // launch that precedes the exec's start, preferring the most recent such
 // launch, and flagging Ambiguous when more than one candidate qualified.

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -74,7 +74,7 @@ func TestTimelineAttachesPCSamplesByCorrelation(t *testing.T) {
 //
 // Both launches deliberately share KernelName "hot_kernel" here so that a
 // reversion of the Critical 2 fix (dropping the
-// `exec.Correlation != (CorrelationID{})` gate in Snapshot, or restoring an
+// `exec.Correlation.Present()` gate in Snapshot, or restoring an
 // unconditional heuristic attempt) would make this test fail by reattaching
 // exec "a" to launch "b" - proving the fix is what prevents it, not an
 // accidental kernel-name mismatch.

--- a/gpu/types.go
+++ b/gpu/types.go
@@ -112,10 +112,51 @@ type GPUExecutionRef struct {
 
 // CorrelationID ties a launch to its later execution/sample events. It is
 // comparable and safe to use directly as a map key.
+//
+// A vendor correlation value is unique only WITHIN one process. CUPTI's
+// correlationId is a process-wide counter (§6.3 finding 4) and ROCm's
+// correlation_id.internal is no different: every process starts its sequence
+// from a low value. The probes, meanwhile, are attached with uprobe_multi
+// against the shim *file*, so every process that maps it feeds one consumer
+// and one Timeline, and system-wide (Config.PID == 0) is the documented
+// default. Two profiled processes therefore collide on correlation within the
+// first handful of launches.
+//
+// PID is what makes the identity whole, and it lives here - rather than as a
+// separate argument each join site is trusted to remember - so the compiler
+// enforces it at every construction site instead. That matters because a
+// launch carries a symbolized CPU stack resolved against /proc/<pid>/maps of
+// the process that produced it: a join across processes does not merely swap
+// metadata, it attributes one process's measured GPU time to a call path in a
+// different address space. A fabricated flame graph is worse than no flame
+// graph (spec §4).
+//
+// PID is the process that produced the event, as observed by the probe (the
+// batch header's pid), not a thread id; LaunchContext.TID carries the thread.
+// A backend with no process to name (a device-global lifecycle producer)
+// leaves it zero, and all such events then share one process namespace, which
+// is exactly what they mean.
+//
+// Present, not the zero value, is the test for "this record carried a
+// correlation at all" - see that method.
 type CorrelationID struct {
 	Backend GPUBackendID `json:"backend"`
+	PID     uint32       `json:"pid,omitempty"`
 	Value   string       `json:"value"`
 }
+
+// Present reports whether a correlation was actually supplied for this
+// record. Value is the whole of that answer: PID and Backend are context the
+// producer knows regardless, so a record that carries no vendor correlation
+// may still arrive with both filled in, and comparing against the zero
+// CorrelationID would then read it as a real, joinable id.
+//
+// This distinction is load-bearing. Timeline.Snapshot routes a correlation-
+// less execution to the heuristic join and an execution whose correlation
+// merely MISSED the cache to unattributed (spec §13, review Critical 2);
+// mistaking the first for the second, or the reverse, is how an execution
+// gets guess-attached to a launch it has no relationship with.
+func (c CorrelationID) Present() bool { return c.Value != "" }
 
 // ClockDomain identifies which clock a *_ns timestamp was measured against.
 //
@@ -232,6 +273,12 @@ type GPUKernelLaunch struct {
 
 // GPUKernelExec is emitted when a launched kernel's execution window is
 // known (start/end on-device), joined back to its launch by Correlation.
+//
+// There is no separate PID field: the process that produced this execution is
+// carried by Correlation (see CorrelationID), which is the only identity the
+// join uses and therefore the only place it cannot be forgotten. An execution
+// that carried no correlation at all has no process either, and takes the
+// heuristic path.
 type GPUKernelExec struct {
 	Execution   GPUExecutionRef `json:"execution"`
 	Correlation CorrelationID   `json:"correlation"`
@@ -268,8 +315,12 @@ type GPUModule struct {
 // Module, not Correlation, is the identity that always arrives. CUPTI populates
 // a PC sample's correlation ID only in kernel-serialized collection, which
 // serializes execution and so is not what we run; in continuous mode it is
-// always zero. Correlation is therefore optional here (zero means unknown) and
-// attribution goes through the module and PC offset.
+// always zero. Correlation is therefore optional here (Present() == false
+// means unknown) and attribution goes through the module and PC offset.
+//
+// When a correlation IS supplied, it carries the producing process with it
+// (see CorrelationID), so a sample can only ever be handed to an execution
+// from the same process.
 type GPUPCSample struct {
 	Correlation CorrelationID `json:"correlation"`
 	Module      ModuleRef     `json:"module"`

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -1212,22 +1212,33 @@ func (c *Consumer) noteSeq(kind, pid uint32, seq uint64) {
 
 // correlationOf converts a wire correlation into the core's CorrelationID.
 //
+// pid is the batch header's — the process that fired the probe — and it is
+// part of the id, not decoration. Vendor correlation counters restart from a
+// low value in every process and the probes fire for every process that maps
+// the shim, so a correlation without its pid collides across processes within
+// the first handful of launches; see gpu.CorrelationID. Taking it as a
+// parameter is what makes it impossible to build one of these without
+// deciding whose it is.
+//
 // A wire value of zero means "this record carries no correlation" — the ABI
 // says so explicitly for PC samples in continuous collection, the mode this
-// project ships (shim/core/usdt_abi.h, spec §6.3 finding 3). It must map to
-// the *zero* gpu.CorrelationID, because that is the value gpu/timeline.go
+// project ships (shim/core/usdt_abi.h, spec §6.3 finding 3). It must map to a
+// correlation that is not Present(), because that is what gpu/timeline.go
 // tests to decide a record needs the heuristic join. Formatting it as the
 // string "0" would produce a perfectly valid-looking ID that every
-// uncorrelated record shares, collapsing them into one exact-join bucket and
-// yielding confident, wrong joins with nothing counted.
+// uncorrelated record in one process shares, collapsing them into one
+// exact-join bucket and yielding confident, wrong joins with nothing counted.
+// The whole zero value is returned rather than one carrying only the pid, so
+// that the older `== gpu.CorrelationID{}` reading and the Present() reading
+// agree on these records.
 //
 // Caller holds mu: the zero case bumps a counter so the demotion is visible.
-func (c *Consumer) correlationOf(v uint64) gpu.CorrelationID {
+func (c *Consumer) correlationOf(pid uint32, v uint64) gpu.CorrelationID {
 	if v == 0 {
 		c.stats.ZeroCorrelation++
 		return gpu.CorrelationID{}
 	}
-	return gpu.CorrelationID{Backend: c.cfg.Backend, Value: strconv.FormatUint(v, 10)}
+	return gpu.CorrelationID{Backend: c.cfg.Backend, PID: pid, Value: strconv.FormatUint(v, 10)}
 }
 
 // Run reads batches until the context is cancelled or the consumer is
@@ -1313,7 +1324,7 @@ func (c *Consumer) applyBatch(b batch) {
 		for _, l := range b.Launches {
 			c.stats.Records++
 			ev := gpu.GPUKernelLaunch{
-				Correlation: c.correlationOf(l.Correlation),
+				Correlation: c.correlationOf(b.PID, l.Correlation),
 				// The shim stamps CLOCK_MONOTONIC, which is the only domain
 				// the core accepts; say so rather than leaning on
 				// NormalizeClockDomain's zero-value default.
@@ -1333,7 +1344,7 @@ func (c *Consumer) applyBatch(b batch) {
 		for _, e := range b.Execs {
 			c.stats.Records++
 			ev := gpu.GPUKernelExec{
-				Correlation: c.correlationOf(e.Correlation),
+				Correlation: c.correlationOf(b.PID, e.Correlation),
 				ClockDomain: gpu.ClockDomainCPUMonotonic,
 				StartNs:     e.StartNs,
 				EndNs:       e.EndNs,
@@ -1388,16 +1399,19 @@ func (c *Consumer) applyBatch(b batch) {
 //
 // The first two cases can therefore overtake a launch already held from the
 // same batch. That reordering is bounded by one batch and is harmless to the
-// consumers that exist: gpu.LaunchCache keys on correlation, orders eviction
+// consumers that exist: gpu.LaunchCache keys on the process-qualified
+// correlation, orders eviction
 // by insertion rather than by timestamp, and ignores a timestamp older than
 // the newest it has seen (observeTimestampLocked), so an out-of-order Put
 // neither displaces the wrong entry nor moves the horizon.
 func (c *Consumer) admitLaunchLocked(ev gpu.GPUKernelLaunch, kernelID uint64) {
-	if ev.Correlation == (gpu.CorrelationID{}) {
+	if !ev.Correlation.Present() {
 		c.emitLaunchLocked(ev, kernelID)
 		return
 	}
-	key := launchKey{pid: ev.Launch.PID, corr: ev.Correlation}
+	// The correlation already names the process (correlationOf), so it is the
+	// whole key: nothing here has to remember to add a pid.
+	key := ev.Correlation
 	if st, ok := c.pending.take(key); ok {
 		c.attachLocked(&ev, st.frames, st.period)
 		c.emitLaunchLocked(ev, kernelID)
@@ -1450,13 +1464,12 @@ func (c *Consumer) attachSampledStackLocked(pid uint32, stackID int32, sl gpuabi
 	case stackAttributable:
 	}
 
-	// Keyed on (pid, correlation), never correlation alone: see launchKey.
-	// pid is the batch header's, i.e. the process that fired the probe, which
-	// is the same field the batched twin's launch carries.
-	key := launchKey{
-		pid:  pid,
-		corr: gpu.CorrelationID{Backend: c.cfg.Backend, Value: strconv.FormatUint(sl.Correlation, 10)},
-	}
+	// Built through the same correlationOf as the batched twin's, from the
+	// same batch-header pid, so the two keys are equal by construction and
+	// neither can be a bare correlation value. sl.Correlation is non-zero
+	// here (checked above), so correlationOf cannot take its ZeroCorrelation
+	// branch and this does not double-count that demotion.
+	key := c.correlationOf(pid, sl.Correlation)
 	// The batched twin arrived first and is still being held: attach and let
 	// it go now, since nothing more can arrive for it.
 	if held, ok := c.deferred.take(key); ok {

--- a/gpuprobe/consumer_test.go
+++ b/gpuprobe/consumer_test.go
@@ -341,7 +341,9 @@ func TestApplyBatchNormalizesLaunches(t *testing.T) {
 
 	require.Len(t, sink.launches, 1)
 	got := sink.launches[0]
-	assert.Equal(t, gpu.CorrelationID{Backend: gpu.BackendCUPTI, Value: "77"}, got.Correlation)
+	// The correlation carries the batch header's pid: a vendor value alone
+	// collides across processes (gpu.CorrelationID, issue #36).
+	assert.Equal(t, gpu.CorrelationID{Backend: gpu.BackendCUPTI, PID: 4242, Value: "77"}, got.Correlation)
 	assert.Equal(t, uint64(900), got.TimeNs)
 	assert.Equal(t, uint32(4242), got.Launch.PID)
 	assert.Equal(t, uint32(55), got.Launch.TID)
@@ -358,6 +360,7 @@ func TestApplyBatchNormalizesExecs(t *testing.T) {
 	buf := make([]byte, batchHdrSize+48)
 	putU32(buf[0:], kindExec)
 	putU32(buf[4:], 1)
+	putU32(buf[16:], 4242) // pid comes from the batch header
 	putU64(buf[24:], 48)
 	putU64(buf[batchHdrSize+0:], 88)   // correlation
 	putU64(buf[batchHdrSize+32:], 10)  // start_ns
@@ -369,6 +372,11 @@ func TestApplyBatchNormalizesExecs(t *testing.T) {
 
 	require.Len(t, sink.execs, 1)
 	assert.Equal(t, "88", sink.execs[0].Correlation.Value)
+	// GPUKernelExec has no PID field of its own; the correlation is where an
+	// execution's process identity lives, and the join depends on it being
+	// there (issue #36).
+	assert.Equal(t, uint32(4242), sink.execs[0].Correlation.PID,
+		"an execution's correlation must name the process that produced it")
 	assert.Equal(t, uint64(10), sink.execs[0].StartNs)
 	assert.Equal(t, uint64(200), sink.execs[0].EndNs)
 }
@@ -2512,4 +2520,68 @@ func TestRepeatedDecodeFailuresDoNotAllocate(t *testing.T) {
 	// its business; what matters is that every one of them was counted.
 	assert.Greater(t, tbl.snapshot()[0].Count, uint64(1000),
 		"every repeat must still be counted, allocation-free or not")
+}
+
+// execBatchWith builds an exec batch carrying the given correlations, in
+// order, all from one pid.
+func execBatchWith(pid uint32, startNs uint64, corrs ...uint64) []byte {
+	buf := make([]byte, batchHdrSize+len(corrs)*gpuabi.SizeExec)
+	putU32(buf[0:], kindExec)
+	putU32(buf[4:], uint32(len(corrs)))
+	putU32(buf[16:], pid)
+	putU64(buf[24:], uint64(len(corrs)*gpuabi.SizeExec))
+	putU32(buf[32:], ^uint32(0)) // stack_id = -1 on every non-sampled kind
+	for i, corr := range corrs {
+		rec := buf[batchHdrSize+i*gpuabi.SizeExec:]
+		putU64(rec[0:], corr)
+		putU64(rec[32:], startNs+uint64(i)) // start_ns
+		putU64(rec[40:], startNs+uint64(i)+10)
+	}
+	return buf
+}
+
+// TestSameCorrelationInTwoProcessesJoinsInTheTimeline is issue #36 end to
+// end: the consumer's own side tables were already (pid, correlation)-keyed,
+// but the gpu.Timeline underneath them was not, so a launch that kept its own
+// stack all the way through the consumer could still be handed to the other
+// process's execution one layer down.
+//
+// Both processes use wire correlation 7 - the collision is not contrived,
+// vendor correlation counters restart from a low value in every process and
+// the probes fire for every process that maps the shim.
+func TestSameCorrelationInTwoProcessesJoinsInTheTimeline(t *testing.T) {
+	tl := gpu.NewTimeline(gpu.TimelineConfig{})
+	c, sm, _ := stackConsumer(t, tl, Config{})
+	sm.put(1, 0x1000) // the stack captured in pid 4242
+	sm.put(2, 0x2000) // the stack captured in pid 5353
+
+	apply(t, c, sampledBatchWith(4242, 7, 1, 8))
+	apply(t, c, sampledBatchWith(5353, 7, 2, 8))
+	apply(t, c, launchBatchWith(4242, 7))
+	apply(t, c, launchBatchWith(5353, 7))
+	c.Flush()
+	apply(t, c, execBatchWith(4242, 1000, 7))
+	apply(t, c, execBatchWith(5353, 2000, 7))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 2)
+
+	wantStack := map[uint64]string{1000: "fn_1000", 2000: "fn_2000"}
+	wantPID := map[uint64]uint32{1000: 4242, 2000: 5353}
+	for _, view := range snap.Executions {
+		pid := wantPID[view.Exec.StartNs]
+		require.NotNilf(t, view.Launch, "pid %d's execution lost its launch", pid)
+		assert.Equalf(t, gpu.JoinExact, view.Join,
+			"pid %d supplied a correlation live in its own process", pid)
+		assert.Equalf(t, pid, view.Launch.Launch.PID,
+			"pid %d's execution joined a launch from pid %d", pid, view.Launch.Launch.PID)
+		assert.Equalf(t, []string{wantStack[view.Exec.StartNs]}, frameNames(view.Launch.Launch.CPUStack),
+			"pid %d's GPU time must carry the call path captured in pid %d, not the other process's", pid, pid)
+	}
+	assert.Equal(t, uint64(2), snap.JoinStats.ExactExecutionJoinCount)
+	assert.Equal(t, uint64(2), snap.JoinStats.MatchedLaunchCount,
+		"two distinct launches were matched, not one matched twice")
+	assert.Zero(t, snap.JoinStats.UnmatchedExecutionCount)
+	assert.Zero(t, snap.JoinStats.UnmatchedLaunchCount)
+	assert.Equal(t, uint64(2), c.Stats().StacksAttached)
 }

--- a/gpuprobe/sampledstacks.go
+++ b/gpuprobe/sampledstacks.go
@@ -62,22 +62,25 @@ import (
 // rate, which is exactly the class of bug the bounded stores in gpu/ exist
 // to avoid.
 
-// launchKey identifies one launch. A correlation alone does not.
+// The side tables below key on gpu.CorrelationID, which carries the
+// producing process. A correlation VALUE alone does not identify a launch.
 //
 // The probes are attached with uprobe_multi against the shim *file*, so
 // every process that maps it fires them, and Config.PID == 0 (system-wide)
 // is a supported mode. CUPTI hands out correlation ids per process, each
 // sequence starting from a low value, so two profiled processes collide on
-// correlation within the first handful of launches. Keying the side tables
-// on correlation alone would let process A's stack - symbolized against
+// correlation within the first handful of launches. Keying these tables on
+// the value alone would let process A's stack - symbolized against
 // /proc/A/maps - be attached to process B's launch, projecting B's measured
 // GPU time under a call path that provably did not produce it. A fabricated
-// flame graph is worse than no flame graph, so the pid is part of the key on
-// every insert, lookup, eviction and drain path.
-type launchKey struct {
-	pid  uint32
-	corr gpu.CorrelationID
-}
+// flame graph is worse than no flame graph.
+//
+// This used to be a local launchKey{pid, corr} pair, because the core's
+// CorrelationID was pid-blind and the timeline underneath these tables had
+// the same defect (issue #36). Now that the pid lives in the id itself, the
+// pair would be two copies of the same fact that could drift apart, so the
+// key IS the correlation: Consumer builds every one of them through
+// correlationOf, which cannot be called without naming a process.
 
 // resolvedStack is a capture that has already been read out of the stackmap
 // and symbolized, waiting for the batched launch it belongs to.
@@ -93,7 +96,7 @@ type resolvedStack struct {
 	gen uint64
 }
 
-// pendingStacks is the bounded (pid, correlation) -> stack side table for
+// pendingStacks is the bounded correlation -> stack side table for
 // captures that arrived before their batched twin. Eviction is FIFO: the
 // oldest
 // parked capture is the one whose twin is least likely to still be coming
@@ -102,7 +105,7 @@ type resolvedStack struct {
 //
 // Not internally synchronized; Consumer calls it under its own mutex.
 type pendingStacks struct {
-	byKey    map[launchKey]resolvedStack
+	byKey    map[gpu.CorrelationID]resolvedStack
 	order    []stackPos
 	head     int
 	gen      uint64
@@ -110,7 +113,7 @@ type pendingStacks struct {
 }
 
 type stackPos struct {
-	key launchKey
+	key gpu.CorrelationID
 	gen uint64
 }
 
@@ -119,7 +122,7 @@ func newPendingStacks(capacity int) *pendingStacks {
 		capacity = defaultSampledStackCapacity
 	}
 	return &pendingStacks{
-		byKey:    make(map[launchKey]resolvedStack),
+		byKey:    make(map[gpu.CorrelationID]resolvedStack),
 		capacity: capacity,
 	}
 }
@@ -130,7 +133,7 @@ func newPendingStacks(capacity int) *pendingStacks {
 // is not itself an eviction of a *pending* stack - the caller counts the
 // replaced one as evicted all the same, because its stack will never reach
 // a launch either.
-func (p *pendingStacks) park(key launchKey, frames []pp.Frame, period uint32) (evicted int) {
+func (p *pendingStacks) park(key gpu.CorrelationID, frames []pp.Frame, period uint32) (evicted int) {
 	if _, replaced := p.byKey[key]; replaced {
 		evicted++
 	}
@@ -206,7 +209,7 @@ func (p *pendingStacks) reclaimOrder() {
 }
 
 // take removes and returns the capture parked for key, if any.
-func (p *pendingStacks) take(key launchKey) (resolvedStack, bool) {
+func (p *pendingStacks) take(key gpu.CorrelationID) (resolvedStack, bool) {
 	st, ok := p.byKey[key]
 	if !ok {
 		return resolvedStack{}, false
@@ -292,14 +295,14 @@ func (d *deferredLaunches) pop() (deferredLaunch, bool) {
 	return l, true
 }
 
-// take removes the queued launch with this (pid, correlation), if it is
-// still held. The pair is unique per launch - a correlation on its own is
-// not, see launchKey - so the first match is the only one; the scan runs
-// from the newest end because the twin of a just-arrived sampled record is
-// the launch that was queued most recently.
-func (d *deferredLaunches) take(key launchKey) (deferredLaunch, bool) {
+// take removes the queued launch with this correlation, if it is still held.
+// A process-qualified correlation is unique per launch - a correlation value
+// on its own is not, see the note above pendingStacks - so the first match is
+// the only one; the scan runs from the newest end because the twin of a
+// just-arrived sampled record is the launch that was queued most recently.
+func (d *deferredLaunches) take(key gpu.CorrelationID) (deferredLaunch, bool) {
 	for i := len(d.buf) - 1; i >= d.head; i-- {
-		if d.buf[i].launch.Launch.PID != key.pid || d.buf[i].launch.Correlation != key.corr {
+		if d.buf[i].launch.Correlation != key {
 			continue
 		}
 		l := d.buf[i]

--- a/gpuprobe/sampledstacks_test.go
+++ b/gpuprobe/sampledstacks_test.go
@@ -11,11 +11,8 @@ import (
 	pp "github.com/dpsoft/perf-agent/pprof"
 )
 
-func testCorr(i int) launchKey {
-	return launchKey{
-		pid:  1,
-		corr: gpu.CorrelationID{Backend: gpu.BackendCUPTI, Value: strconv.Itoa(i)},
-	}
+func testCorr(i int) gpu.CorrelationID {
+	return gpu.CorrelationID{Backend: gpu.BackendCUPTI, PID: 1, Value: strconv.Itoa(i)}
 }
 
 // The steady state of the sampled-first path is park-then-take with the map


### PR DESCRIPTION
Closes #36.

`gpu.LaunchCache` and `Timeline.pending` keyed joins on correlation ID alone. Vendor
correlation IDs restart from a low value in **every process**, so in system-wide mode —
the documented default — two profiled processes collide almost immediately and an
execution can join another process's launch.

Since Phase 4a a launch carries a symbolized CPU stack resolved against
`/proc/<pid>/maps`. A mis-join therefore attributes one process's GPU time to a call path
in a different process: a flame graph that is confidently, specifically wrong.

### The fix

`CorrelationID` now carries `PID`. Both maps are keyed on `CorrelationID`, so **widening
the type widened the key — neither join site needed a code change.** Process identity is
enforced at every *construction* site by the compiler rather than at every *join* site by
memory, which is precisely the failure mode this bug is.

`Consumer.correlationOf(pid, v)` is the only construction point in non-test code; all
three callers pass the batch header's pid. The USDT wire ABI is untouched — the pid
already travelled in the batch header and was simply being discarded on the
exec/correlation path.

`gpuprobe.launchKey` is **deleted**. With the pid in the id, `launchKey{pid, corr}` was
two copies of one fact that could drift apart. The sampled-stack key and its batched twin
now both go through `correlationOf`, so they are equal by construction rather than by two
literals agreeing — strictly better than before, where the sampled path used a
hand-written literal that bypassed `correlationOf` entirely.

`CorrelationID.Present()` (`Value != ""`) replaces `correlation != CorrelationID{}` as the
"did this carry a correlation at all" predicate at all four sites. Adding a field breaks
the zero-struct test, which would route a correlation-less exec to the heuristic path and
a merely-missed one to unattributed.

### Pre-fix behaviour, reproduced against `main`

Two processes reusing the same correlation value. Four assertions fail, one passes, and
which one passes is the point:

- pid 4242's execution is shown running `fn_2000` — a symbol from **pid 5353's** address
  space — because `LaunchCache` had discarded pid 4242's launch as a "replacement".
- With only pid 4242 having launched, pid 5353's execution is handed pid 4242's launch
  object including its `CPUStack`, and reported as `ExactExecutionJoinCount == 1`,
  `UnmatchedExecutionCount == 0`. **Every honesty signal reads clean while the output is
  fabricated.**
- pid 5353's own stack assertion *passes*: the consumer-side `launchKey` fix
  (`63e9f610`) did its job one layer up and could not help. The corruption is entirely in
  the timeline underneath it — the issue's framing, verbatim.

### Counters

A cross-process pair used to land in `ExactExecutionJoinCount` — green while wrong. It now
misses the cache and lands in `UnmatchedExecutionCount` with `Launch == nil` and
`gpu_join="unmatched"`. No counter was added or removed. The counter that *falls* is
`Replaced`, which had been quietly absorbing cross-process collisions and reading as
benign correlation reuse.

### Bounded caches

Both bounds are global and unscaled (`LaunchCache` capacity 65536, `pendingCap` the same),
so an N-process run reaches capacity roughly N× sooner. This is a consequence, not a
regression: what survived before was the *wrong* entry, every eviction path is already
counted and reaches the serialized `Snapshot`, and an evicted launch degrades honestly to
`unmatched`. The storage that looked adequate was partly an illusion created by the very
collision this fixes. Eviction is global FIFO, so a busy process can evict a quiet one's
entries — named in the report; not new, but this change makes it reachable.

### Deliberately not fixed

The heuristic join stays process-blind and cannot be fixed here: it runs only for an exec
that supplied no correlation, and after this change the correlation is the only place an
exec's process lives. It is a disclosed guess — labelled `heuristic`, counted separately,
never presented as vendor truth. Filed as #52. Also filed: #51 (these counters are never
surfaced) and #53 (no `gpu_pid` label; `gpu_correlation` is ambiguous across processes).

Single-process profiling is unaffected, proven by a control test that was mutation-tested
to confirm it fails when single-process joins break, plus the entire pre-existing `gpu`
suite, which is a `PID == 0` corpus and passes unchanged.
