### PR TITLE
test: collect until the profile is judgeable, not for a fixed window

### DIFF
--- a/.superpowers/sdd/issue-42-report.md
+++ b/.superpowers/sdd/issue-42-report.md
@@ -1,0 +1,656 @@
+# Issue #42 — the integration suite asserted on a fixed wall-clock window
+
+Branch `fix/integration-collect-until`, worktree `.worktrees/ci-flake-fix`, cut from
+`origin/main` (`35d5d496`).
+
+Scope was `test/` only. Nothing outside `test/` was changed. One thing arguably *should*
+change outside it — see §6 — and is flagged rather than done.
+
+**Read §3 first if you read nothing else: this change does not make issue #42's third
+symptom green, and that is a deliberate, defended decision rather than an oversight.**
+
+Revised twice after review; §11 records what each round changed.
+
+---
+
+## 1. The diagnosis this fix acts on
+
+The issue body and its three comments record three symptoms:
+
+| symptom | seen on |
+|---|---|
+| samples captured, every frame kernel-side | `TestKernelStackResolution`, both arches |
+| zero samples captured at all → empty profile → bare `EOF` | `TestKernelStackResolution`, arm64 (PR #46) |
+| samples + kernel symbols, no real user mapping | `TestPerfAgentSystemWideDwarfProfile`, amd64 (PR #48) |
+
+and the datum that settles causation for the first two: commit `8403e54e` on arm64 failed
+**twice with two different symptoms and passed on the third attempt**, same runner image.
+A failure non-deterministic on fixed code is not caused by that code.
+
+The shared structure: a test starts a real workload, samples it for a fixed wall-clock
+window (3–10 s at 99 Hz), and asserts on whatever landed. A `cpu-clock` sample only fires
+while the target is **on CPU**, so against an I/O-bound workload on a contended runner
+"whatever landed" is a coin toss.
+
+The fix is the issue's first suggested direction: **collect until the condition is
+observed, with a deadline**. Symptom 3 turns out not to belong to this family at all —
+§3.
+
+---
+
+## 2. What must be retried, and what must never be
+
+This is the distinction the whole change turns on, and the one the first version of it
+got wrong at three sites.
+
+A collect-until loop is only honest if its condition is a **precondition** — "did this
+capture exercise the thing under test at all?" — and never the **assertion** itself. If
+the loop waits for the assertion to hold, then on the success path the assertion cannot
+fail, and an intermittent regression is retried into a pass: at a 60% per-capture success
+rate, three attempts turn a real 40%-of-the-time bug into a 94% green rate.
+
+The two halves are separable, and `fidelityDiagnosis` computes the split for the reader:
+
+| observation | half | treatment |
+|---|---|---|
+| too few samples to judge | precondition unmet | retry |
+| samples, but every frame kernel-side | precondition unmet — never on-CPU in user space | retry |
+| enough samples, user-space PCs, resolving to no binary mapping | assertion violated — mapping resolution is the suspect | **fail now** |
+
+So the loop condition for the three fidelity-checking sites is `profileFidelityJudgeable`:
+`Samples >= degenerateSampleFloor && userSpaceFrames(sum) > 0`.
+
+Two properties make that safe:
+
+- **Neither conjunct implies `RealMappings >= 1`.** `UserFrames > 0` alone would *not*
+  have worked — a location's mapping must appear in the profile's mapping table, so it
+  implies `RealMappings >= 1` just as surely as the original condition did, and would
+  have preserved the defect in a subtler form. Counting the **unmapped** frames is what
+  makes it a precondition rather than a restatement.
+  `TestUserSpacePreconditionDoesNotImplyRealMapping` pins both directions.
+- **The sample floor is not invented here.** `isDegenerateProfile` already uses
+  `degenerateSampleFloor` to decide when a zero-real-mapping profile is tolerated and
+  when it is "a genuine bug worth a loud failure" — its own words. Reusing the constant
+  keeps the retry policy and the tolerance policy from disagreeing: re-collect exactly
+  while the capture is below the bar the suite already set for judging it, then hand it
+  over the moment it clears.
+
+---
+
+## 3. Does this change fix symptom 3? No — and here is the derivation
+
+The reviewer asked this directly, and it is worth the space. **The answer is no**: the
+capture behind symptom 3 clears the precondition, so it is judged rather than retried,
+and `assertPprofFidelity` fails on the first attempt.
+
+### 3.1 The message that seeded symptom 3 is uninterpretable
+
+```
+integration_test.go:1322: expected >=1 real mapping, got 0: [0x1311ff8c230]
+integration_test.go:1322: pprof fidelity: real_mappings=0 has_build_id=false
+```
+
+The old code was `t.Errorf("... got %d: %+v", real, p.Mapping)`, and `p.Mapping` is
+`[]*profile.Mapping`. `fmt` only uses the `&{...}` form at depth 0; inside a slice it
+prints pointers as bare addresses. Verified directly:
+
+```
+one mapping,  %+v:  [0x3a0e45bf4a50]
+two mappings, %+v:  [0x3a0e45bf4a80 0x3a0e45bf4ab0]
+top-level ptr %+v:  &{ID:1 Start:0 File: BuildID:}
+```
+
+So `[0x1311ff8c230]` is a **Go heap pointer to one `profile.Mapping`**. It is not an
+address from the capture, not a mapping's `Start`, and carries no field of any mapping.
+The only datum in it is the count: **one mapping**. The reading recorded in the issue —
+"every user PC landed in one anonymous region, and the symbolized functions came from
+`[kernel]`" — could not have been derived from this message, and §3.2 shows the
+`[kernel]` half is contradicted by the code.
+
+### 3.2 What the code does let us recover
+
+| fact | source |
+|---|---|
+| the builder **always** pre-creates `Mapping[0] = {ID: 1}` with `File: ""` | `pprof/pprof.go:182-186` |
+| any kernel frame appends a `[kernel]` sentinel mapping | `addLocation` case 1 + `addMapping` (appends) |
+| any JIT frame appends a `[jit]` sentinel mapping | `addLocation` case 2 |
+| any resolver hit appends a file-backed mapping | `addLocation` case 3 |
+| everything else falls back onto `Mapping[0]` | `addLocation` case 4 |
+| the write path is `Profile.WriteUncompressed` — no `Compact`, no `Merge` | `ProfileBuilder.Write`, `profile/profiler.go:255` |
+| a write/parse round trip keeps unreferenced mappings | verified — `TestProfileRoundTripKeepsUnreferencedMappings` |
+
+`len(p.Mapping) == 1` therefore means the single mapping **is** the always-present
+default, and that **no kernel, JIT or resolver-derived mapping was ever created**. There
+were no kernel frames in that profile at all.
+
+One more fact falls out of the tolerance ladder. The failure reached `default:`, so
+`isDegenerateProfile(p)` returned false; with `real == 0` and no JIT mapping its own loop
+cannot return false, so it returned false because `len(p.Sample) >= degenerateSampleFloor`.
+
+**The capture was: ≥ 20 samples, every frame on the default anonymous mapping, zero
+kernel frames.**
+
+### 3.3 The three answers
+
+1. **What is `[0x1311ff8c230]`?** A Go heap pointer to one `profile.Mapping` struct. The
+   message printed a mapping *count* and nothing else.
+2. **Would `profileHasUserSpaceFrames` return true on it?** **Yes** — every one of its
+   ≥ 20 frames counts as an unmapped user-space frame. It also clears the sample floor.
+   So the loop exits on the first capture and `assertPprofFidelity` hard-fails. **This
+   change does not fix symptom 3.** It is not "intended behaviour" in the sense of
+   solving it; it is a deliberate refusal to solve it by retrying.
+3. **Profiler defect or starved capture?** Neither reading in the issue survives contact
+   with the code. Not "all kernel-side" — there were no kernel frames. Not starved by the
+   suite's own standard — it was above `degenerateSampleFloor`. What it actually was:
+   **every sampled PC failed resolver attribution**, which is the shape of a
+   mapping-resolution failure, not of a workload that was never on-CPU in user space.
+   The sibling `TestPerfAgentSystemWideDwarfOffCPU` resolving 28 mappings in the same run
+   is consistent with that reading, though it was a separate agent invocation.
+
+### 3.4 Why fail rather than retry, and what I cannot prove
+
+I **cannot** prove the cause from the available evidence. A `-a` capture in which every
+sampled PID exited before `/proc/<pid>/maps` could be read would produce the same profile
+and would be environmental. Ruling that in or out needs data the log does not contain.
+
+Given the uncertainty, the tie-break comes from the issue's own thesis: a suite that
+fails randomly "makes a genuine regression indistinguishable from noise". We cannot show
+this is noise, so we must not encode it as noise. The change therefore fails fast and
+explains itself, rather than retrying until the mapping appears — which would have made a
+possible resolver bug invisible. `TestSymptomThreeIsJudgedNotRetried` pins the outcome so
+that nobody later "fixes" the red by widening the loop condition back.
+
+The practical difference from `main` for this one site is that it fails **faster and
+legibly** rather than being fixed. Reconstructing the capture and asking the new message
+what it says:
+
+```
+expected >=1 real (file-backed) mapping, got 0.
+  captured: samples=40 value_total=40 locations=1 functions=1(named=1) frames{user=0 kernel=0 jit=0 unmapped=40} mappings{real=0 kernel=0 jit=0 anon=1} build_id=false
+  reading:  40 frame(s) carried a user-space PC that resolved to no binary mapping — mapping resolution (procmap/blazesym) is the suspect
+  mappings: 1 mapping(s): [#1 file="" start=0x0 limit=0x0 off=0x0 build_id=""]
+```
+
+Everything §3.2 needed a code read to derive is now in the failure text.
+
+### 3.5 What evidence would settle it
+
+If it recurs, these decide it — the first two are now printed automatically:
+
+- **the frame split and the mapping table** (above): `unmapped=N, kernel=0` with N large
+  rules out the "never on-CPU in user space" reading on the spot;
+- **the agent's own `symbolize:` / `dwarfagent:` counter line** on stderr, which the CI
+  log captures for other tests but the issue comment did not quote;
+- **whether the samples came from one PID or many** — these pprof samples carry no pid
+  label, so this needs either a label added to the builder (outside `test/`) or a
+  cross-read against the perf.data from the same run.
+
+If it recurs with a large `unmapped` count and zero real mappings, that is a
+mapping-resolution bug and deserves its own issue, not a retry.
+
+---
+
+## 4. The harness — `test/collect_until.go` (new)
+
+```go
+func collectUntil(t *testing.T, what string, window, budget time.Duration,
+        attempt func(n int) (ok bool, detail string)) (bool, string)
+
+func collectProfileUntil(t *testing.T, what string, window time.Duration,
+        collect func(n int) (*profile.Profile, error),
+        cond func(*profile.Profile) bool) (*profile.Profile, bool, string)
+```
+
+One *attempt* is one complete collection: spawn the agent for `window`, or run one
+in-process `Start`/sleep/`Stop` cycle. Attempts repeat until `cond` holds or a budget is
+spent. The workload stays alive across attempts, so this re-samples the same live target;
+it does not re-run the test.
+
+**How a timeout is handled is per-site, and is not uniform.** Counted exactly: 24 call
+sites, 15 of which report the loop's failure with `t.Logf("WARN: %s", report)` and then
+let the test's own assertions run on the last capture and decide — for the sites with a
+tolerance ladder (`TestProfileMode`, `assertPprofFidelity`) that ladder is reached
+exactly as it was before this change. The other 9 make the timeout fatal.
+
+Of those 9, **7 are followed by assertions that restate the loop condition** and are
+therefore unreachable-if-satisfied: `integration_test.go:1696`, `:1757`, `:1850`,
+`:1928`, `:2118`, `:2743` (which restates it verbatim) and
+`debuginfod_integration_test.go:189`. They are kept as executable documentation of intent
+and as a guard against a mistake in `cond`, but they do no independent verification and
+this report does not claim they do. One more (`runStripped`, `:2637`) has nothing after
+it. The ninth is `TestOffBoxLibcResolution` (`:2909`), where the fatal guards a
+*precondition* and the assertion that follows — "libc was not fetched" — is genuinely
+independent of it; that is the shape the other fatal sites would ideally have.
+
+**Per-loop budget** (`collectBudgetFor`): `min(max(3×window, 15s), 25s)` — 3 s → 15 s
+(~5 attempts), 5 s → 15 s (3), 6 s → 18 s (3), 10 s → 25 s (2).
+
+**Package-wide allowance** (`suiteRetryBudget`, 3 min): §6.
+
+**Workload lifetime.** Workloads spawned by converted tests now run for
+`workloadRuntime = 150s` (`workloadRuntimeFlag` = `-duration=150s` for the Go workloads,
+`workloadRuntimeSecs` = `"150"` for the Rust/Python ones, which take bare seconds as
+`argv[1]`). All are killed in the existing `defer`, so nothing actually runs longer than
+before. `requireWorkloadAlive` re-checks liveness before every attempt via
+`/proc/<pid>/stat` (a killed-but-unreaped child still answers signal 0) and fails loudly
+rather than letting a dead target masquerade as a broken profiler.
+
+**A hazard this change introduced, and closed.** Raising workload lifetimes meant passing
+a duration to `spawnBinaryAsWorkload`, which on `main` took no arguments at all. Passing
+the Rust form (bare `"150"`) to the Go workload would have been silently wrong — Go's
+`flag` ignores positional arguments and the workload would have kept its 30 s default,
+dying mid-budget. The helper now *requires* an explicit duration and its doc names the
+two incompatible forms. Self-inflicted, caught, guarded — not a pre-existing bug.
+
+`test/collect_until_test.go` (new) unit-tests the harness: 18 tests, no BPF, no workload,
+no capabilities. They **were executed and pass** (§10).
+
+---
+
+## 5. Tests converted — before / after control flow
+
+*Before* in every case: run the agent once for a fixed `--duration`, parse, assert.
+*After*: `collectProfileUntil` with the condition below; then the test's own assertions.
+
+| test | window → budget | loop condition (precondition) |
+|---|---|---|
+| `TestProfileMode` (×5 subtests) | 10s → 25s | samples > 0 ∧ has stacks ∧ has symbols |
+| `TestOffCPUMode` (×2) | 10s → 25s | samples > 0 |
+| `TestCombinedMode` | 10s → 25s | CPU-profile samples > 0 |
+| `TestSystemWideProfile` | 5s → 15s | samples > 0 |
+| `TestSystemWideOffCPU` | 5s → 15s | **fidelity-judgeable** (≥ floor samples ∧ ≥ 1 user-space frame) |
+| `TestStreamingProfileOutput` | 3s → 15s | samples > 0 ∧ has symbols |
+| `TestStreamingOffCPUProfileOutput` | 3s → 15s | samples > 0 |
+| `TestStreamingCombinedProfileOutput` | 3s → 15s | CPU samples > 0 |
+| `TestLibraryPMUMetrics` | 3s → 15s | a snapshot process with `SampleCount > 0` |
+| `TestPerfDwarfWalker` | 5s → 20s | samples > 5 ∧ maxFrames > 2 ∧ dwarfSamples > 0 |
+| `TestPerfAgentSystemWideDwarfProfile` | 5s → 15s | **fidelity-judgeable** ∧ functions > 0 |
+| `TestPerfAgentSystemWideDwarfOffCPU` | 5s → 15s | **fidelity-judgeable** ∧ blocking-ns > 0 |
+| `TestPerfAgentDwarfUnwind` | 5s → 15s | samples > 0 ∧ a `cpu_intensive_work` frame |
+| `TestPerfAgentOffCPUDwarfUnwind` | 5s → 15s | samples > 0 ∧ blocking-ns > 0 |
+| `TestPerfDataOutput` | 5s → 15s | perf.data > 200 B ∧ `perf script` output non-empty |
+| `TestKernelStackResolution` | 3s → 15s | samples > 0 ∧ a `main.*`/`runtime.*` frame ∧ (kptr_restrict≠0 ∨ a resolved kernel symbol) |
+| `TestPerfDataUserspaceMmap2_SystemWide` | 3s → 15s | io_bound MMAP2 present ∧ ≥ 2 distinct PIDs |
+| `TestStrippedRustOffBoxSymbolization` | 6s → 18s | either expected Rust symbol present |
+| `TestStrippedGoOffBoxSymbolization` | 6s → 18s | any expected Go symbol present |
+| `TestFileModeFrameAddressPreservesMapping` | 6s → 18s | ≥ 1 symbolized `rust_workload::` frame |
+| `TestStrippedSidecarUnreachableSymbolicPath` | 6s → 18s | `rust_workload::cpu_intensive_work` present |
+| `TestOffBoxLibcResolution` | 6s → 18s | samples > 0 ∧ ≥ 1 symbolized `rust_workload::` frame |
+| `TestFileModeParseFailDemotes` (2nd run) | 3s → 15s | samples > 0 ∧ a `rust-workload` mapping |
+| `runStripped` (used by 2 tests) | 3s → 15s | the fetched `.debug` is in the symbol cache |
+| `profileAndAssert` (debuginfod, `-tags integration`) | 3s → 15s | any fixture function present |
+
+The three bolded rows are §2 and §3's subject. A side effect of adding the sample floor
+there: a capture with a handful of samples, all unmapped, is now **re-collected**, where
+the previous revision would have stopped and judged it. That is the starved shape, and
+retrying it is the right move; if the budget runs out, `isDegenerateProfile` tolerates it
+exactly as it always did.
+
+Four others deserve their reasoning spelled out.
+
+**`TestKernelStackResolution`** — the test in symptoms 1 and 2, and the one this change
+genuinely fixes. The Go `io_bound` workload writes 1 MB, `fsync`s, reads it back, then
+sleeps 100 ms, so it is on-CPU in user space only in short bursts. Before: one 3 s window,
+then `t.Fatalf("no user-side function…")` — or, when the profile was empty, `EOF` out of
+`gzip.NewReader` inside `parseProfile`. After: up to ~5 windows, condition evaluated per
+capture, both hard assertions still present afterwards.
+
+**`TestPerfDwarfWalker`** — already had a collect-until loop (`for samples < 40 &&
+before(deadline)`), but the deadline stopped the *collection* while the assertions
+(`maxFrames > 2`, `dwarfSamples > 0`) were checked afterwards on whatever those 40 samples
+held. The condition is now `(samples < 40 || !enough())`, so a healthy run still gathers
+at least the 40 samples it used to and an unhealthy one keeps collecting up to 20 s. The
+only conversion that is strictly *more* collection, never less. (It reads the ringbuf
+directly rather than going through `collectUntil`, so it does not draw on the
+package-wide allowance; its 20 s deadline is fixed.)
+
+**`TestPerfDataUserspaceMmap2_SystemWide`** — not obviously sampling-dependent, but
+`perfagent/agent.go:411` emits COMM+MMAP2 **lazily, on the first sample seen per PID** in
+`--all` mode (eagerly in `--pid` mode). "io_bound has an MMAP2 record" is therefore a
+claim about whether io_bound got sampled. Its `--pid` siblings go through the eager path
+and were left alone.
+
+**`TestOffBoxLibcResolution`** — its only hard assertion is negative ("libc was *not*
+fetched from debuginfod"), and a capture that sampled nothing symbolizes nothing, fetches
+nothing, and satisfies it vacuously. It now collects until the workload's own symbols
+resolve, proving symbolization ran end to end, before asking the question. The
+precondition is deliberately the *workload's* symbols and not libc's: the test documents
+libc frames as environment-dependent and only logs when they are absent, so requiring them
+would invent a requirement the test declines to make. **Residual gap:** a run that
+resolved `rust_workload` but never sampled a libc PC still passes without exercising the
+libc path. Narrower than the vacuous pass it replaces, but not zero.
+
+### `TestStrippedCachedHitNoFetch` passed vacuously on `main`
+
+Worth stating on its own, because it is a worse defect than the flakiness this issue is
+about: **this test could pass on `main` having verified nothing.**
+
+It runs `runStripped` twice and asserts the second run adds no `GET
+/buildid/<id>/debuginfo` entries. The fetch is driven by symbolizing a sampled PC inside
+the stripped binary. If the first 3 s window sampled nothing, no fetch happened, the cache
+stayed empty, the second run also fetched nothing — and `delta == 0` passed. A green
+result proving the cache-hit short-circuit works was indistinguishable from a green result
+proving the profiler collected nothing at all. Converting `runStripped` to collect until
+the `.debug` is actually in the cache closes it.
+
+Its sibling `TestFileModeParseFailDemotes` calls the same helper but then does
+`os.Stat(cached)` → `t.Fatalf`, so the same empty window made it fail **loudly**. That one
+was flaky, not vacuous. The conversion helps both, for different reasons.
+
+### Deliberately not converted
+
+- `TestPMUMode`, `TestPMURunqueueLatency`, `TestPMUTaskStateClassification`,
+  `TestPMUIOWorkloadHasIOWait`, `TestPMUCPUWorkloadMostlyRunning`, `TestSystemWidePMU`,
+  `TestSystemWidePMUPerPID`, `TestSystemWidePMUWithNewMetrics` — assert on the presence of
+  *labels* in the agent's stdout, printed unconditionally. Not sample-dependent.
+- `TestPerfDataKernelMmap2`, `TestPerfDataUserspaceMmap2` — eager `/proc` walk, above.
+- `TestMutuallyExclusiveFlags`, `TestRequiresPIDOrAll`, `TestPerPIDRequiresAll`,
+  `TestPerPIDRequiresPMU` — argument validation; the agent exits before sampling.
+- `TestPerfDwarfMmap2Tracking` — asserts on BPF map contents after a `dlopen`, driven by
+  an MMAP2 event, not by sampling. Left at its original 20 s workload.
+- `TestStrippedCachedHitNoFetch` — its own body counts fetches; the sampling dependency is
+  entirely inside `runStripped`, which is where the fix went.
+- `integration_inject_python_test.go` — asserts on agent stdout and `/proc` state.
+
+### One defect found and left alone
+
+`integration_test.go:914-917` (`TestPMUIOWorkloadHasIOWait`) reads:
+
+```go
+if assert.Contains(t, outputStr, "I/O Wait (D state):") ||
+    assert.Contains(t, outputStr, "Voluntary (sleep/mutex):") {
+```
+
+`assert.Contains` records a failure as a side effect, so the first branch fails the test
+whether or not the second would have matched: the `||` tolerance is fake and the test is
+effectively stricter than its own message claims. Fixing it means switching to
+`strings.Contains`, which **weakens** the assertion that currently executes — and I cannot
+run the suite to check whether the `I/O Wait (D state):` label is printed unconditionally
+(no-op) or conditionally (behaviour change). Pre-existing and outside every conversion
+here; being filed separately.
+
+---
+
+## 6. Suite runtime — corrected
+
+**The first version of this report claimed the worst case added "roughly four minutes".
+That was wrong.** Summing the per-loop budgets across the 30 collect-until instances a
+default-build run executes (24 call sites, of which `TestProfileMode` runs 5×,
+`TestOffCPUMode` 2× and `runStripped` 3×; the two `-tags integration` debuginfod fixtures
+are not built in CI) — 8 at 25 s (window 10 s), 7 at 15 s (5 s), 10 at 15 s (3 s), 5 at
+18 s (6 s), plus the walker's fixed 20 s — gives **565 s of budget**, and a loop may run
+to `budget + one window`, adding **175 s of overshoot**: **~12.3 minutes** on top of the
+suite's own work, against the `-timeout 15m` at `.github/workflows/tests.yml:154`. Add
+per-attempt agent startup and BPF load — real, and unmeasured here — and a
+comprehensively degraded run lands at or past the timeout. A timeout kills the run with a
+goroutine dump and destroys precisely the diagnostics this change exists to produce: a
+strictly worse outcome than a clean assertion failure.
+
+Three ways out. Cutting the per-loop budgets weakens the fix for the one-flaky-test case
+that is actually common. Raising the CI timeout is a change to `.github/workflows/`,
+outside the scope I was given — **flagged, not done**: if the maintainer prefers it,
+`tests.yml:154` is the line, and it would let the budgets stay as they are.
+
+What is implemented instead is a **package-wide allowance**: `suiteRetryBudget = 3m`,
+shared by every collect-until loop in the run. The first attempt of any loop is free — it
+is the collection the test would have made before this change — and only re-collections
+draw on it. Once it is spent, later loops run that single free attempt and let their own
+assertions decide; the suite degrades to its pre-#42 behaviour instead of overrunning.
+
+That makes the bound `baseline + 3m + one in-flight window` regardless of how many tests
+degrade:
+
+| | |
+|---|---|
+| baseline (first attempts = today's fixed windows) | ~195 s |
+| package-wide re-collection allowance | 180 s |
+| in-flight attempt when the allowance runs out | ≤ 10 s |
+| non-converted tests and per-test setup sleeps | ~120 s |
+| **worst case** | **~8.5 min** |
+
+Two properties worth noting. The allowance is charged by **elapsed time**, so per-attempt
+agent startup and BPF-load cost are inside the bound rather than excluded from it — which
+is what makes the number hold despite that cost being unmeasured. And 3 min is sized for
+the case it must absorb, not the pathological one: a normal run has zero or one flaking
+tests, spending at most one per-loop budget (≤ 25 s) between them.
+
+---
+
+## 7. Assertions changed — what each caught before and after
+
+Two changed in substance; both are message-only. Everything else in §5 kept its predicate
+and gained a retry budget in front of it.
+
+### 7.1 `assertPprofFidelity`
+
+Before:
+
+```
+expected >=1 real mapping, got 0: [0x1311ff8c230]
+pprof fidelity: real_mappings=0 has_build_id=false
+```
+
+After (rendered from the reconstructed symptom-3 capture):
+
+```
+expected >=1 real (file-backed) mapping, got 0.
+  captured: samples=40 value_total=40 locations=1 functions=1(named=1) frames{user=0 kernel=0 jit=0 unmapped=40} mappings{real=0 kernel=0 jit=0 anon=1} build_id=false
+  reading:  40 frame(s) carried a user-space PC that resolved to no binary mapping — mapping resolution (procmap/blazesym) is the suspect
+  mappings: 1 mapping(s): [#1 file="" start=0x0 limit=0x0 off=0x0 build_id=""]
+```
+
+- **Caught before:** a profile whose mappings are all sentinel/empty, subject to the
+  pre-existing `hasJit` and `isDegenerateProfile` tolerances.
+- **Caught after:** the same set. Predicate, both tolerance branches, the per-location
+  `Address != 0` check and the observational BuildID log are unchanged. Three things are
+  new in the message: the sample count, the kernel/user/jit/unmapped frame split, and —
+  via `describeMappings` — the mapping table's actual *contents* instead of `%+v`'s heap
+  pointers (§3.1). The same split now also decides which captures get retried (§2), which
+  is what keeps this assertion able to fail at all.
+
+### 7.2 `parseProfile` (empty profile → `EOF`)
+
+Before, a zero-byte profile failed at `gzip.NewReader` with:
+
+```
+Error: Received unexpected error:
+       EOF
+```
+
+After, via the new `readProfile`:
+
+```
+parse profile: profile /tmp/.../profile.pb.gz is EMPTY (0 bytes): the agent collected 0 samples in this window
+```
+
+and for a truncated one:
+
+```
+parse profile: profile /tmp/.../profile.pb.gz (312 bytes) did not parse: <err> — a truncated or empty profile means the collection captured no samples
+```
+
+- **Caught before:** any unreadable profile, reported as a parser error.
+- **Caught after:** the same set, split into "empty" and "corrupt". `parseProfile` still
+  does **not** assert on sample count — each caller keeps its own `len(prof.Sample) > 0` —
+  so no test became stricter by accident.
+
+### 7.3 Assertions that now catch less
+
+**One, deliberately.** `TestPerfAgentDwarfUnwind`'s final check is
+`require.True(hasFunctionContaining(prof, "cpu_intensive_work"))` rather than a
+hand-rolled loop — identical predicate. On the failure path it prints up to 10 *named*
+functions via `topFunctionNames`, where the old code printed the first 10 entries of
+`prof.Function` including empty names. Marginally fewer entries when many are unnamed;
+`describeProfile` prints the named/total count alongside.
+
+**And the seven `t.Fatal(report)` sites**, where the assertions after the loop no longer
+verify anything independent (§4). Not weaker than before — the loop condition carries the
+same predicate — but not carrying their own weight either, and that is stated rather than
+papered over.
+
+Nothing else was weakened: no `t.Skip` added, no `assert` downgraded to a log, no
+threshold lowered. The tolerance ladders in `TestProfileMode` and
+`TestStreamingOffCPUProfileOutput` are untouched; the loop runs *in front of* them, so a
+healthy run reaches the strict branch more often than before and a broken profiler lands
+where it always did.
+
+---
+
+## 8. New failure messages, quoted
+
+Deadline, rendered from the real format string:
+
+```
+timed out waiting for a kernel-stacks profile containing at least one user-side (main.*/runtime.*) frame and at least one resolved kernel symbol: 5 attempt(s) over 15.2s (per-test budget 15s, collection window 3s per attempt); last attempt captured: no usable profile: profile /tmp/x/profile.pb.gz is EMPTY (0 bytes): the agent collected 0 samples in this window
+```
+
+Deadline when the *package-wide* allowance is what stopped it — the signal that the whole
+run was degraded, not just this test:
+
+```
+timed out waiting for a system-wide DWARF profile with enough samples to judge, a symbolized function and at least one user-space frame: 1 attempt(s) over 0s (per-test budget 15s, collection window 5s per attempt); last attempt captured: an EMPTY profile: 0 samples (the collection window caught the workload off-CPU the whole time). NOTE: the package-wide re-collection allowance (3m0s) is spent (2s left), so this test stopped at 1 attempt(s) rather than the 4 its own budget allows — earlier tests in this run were degraded too
+```
+
+`TestKernelStackResolution` appends the symbol set it did see:
+
+```
+  functions in the last capture: [__schedule ext4_writepages vfs_fsync ...]
+```
+
+`TestOffBoxLibcResolution` names why it refuses to proceed:
+
+```
+symbolization never resolved a workload symbol, so the "libc was not fetched" assertion below would pass vacuously: timed out waiting for a profile in which the workload's own symbols resolved (proving symbolization ran): ...
+```
+
+Per-attempt progress is logged as it happens:
+
+```
+collect-until: attempt 1 did not satisfy a CPU profile with samples, stack traces and at least one symbolized function after 10.4s; an EMPTY profile: 0 samples (the collection window caught the workload off-CPU the whole time)
+collect-until: a CPU profile with samples, stack traces and at least one symbolized function satisfied on attempt 2 after 21.1s; samples=612 ...
+```
+
+The dead-workload guard:
+
+```
+workload go/io_bound (pid 9136) exited before the collect-until budget was spent — its run duration is shorter than the collection budget, so the condition under test is unreachable
+```
+
+---
+
+## 9. Termination, spin-freedom, reachability
+
+Walked by hand and pinned by the unit tests in `test/collect_until_test.go`.
+
+**Terminates.** `maxAttempts = budget/window + 1` bounds the iteration count independently
+of the clock. Separately, the loop breaks when `elapsed + window > budget`, and again when
+the package-wide allowance cannot fund another attempt. Upper bound per loop is
+`budget + one window`.
+
+**Cannot spin.** The clock-based break alone would be insufficient if an attempt returned
+instantly — `elapsed` would stay near zero and the loop would iterate as fast as the CPU
+allows. That is why the attempt-count bound exists. `TestCollectUntilCannotSpin` pins it.
+
+**Deadlines enforced.** `TestCollectUntilStopsWhenNoAttemptFits` pins the per-loop clock
+bound (an attempt consuming the whole budget is not retried: exactly 1 call).
+`TestCollectUntilRespectsTheSuiteWideAllowance` pins the global one.
+`TestCollectUntilChargesOnlyReCollections` pins the accounting.
+
+**Preconditions do not imply assertions.**
+`TestUserSpacePreconditionDoesNotImplyRealMapping` and
+`TestSymptomThreeIsJudgedNotRetried` (§2, §3).
+
+**Conditions are reachable in the environment the tests create:**
+
+- `main.*`/`runtime.*` frames from `io_bound` — the workload allocates a 1 MB buffer,
+  `io.ReadAll`s the file back, and is a Go program with a GC, so user-space frames run on
+  every iteration; only the *sampling* of them is probabilistic.
+- resolved kernel symbols under `kptr_restrict=0` — the regex includes `vfs_`, `ksys_`,
+  `do_sys_` and `__schedule`, all present on arm64 as well as amd64.
+- `cpu_intensive_work` — `#[inline(never)]`, the Rust workload's only hot loop.
+- ≥ `degenerateSampleFloor` samples with ≥ 1 user-space frame in a system-wide capture —
+  a 5 s window at 99 Hz on a runner with a CPU-bound rust workload the test started
+  itself; 20 is a low bar, and a timeout here only logs and falls through.
+- ≥ 2 distinct PIDs in a system-wide perf.data — the runner is not idle.
+- the debuginfod cache entry in `runStripped` — populated by symbolizing any sampled PC in
+  a CPU-bound spinner.
+
+**Workload outlives the budget:** 150 s against a worst case of `budget + window` ≤ 35 s
+plus ≤ 3 s of setup.
+
+---
+
+## 10. Cannot verify — what was NOT executed
+
+**The integration suite was not run. Not once, in whole or in part.** This session has
+`CapEff: 0` and no root: every test in `test/integration_test.go` requires root or
+`CAP_BPF`, and `requireBPFRunnable` skips them regardless. No claim here about profiler
+behaviour under load is backed by an observed run, and the integration-test messages in §8
+are renderings of the new format strings, not transcripts.
+
+What *was* executed:
+
+| command | result |
+|---|---|
+| `go build ./...` (root module) | pass |
+| `go vet ./...` (root module) | pass |
+| `golangci-lint run --timeout=5m` (root module) | `0 issues.` |
+| `cd test && go vet ./...` | pass |
+| `cd test && go vet -tags integration ./...` | pass |
+| `cd test && go build ./...` | pass |
+| `cd test && go test -c` | builds |
+| `cd test && go test -tags integration -c` | builds |
+| `gofmt -l test/` | clean |
+| `cd test && golangci-lint run` | 26 issues, all pre-existing (baseline on `main`: 29; the test module is not linted by CI) |
+| `cd test && go test -run '<harness tests>'` | **18 tests pass** |
+| standalone `fmt` probe on `[]*Mapping` (§3.1) | pointers confirmed |
+
+That last group is the only executed *behavioural* evidence. It covers the loop bounds,
+spin-freedom, both deadlines, the retry accounting, the precondition/assertion separation,
+the symptom-3 reconstruction and its verdict, the round-trip mapping-preservation premise,
+the mapping renderer, the frame and mapping split, the empty-vs-corrupt profile
+distinction, the three `fidelityDiagnosis` branches, and `processAlive`. It touches
+neither BPF, nor the agent binary, nor a real workload.
+
+Specifically unverified, worth watching on the first CI run:
+
+1. Whether a *second* collection attempt against the same live workload behaves like the
+   first — repeated BPF load/attach/detach, repeated `--perf-data-output` overwrites, and
+   for the three streaming tests repeated in-process
+   `perfagent.New`/`Start`/`Stop`/`Close` cycles. Nothing in the code suggests otherwise;
+   it has not been observed.
+2. The real per-attempt wall-clock cost. It is inside the package-wide allowance by
+   construction (§6), but it determines how many attempts a test actually gets, so the
+   attempt counts in §5 are upper bounds.
+3. Whether `TestPerfDwarfWalker`'s widened loop condition is ever *not* met within 20 s on
+   a healthy runner. The old 5 s/40-sample loop was evidently sufficient; the new bound is
+   untested.
+4. **Whether `TestPerfAgentSystemWideDwarfProfile` still goes red on CI.** Per §3 it will,
+   on any run that reproduces the PR #48 capture — this change does not fix that symptom.
+   If it recurs, §3.5 lists the evidence that decides whether it is a resolver bug, and
+   the message now prints most of it.
+
+---
+
+## 11. What the reviews changed
+
+**Round 1**
+
+| finding | disposition |
+|---|---|
+| 🔴 three sites looped on `RealMappings >= 1`, which `assertPprofFidelity` asserts | Accepted and fixed — §2. Implemented as user-space frames rather than the suggested `UserFrames > 0`, because that alone still implies `RealMappings >= 1`. |
+| unreachable-if-satisfied assertions at the 7 `t.Fatal` sites | Accepted. Code left as-is; the report's claim was the error and is corrected in §4 and §7.3. |
+| runtime figure wrong, headroom thin | Accepted — ~12.3 min is right. Fixed with a package-wide 3 min allowance rather than by cutting budgets or touching the CI timeout (out of scope, flagged) — §6. |
+| `TestOffBoxLibcResolution` left behind with the defect just fixed | Accepted and converted, residual gap stated — §5. |
+| report claims to correct | Done — the "loop condition IS the assertion" claim, the `spawnBinaryAsWorkload` framing, the vacuous-pass finding narrowed to its one real caller and promoted. |
+| minor: fake `||` tolerance at `:914-917` | Left alone with reasons; being filed separately. |
+
+**Round 2 — "does this still fix symptom 3?"**
+
+| question | answer |
+|---|---|
+| What is `[0x1311ff8c230]`? | A Go heap pointer to one `profile.Mapping`; `%+v` on a slice of struct pointers prints addresses, not fields. The message carried a mapping count and nothing else — §3.1. |
+| Would `profileHasUserSpaceFrames` return true on that profile? | **Yes.** The loop exits on the first capture and the assertion fails. **This change does not fix symptom 3**, and §3.3 and §10 now say so plainly instead of filing it as a watch item. |
+| Profiler defect or starved capture? | Neither of the issue's readings survives the code: no kernel frames existed, and it was above the sample floor. It was every sampled PC failing resolver attribution. The cause cannot be proven from the log — §3.4 — and §3.5 lists the evidence that would settle it. |
+| precondition needs to be something a starved capture genuinely fails | Done: `profileFidelityJudgeable` adds `Samples >= degenerateSampleFloor`, the suite's own threshold for when a zero-real-mapping profile is "a genuine bug worth a loud failure". A side effect is that few-samples-all-unmapped captures are now retried where the previous revision judged them. |
+| don't paper over it either way | The verdict is pinned by `TestSymptomThreeIsJudgedNotRetried`, and the message defect that made it undiagnosable is fixed by `describeMappings` — §7.1. |

--- a/test/collect_until.go
+++ b/test/collect_until.go
@@ -1,0 +1,611 @@
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/pprof/profile"
+)
+
+// ---------------------------------------------------------------------
+// Collect-until-condition harness (issue #42)
+// ---------------------------------------------------------------------
+//
+// The integration suite used to sample for a fixed wall-clock window
+// (3-10s at 99 Hz) and then assert on whatever happened to land. On a
+// contended shared runner that is a coin flip: a sampled task only
+// yields samples while it is ON CPU, so an I/O-bound workload that the
+// scheduler keeps off-CPU produces few samples, all of them taken deep
+// inside kernel I/O. Issue #42 recorded three shapes of the same
+// condition — zero samples at all, samples whose every frame is
+// kernel-side, and samples with kernel symbols but no user mapping —
+// and the decisive datum that one commit failed twice with two
+// different shapes and passed on the third attempt.
+//
+// The fix is to stop asserting on a fixed window. A collection here is
+// cheap and repeatable (spawn the agent again against the same live
+// workload), so we collect until the condition the test actually cares
+// about is observed, bounded by a deadline. If the deadline expires the
+// test still fails — the assertion is not weakened, it is given a
+// bounded budget — and it fails with a message that says what was being
+// waited for and what was actually captured.
+//
+// Two invariants keep this from becoming a "retry until green" loop:
+//
+//  1. The loop condition IS the assertion under test (or a precondition
+//     strictly implied by it). A profiler that genuinely stopped
+//     producing user frames never satisfies it, and the test fails at
+//     the deadline.
+//  2. The budget is finite and small, and every attempt costs at least
+//     one collection window, so the loop cannot spin and cannot run
+//     longer than `budget + one window`.
+
+// collectBudgetFor returns the total wall-clock budget a collect-until
+// loop may spend for a per-attempt collection window of `window`.
+//
+// Generously above the fixed window it replaces (so a run that lost the
+// scheduling coin flip gets several more tosses) but bounded: 3s -> 15s
+// (about 5 attempts), 5s -> 15s (3), 6s -> 18s (3), 10s -> 25s (2).
+//
+// This bounds ONE degraded test. It does not bound a comprehensively
+// degraded run: the per-loop budgets sum to ~562s of re-collection
+// across the converted sites, plus ~172s of overshoot (a loop may run
+// to `budget + one window`), which is ~12 minutes on top of the suite's
+// own work — over the `-timeout 15m` in .github/workflows/tests.yml.
+// suiteRetryBudget below is what actually bounds that case.
+func collectBudgetFor(window time.Duration) time.Duration {
+	const (
+		minBudget = 15 * time.Second
+		maxBudget = 25 * time.Second
+	)
+	return min(max(3*window, minBudget), maxBudget)
+}
+
+// suiteRetryBudget bounds the TOTAL wall-clock time this package may
+// spend on RE-collections — attempts 2..N of any collect-until loop —
+// summed across every test in the run.
+//
+// Per-loop budgets (collectBudgetFor) bound one degraded test; they do
+// not bound a run in which everything degrades at once. Summed, they
+// exceed the CI `-timeout 15m`, and blowing that timeout kills the run
+// with a goroutine dump — destroying exactly the diagnostics this
+// harness exists to produce. A clean assertion failure is strictly more
+// useful than a timeout.
+//
+// So the package shares one retry allowance. The FIRST attempt of every
+// loop is free: it is the collection the test would have made before
+// this change, and it is charged to the suite's baseline, not here.
+// Once the allowance is spent, later loops still run that first attempt
+// and let their own assertions decide — the suite degrades to its
+// pre-#42 behaviour rather than timing out. Worst case for the package
+// therefore becomes `baseline + suiteRetryBudget + one window`, which
+// is ~9 minutes against the 15m timeout.
+//
+// Sized for the case it is meant to absorb, not the pathological one: a
+// normal run has zero or one flaking tests, costing at most one per-loop
+// budget (<= 25s) between them.
+const suiteRetryBudget = 3 * time.Minute
+
+// suiteRetrySpentNs accumulates nanoseconds spent on re-collections.
+// Tests in this package do not run in parallel, but the counter is
+// atomic so that a future t.Parallel cannot corrupt it.
+var suiteRetrySpentNs atomic.Int64
+
+// claimSuiteRetry reports whether a re-collection of up to `window` may
+// start, along with how much of the shared allowance remains.
+func claimSuiteRetry(window time.Duration) (bool, time.Duration) {
+	left := max(suiteRetryBudget-time.Duration(suiteRetrySpentNs.Load()), 0)
+	return window <= left, left
+}
+
+// chargeSuiteRetry books time spent on a re-collection.
+func chargeSuiteRetry(d time.Duration) { suiteRetrySpentNs.Add(int64(d)) }
+
+// workloadRuntime is how long test workloads are asked to run for.
+//
+// It must comfortably exceed the largest collect-until budget plus
+// per-test setup: a retrying test that outlives its own workload would
+// be asserting against a dead process, and the deadline message would
+// blame the profiler for it. requireWorkloadAlive is the backstop that
+// catches it anyway.
+const workloadRuntime = 150 * time.Second
+
+// workloadRuntimeFlag is `-duration=...` for the Go workloads.
+var workloadRuntimeFlag = fmt.Sprintf("-duration=%s", workloadRuntime)
+
+// workloadRuntimeSecs is the bare seconds argument the Rust and Python
+// workloads take as argv[1].
+var workloadRuntimeSecs = fmt.Sprintf("%d", int(workloadRuntime.Seconds()))
+
+// collectUntil runs `attempt` repeatedly until it reports success or the
+// budget is exhausted.
+//
+// `what` names the condition in the first person of the test ("samples
+// containing at least one user-space frame"); it is quoted verbatim in
+// the timeout message. `window` is how long a single attempt spends
+// collecting — used both to decide whether another attempt fits in the
+// budget and to bound the iteration count.
+//
+// Returns (true, "") on success, and (false, report) when the budget
+// ran out; `report` names the condition, the attempts spent, and the
+// diagnostic string of the last attempt.
+//
+// Termination: `maxAttempts` bounds the iteration count independently of
+// the clock, so an `attempt` that returns instantly (a collection that
+// failed to start, say) cannot spin.
+func collectUntil(t *testing.T, what string, window, budget time.Duration, attempt func(n int) (ok bool, detail string)) (bool, string) {
+	t.Helper()
+	if window <= 0 {
+		window = time.Second
+	}
+	if budget < window {
+		budget = window
+	}
+	maxAttempts := int(budget/window) + 1
+
+	start := time.Now()
+	detail := "no attempt completed"
+	attempts := 0
+	starved := ""
+	for n := 1; n <= maxAttempts; n++ {
+		attemptStart := time.Now()
+		var ok bool
+		ok, detail = attempt(n)
+		attempts = n
+		if n > 1 {
+			// Attempt 1 is the collection the test would have made
+			// anyway; only re-collections draw on the shared allowance.
+			chargeSuiteRetry(time.Since(attemptStart))
+		}
+		elapsed := time.Since(start)
+		if ok {
+			if n > 1 {
+				t.Logf("collect-until: %s satisfied on attempt %d after %s; %s",
+					what, n, elapsed.Round(time.Millisecond), detail)
+			}
+			return true, ""
+		}
+		t.Logf("collect-until: attempt %d did not satisfy %s after %s; %s",
+			n, what, elapsed.Round(time.Millisecond), detail)
+		if elapsed+window > budget {
+			break
+		}
+		if allowed, left := claimSuiteRetry(window); !allowed {
+			starved = fmt.Sprintf(
+				". NOTE: the package-wide re-collection allowance (%s) is spent (%s left), "+
+					"so this test stopped at %d attempt(s) rather than the %d its own budget allows — "+
+					"earlier tests in this run were degraded too",
+				suiteRetryBudget, left.Round(time.Second), n, maxAttempts)
+			break
+		}
+	}
+
+	// Deliberately not "exhausted the budget": when the shared allowance
+	// stopped the loop early that would be false, and `starved` says so.
+	return false, fmt.Sprintf(
+		"timed out waiting for %s: %d attempt(s) over %s (per-test budget %s, "+
+			"collection window %s per attempt); last attempt captured: %s%s",
+		what, attempts, time.Since(start).Round(time.Millisecond), budget, window, detail, starved)
+}
+
+// collectProfileUntil repeats one full collection per attempt until
+// `cond` holds on the resulting pprof or the budget expires.
+//
+// `collect` performs a single collection and returns the parsed profile;
+// an error from it (empty output, unparseable output, agent produced
+// nothing) is NOT fatal — it is exactly one of the failure shapes issue
+// #42 is about, so it is reported as an unsatisfied attempt and retried.
+// Hard environmental failures (the agent refusing to run at all) should
+// t.Fatal from inside `collect`.
+//
+// Returns the profile from the last attempt (nil when the last attempt
+// produced none), whether `cond` was satisfied, and the timeout report
+// to hand to t.Fatal when it was not.
+func collectProfileUntil(
+	t *testing.T,
+	what string,
+	window time.Duration,
+	collect func(n int) (*profile.Profile, error),
+	cond func(*profile.Profile) bool,
+) (*profile.Profile, bool, string) {
+	t.Helper()
+	var last *profile.Profile
+	ok, report := collectUntil(t, what, window, collectBudgetFor(window), func(n int) (bool, string) {
+		p, err := collect(n)
+		last = p
+		if err != nil {
+			return false, fmt.Sprintf("no usable profile: %v", err)
+		}
+		return cond(p), describeProfile(p)
+	})
+	return last, ok, report
+}
+
+// ---------------------------------------------------------------------
+// Profile diagnostics
+// ---------------------------------------------------------------------
+
+const (
+	kernelMappingFile = "[kernel]"
+	jitMappingFile    = "[jit]"
+)
+
+// profileSummary is the "what actually landed" snapshot printed by every
+// collect-until timeout and by assertPprofFidelity on failure.
+//
+// The split that matters is user vs kernel frames: issue #42's amd64
+// failure ("expected >=1 real mapping, got 0") could not distinguish "the
+// profiler produced bad mappings" from "the workload was never on-CPU in
+// user space", and that distinction is what decides whether the failure
+// is a real regression.
+type profileSummary struct {
+	Samples   int
+	Locations int
+	Functions int
+	// NamedFunctions counts functions with a resolved (non-empty,
+	// non-"??") name — symbolization actually worked for them.
+	NamedFunctions int
+
+	// Frame counts are per sample-location occurrence, not per distinct
+	// location, so they describe where the sampled time went.
+	UserFrames     int
+	KernelFrames   int
+	JitFrames      int
+	UnmappedFrames int
+
+	RealMappings   int
+	KernelMappings int
+	JitMappings    int
+	AnonMappings   int
+
+	HasBuildID bool
+	TotalValue int64
+}
+
+// mappingClass buckets a pprof mapping into the four kinds this suite
+// cares about. A nil mapping and the builder's default zero-file mapping
+// are both "anon": a PC that resolved to no binary at all.
+func mappingClass(m *profile.Mapping) string {
+	switch {
+	case m == nil || m.File == "":
+		return "anon"
+	case m.File == kernelMappingFile:
+		return "kernel"
+	case m.File == jitMappingFile:
+		return "jit"
+	default:
+		return "real"
+	}
+}
+
+func summarizeProfile(p *profile.Profile) profileSummary {
+	var s profileSummary
+	if p == nil {
+		return s
+	}
+	s.Samples = len(p.Sample)
+	s.Locations = len(p.Location)
+	s.Functions = len(p.Function)
+
+	for _, fn := range p.Function {
+		if fn.Name != "" && fn.Name != "??" {
+			s.NamedFunctions++
+		}
+	}
+	for _, m := range p.Mapping {
+		switch mappingClass(m) {
+		case "kernel":
+			s.KernelMappings++
+		case "jit":
+			s.JitMappings++
+		case "anon":
+			s.AnonMappings++
+		default:
+			s.RealMappings++
+		}
+		if m.BuildID != "" {
+			s.HasBuildID = true
+		}
+	}
+	for _, sample := range p.Sample {
+		for _, v := range sample.Value {
+			s.TotalValue += v
+		}
+		for _, loc := range sample.Location {
+			var m *profile.Mapping
+			if loc != nil {
+				m = loc.Mapping
+			}
+			switch mappingClass(m) {
+			case "kernel":
+				s.KernelFrames++
+			case "jit":
+				s.JitFrames++
+			case "anon":
+				s.UnmappedFrames++
+			default:
+				s.UserFrames++
+			}
+		}
+	}
+	return s
+}
+
+func (s profileSummary) String() string {
+	return fmt.Sprintf(
+		"samples=%d value_total=%d locations=%d functions=%d(named=%d) "+
+			"frames{user=%d kernel=%d jit=%d unmapped=%d} "+
+			"mappings{real=%d kernel=%d jit=%d anon=%d} build_id=%v",
+		s.Samples, s.TotalValue, s.Locations, s.Functions, s.NamedFunctions,
+		s.UserFrames, s.KernelFrames, s.JitFrames, s.UnmappedFrames,
+		s.RealMappings, s.KernelMappings, s.JitMappings, s.AnonMappings,
+		s.HasBuildID)
+}
+
+// describeProfile renders a one-line diagnostic for a profile that may be
+// nil or empty. "0 samples" is stated in words, because an empty profile
+// used to surface as a bare `EOF` from the pprof parser.
+func describeProfile(p *profile.Profile) string {
+	if p == nil {
+		return "no profile at all (the collection produced no parseable output)"
+	}
+	if len(p.Sample) == 0 {
+		return "an EMPTY profile: 0 samples (the collection window caught the workload off-CPU the whole time)"
+	}
+	return summarizeProfile(p).String()
+}
+
+// topFunctionNames returns up to n resolved function names, for failure
+// messages that need to show what DID symbolize.
+func topFunctionNames(p *profile.Profile, n int) []string {
+	if p == nil {
+		return nil
+	}
+	out := make([]string, 0, n)
+	for _, fn := range p.Function {
+		if fn.Name == "" {
+			continue
+		}
+		out = append(out, fn.Name)
+		if len(out) == n {
+			break
+		}
+	}
+	return out
+}
+
+// hasFunctionContaining reports whether any function name in the profile
+// contains any of the given substrings.
+func hasFunctionContaining(p *profile.Profile, subs ...string) bool {
+	if p == nil {
+		return false
+	}
+	for _, fn := range p.Function {
+		for _, sub := range subs {
+			if strings.Contains(fn.Name, sub) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------
+// Reading profiles
+// ---------------------------------------------------------------------
+
+// readProfile parses a pprof file, distinguishing "the agent wrote
+// nothing because it captured nothing" from "the profile is corrupt".
+//
+// The old path (gzip.NewReader on a zero-byte file) reported the first
+// case as a bare `EOF`, which is what issue #42's arm64 run had to be
+// diagnosed from. profile.Parse handles the gzip wrapper itself.
+func readProfile(path string) (*profile.Profile, error) {
+	st, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("profile %s was never written: %w", path, err)
+	}
+	if st.Size() == 0 {
+		return nil, fmt.Errorf(
+			"profile %s is EMPTY (0 bytes): the agent collected 0 samples in this window", path)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read profile %s: %w", path, err)
+	}
+	p, err := profile.Parse(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf(
+			"profile %s (%d bytes) did not parse: %w — a truncated or empty profile means the collection captured no samples",
+			path, len(body), err)
+	}
+	return p, nil
+}
+
+// ---------------------------------------------------------------------
+// Workload liveness
+// ---------------------------------------------------------------------
+
+// processAlive reports whether pid names a live, non-zombie process.
+// A killed-but-unreaped child still answers signal 0, so read the state
+// field out of /proc/<pid>/stat instead.
+func processAlive(pid int) bool {
+	body, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return false
+	}
+	// "<pid> (<comm>) <state> ..." — comm can contain spaces and
+	// parentheses, so anchor on the LAST ')'.
+	i := bytes.LastIndexByte(body, ')')
+	if i < 0 || i+2 >= len(body) {
+		return false
+	}
+	switch body[i+2] {
+	case 'Z', 'X', 'x':
+		return false
+	}
+	return true
+}
+
+// requireWorkloadAlive fails the test when the workload died before the
+// collect-until loop finished with it.
+//
+// Without this, a workload whose own duration is shorter than the
+// collection budget turns every later attempt into a guaranteed miss,
+// and the deadline message would blame the profiler for a dead target.
+func requireWorkloadAlive(t *testing.T, cmd *exec.Cmd, name string) {
+	t.Helper()
+	if cmd == nil || cmd.Process == nil {
+		t.Fatalf("workload %s was never started", name)
+	}
+	if !processAlive(cmd.Process.Pid) {
+		t.Fatalf("workload %s (pid %d) exited before the collect-until budget was spent — "+
+			"its run duration is shorter than the collection budget, so the condition under test is unreachable",
+			name, cmd.Process.Pid)
+	}
+}
+
+// profileHasStacks reports whether any sample carries at least one
+// location — i.e. stack capture produced something.
+func profileHasStacks(p *profile.Profile) bool {
+	if p == nil {
+		return false
+	}
+	for _, s := range p.Sample {
+		if len(s.Location) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// profileHasSymbols reports whether at least one function carries a
+// resolved name.
+func profileHasSymbols(p *profile.Profile) bool {
+	if p == nil {
+		return false
+	}
+	for _, fn := range p.Function {
+		if fn.Name != "" && fn.Name != "??" {
+			return true
+		}
+	}
+	return false
+}
+
+// userSpaceFrames counts sampled frames that came from user space,
+// whether or not they resolved to a binary: file-backed, JIT, and PCs
+// that resolved to no mapping at all. Kernel frames are excluded.
+//
+// This is the PRECONDITION half of a fidelity check, deliberately kept
+// distinct from the assertion half. "Did the capture catch the target
+// on-CPU in user space?" is an environmental question and worth
+// retrying; "did those user-space PCs resolve to a real mapping?" is a
+// correctness question about the profiler and must NOT be retried — a
+// loop that waits for a real mapping can never fail the assertion that
+// a real mapping exists. See fidelityDiagnosis, which splits the same
+// two cases for the reader.
+//
+// Note that `UserFrames > 0` alone would NOT do: a location's mapping
+// must appear in the profile's mapping table, so UserFrames > 0 implies
+// RealMappings >= 1 just as surely. Including the unmapped frames is
+// what makes this a precondition rather than a restatement.
+func userSpaceFrames(s profileSummary) int {
+	return s.UserFrames + s.JitFrames + s.UnmappedFrames
+}
+
+// profileHasUserSpaceFrames reports whether the capture caught the
+// target on-CPU in user space at all.
+func profileHasUserSpaceFrames(p *profile.Profile) bool {
+	return userSpaceFrames(summarizeProfile(p)) > 0
+}
+
+// degenerateSampleFloor is the sample-count threshold below which the
+// pprof fidelity / symbolization assertions are considered too noisy
+// to be meaningful. A healthy 10s @ 99Hz CPU-bound run produces
+// hundreds of user-space samples; the IO-bound subtests on slow CI
+// runners can drop into the low tens or single digits.
+//
+// Lives here rather than beside isDegenerateProfile because the
+// collect-until preconditions need it too, and a non-test file cannot
+// see a constant declared in a _test.go one — `go build ./...` catches
+// that even though `go vet` and `go test -c` do not.
+const degenerateSampleFloor = 20
+
+// profileFidelityJudgeable reports whether a capture carries enough
+// signal for assertPprofFidelity's verdict to mean anything: at least
+// degenerateSampleFloor samples, and at least one of them from user
+// space.
+//
+// The sample floor is not a number invented here. isDegenerateProfile
+// already uses degenerateSampleFloor to decide when a zero-real-mapping
+// profile is tolerated and when it is "a genuine bug worth a loud
+// failure" — its words. Reusing the same constant keeps the retry
+// policy and the tolerance policy from disagreeing: we re-collect
+// exactly while the capture is below the bar the suite already set for
+// judging it, and hand it to the assertion the moment it clears it.
+//
+// Neither conjunct implies `RealMappings >= 1`, which is what keeps
+// assertPprofFidelity able to fail — see userSpaceFrames.
+func profileFidelityJudgeable(p *profile.Profile) bool {
+	s := summarizeProfile(p)
+	return s.Samples >= degenerateSampleFloor && userSpaceFrames(s) > 0
+}
+
+// describeMappings renders a profile's mapping table.
+//
+// Deliberately NOT `%+v` on p.Mapping. fmt prints a slice of struct
+// POINTERS as bare heap addresses — `[0x1311ff8c230]` — because it only
+// uses the `&{...}` form at depth 0. That is exactly what the message
+// behind issue #42's symptom 3 said:
+//
+//	expected >=1 real mapping, got 0: [0x1311ff8c230]
+//
+// which is a Go pointer to one profile.Mapping, not an address from the
+// capture and not any mapping's contents. The message carried a
+// mapping COUNT and nothing else, so the reading recorded in the issue
+// ("every user PC landed in one anonymous region") could not have been
+// derived from it. This renders the fields, so the next occurrence is
+// diagnosable from the log alone.
+func describeMappings(p *profile.Profile) string {
+	if p == nil || len(p.Mapping) == 0 {
+		return "no mappings"
+	}
+	const maxShown = 12
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d mapping(s):", len(p.Mapping))
+	for i, m := range p.Mapping {
+		if i == maxShown {
+			fmt.Fprintf(&b, " ... and %d more", len(p.Mapping)-maxShown)
+			break
+		}
+		if m == nil {
+			b.WriteString(" <nil>")
+			continue
+		}
+		fmt.Fprintf(&b, " [#%d file=%q start=%#x limit=%#x off=%#x build_id=%q]",
+			m.ID, m.File, m.Start, m.Limit, m.Offset, m.BuildID)
+	}
+	return b.String()
+}
+
+// profileTotalValue sums every value of every sample — the blocking-ns
+// total for an off-CPU profile.
+func profileTotalValue(p *profile.Profile) int64 {
+	if p == nil {
+		return 0
+	}
+	var total int64
+	for _, s := range p.Sample {
+		for _, v := range s.Value {
+			total += v
+		}
+	}
+	return total
+}

--- a/test/collect_until_test.go
+++ b/test/collect_until_test.go
@@ -1,0 +1,440 @@
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/pprof/profile"
+)
+
+// These tests cover the collect-until harness itself. They load no BPF
+// and spawn no workload, so they run without root or capabilities —
+// the harness is the one part of the integration suite whose logic can
+// be checked on an unprivileged machine.
+
+func TestCollectBudgetForClampsBothEnds(t *testing.T) {
+	if got := collectBudgetFor(1 * time.Second); got != 15*time.Second {
+		t.Errorf("collectBudgetFor(1s) = %s, want the 15s floor", got)
+	}
+	if got := collectBudgetFor(6 * time.Second); got != 18*time.Second {
+		t.Errorf("collectBudgetFor(6s) = %s, want 3x = 18s", got)
+	}
+	if got := collectBudgetFor(60 * time.Second); got != 25*time.Second {
+		t.Errorf("collectBudgetFor(60s) = %s, want the 25s ceiling", got)
+	}
+}
+
+func TestCollectUntilReturnsOnFirstSatisfyingAttempt(t *testing.T) {
+	calls := 0
+	ok, report := collectUntil(t, "the condition", 10*time.Millisecond, time.Second,
+		func(int) (bool, string) {
+			calls++
+			return calls == 2, "detail"
+		})
+	if !ok {
+		t.Fatalf("expected success, got report: %s", report)
+	}
+	if calls != 2 {
+		t.Errorf("attempt called %d times, want exactly 2 (stop as soon as satisfied)", calls)
+	}
+	if report != "" {
+		t.Errorf("report on success = %q, want empty", report)
+	}
+}
+
+// TestCollectUntilCannotSpin pins the property that matters most for a
+// loop with a deadline: an attempt that returns instantly and never
+// succeeds is bounded by the attempt count, not just by the clock.
+func TestCollectUntilCannotSpin(t *testing.T) {
+	calls := 0
+	window := 10 * time.Millisecond
+	budget := 50 * time.Millisecond
+	ok, report := collectUntil(t, "an impossible condition", window, budget,
+		func(int) (bool, string) {
+			calls++
+			return false, "nothing landed"
+		})
+	if ok {
+		t.Fatal("expected failure for an impossible condition")
+	}
+	maxAttempts := int(budget/window) + 1
+	if calls > maxAttempts {
+		t.Errorf("attempt called %d times, want <= %d", calls, maxAttempts)
+	}
+	for _, want := range []string{"an impossible condition", "nothing landed", "attempt(s)"} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report %q does not mention %q", report, want)
+		}
+	}
+}
+
+// TestCollectUntilStopsWhenNoAttemptFits covers the clock-side bound:
+// an attempt that consumes the whole budget is not retried.
+func TestCollectUntilStopsWhenNoAttemptFits(t *testing.T) {
+	calls := 0
+	ok, _ := collectUntil(t, "a condition", 20*time.Millisecond, 30*time.Millisecond,
+		func(int) (bool, string) {
+			calls++
+			time.Sleep(25 * time.Millisecond)
+			return false, "still nothing"
+		})
+	if ok {
+		t.Fatal("expected failure")
+	}
+	if calls != 1 {
+		t.Errorf("attempt called %d times, want 1 (a second attempt does not fit the budget)", calls)
+	}
+}
+
+func TestCollectProfileUntilRetriesUnreadableProfiles(t *testing.T) {
+	calls := 0
+	p, ok, report := collectProfileUntil(t, "a profile with samples", 10*time.Millisecond,
+		func(int) (*profile.Profile, error) {
+			calls++
+			if calls == 1 {
+				return nil, os.ErrNotExist
+			}
+			return &profile.Profile{Sample: []*profile.Sample{{}}}, nil
+		},
+		func(p *profile.Profile) bool { return len(p.Sample) > 0 })
+	if !ok {
+		t.Fatalf("expected success on the second attempt; report: %s", report)
+	}
+	if calls != 2 {
+		t.Errorf("collect called %d times, want 2", calls)
+	}
+	if p == nil || len(p.Sample) != 1 {
+		t.Errorf("returned profile = %v, want the one from the last attempt", p)
+	}
+}
+
+// buildSyntheticProfile returns a profile with one sample carrying one
+// frame of each mapping class.
+func buildSyntheticProfile() *profile.Profile {
+	realMapping := &profile.Mapping{ID: 1, File: "/usr/bin/workload", BuildID: "abcd"}
+	kernelMapping := &profile.Mapping{ID: 2, File: kernelMappingFile}
+	jitMapping := &profile.Mapping{ID: 3, File: jitMappingFile}
+	anonMapping := &profile.Mapping{ID: 4}
+
+	locs := []*profile.Location{
+		{ID: 1, Mapping: realMapping, Address: 0x10},
+		{ID: 2, Mapping: kernelMapping, Address: 0x20},
+		{ID: 3, Mapping: jitMapping},
+		{ID: 4, Mapping: anonMapping, Address: 0x40},
+	}
+	return &profile.Profile{
+		Mapping:  []*profile.Mapping{realMapping, kernelMapping, jitMapping, anonMapping},
+		Location: locs,
+		Function: []*profile.Function{{ID: 1, Name: "main.work"}, {ID: 2, Name: ""}},
+		Sample:   []*profile.Sample{{Location: locs, Value: []int64{7}}},
+	}
+}
+
+func TestSummarizeProfileSplitsFramesAndMappings(t *testing.T) {
+	s := summarizeProfile(buildSyntheticProfile())
+	if s.Samples != 1 || s.TotalValue != 7 {
+		t.Errorf("samples=%d total=%d, want 1 and 7", s.Samples, s.TotalValue)
+	}
+	if s.UserFrames != 1 || s.KernelFrames != 1 || s.JitFrames != 1 || s.UnmappedFrames != 1 {
+		t.Errorf("frame split = user %d kernel %d jit %d unmapped %d, want 1 each",
+			s.UserFrames, s.KernelFrames, s.JitFrames, s.UnmappedFrames)
+	}
+	if s.RealMappings != 1 || s.KernelMappings != 1 || s.JitMappings != 1 || s.AnonMappings != 1 {
+		t.Errorf("mapping split = real %d kernel %d jit %d anon %d, want 1 each",
+			s.RealMappings, s.KernelMappings, s.JitMappings, s.AnonMappings)
+	}
+	if s.NamedFunctions != 1 || !s.HasBuildID {
+		t.Errorf("named=%d build_id=%v, want 1 and true", s.NamedFunctions, s.HasBuildID)
+	}
+	for _, want := range []string{"samples=1", "user=1", "kernel=1", "real=1"} {
+		if !strings.Contains(s.String(), want) {
+			t.Errorf("summary %q does not contain %q", s, want)
+		}
+	}
+}
+
+func TestDescribeProfileNamesTheEmptyCases(t *testing.T) {
+	if got := describeProfile(nil); !strings.Contains(got, "no profile") {
+		t.Errorf("describeProfile(nil) = %q", got)
+	}
+	got := describeProfile(&profile.Profile{})
+	if !strings.Contains(got, "EMPTY") || !strings.Contains(got, "0 samples") {
+		t.Errorf("describeProfile(empty) = %q, want it to say EMPTY and 0 samples", got)
+	}
+}
+
+func TestReadProfileReportsEmptyFileAsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profile.pb.gz")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readProfile(path)
+	if err == nil {
+		t.Fatal("expected an error for a zero-byte profile")
+	}
+	if !strings.Contains(err.Error(), "EMPTY") || !strings.Contains(err.Error(), "0 samples") {
+		t.Errorf("error %q does not say the profile was empty", err)
+	}
+}
+
+func TestReadProfileReportsGarbageAsUnparseable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profile.pb.gz")
+	if err := os.WriteFile(path, []byte("not a profile"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readProfile(path); err == nil || !strings.Contains(err.Error(), "did not parse") {
+		t.Errorf("error = %v, want a 'did not parse' diagnosis", err)
+	}
+}
+
+func TestFidelityDiagnosisDistinguishesTheCases(t *testing.T) {
+	cases := []struct {
+		name string
+		sum  profileSummary
+		want string
+	}{
+		{"nothing sampled", profileSummary{}, "nothing was sampled"},
+		{"user PCs with no mapping", profileSummary{Samples: 3, UnmappedFrames: 9}, "mapping resolution"},
+		{"all kernel", profileSummary{Samples: 3, KernelFrames: 9}, "never on-CPU in user space"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fidelityDiagnosis(tc.sum); !strings.Contains(got, tc.want) {
+				t.Errorf("fidelityDiagnosis = %q, want it to mention %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProcessAliveTracksSelfAndNonexistent(t *testing.T) {
+	if !processAlive(os.Getpid()) {
+		t.Error("processAlive(self) = false")
+	}
+	if processAlive(1 << 30) {
+		t.Error("processAlive(bogus pid) = true")
+	}
+}
+
+func TestHasFunctionContaining(t *testing.T) {
+	p := buildSyntheticProfile()
+	if !hasFunctionContaining(p, "runtime.", "main.") {
+		t.Error("expected main.work to match")
+	}
+	if hasFunctionContaining(p, "nope") {
+		t.Error("unexpected match")
+	}
+	if hasFunctionContaining(nil, "main.") {
+		t.Error("nil profile should not match")
+	}
+}
+
+// TestUserSpacePreconditionDoesNotImplyRealMapping is the regression
+// guard for the defect this harness must not have: if the loop waits on
+// something that implies the assertion, the assertion can never fail
+// after a successful loop, and an intermittent regression is retried
+// into a pass.
+//
+// The precondition must hold for a capture whose user-space PCs
+// resolved to NO binary — the exact shape issue #42 saw on amd64 —
+// while summarizeProfile still reports zero real mappings, so
+// assertPprofFidelity can fail on it.
+func TestUserSpacePreconditionDoesNotImplyRealMapping(t *testing.T) {
+	anon := &profile.Mapping{ID: 1, Start: 0x1311ff8c000}
+	locs := []*profile.Location{{ID: 1, Mapping: anon, Address: 0x1311ff8c230}}
+	p := &profile.Profile{
+		Mapping:  []*profile.Mapping{anon},
+		Location: locs,
+		Sample:   []*profile.Sample{{Location: locs, Value: []int64{1}}},
+	}
+	if !profileHasUserSpaceFrames(p) {
+		t.Error("a capture with an unmapped user PC must satisfy the precondition")
+	}
+	if got := summarizeProfile(p).RealMappings; got != 0 {
+		t.Errorf("RealMappings = %d, want 0 — the fidelity assertion must still be able to fail", got)
+	}
+
+	// The other half: a kernel-only capture must NOT satisfy the
+	// precondition, so it is retried rather than judged.
+	kern := &profile.Mapping{ID: 2, File: kernelMappingFile}
+	klocs := []*profile.Location{{ID: 2, Mapping: kern, Address: 0xffffffff8f6a831c}}
+	kp := &profile.Profile{
+		Mapping:  []*profile.Mapping{kern},
+		Location: klocs,
+		Sample:   []*profile.Sample{{Location: klocs, Value: []int64{1}}},
+	}
+	if profileHasUserSpaceFrames(kp) {
+		t.Error("a kernel-only capture must not satisfy the user-space precondition")
+	}
+}
+
+// TestCollectUntilRespectsTheSuiteWideAllowance pins the global bound:
+// once the package's shared re-collection allowance is spent, a loop
+// runs its (free) first attempt and stops, so a comprehensively
+// degraded run degrades to pre-#42 behaviour instead of overrunning the
+// CI timeout.
+func TestCollectUntilRespectsTheSuiteWideAllowance(t *testing.T) {
+	saved := suiteRetrySpentNs.Swap(int64(suiteRetryBudget))
+	defer suiteRetrySpentNs.Store(saved)
+
+	calls := 0
+	ok, report := collectUntil(t, "a condition", 10*time.Millisecond, time.Second,
+		func(int) (bool, string) {
+			calls++
+			return false, "nothing landed"
+		})
+	if ok {
+		t.Fatal("expected failure")
+	}
+	if calls != 1 {
+		t.Errorf("attempt called %d times, want 1 (the shared allowance is spent)", calls)
+	}
+	if !strings.Contains(report, "package-wide re-collection allowance") {
+		t.Errorf("report %q does not explain that the shared allowance ran out", report)
+	}
+}
+
+// TestCollectUntilChargesOnlyReCollections pins the accounting: the
+// first attempt of a loop is the collection the test would have made
+// anyway and must not draw on the shared allowance; attempts after it
+// must.
+func TestCollectUntilChargesOnlyReCollections(t *testing.T) {
+	saved := suiteRetrySpentNs.Swap(0)
+	defer suiteRetrySpentNs.Store(saved)
+
+	collectUntil(t, "a condition met immediately", 10*time.Millisecond, 15*time.Millisecond,
+		func(int) (bool, string) {
+			time.Sleep(12 * time.Millisecond)
+			return true, "satisfied"
+		})
+	if spent := suiteRetrySpentNs.Load(); spent != 0 {
+		t.Errorf("charged %dns for a single-attempt loop, want 0", spent)
+	}
+
+	n := 0
+	collectUntil(t, "a condition met on the second attempt", 5*time.Millisecond, 500*time.Millisecond,
+		func(int) (bool, string) {
+			n++
+			time.Sleep(6 * time.Millisecond)
+			return n == 2, "detail"
+		})
+	if spent := suiteRetrySpentNs.Load(); spent <= 0 {
+		t.Errorf("charged %dns for a loop that re-collected, want > 0", spent)
+	}
+}
+
+// symptomThreeProfile reconstructs the capture behind issue #42's third
+// comment, from what the code guarantees rather than from the log text:
+//
+//   - pprof/pprof.go:182 always pre-creates Mapping[0] = {ID:1} with an
+//     empty File, referenced or not;
+//   - every kernel frame appends a "[kernel]" sentinel mapping, every
+//     JIT frame a "[jit]" one, every resolver hit a file-backed one;
+//   - the write path is WriteUncompressed with no Compact/Merge, and a
+//     round trip preserves unreferenced mappings
+//     (TestProfileRoundTripKeepsUnreferencedMappings);
+//   - the failure printed exactly ONE mapping pointer, and
+//     isDegenerateProfile returned false with real=0 and jit=0, which
+//     given its own logic can only mean len(Sample) >= the floor.
+//
+// So: >= 20 samples, every frame on the default anon mapping, and NO
+// kernel frames at all.
+func symptomThreeProfile(samples int) *profile.Profile {
+	def := &profile.Mapping{ID: 1}
+	locs := []*profile.Location{{ID: 1, Mapping: def, Address: 0x2a10}}
+	p := &profile.Profile{
+		Mapping:  []*profile.Mapping{def},
+		Location: locs,
+		Function: []*profile.Function{{ID: 1, Name: "rust_workload::cpu_intensive_work"}},
+	}
+	for range samples {
+		p.Sample = append(p.Sample, &profile.Sample{Location: locs, Value: []int64{1}})
+	}
+	return p
+}
+
+// TestProfileRoundTripKeepsUnreferencedMappings pins the fact the
+// symptom-3 reconstruction rests on: nothing in the write/parse path
+// prunes a mapping just because no location points at it. If this ever
+// stops holding, "exactly one mapping" no longer implies "the default
+// one", and the reasoning in symptomThreeProfile has to be redone.
+func TestProfileRoundTripKeepsUnreferencedMappings(t *testing.T) {
+	def := &profile.Mapping{ID: 1}
+	kern := &profile.Mapping{ID: 2, File: kernelMappingFile}
+	loc := &profile.Location{ID: 1, Mapping: kern, Address: 0xffffffff8f6a831c}
+	p := &profile.Profile{
+		SampleType: []*profile.ValueType{{Type: "samples", Unit: "count"}},
+		PeriodType: &profile.ValueType{Type: "cpu", Unit: "nanoseconds"},
+		Period:     1,
+		Mapping:    []*profile.Mapping{def, kern},
+		Location:   []*profile.Location{loc},
+		Sample:     []*profile.Sample{{Location: []*profile.Location{loc}, Value: []int64{1}}},
+	}
+	var buf bytes.Buffer
+	if err := p.Write(&buf); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	back, err := profile.Parse(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(back.Mapping) != 2 {
+		t.Fatalf("round trip kept %d mapping(s), want 2 (the unreferenced default must survive)", len(back.Mapping))
+	}
+	if back.Mapping[0].File != "" {
+		t.Errorf("mapping[0].File = %q, want the empty default", back.Mapping[0].File)
+	}
+}
+
+// TestSymptomThreeIsJudgedNotRetried states the outcome plainly: the
+// capture behind symptom 3 clears the fidelity precondition, so it is
+// handed to assertPprofFidelity and fails on the first attempt. This
+// change does not make that failure green, and the test exists so that
+// nobody "fixes" it later by widening the loop condition.
+func TestSymptomThreeIsJudgedNotRetried(t *testing.T) {
+	p := symptomThreeProfile(40)
+
+	if !profileFidelityJudgeable(p) {
+		t.Fatal("symptom 3's capture must clear the precondition — it is judged, not retried")
+	}
+	if got := summarizeProfile(p).RealMappings; got != 0 {
+		t.Fatalf("RealMappings = %d, want 0 — assertPprofFidelity must still fail on it", got)
+	}
+	if diag := fidelityDiagnosis(summarizeProfile(p)); !strings.Contains(diag, "mapping resolution") {
+		t.Errorf("diagnosis = %q, want it to name mapping resolution as the suspect", diag)
+	}
+
+	// The starved shape — same mappings, too few samples — is retried
+	// instead, and if the budget runs out isDegenerateProfile tolerates
+	// it exactly as it did before this change.
+	starved := symptomThreeProfile(degenerateSampleFloor - 1)
+	if profileFidelityJudgeable(starved) {
+		t.Error("a capture below the sample floor must be re-collected, not judged")
+	}
+	if !isDegenerateProfile(starved) {
+		t.Error("the starved shape must still hit the pre-existing degenerate tolerance")
+	}
+}
+
+// TestDescribeMappingsRendersContentsNotPointers guards the message
+// defect that made symptom 3 undiagnosable: `%+v` on a slice of struct
+// pointers prints heap addresses, not fields.
+func TestDescribeMappingsRendersContentsNotPointers(t *testing.T) {
+	p := symptomThreeProfile(40)
+
+	got := describeMappings(p)
+	for _, want := range []string{"1 mapping(s)", `file=""`, "#1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("describeMappings = %q, want it to contain %q", got, want)
+		}
+	}
+	// The old form carried none of that — a count and a heap address.
+	if old := fmt.Sprintf("%+v", p.Mapping); strings.Contains(old, "file=") || strings.Contains(old, "File:") {
+		t.Errorf("premise check failed: %%+v on []*Mapping now renders fields (%q); "+
+			"the reasoning about issue #42's message needs revisiting", old)
+	}
+}

--- a/test/debuginfod_integration_test.go
+++ b/test/debuginfod_integration_test.go
@@ -3,10 +3,8 @@
 package test
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"io"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -147,66 +145,60 @@ func profileAndAssert(t *testing.T, fixtureDir string, fx fixture) {
 	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
 
 	out := filepath.Join(t.TempDir(), "profile.pb.gz")
-	agent := exec.Command(bin,
-		"--profile",
-		"--pid", strconv.Itoa(cmd.Process.Pid),
-		"--duration", "3s",
-		"--profile-output", out,
-		"--debuginfod-url", "http://localhost:8002",
-		"--symbol-cache-dir", t.TempDir(),
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run for %s: %v", fx.name, err)
-	}
+	cacheDir := t.TempDir()
 
-	body, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatalf("read profile: %v", err)
-	}
-	gr, err := gzip.NewReader(bytes.NewReader(body))
-	if err != nil {
-		t.Fatalf("gunzip: %v", err)
-	}
-	defer func() { _ = gr.Close() }()
-	raw, err := io.ReadAll(gr)
-	if err != nil {
-		t.Fatalf("read inflated: %v", err)
-	}
-
-	p, err := pprofpb.ParseUncompressed(raw)
-	if err != nil {
-		t.Fatalf("parse pprof: %v", err)
-	}
-
-	got := map[string]bool{}
-	for _, fn := range p.Function {
-		got[fn.Name] = true
-		// Rust mangling preserves the unmangled name in DWARF; blazesym
-		// demangles to a Rust-style "crate::module::func" form. Match the
-		// suffix in case we got the mangled symbol.
-		for _, want := range fx.wantAnyFunc {
-			if fn.Name == want {
-				return
+	// Rust mangling preserves the unmangled name in DWARF; blazesym
+	// demangles to a Rust-style "crate::module::func" form, so match on
+	// substring as well as equality.
+	matches := func(p *pprofpb.Profile) bool {
+		for _, fn := range p.Function {
+			for _, want := range fx.wantAnyFunc {
+				if fn.Name == want || contains(fn.Name, want) {
+					return true
+				}
 			}
 		}
+		return false
 	}
-	// Also scan as fuzzy contains for Rust-mangled-name fallback.
-	for _, fn := range p.Function {
-		for _, want := range fx.wantAnyFunc {
-			if want != "" && contains(fn.Name, want) {
-				return
+
+	// Collect until the fixture's own functions appear, with a deadline
+	// (issue #42): a 3s window that caught the fixture off-CPU says
+	// nothing about whether debuginfod symbolization worked.
+	const window = 3 * time.Second
+	p, collected, report := collectProfileUntil(t,
+		fmt.Sprintf("a profile of the %s fixture containing any of %v", fx.name, fx.wantAnyFunc),
+		window,
+		func(int) (*pprofpb.Profile, error) {
+			requireWorkloadAlive(t, cmd, fx.spawn)
+			agent := exec.Command(bin,
+				"--profile",
+				"--pid", strconv.Itoa(cmd.Process.Pid),
+				"--duration", window.String(),
+				"--profile-output", out,
+				"--debuginfod-url", "http://localhost:8002",
+				"--symbol-cache-dir", cacheDir,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run for %s: %v", fx.name, err)
 			}
-		}
+			return readProfile(out)
+		},
+		matches)
+	if collected {
+		return
 	}
-	names := make([]string, 0, len(got))
-	for k := range got {
-		names = append(names, k)
+
+	names := make([]string, 0)
+	if p != nil {
+		for _, fn := range p.Function {
+			names = append(names, fn.Name)
+		}
 	}
 	slices.Sort(names)
-	t.Fatalf("no expected fixture function for %s; wanted any of %v; got: %v",
-		fx.name, fx.wantAnyFunc, names)
+	t.Fatalf("no expected fixture function for %s; wanted any of %v; %s; got: %v\n%s",
+		fx.name, fx.wantAnyFunc, describeProfile(p), names, report)
 }
 
 func contains(s, sub string) bool {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2,13 +2,11 @@ package test
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"debug/elf"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -51,31 +49,31 @@ var workloads = []TestWorkload{
 	{
 		Name:     "go-cpu",
 		Binary:   "./workloads/go/cpu_bound",
-		Args:     []string{"-duration=20s", "-threads=4"},
+		Args:     []string{workloadRuntimeFlag, "-threads=4"},
 		Language: "go",
 	},
 	{
 		Name:     "go-io",
 		Binary:   "./workloads/go/io_bound",
-		Args:     []string{"-duration=20s", "-threads=2"},
+		Args:     []string{workloadRuntimeFlag, "-threads=2"},
 		Language: "go",
 	},
 	{
 		Name:     "rust-cpu",
 		Binary:   "./workloads/rust/target/release/rust-workload",
-		Args:     []string{"20", "4"},
+		Args:     []string{workloadRuntimeSecs, "4"},
 		Language: "rust",
 	},
 	{
 		Name:     "python-cpu",
 		Binary:   "python3",
-		Args:     []string{"-X", "perf", "./workloads/python/cpu_bound.py", "20", "4"},
+		Args:     []string{"-X", "perf", "./workloads/python/cpu_bound.py", workloadRuntimeSecs, "4"},
 		Language: "python",
 	},
 	{
 		Name:     "python-io",
 		Binary:   "python3",
-		Args:     []string{"-X", "perf", "./workloads/python/io_bound.py", "20", "2"},
+		Args:     []string{"-X", "perf", "./workloads/python/io_bound.py", workloadRuntimeSecs, "2"},
 		Language: "python",
 	},
 }
@@ -105,31 +103,46 @@ func TestProfileMode(t *testing.T) {
 				time.Sleep(2 * time.Second) // Let workload stabilize
 			}
 
-			// Run perf-agent
+			// Run perf-agent. Collect until the capture is one the
+			// assertions below can actually speak to — samples, stacks
+			// and at least one symbol — rather than sampling once for a
+			// fixed window and asserting on whatever landed (issue #42).
+			// If the budget runs out we fall through to the historical
+			// tolerance ladder unchanged, so this can only add signal.
 			outputFile := "profile.pb.gz"
 			defer os.Remove(outputFile)
 
-			agent := exec.Command(agentPath,
-				"--profile",
-				"--profile-output", outputFile,
-				"--pid", fmt.Sprintf("%d", workload.Process.Pid),
-				"--duration", "10s",
-			)
-
-			output, err := agent.CombinedOutput()
-			if err != nil {
-				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			const window = 10 * time.Second
+			prof, collected, report := collectProfileUntil(t,
+				"a CPU profile with samples, stack traces and at least one symbolized function",
+				window,
+				func(int) (*profile.Profile, error) {
+					requireWorkloadAlive(t, workload, wl.Name)
+					agent := exec.Command(agentPath,
+						"--profile",
+						"--profile-output", outputFile,
+						"--pid", fmt.Sprintf("%d", workload.Process.Pid),
+						"--duration", window.String(),
+					)
+					output, err := agent.CombinedOutput()
+					if err != nil {
+						t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+					}
+					return readProfile(outputFile)
+				},
+				func(p *profile.Profile) bool {
+					return len(p.Sample) > 0 && profileHasStacks(p) && profileHasSymbols(p)
+				})
+			if !collected {
+				t.Logf("WARN: %s", report)
 			}
+			require.NotNil(t, prof, "no readable profile after the collect-until budget: %s", report)
 
 			// Verify profile.pb.gz was created
 			assert.FileExists(t, outputFile)
 
-			// Parse and validate profile
-			prof := parseProfile(t, outputFile)
-			require.NotNil(t, prof)
-
 			// Should have samples
-			assert.Greater(t, len(prof.Sample), 0, "Profile should contain samples")
+			assert.Greater(t, len(prof.Sample), 0, "Profile should contain samples: %s", describeProfile(prof))
 
 			// Should have valid sample types
 			require.Greater(t, len(prof.SampleType), 0)
@@ -138,14 +151,7 @@ func TestProfileMode(t *testing.T) {
 				"Expected sample type to be 'sample', 'cpu', or 'samples', got: %s", sampleType)
 
 			// Verify we captured stack traces
-			hasStacks := false
-			for _, sample := range prof.Sample {
-				if len(sample.Location) > 0 {
-					hasStacks = true
-					break
-				}
-			}
-			assert.True(t, hasStacks, "Profile should contain stack traces")
+			assert.True(t, profileHasStacks(prof), "Profile should contain stack traces: %s", describeProfile(prof))
 
 			// Verify symbolization worked (at least some symbols).
 			//
@@ -159,13 +165,7 @@ func TestProfileMode(t *testing.T) {
 			// that as a known environmental limitation rather than a
 			// regression — the agent did capture samples, just couldn't
 			// symbolize them.
-			hasSymbols := false
-			for _, fn := range prof.Function {
-				if fn.Name != "" && fn.Name != "??" {
-					hasSymbols = true
-					break
-				}
-			}
+			hasSymbols := profileHasSymbols(prof)
 			switch {
 			case hasSymbols:
 				// good
@@ -177,7 +177,7 @@ func TestProfileMode(t *testing.T) {
 				t.Logf("WARN: only %d samples captured (< %d threshold); symbolization assertion skipped — too few user-space PCs to reliably hit symbolizable code",
 					len(prof.Sample), degenerateSampleFloor)
 			default:
-				assert.True(t, hasSymbols, "Profile should contain symbolized functions")
+				assert.True(t, hasSymbols, "Profile should contain symbolized functions: %s", describeProfile(prof))
 			}
 
 			// verify pprof fidelity guarantees
@@ -208,31 +208,41 @@ func TestOffCPUMode(t *testing.T) {
 
 			time.Sleep(2 * time.Second)
 
-			// Run perf-agent with off-CPU profiling
+			// Run perf-agent with off-CPU profiling, re-collecting until
+			// the I/O workload's blocking actually landed in a capture
+			// (issue #42) rather than asserting on one fixed window.
 			outputFile := "offcpu.pb.gz"
 			defer os.Remove(outputFile)
 
-			agent := exec.Command(agentPath,
-				"--offcpu",
-				"--offcpu-output", outputFile,
-				"--pid", fmt.Sprintf("%d", workload.Process.Pid),
-				"--duration", "10s",
-			)
-
-			output, err := agent.CombinedOutput()
-			if err != nil {
-				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			const window = 10 * time.Second
+			prof, collected, report := collectProfileUntil(t,
+				"an off-CPU profile with at least one blocking sample",
+				window,
+				func(int) (*profile.Profile, error) {
+					requireWorkloadAlive(t, workload, wl.Name)
+					agent := exec.Command(agentPath,
+						"--offcpu",
+						"--offcpu-output", outputFile,
+						"--pid", fmt.Sprintf("%d", workload.Process.Pid),
+						"--duration", window.String(),
+					)
+					output, err := agent.CombinedOutput()
+					if err != nil {
+						t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+					}
+					return readProfile(outputFile)
+				},
+				func(p *profile.Profile) bool { return len(p.Sample) > 0 })
+			if !collected {
+				t.Logf("WARN: %s", report)
 			}
+			require.NotNil(t, prof, "no readable off-CPU profile after the collect-until budget: %s", report)
 
 			// Verify offcpu.pb.gz was created
 			assert.FileExists(t, outputFile)
 
-			// Parse and validate profile
-			prof := parseProfile(t, outputFile)
-			require.NotNil(t, prof)
-
 			// Should have samples (I/O workloads block on I/O)
-			assert.Greater(t, len(prof.Sample), 0, "Off-CPU profile should contain samples")
+			assert.Greater(t, len(prof.Sample), 0, "Off-CPU profile should contain samples: %s", describeProfile(prof))
 
 			// verify pprof fidelity guarantees
 			assertPprofFidelity(t, outputFile)
@@ -306,33 +316,47 @@ func TestCombinedMode(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	// Run perf-agent with all features
-	agent := exec.Command(agentPath,
-		"--profile",
-		"--profile-output", "profile.pb.gz",
-		"--offcpu",
-		"--offcpu-output", "offcpu.pb.gz",
-		"--pmu",
-		"--pid", fmt.Sprintf("%d", workload.Process.Pid),
-		"--duration", "10s",
-	)
-
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
-	}
-
 	// Verify both profile files exist
 	defer os.Remove("profile.pb.gz")
 	defer os.Remove("offcpu.pb.gz")
+
+	// Run perf-agent with all features, re-collecting until the CPU
+	// profile has samples (issue #42).
+	const window = 10 * time.Second
+	var output []byte
+	cpuProf, collected, report := collectProfileUntil(t,
+		"a combined-mode CPU profile with samples",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload, wl.Name)
+			agent := exec.Command(agentPath,
+				"--profile",
+				"--profile-output", "profile.pb.gz",
+				"--offcpu",
+				"--offcpu-output", "offcpu.pb.gz",
+				"--pmu",
+				"--pid", fmt.Sprintf("%d", workload.Process.Pid),
+				"--duration", window.String(),
+			)
+			var err error
+			output, err = agent.CombinedOutput()
+			if err != nil {
+				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			}
+			return readProfile("profile.pb.gz")
+		},
+		func(p *profile.Profile) bool { return len(p.Sample) > 0 })
+	if !collected {
+		t.Logf("WARN: %s", report)
+	}
+	require.NotNil(t, cpuProf, "no readable CPU profile after the collect-until budget: %s", report)
 
 	assert.FileExists(t, "profile.pb.gz")
 	assert.FileExists(t, "offcpu.pb.gz")
 	assert.Contains(t, string(output), "Metrics")
 
 	// Verify profiles are valid
-	cpuProf := parseProfile(t, "profile.pb.gz")
-	assert.Greater(t, len(cpuProf.Sample), 0)
+	assert.Greater(t, len(cpuProf.Sample), 0, "combined-mode CPU profile should contain samples: %s", describeProfile(cpuProf))
 
 	offcpuProf := parseProfile(t, "offcpu.pb.gz")
 	assert.NotNil(t, offcpuProf)
@@ -438,13 +462,6 @@ func isDegenerateProfile(p *profile.Profile) bool {
 	return true
 }
 
-// degenerateSampleFloor is the sample-count threshold below which the
-// pprof fidelity / symbolization assertions are considered too noisy
-// to be meaningful. A healthy 10s @ 99Hz CPU-bound run produces
-// hundreds of user-space samples; the IO-bound subtests on slow CI
-// runners can drop into the low tens or single digits.
-const degenerateSampleFloor = 20
-
 // assertPprofFidelity verifies pprof fidelity guarantees on a
 // captured profile: >=1 real (non-sentinel) mapping and every
 // user-space Location has a non-zero Address. BuildID presence is
@@ -453,36 +470,17 @@ const degenerateSampleFloor = 20
 // older system binaries, custom builds with --build-id=none).
 func assertPprofFidelity(t *testing.T, path string) {
 	t.Helper()
-	f, err := os.Open(path)
+	p, err := readProfile(path)
 	if err != nil {
-		t.Fatalf("open profile: %v", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	p, err := profile.Parse(f)
-	if err != nil {
-		t.Fatalf("parse profile: %v", err)
+		t.Fatalf("pprof fidelity: %v", err)
 	}
 	if err := p.CheckValid(); err != nil {
 		t.Fatalf("pprof invalid: %v", err)
 	}
 
-	var real int
-	var hasJit bool
-	var hasBuildID bool
-	for _, m := range p.Mapping {
-		switch {
-		case m.File == "" || m.File == "[kernel]":
-			// ignore
-		case m.File == "[jit]":
-			hasJit = true
-		default:
-			real++
-		}
-		if m.BuildID != "" {
-			hasBuildID = true
-		}
-	}
+	sum := summarizeProfile(p)
+	real := sum.RealMappings
+	hasJit := sum.JitMappings > 0
 	// At least one real mapping — proves we're not falling back to the
 	// hardcoded single-mapping default. Static binaries (Go) legitimately
 	// produce exactly 1; dynamically-linked binaries produce N+ (target +
@@ -496,15 +494,19 @@ func assertPprofFidelity(t *testing.T, path string) {
 	case hasJit:
 		t.Logf("WARN: profile has only [jit] mapping (no file-backed); accepting JIT-only profile")
 	case isDegenerateProfile(p):
-		t.Logf("WARN: degenerate profile (real=0, jit=0); known CI flake on slow runners: %+v", p.Mapping)
+		t.Logf("WARN: degenerate profile (real=0, jit=0); known CI flake on slow runners: %s", describeMappings(p))
 	default:
-		t.Errorf("expected >=1 real mapping, got %d: %+v", real, p.Mapping)
+		t.Errorf("expected >=1 real (file-backed) mapping, got 0.\n"+
+			"  captured: %s\n"+
+			"  reading:  %s\n"+
+			"  mappings: %s",
+			sum, fidelityDiagnosis(sum), describeMappings(p))
 	}
 	// BuildID is observational only — record presence/absence so a
 	// regression that wipes BuildIDs across the board is visible in
 	// test output, but don't fail when the captured binaries simply
 	// don't carry build-ids.
-	t.Logf("pprof fidelity: real_mappings=%d has_build_id=%v", real, hasBuildID)
+	t.Logf("pprof fidelity: %s", sum)
 
 	for _, loc := range p.Location {
 		if loc.Mapping == nil {
@@ -520,22 +522,42 @@ func assertPprofFidelity(t *testing.T, path string) {
 	}
 }
 
+// parseProfile reads a captured pprof and fails the test if it cannot be
+// read.
+//
+// It does NOT assert on sample count — callers keep their own
+// expectations about that — but an empty or truncated file is reported
+// as "EMPTY (0 bytes): the agent collected 0 samples", not as the bare
+// `EOF` from a gzip reader that issue #42's arm64 run had to be
+// diagnosed from.
 func parseProfile(t *testing.T, filename string) *profile.Profile {
-	f, err := os.Open(filename)
-	require.NoError(t, err)
-	defer f.Close()
-
-	gzr, err := gzip.NewReader(f)
-	require.NoError(t, err)
-	defer gzr.Close()
-
-	data, err := io.ReadAll(gzr)
-	require.NoError(t, err)
-
-	prof, err := profile.Parse(bytes.NewReader(data))
-	require.NoError(t, err)
-
+	t.Helper()
+	prof, err := readProfile(filename)
+	if err != nil {
+		t.Fatalf("parse profile: %v", err)
+	}
 	return prof
+}
+
+// fidelityDiagnosis turns a profile summary into the sentence a reader
+// needs to decide whether a "no real mapping" failure is a profiler
+// regression or a workload that was never on-CPU in user space —
+// precisely the distinction issue #42 called out as missing.
+func fidelityDiagnosis(s profileSummary) string {
+	switch {
+	case s.Samples == 0:
+		return "nothing was sampled at all, so this says nothing about mapping resolution"
+	case s.UnmappedFrames > 0:
+		return fmt.Sprintf(
+			"%d frame(s) carried a user-space PC that resolved to no binary mapping — "+
+				"mapping resolution (procmap/blazesym) is the suspect", s.UnmappedFrames)
+	case s.KernelFrames > 0 && s.UserFrames == 0:
+		return fmt.Sprintf(
+			"all %d sampled frames were kernel-side and none were user-side — "+
+				"the target was never on-CPU in user space during this window", s.KernelFrames)
+	default:
+		return "samples exist but carry no file-backed mapping"
+	}
 }
 
 // System-wide profiling tests
@@ -546,8 +568,8 @@ func TestSystemWideProfile(t *testing.T) {
 	agentPath := getAgentPath(t)
 
 	// Start multiple workloads
-	workload1 := exec.Command("./workloads/go/cpu_bound", "-duration=15s", "-threads=2")
-	workload2 := exec.Command("./workloads/go/io_bound", "-duration=15s", "-threads=2")
+	workload1 := exec.Command("./workloads/go/cpu_bound", workloadRuntimeFlag, "-threads=2")
+	workload2 := exec.Command("./workloads/go/io_bound", workloadRuntimeFlag, "-threads=2")
 	require.NoError(t, workload1.Start())
 	require.NoError(t, workload2.Start())
 	defer func() {
@@ -563,22 +585,35 @@ func TestSystemWideProfile(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	// Run system-wide profiling
+	// Run system-wide profiling, re-collecting until samples land
+	// (issue #42).
 	outputFile := "profile.pb.gz"
 	defer os.Remove(outputFile)
 
-	agent := exec.Command(agentPath, "--profile", "--profile-output", outputFile, "-a", "--duration", "5s")
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+	const window = 5 * time.Second
+	var output []byte
+	prof, collected, report := collectProfileUntil(t,
+		"a system-wide CPU profile with samples",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload1, "go/cpu_bound")
+			agent := exec.Command(agentPath, "--profile", "--profile-output", outputFile, "-a", "--duration", window.String())
+			var err error
+			output, err = agent.CombinedOutput()
+			if err != nil {
+				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			}
+			return readProfile(outputFile)
+		},
+		func(p *profile.Profile) bool { return len(p.Sample) > 0 })
+	if !collected {
+		t.Logf("WARN: %s", report)
 	}
+	require.NotNil(t, prof, "no readable system-wide profile after the collect-until budget: %s", report)
 
 	assert.Contains(t, string(output), "system-wide")
 	assert.FileExists(t, outputFile)
-
-	prof := parseProfile(t, outputFile)
-	require.NotNil(t, prof)
-	assert.Greater(t, len(prof.Sample), 0, "System-wide profile should contain samples")
+	assert.Greater(t, len(prof.Sample), 0, "System-wide profile should contain samples: %s", describeProfile(prof))
 }
 
 func TestSystemWideOffCPU(t *testing.T) {
@@ -586,7 +621,7 @@ func TestSystemWideOffCPU(t *testing.T) {
 
 	agentPath := getAgentPath(t)
 
-	workload := exec.Command("./workloads/go/io_bound", "-duration=15s", "-threads=2")
+	workload := exec.Command("./workloads/go/io_bound", workloadRuntimeFlag, "-threads=2")
 	require.NoError(t, workload.Start())
 	defer func() {
 		if workload.Process != nil {
@@ -600,11 +635,31 @@ func TestSystemWideOffCPU(t *testing.T) {
 	outputFile := "offcpu.pb.gz"
 	defer os.Remove(outputFile)
 
-	agent := exec.Command(agentPath, "--offcpu", "--offcpu-output", outputFile, "-a", "--duration", "5s")
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+	// Collect until the capture is one assertPprofFidelity's verdict can
+	// mean something: enough samples to be worth judging, at least one
+	// of them from user space (issue #42). Deliberately NOT "at least
+	// one file-backed mapping" — that is what the assertion checks, and
+	// a loop that waits for it could never fail it.
+	const window = 5 * time.Second
+	var output []byte
+	prof, collected, report := collectProfileUntil(t,
+		"a system-wide off-CPU profile with enough samples to judge and at least one user-space frame",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload, "go/io_bound")
+			agent := exec.Command(agentPath, "--offcpu", "--offcpu-output", outputFile, "-a", "--duration", window.String())
+			var err error
+			output, err = agent.CombinedOutput()
+			if err != nil {
+				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			}
+			return readProfile(outputFile)
+		},
+		profileFidelityJudgeable)
+	if !collected {
+		t.Logf("WARN: %s", report)
 	}
+	require.NotNil(t, prof, "no readable system-wide off-CPU profile after the collect-until budget: %s", report)
 
 	assert.Contains(t, string(output), "system-wide")
 	assert.FileExists(t, outputFile)
@@ -932,7 +987,7 @@ func TestStreamingProfileOutput(t *testing.T) {
 	requireBPFRunnable(t, "")
 
 	// Start a CPU workload
-	workload := exec.Command("./workloads/go/cpu_bound", "-duration=20s", "-threads=4")
+	workload := exec.Command("./workloads/go/cpu_bound", workloadRuntimeFlag, "-threads=4")
 	require.NoError(t, workload.Start())
 	defer func() {
 		if workload.Process != nil {
@@ -943,46 +998,57 @@ func TestStreamingProfileOutput(t *testing.T) {
 
 	time.Sleep(2 * time.Second) // warmup
 
+	// One attempt = one full Start/collect/Stop cycle of the in-process
+	// agent; the streamed profile is only written on Stop. Collect until
+	// the profile carries samples and symbols (issue #42).
+	const window = 3 * time.Second
 	var buf bytes.Buffer
+	prof, collected, report := collectProfileUntil(t,
+		"a streamed CPU profile with samples and at least one symbolized function",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload, "go/cpu_bound")
+			buf.Reset()
 
-	agent, err := perfagent.New(
-		perfagent.WithPID(workload.Process.Pid),
-		perfagent.WithCPUProfileWriter(&buf),
-		perfagent.WithSampleRate(99),
-	)
-	require.NoError(t, err)
-	defer agent.Close()
+			agent, err := perfagent.New(
+				perfagent.WithPID(workload.Process.Pid),
+				perfagent.WithCPUProfileWriter(&buf),
+				perfagent.WithSampleRate(99),
+			)
+			require.NoError(t, err)
+			defer agent.Close()
 
-	ctx := context.Background()
-	require.NoError(t, agent.Start(ctx))
+			ctx := context.Background()
+			require.NoError(t, agent.Start(ctx))
+			time.Sleep(window)
+			require.NoError(t, agent.Stop(ctx))
 
-	time.Sleep(3 * time.Second)
-
-	require.NoError(t, agent.Stop(ctx))
+			if buf.Len() == 0 {
+				return nil, fmt.Errorf("profile writer received 0 bytes: the agent captured no samples in this %s window", window)
+			}
+			return profile.Parse(bytes.NewReader(buf.Bytes()))
+		},
+		func(p *profile.Profile) bool {
+			return len(p.Sample) > 0 && profileHasSymbols(p)
+		})
+	if !collected {
+		t.Logf("WARN: %s", report)
+	}
 
 	// Verify profile
-	require.Greater(t, buf.Len(), 0, "profile buffer should have data")
-
-	prof, err := profile.Parse(&buf)
-	require.NoError(t, err)
-	require.Greater(t, len(prof.Sample), 0, "profile should contain samples")
+	require.Greater(t, buf.Len(), 0, "profile buffer should have data: %s", report)
+	require.NotNil(t, prof, "streamed profile did not parse: %s", report)
+	require.Greater(t, len(prof.Sample), 0, "profile should contain samples: %s", describeProfile(prof))
 
 	// Verify we got symbolized functions
-	hasSymbols := false
-	for _, fn := range prof.Function {
-		if fn.Name != "" && fn.Name != "??" {
-			hasSymbols = true
-			break
-		}
-	}
-	assert.True(t, hasSymbols, "Profile should contain symbolized functions")
+	assert.True(t, profileHasSymbols(prof), "Profile should contain symbolized functions: %s", describeProfile(prof))
 }
 
 func TestStreamingOffCPUProfileOutput(t *testing.T) {
 	requireBPFRunnable(t, "")
 
 	// Start an I/O workload
-	workload := exec.Command("./workloads/go/io_bound", "-duration=20s", "-threads=2")
+	workload := exec.Command("./workloads/go/io_bound", workloadRuntimeFlag, "-threads=2")
 	require.NoError(t, workload.Start())
 	defer func() {
 		if workload.Process != nil {
@@ -993,27 +1059,44 @@ func TestStreamingOffCPUProfileOutput(t *testing.T) {
 
 	time.Sleep(2 * time.Second) // warmup
 
+	const window = 3 * time.Second
 	var buf bytes.Buffer
+	prof, collected, report := collectProfileUntil(t,
+		"a streamed off-CPU profile with at least one blocking sample",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload, "go/io_bound")
+			buf.Reset()
 
-	agent, err := perfagent.New(
-		perfagent.WithPID(workload.Process.Pid),
-		perfagent.WithOffCPUProfileWriter(&buf),
-	)
-	require.NoError(t, err)
-	defer agent.Close()
+			agent, err := perfagent.New(
+				perfagent.WithPID(workload.Process.Pid),
+				perfagent.WithOffCPUProfileWriter(&buf),
+			)
+			require.NoError(t, err)
+			defer agent.Close()
 
-	ctx := context.Background()
-	require.NoError(t, agent.Start(ctx))
+			ctx := context.Background()
+			require.NoError(t, agent.Start(ctx))
+			time.Sleep(window)
+			require.NoError(t, agent.Stop(ctx))
 
-	time.Sleep(3 * time.Second)
+			if buf.Len() == 0 {
+				return nil, fmt.Errorf("off-CPU profile writer received 0 bytes in this %s window", window)
+			}
+			return profile.Parse(bytes.NewReader(buf.Bytes()))
+		},
+		func(p *profile.Profile) bool { return len(p.Sample) > 0 })
+	if !collected {
+		t.Logf("WARN: %s", report)
+	}
 
-	require.NoError(t, agent.Stop(ctx))
-
-	// Off-CPU profile should have data for I/O workload
+	// Off-CPU profile should have data for I/O workload. Kept
+	// conditional: this assertion has always tolerated an empty
+	// buffer, and the collect-until loop above only improves the odds
+	// of having one to check.
 	if buf.Len() > 0 {
-		prof, err := profile.Parse(&buf)
-		require.NoError(t, err)
-		require.Greater(t, len(prof.Sample), 0, "off-CPU profile should contain samples")
+		require.NotNil(t, prof, "off-CPU profile did not parse: %s", report)
+		require.Greater(t, len(prof.Sample), 0, "off-CPU profile should contain samples: %s", describeProfile(prof))
 	}
 }
 
@@ -1021,7 +1104,7 @@ func TestStreamingCombinedProfileOutput(t *testing.T) {
 	requireBPFRunnable(t, "")
 
 	// Start workload
-	workload := exec.Command("./workloads/go/cpu_bound", "-duration=20s", "-threads=4")
+	workload := exec.Command("./workloads/go/cpu_bound", workloadRuntimeFlag, "-threads=4")
 	require.NoError(t, workload.Start())
 	defer func() {
 		if workload.Process != nil {
@@ -1032,33 +1115,48 @@ func TestStreamingCombinedProfileOutput(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
+	const window = 3 * time.Second
 	var cpuBuf, offcpuBuf bytes.Buffer
+	cpuProf, collected, report := collectProfileUntil(t,
+		"a streamed combined-mode CPU profile with samples",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload, "go/cpu_bound")
+			cpuBuf.Reset()
+			offcpuBuf.Reset()
 
-	agent, err := perfagent.New(
-		perfagent.WithPID(workload.Process.Pid),
-		perfagent.WithCPUProfileWriter(&cpuBuf),
-		perfagent.WithOffCPUProfileWriter(&offcpuBuf),
-		perfagent.WithSampleRate(99),
-	)
-	require.NoError(t, err)
-	defer agent.Close()
+			agent, err := perfagent.New(
+				perfagent.WithPID(workload.Process.Pid),
+				perfagent.WithCPUProfileWriter(&cpuBuf),
+				perfagent.WithOffCPUProfileWriter(&offcpuBuf),
+				perfagent.WithSampleRate(99),
+			)
+			require.NoError(t, err)
+			defer agent.Close()
 
-	ctx := context.Background()
-	require.NoError(t, agent.Start(ctx))
+			ctx := context.Background()
+			require.NoError(t, agent.Start(ctx))
+			time.Sleep(window)
+			require.NoError(t, agent.Stop(ctx))
 
-	time.Sleep(3 * time.Second)
-
-	require.NoError(t, agent.Stop(ctx))
+			if cpuBuf.Len() == 0 {
+				return nil, fmt.Errorf("CPU profile writer received 0 bytes in this %s window", window)
+			}
+			return profile.Parse(bytes.NewReader(cpuBuf.Bytes()))
+		},
+		func(p *profile.Profile) bool { return len(p.Sample) > 0 })
+	if !collected {
+		t.Logf("WARN: %s", report)
+	}
 
 	// Verify CPU profile
-	require.Greater(t, cpuBuf.Len(), 0, "CPU profile buffer should have data")
-	cpuProf, err := profile.Parse(&cpuBuf)
-	require.NoError(t, err)
-	require.NotNil(t, cpuProf)
+	require.Greater(t, cpuBuf.Len(), 0, "CPU profile buffer should have data: %s", report)
+	require.NotNil(t, cpuProf, "streamed CPU profile did not parse: %s", report)
+	require.Greater(t, len(cpuProf.Sample), 0, "streamed CPU profile should contain samples: %s", describeProfile(cpuProf))
 
 	// Off-CPU may or may not have data for CPU-bound workload
 	if offcpuBuf.Len() > 0 {
-		offcpuProf, err := profile.Parse(&offcpuBuf)
+		offcpuProf, err := profile.Parse(bytes.NewReader(offcpuBuf.Bytes()))
 		require.NoError(t, err)
 		require.NotNil(t, offcpuProf)
 	}
@@ -1068,7 +1166,7 @@ func TestLibraryPMUMetrics(t *testing.T) {
 	requireBPFRunnable(t, "")
 
 	// Start a CPU workload
-	workload := exec.Command("./workloads/go/cpu_bound", "-duration=20s", "-threads=4")
+	workload := exec.Command("./workloads/go/cpu_bound", workloadRuntimeFlag, "-threads=4")
 	require.NoError(t, workload.Start())
 	defer func() {
 		if workload.Process != nil {
@@ -1090,8 +1188,29 @@ func TestLibraryPMUMetrics(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, agent.Start(ctx))
 
-	// Collect for a few seconds
-	time.Sleep(3 * time.Second)
+	// Collect until the PMU snapshot actually carries a process, with a
+	// deadline, instead of sleeping a fixed 3s and asserting on whatever
+	// the monitor happened to have (issue #42). The agent keeps running
+	// across attempts — GetMetrics is a read of accumulating state — so
+	// this only re-reads, it does not re-collect.
+	const window = 3 * time.Second
+	ok, report := collectUntil(t, "a PMU snapshot containing at least one process with samples",
+		window, collectBudgetFor(window), func(int) (bool, string) {
+			requireWorkloadAlive(t, workload, "go/cpu_bound")
+			time.Sleep(window)
+			snap, err := agent.GetMetrics()
+			require.NoError(t, err)
+			require.NotNil(t, snap)
+			for _, pm := range snap.Processes {
+				if pm.SampleCount > 0 {
+					return true, fmt.Sprintf("%d process(es) in snapshot", len(snap.Processes))
+				}
+			}
+			return false, fmt.Sprintf("%d process(es) in snapshot, none with samples", len(snap.Processes))
+		})
+	if !ok {
+		t.Logf("WARN: %s", report)
+	}
 
 	// Test GetMetrics() API
 	snapshot, err := agent.GetMetrics()
@@ -1134,7 +1253,7 @@ func TestPerfDwarfWalker(t *testing.T) {
 		t.Skipf("rust workload not built: %v", err)
 	}
 
-	workload := exec.Command(binPath, "20", "2")
+	workload := exec.Command(binPath, workloadRuntimeSecs, "2")
 	require.NoError(t, workload.Start())
 	defer func() {
 		if workload.Process != nil {
@@ -1227,11 +1346,22 @@ func TestPerfDwarfWalker(t *testing.T) {
 	require.NoError(t, err)
 	defer rd.Close()
 
-	deadline := time.Now().Add(5 * time.Second)
+	// Collect until the ringbuf has produced the evidence all three
+	// assertions below need — enough samples, a chain deeper than 2,
+	// and at least one DWARF-unwound sample — bounded by a deadline
+	// (issue #42). The old loop stopped at 40 samples and then asserted
+	// on whatever those 40 happened to contain; on a contended runner a
+	// 5s window can deliver 40 shallow FP-only samples and no DWARF
+	// one. The `samples < 40` term is retained so a healthy run still
+	// gathers at least as much evidence as it used to.
+	const walkerBudget = 20 * time.Second
+	start := time.Now()
+	deadline := start.Add(walkerBudget)
 	var samples, dwarfSamples, maxFrames int
 	flagCounts := map[byte]int{}
 	var samplePrinted bool
-	for samples < 40 && time.Now().Before(deadline) {
+	enough := func() bool { return samples > 5 && maxFrames > 2 && dwarfSamples > 0 }
+	for (samples < 40 || !enough()) && time.Now().Before(deadline) {
 		rd.SetDeadline(time.Now().Add(500 * time.Millisecond))
 		rec, err := rd.Read()
 		if err != nil {
@@ -1269,10 +1399,12 @@ func TestPerfDwarfWalker(t *testing.T) {
 		}
 	}
 
-	t.Logf("samples=%d dwarf_samples=%d max_frames=%d flag_counts=%v", samples, dwarfSamples, maxFrames, flagCounts)
-	require.Greater(t, samples, 5, "no samples consumed — perf events may not have fired")
-	require.Greater(t, maxFrames, 2, "chains too shallow — walker producing tiny stacks")
-	require.Greater(t, dwarfSamples, 0, "DWARF path never fired — libstd/Rust frames should be FP-less in release")
+	stats := fmt.Sprintf("samples=%d dwarf_samples=%d max_frames=%d flag_counts=%v collected_for=%s (budget %s)",
+		samples, dwarfSamples, maxFrames, flagCounts, time.Since(start).Round(time.Millisecond), walkerBudget)
+	t.Logf("%s", stats)
+	require.Greater(t, samples, 5, "no samples consumed — perf events may not have fired; %s", stats)
+	require.Greater(t, maxFrames, 2, "chains too shallow — walker producing tiny stacks; %s", stats)
+	require.Greater(t, dwarfSamples, 0, "DWARF path never fired — libstd/Rust frames should be FP-less in release; %s", stats)
 }
 
 // TestPerfAgentSystemWideDwarfProfile runs perf-agent with
@@ -1290,7 +1422,7 @@ func TestPerfAgentSystemWideDwarfProfile(t *testing.T) {
 		t.Skipf("rust workload not built: %v", err)
 	}
 
-	workload := exec.Command(binPath, "20", "2")
+	workload := exec.Command(binPath, workloadRuntimeSecs, "2")
 	require.NoError(t, workload.Start())
 	defer func() {
 		_ = workload.Process.Kill()
@@ -1301,22 +1433,50 @@ func TestPerfAgentSystemWideDwarfProfile(t *testing.T) {
 	outputFile := "profile-dwarf-sys.pb.gz"
 	defer os.Remove(outputFile)
 
-	agent := exec.Command(agentPath,
-		"--profile",
-		"--profile-output", outputFile,
-		"--unwind", "dwarf",
-		"-a",
-		"--duration", "5s",
-	)
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+	// Collect until the capture is worth judging — enough samples, at
+	// least one from user space — and then let assertPprofFidelity
+	// render the verdict. Whether those user PCs resolved to a real
+	// mapping stays OUT of the loop condition on purpose: a loop that
+	// waits for a real mapping can never fail the assertion that one
+	// exists.
+	//
+	// This is the test and the assertion from issue #42's third
+	// comment. Note that this does NOT make that failure green — see
+	// the report's "Does this fix symptom 3?" section. That capture had
+	// >= 20 samples and at least one user-space PC, so it clears this
+	// precondition and is judged, not retried. Making it green would
+	// require looping on the assertion itself, which is the one thing
+	// this harness must not do.
+	const window = 5 * time.Second
+	prof, collected, report := collectProfileUntil(t,
+		"a system-wide DWARF profile with enough samples to judge, a symbolized function and at least one user-space frame",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload, "rust-workload")
+			agent := exec.Command(agentPath,
+				"--profile",
+				"--profile-output", outputFile,
+				"--unwind", "dwarf",
+				"-a",
+				"--duration", window.String(),
+			)
+			output, err := agent.CombinedOutput()
+			if err != nil {
+				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			}
+			return readProfile(outputFile)
+		},
+		func(p *profile.Profile) bool {
+			return profileFidelityJudgeable(p) && len(p.Function) > 0
+		})
+	if !collected {
+		t.Logf("WARN: %s", report)
 	}
+	require.NotNil(t, prof, "no readable system-wide DWARF profile after the collect-until budget: %s", report)
+
 	assert.FileExists(t, outputFile)
-	prof := parseProfile(t, outputFile)
-	require.NotNil(t, prof)
-	require.Greater(t, len(prof.Sample), 0, "system-wide profile should have samples")
-	require.Greater(t, len(prof.Function), 0, "system-wide profile should have at least one symbolized function")
+	require.Greater(t, len(prof.Sample), 0, "system-wide profile should have samples: %s", describeProfile(prof))
+	require.Greater(t, len(prof.Function), 0, "system-wide profile should have at least one symbolized function: %s", describeProfile(prof))
 
 	// verify pprof fidelity guarantees
 	assertPprofFidelity(t, outputFile)
@@ -1334,7 +1494,7 @@ func TestPerfAgentSystemWideDwarfOffCPU(t *testing.T) {
 		t.Skipf("rust workload not built: %v", err)
 	}
 
-	workload := exec.Command(binPath, "20", "2")
+	workload := exec.Command(binPath, workloadRuntimeSecs, "2")
 	require.NoError(t, workload.Start())
 	defer func() {
 		_ = workload.Process.Kill()
@@ -1345,29 +1505,40 @@ func TestPerfAgentSystemWideDwarfOffCPU(t *testing.T) {
 	outputFile := "offcpu-dwarf-sys.pb.gz"
 	defer os.Remove(outputFile)
 
-	agent := exec.Command(agentPath,
-		"--offcpu",
-		"--offcpu-output", outputFile,
-		"--unwind", "dwarf",
-		"-a",
-		"--duration", "5s",
-	)
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+	// As above: enough samples plus a user-space frame is the
+	// precondition; the mapping verdict belongs to assertPprofFidelity.
+	const window = 5 * time.Second
+	prof, collected, report := collectProfileUntil(t,
+		"a system-wide DWARF off-CPU profile with enough samples to judge, non-zero blocking time and at least one user-space frame",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload, "rust-workload")
+			agent := exec.Command(agentPath,
+				"--offcpu",
+				"--offcpu-output", outputFile,
+				"--unwind", "dwarf",
+				"-a",
+				"--duration", window.String(),
+			)
+			output, err := agent.CombinedOutput()
+			if err != nil {
+				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			}
+			return readProfile(outputFile)
+		},
+		func(p *profile.Profile) bool {
+			return profileFidelityJudgeable(p) && profileTotalValue(p) > 0
+		})
+	if !collected {
+		t.Logf("WARN: %s", report)
 	}
-	assert.FileExists(t, outputFile)
-	prof := parseProfile(t, outputFile)
-	require.NotNil(t, prof)
-	require.Greater(t, len(prof.Sample), 0, "system-wide off-CPU profile should have samples")
+	require.NotNil(t, prof, "no readable system-wide DWARF off-CPU profile after the collect-until budget: %s", report)
 
-	var totalNs int64
-	for _, s := range prof.Sample {
-		for _, v := range s.Value {
-			totalNs += v
-		}
-	}
-	require.Greater(t, totalNs, int64(0), "system-wide off-CPU profile should have non-zero blocking-ns")
+	assert.FileExists(t, outputFile)
+	require.Greater(t, len(prof.Sample), 0, "system-wide off-CPU profile should have samples: %s", describeProfile(prof))
+
+	totalNs := profileTotalValue(prof)
+	require.Greater(t, totalNs, int64(0), "system-wide off-CPU profile should have non-zero blocking-ns: %s", describeProfile(prof))
 	t.Logf("system-wide off-CPU total: %d ns across %d samples", totalNs, len(prof.Sample))
 
 	// verify pprof fidelity guarantees
@@ -1480,7 +1651,7 @@ func TestPerfAgentDwarfUnwind(t *testing.T) {
 		t.Skipf("rust workload not built: %v", err)
 	}
 
-	workload := exec.Command(binPath, "20", "2")
+	workload := exec.Command(binPath, workloadRuntimeSecs, "2")
 	require.NoError(t, workload.Start())
 	defer func() {
 		_ = workload.Process.Kill()
@@ -1491,40 +1662,41 @@ func TestPerfAgentDwarfUnwind(t *testing.T) {
 	outputFile := "profile-dwarf.pb.gz"
 	defer os.Remove(outputFile)
 
-	agent := exec.Command(agentPath,
-		"--profile",
-		"--profile-output", outputFile,
-		"--unwind", "dwarf",
-		"--pid", fmt.Sprintf("%d", workload.Process.Pid),
-		"--duration", "5s",
-	)
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+	// Collect until the workload's hot function shows up, with a
+	// deadline (issue #42): a single 5s window can miss it entirely on
+	// a contended runner, and "missed it" and "the DWARF walker is
+	// broken" then look identical.
+	const window = 5 * time.Second
+	prof, collected, report := collectProfileUntil(t,
+		"a DWARF-unwound profile containing the workload's cpu_intensive_work frame",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload, "rust-workload")
+			agent := exec.Command(agentPath,
+				"--profile",
+				"--profile-output", outputFile,
+				"--unwind", "dwarf",
+				"--pid", fmt.Sprintf("%d", workload.Process.Pid),
+				"--duration", window.String(),
+			)
+			output, err := agent.CombinedOutput()
+			if err != nil {
+				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			}
+			return readProfile(outputFile)
+		},
+		func(p *profile.Profile) bool {
+			return len(p.Sample) > 0 && hasFunctionContaining(p, "cpu_intensive_work")
+		})
+	if !collected {
+		t.Fatalf("%s\n  first few symbolized functions: %v", report, topFunctionNames(prof, 10))
 	}
 	assert.FileExists(t, outputFile)
-
-	prof := parseProfile(t, outputFile)
 	require.NotNil(t, prof)
-	require.Greater(t, len(prof.Sample), 0, "profile should have samples")
-
-	hit := false
-	for _, fn := range prof.Function {
-		if strings.Contains(fn.Name, "cpu_intensive_work") {
-			hit = true
-			break
-		}
-	}
-	if !hit {
-		names := make([]string, 0, min(10, len(prof.Function)))
-		for i, fn := range prof.Function {
-			if i >= 10 {
-				break
-			}
-			names = append(names, fn.Name)
-		}
-		t.Fatalf("no function named *cpu_intensive_work* in pprof; first few: %v", names)
-	}
+	require.Greater(t, len(prof.Sample), 0, "profile should have samples: %s", describeProfile(prof))
+	require.True(t, hasFunctionContaining(prof, "cpu_intensive_work"),
+		"no function named *cpu_intensive_work* in pprof; %s; first few: %v",
+		describeProfile(prof), topFunctionNames(prof, 10))
 }
 
 // TestPerfAgentOffCPUDwarfUnwind runs the full perf-agent binary with
@@ -1544,7 +1716,7 @@ func TestPerfAgentOffCPUDwarfUnwind(t *testing.T) {
 		t.Skipf("rust workload not built: %v", err)
 	}
 
-	workload := exec.Command(binPath, "20", "2")
+	workload := exec.Command(binPath, workloadRuntimeSecs, "2")
 	require.NoError(t, workload.Start())
 	defer func() {
 		_ = workload.Process.Kill()
@@ -1555,30 +1727,37 @@ func TestPerfAgentOffCPUDwarfUnwind(t *testing.T) {
 	outputFile := "offcpu-dwarf.pb.gz"
 	defer os.Remove(outputFile)
 
-	agent := exec.Command(agentPath,
-		"--offcpu",
-		"--offcpu-output", outputFile,
-		"--unwind", "dwarf",
-		"--pid", fmt.Sprintf("%d", workload.Process.Pid),
-		"--duration", "5s",
-	)
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+	const window = 5 * time.Second
+	prof, collected, report := collectProfileUntil(t,
+		"a DWARF-unwound off-CPU profile with non-zero blocking time",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, workload, "rust-workload")
+			agent := exec.Command(agentPath,
+				"--offcpu",
+				"--offcpu-output", outputFile,
+				"--unwind", "dwarf",
+				"--pid", fmt.Sprintf("%d", workload.Process.Pid),
+				"--duration", window.String(),
+			)
+			output, err := agent.CombinedOutput()
+			if err != nil {
+				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			}
+			return readProfile(outputFile)
+		},
+		func(p *profile.Profile) bool {
+			return len(p.Sample) > 0 && profileTotalValue(p) > 0
+		})
+	if !collected {
+		t.Fatal(report)
 	}
 	assert.FileExists(t, outputFile)
-
-	prof := parseProfile(t, outputFile)
 	require.NotNil(t, prof)
-	require.Greater(t, len(prof.Sample), 0, "off-CPU profile should have samples")
+	require.Greater(t, len(prof.Sample), 0, "off-CPU profile should have samples: %s", describeProfile(prof))
 
-	var totalNs int64
-	for _, s := range prof.Sample {
-		for _, v := range s.Value {
-			totalNs += v
-		}
-	}
-	require.Greater(t, totalNs, int64(0), "off-CPU profile should have non-zero blocking-ns values")
+	totalNs := profileTotalValue(prof)
+	require.Greater(t, totalNs, int64(0), "off-CPU profile should have non-zero blocking-ns values: %s", describeProfile(prof))
 	t.Logf("off-CPU total: %d ns across %d samples", totalNs, len(prof.Sample))
 }
 
@@ -1605,7 +1784,7 @@ func TestPerfDataOutput(t *testing.T) {
 		t.Skipf("rust workload not built: %v", err)
 	}
 
-	workload := exec.Command(binPath, "20", "2")
+	workload := exec.Command(binPath, workloadRuntimeSecs, "2")
 	require.NoError(t, workload.Start())
 	defer func() {
 		if workload.Process != nil {
@@ -1619,26 +1798,52 @@ func TestPerfDataOutput(t *testing.T) {
 	pprofOut := filepath.Join(outDir, "profile.pb.gz")
 	perfDataOut := filepath.Join(outDir, "test.perf.data")
 
-	agent := exec.Command(getAgentPath(t),
-		"--profile",
-		"--profile-output", pprofOut,
-		"--perf-data-output", perfDataOut,
-		"--pid", fmt.Sprintf("%d", workload.Process.Pid),
-		"--duration", "5s",
-	)
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
-	}
+	// Collect until the capture is one `perf script` can decode into at
+	// least one line, with a deadline (issue #42). A perf.data with
+	// headers but no samples is the "nothing landed" shape, not a
+	// perf.data-format regression, and the two used to be
+	// indistinguishable here.
+	const window = 5 * time.Second
+	var scriptOut []byte
+	ok, report := collectUntil(t,
+		"a perf.data that `perf script` decodes into at least one line",
+		window, collectBudgetFor(window),
+		func(int) (bool, string) {
+			requireWorkloadAlive(t, workload, "rust-workload")
+			agent := exec.Command(getAgentPath(t),
+				"--profile",
+				"--profile-output", pprofOut,
+				"--perf-data-output", perfDataOut,
+				"--pid", fmt.Sprintf("%d", workload.Process.Pid),
+				"--duration", window.String(),
+			)
+			output, err := agent.CombinedOutput()
+			if err != nil {
+				t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
+			}
 
-	st, err := os.Stat(perfDataOut)
-	require.NoError(t, err, "perf.data not created")
-	require.Greater(t, st.Size(), int64(200), "perf.data suspiciously small: %d bytes", st.Size())
+			st, err := os.Stat(perfDataOut)
+			if err != nil {
+				return false, fmt.Sprintf("perf.data was not created: %v", err)
+			}
+			if st.Size() <= 200 {
+				return false, fmt.Sprintf("perf.data is only %d bytes (want > 200): headers were written but no samples", st.Size())
+			}
 
-	cmd := exec.Command("perf", "script", "-i", perfDataOut)
-	scriptOut, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf script failed on our output: %v\n%s", err, string(scriptOut))
+			cmd := exec.Command("perf", "script", "-i", perfDataOut)
+			scriptOut, err = cmd.CombinedOutput()
+			if err != nil {
+				// A decode failure is a real regression in our
+				// perf.data writer, not a scheduling miss — fail now.
+				t.Fatalf("perf script failed on our output: %v\n%s", err, string(scriptOut))
+			}
+			if len(scriptOut) == 0 {
+				return false, fmt.Sprintf("perf script decoded a %d-byte perf.data into 0 bytes of output (no samples in perf.data)", st.Size())
+			}
+			return true, fmt.Sprintf("perf.data %d bytes, perf script output %d bytes", st.Size(), len(scriptOut))
+		})
+	if !ok {
+		t.Fatal(report)
 	}
 	require.NotEmpty(t, scriptOut, "perf script produced no output (no samples in perf.data?)")
 	t.Logf("perf script captured %d bytes of output", len(scriptOut))
@@ -1660,49 +1865,74 @@ func TestKernelStackResolution(t *testing.T) {
 	defer cleanup()
 
 	out := filepath.Join(t.TempDir(), "profile.pb.gz")
-	agent := exec.Command(bin,
-		"--profile",
-		"--kernel-stacks",
-		"--pid", strconv.Itoa(cmd.Process.Pid),
-		"--duration", "3s",
-		"--profile-output", out,
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run: %v", err)
+
+	// The io_bound workload is only on-CPU in user space in short
+	// bursts between blocking I/O, so a single fixed 3s window at 99 Hz
+	// can legitimately capture zero samples, or samples whose every
+	// frame is kernel-side. Issue #42 saw both, on the same commit.
+	// Collect until the profile is one the assertions below can speak
+	// to, with a deadline; a profiler that has genuinely stopped
+	// producing user frames still fails, at the deadline, with the
+	// frame split printed.
+	kernelRe := regexp.MustCompile(`^(do_sys_|ksys_|__x64_sys_|vfs_|__schedule|read_|sock_|tcp_)`)
+	hasUserFn := func(p *profile.Profile) bool {
+		return hasFunctionContaining(p, "main.", "runtime.")
+	}
+	hasKernelFn := func(p *profile.Profile) bool {
+		for _, fn := range p.Function {
+			if kernelRe.MatchString(fn.Name) {
+				return true
+			}
+		}
+		return false
 	}
 
-	p := parseProfile(t, out)
+	what := "a kernel-stacks profile containing at least one user-side (main.*/runtime.*) frame"
+	if kptrZero {
+		what += " and at least one resolved kernel symbol"
+	}
+
+	const window = 3 * time.Second
+	p, collected, report := collectProfileUntil(t, what, window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, cmd, "go/io_bound")
+			agent := exec.Command(bin,
+				"--profile",
+				"--kernel-stacks",
+				"--pid", strconv.Itoa(cmd.Process.Pid),
+				"--duration", window.String(),
+				"--profile-output", out,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run: %v", err)
+			}
+			return readProfile(out)
+		},
+		func(p *profile.Profile) bool {
+			return len(p.Sample) > 0 && hasUserFn(p) && (!kptrZero || hasKernelFn(p))
+		})
+
 	got := map[string]bool{}
-	for _, fn := range p.Function {
-		got[fn.Name] = true
+	if p != nil {
+		for _, fn := range p.Function {
+			got[fn.Name] = true
+		}
+	}
+	if !collected {
+		t.Fatalf("%s\n  functions in the last capture: %v", report, sortedKeys(got))
 	}
 
 	// Always assert at least one user-side function from io_bound appears.
-	hasUser := false
-	for name := range got {
-		if strings.Contains(name, "main.") || strings.Contains(name, "runtime.") {
-			hasUser = true
-			break
-		}
-	}
-	if !hasUser {
-		t.Fatalf("no user-side function in profile; got: %v", sortedKeys(got))
+	if !hasUserFn(p) {
+		t.Fatalf("no user-side function in profile; %s; got: %v", describeProfile(p), sortedKeys(got))
 	}
 
 	if kptrZero {
 		// Expect at least one resolved kernel symbol.
-		kernelRe := regexp.MustCompile(`^(do_sys_|ksys_|__x64_sys_|vfs_|__schedule|read_|sock_|tcp_)`)
-		matched := false
-		for name := range got {
-			if kernelRe.MatchString(name) {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			t.Fatalf("no resolved kernel symbol matched expected regex; got: %v", sortedKeys(got))
+		if !hasKernelFn(p) {
+			t.Fatalf("no resolved kernel symbol matched expected regex; %s; got: %v", describeProfile(p), sortedKeys(got))
 		}
 	} else {
 		// kptr_restrict != 0 → kernel frames may appear as raw 0xffff… names
@@ -1839,28 +2069,49 @@ func TestPerfDataUserspaceMmap2_SystemWide(t *testing.T) {
 
 	bin := getAgentPath(t)
 
-	_, cleanup := spawnIoBoundWorkload(t)
+	cmd, cleanup := spawnIoBoundWorkload(t)
 	defer cleanup()
 
 	outDir := t.TempDir()
 	pb := filepath.Join(outDir, "profile.pb.gz")
 	pd := filepath.Join(outDir, "perf.data")
-	agent := exec.Command(bin,
-		"--profile",
-		"--all",
-		"--duration", "3s",
-		"--profile-output", pb,
-		"--perf-data-output", pd,
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run: %v", err)
-	}
 
-	body, err := os.ReadFile(pd)
-	if err != nil {
-		t.Fatalf("read perf.data: %v", err)
+	// Under --all, COMM+MMAP2 are emitted LAZILY on the first sample
+	// seen per PID (perfagent/agent.go), so this test's assertions are
+	// sampling-dependent: a window in which the workload never got a
+	// sample produces a perf.data with no io_bound MMAP2 at all.
+	// Collect until the records are there, with a deadline (issue #42).
+	const window = 3 * time.Second
+	var body []byte
+	ok, report := collectUntil(t,
+		"a system-wide perf.data carrying MMAP2 records for io_bound and for >= 2 distinct PIDs",
+		window, collectBudgetFor(window),
+		func(int) (bool, string) {
+			requireWorkloadAlive(t, cmd, "go/io_bound")
+			agent := exec.Command(bin,
+				"--profile",
+				"--all",
+				"--duration", window.String(),
+				"--profile-output", pb,
+				"--perf-data-output", pd,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run: %v", err)
+			}
+			var err error
+			body, err = os.ReadFile(pd)
+			if err != nil {
+				t.Fatalf("read perf.data: %v", err)
+			}
+			hasWorkload := bytes.Contains(body, []byte("io_bound"))
+			pids := countDistinctNonSentinelPIDsInPerfData(body)
+			return hasWorkload && pids >= 2,
+				fmt.Sprintf("perf.data %d bytes, io_bound MMAP2 present=%v, distinct PIDs=%d", len(body), hasWorkload, pids)
+		})
+	if !ok {
+		t.Fatal(report)
 	}
 
 	// Workload binary must show up in at least one MMAP2 record.
@@ -1922,7 +2173,7 @@ func spawnIoBoundWorkload(t *testing.T) (*exec.Cmd, func()) {
 	if _, err := os.Stat(bin); err != nil {
 		t.Skipf("io_bound workload not built: %v", err)
 	}
-	cmd := exec.Command(bin, "-duration=30s", "-threads=2")
+	cmd := exec.Command(bin, workloadRuntimeFlag, "-threads=2")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start io_bound: %v", err)
 	}
@@ -1981,34 +2232,50 @@ func TestStrippedRustOffBoxSymbolization(t *testing.T) {
 	stripWorkload(t, rustSrc, stripped)
 	waitForDebuginfodReady(t, buildID)
 
-	cmd, cleanup := spawnBinaryAsWorkload(t, stripped)
+	cmd, cleanup := spawnBinaryAsWorkload(t, stripped, workloadRuntimeSecs)
 	defer cleanup()
 
 	out := filepath.Join(t.TempDir(), "profile.pb.gz")
 	cacheDir := filepath.Join(t.TempDir(), "symbol-cache")
-	agent := exec.Command(agentBin,
-		"--profile",
-		"--debuginfod-url", "http://localhost:8002",
-		"--symbol-cache-dir", cacheDir,
-		"--pid", strconv.Itoa(cmd.Process.Pid),
-		"--duration", "6s",
-		"--profile-output", out,
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run: %v", err)
-	}
-
-	p := parseProfile(t, out)
-	got := map[string]bool{}
-	for _, fn := range p.Function {
-		got[fn.Name] = true
-	}
 
 	want := []string{
 		"rust_workload::cpu_intensive_work",
 		"core::num::<impl u64>::wrapping_add",
+	}
+
+	// Collect until the off-box symbols land, with a deadline: a window
+	// that caught the workload off-CPU proves nothing about
+	// symbolization (issue #42).
+	const window = 6 * time.Second
+	p, collected, report := collectProfileUntil(t,
+		"a profile of the stripped rust workload carrying its off-box-resolved symbols",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, cmd, "rust-workload-stripped")
+			agent := exec.Command(agentBin,
+				"--profile",
+				"--debuginfod-url", "http://localhost:8002",
+				"--symbol-cache-dir", cacheDir,
+				"--pid", strconv.Itoa(cmd.Process.Pid),
+				"--duration", window.String(),
+				"--profile-output", out,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run: %v", err)
+			}
+			return readProfile(out)
+		},
+		func(p *profile.Profile) bool { return hasFunctionContaining(p, want...) })
+	if !collected {
+		t.Logf("WARN: %s", report)
+	}
+	require.NotNil(t, p, "no readable profile after the collect-until budget: %s", report)
+
+	got := map[string]bool{}
+	for _, fn := range p.Function {
+		got[fn.Name] = true
 	}
 	for _, w := range want {
 		found := false
@@ -2019,7 +2286,7 @@ func TestStrippedRustOffBoxSymbolization(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("missing expected symbol %q in stripped pprof; got: %v", w, sortedKeys(got))
+			t.Errorf("missing expected symbol %q in stripped pprof; %s; got: %v", w, describeProfile(p), sortedKeys(got))
 		}
 	}
 }
@@ -2043,11 +2310,20 @@ func requireTool(t *testing.T, tool string) {
 }
 
 // spawnBinaryAsWorkload starts the binary and returns the running command.
-// Caller MUST call cleanup() to kill+wait the process. The binary is
-// expected to be CPU-bound for at least 15s.
-func spawnBinaryAsWorkload(t *testing.T, bin string) (*exec.Cmd, func()) {
+// Caller MUST call cleanup() to kill+wait the process.
+//
+// `args` MUST carry a run duration in the form the binary understands —
+// bare seconds (workloadRuntimeSecs) for the Rust workload, a
+// `-duration=` flag (workloadRuntimeFlag) for the Go ones — long enough
+// to outlive the collect-until budget the caller spends against it. The
+// Go workloads silently ignore a positional argument and fall back to
+// their 30s default, so the two forms are not interchangeable.
+func spawnBinaryAsWorkload(t *testing.T, bin string, args ...string) (*exec.Cmd, func()) {
 	t.Helper()
-	cmd := exec.Command(bin)
+	if len(args) == 0 {
+		t.Fatalf("spawnBinaryAsWorkload(%s): pass an explicit run duration", bin)
+	}
+	cmd := exec.Command(bin, args...)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start %s: %v", bin, err)
 	}
@@ -2089,33 +2365,47 @@ func TestStrippedGoOffBoxSymbolization(t *testing.T) {
 	stripWorkload(t, goSrc, stripped)
 	waitForDebuginfodReady(t, buildID)
 
-	cmd, cleanup := spawnBinaryAsWorkload(t, stripped)
+	cmd, cleanup := spawnBinaryAsWorkload(t, stripped, workloadRuntimeFlag)
 	defer cleanup()
 
 	out := filepath.Join(t.TempDir(), "profile.pb.gz")
 	cacheDir := filepath.Join(t.TempDir(), "symbol-cache")
-	agent := exec.Command(bin,
-		"--profile",
-		"--debuginfod-url", "http://localhost:8002",
-		"--symbol-cache-dir", cacheDir,
-		"--pid", strconv.Itoa(cmd.Process.Pid),
-		"--duration", "6s",
-		"--profile-output", out,
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run: %v", err)
-	}
 
-	p := parseProfile(t, out)
+	// main.main is always present in a Go binary; cpu_bound's worker
+	// loop is typically in main.cpuWork or main.run — accept either.
+	wantAny := []string{"main.main", "main.cpuWork", "main.run", "main.worker"}
+
+	const window = 6 * time.Second
+	p, collected, report := collectProfileUntil(t,
+		"a profile of the stripped Go workload carrying an off-box-resolved user function",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, cmd, "go-cpu-bound-stripped")
+			agent := exec.Command(bin,
+				"--profile",
+				"--debuginfod-url", "http://localhost:8002",
+				"--symbol-cache-dir", cacheDir,
+				"--pid", strconv.Itoa(cmd.Process.Pid),
+				"--duration", window.String(),
+				"--profile-output", out,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run: %v", err)
+			}
+			return readProfile(out)
+		},
+		func(p *profile.Profile) bool { return hasFunctionContaining(p, wantAny...) })
+	if !collected {
+		t.Logf("WARN: %s", report)
+	}
+	require.NotNil(t, p, "no readable profile after the collect-until budget: %s", report)
+
 	got := map[string]bool{}
 	for _, fn := range p.Function {
 		got[fn.Name] = true
 	}
-	// main.main is always present in a Go binary; cpu_bound's worker
-	// loop is typically in main.cpuWork or main.run — accept either.
-	wantAny := []string{"main.main", "main.cpuWork", "main.run", "main.worker"}
 	found := false
 	for _, w := range wantAny {
 		for name := range got {
@@ -2129,7 +2419,7 @@ func TestStrippedGoOffBoxSymbolization(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("no Go user-side function found in stripped pprof; got: %v", sortedKeys(got))
+		t.Errorf("no Go user-side function found in stripped pprof; %s; got: %v", describeProfile(p), sortedKeys(got))
 	}
 }
 
@@ -2174,26 +2464,41 @@ func TestFileModeFrameAddressPreservesMapping(t *testing.T) {
 	stripWorkload(t, rustSrc, stripped)
 	waitForDebuginfodReady(t, buildID)
 
-	cmd, cleanup := spawnBinaryAsWorkload(t, stripped)
+	cmd, cleanup := spawnBinaryAsWorkload(t, stripped, workloadRuntimeSecs)
 	defer cleanup()
 
 	out := filepath.Join(t.TempDir(), "profile.pb.gz")
 	cacheDir := filepath.Join(t.TempDir(), "symbol-cache")
-	agent := exec.Command(bin,
-		"--profile",
-		"--debuginfod-url", "http://localhost:8002",
-		"--symbol-cache-dir", cacheDir,
-		"--pid", strconv.Itoa(cmd.Process.Pid),
-		"--duration", "6s",
-		"--profile-output", out,
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run: %v", err)
-	}
 
-	p := parseProfile(t, out)
+	// Collect until at least one Rust frame is present — the invariant
+	// below is checked per Rust frame, so a capture with none proves
+	// nothing (issue #42).
+	const window = 6 * time.Second
+	p, collected, report := collectProfileUntil(t,
+		"a profile containing at least one symbolized rust_workload frame",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, cmd, "rust-workload-stripped")
+			agent := exec.Command(bin,
+				"--profile",
+				"--debuginfod-url", "http://localhost:8002",
+				"--symbol-cache-dir", cacheDir,
+				"--pid", strconv.Itoa(cmd.Process.Pid),
+				"--duration", window.String(),
+				"--profile-output", out,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run: %v", err)
+			}
+			return readProfile(out)
+		},
+		func(p *profile.Profile) bool { return hasFunctionContaining(p, "rust_workload::") })
+	if !collected {
+		t.Logf("WARN: %s", report)
+	}
+	require.NotNil(t, p, "no readable profile after the collect-until budget: %s", report)
 
 	// For each Location whose function name looks like a Rust symbol
 	// (rust_workload::*), assert it is tied to a real Mapping with the
@@ -2233,7 +2538,7 @@ func TestFileModeFrameAddressPreservesMapping(t *testing.T) {
 		}
 	}
 	if checked == 0 {
-		t.Fatal("no rust frames in pprof — symbolization didn't fire at all")
+		t.Fatalf("no rust frames in pprof — symbolization didn't fire at all; %s", describeProfile(p))
 	}
 }
 
@@ -2261,13 +2566,13 @@ func TestStrippedCachedHitNoFetch(t *testing.T) {
 	cacheDir := filepath.Join(t.TempDir(), "symbol-cache")
 
 	// First run: should fetch.
-	runStripped(t, bin, stripped, cacheDir, t.TempDir())
+	runStripped(t, bin, stripped, cacheDir, t.TempDir(), buildID)
 
 	// Snapshot the debuginfod container access log line count.
 	prevHits := countDebuginfodHits(t, buildID)
 
 	// Second run: should NOT fetch (cache hit).
-	runStripped(t, bin, stripped, cacheDir, t.TempDir())
+	runStripped(t, bin, stripped, cacheDir, t.TempDir(), buildID)
 
 	newHits := countDebuginfodHits(t, buildID)
 	delta := newHits - prevHits
@@ -2277,25 +2582,62 @@ func TestStrippedCachedHitNoFetch(t *testing.T) {
 	}
 }
 
-// runStripped is a small helper that runs the agent for one short profile.
-func runStripped(t *testing.T, agentBin, target, cacheDir, outDir string) {
+// runStripped runs the agent against the stripped target until the
+// debuginfod fetch it is supposed to trigger has actually populated the
+// cache, or the deadline expires.
+//
+// The fetch is driven by symbolizing a sampled PC inside the stripped
+// binary: a window that captured no samples performs no fetch, leaves
+// the cache empty, and makes the callers' later assertions
+// ("expected cached .debug at ...", "0 new fetches on the second run")
+// meaningless. Issue #42's condition, one step removed.
+//
+// `target` is a copy of the Rust workload (argv[1] = seconds).
+func runStripped(t *testing.T, agentBin, target, cacheDir, outDir, buildID string) {
 	t.Helper()
-	cmd, cleanup := spawnBinaryAsWorkload(t, target)
+	cmd, cleanup := spawnBinaryAsWorkload(t, target, workloadRuntimeSecs)
 	defer cleanup()
 	out := filepath.Join(outDir, "profile.pb.gz")
-	agent := exec.Command(agentBin,
-		"--profile",
-		"--debuginfod-url", "http://localhost:8002",
-		"--symbol-cache-dir", cacheDir,
-		"--pid", strconv.Itoa(cmd.Process.Pid),
-		"--duration", "3s",
-		"--profile-output", out,
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run: %v", err)
+	cached := cachedDebugPath(cacheDir, buildID)
+
+	const window = 3 * time.Second
+	ok, report := collectUntil(t,
+		fmt.Sprintf("the debuginfod cache to hold %s", cached),
+		window, collectBudgetFor(window),
+		func(int) (bool, string) {
+			requireWorkloadAlive(t, cmd, target)
+			agent := exec.Command(agentBin,
+				"--profile",
+				"--debuginfod-url", "http://localhost:8002",
+				"--symbol-cache-dir", cacheDir,
+				"--pid", strconv.Itoa(cmd.Process.Pid),
+				"--duration", window.String(),
+				"--profile-output", out,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run: %v", err)
+			}
+			st, err := os.Stat(cached)
+			if err != nil {
+				p, rerr := readProfile(out)
+				if rerr != nil {
+					return false, fmt.Sprintf("cache still empty and %v", rerr)
+				}
+				return false, fmt.Sprintf("cache still empty (%v); captured %s", err, describeProfile(p))
+			}
+			return true, fmt.Sprintf("cached .debug is %d bytes", st.Size())
+		})
+	if !ok {
+		t.Fatal(report)
 	}
+}
+
+// cachedDebugPath is the symbol cache layout perf-agent writes fetched
+// debuginfo into: <cacheDir>/.build-id/<first 2>/<rest>.debug
+func cachedDebugPath(cacheDir, buildID string) string {
+	return filepath.Join(cacheDir, ".build-id", buildID[:2], buildID[2:]+".debug")
 }
 
 // countDebuginfodHits returns the number of `GET /buildid/<buildID>/debuginfo`
@@ -2343,10 +2685,10 @@ func TestFileModeParseFailDemotes(t *testing.T) {
 	cacheDir := filepath.Join(t.TempDir(), "symbol-cache")
 
 	// First run: populates the cache.
-	runStripped(t, bin, stripped, cacheDir, t.TempDir())
+	runStripped(t, bin, stripped, cacheDir, t.TempDir(), buildID)
 
 	// Corrupt the cached .debug.
-	cached := filepath.Join(cacheDir, ".build-id", buildID[:2], buildID[2:]+".debug")
+	cached := cachedDebugPath(cacheDir, buildID)
 	if _, err := os.Stat(cached); err != nil {
 		t.Fatalf("expected cached .debug at %s: %v", cached, err)
 	}
@@ -2357,37 +2699,52 @@ func TestFileModeParseFailDemotes(t *testing.T) {
 	// Second run: parse fails, mapping demotes to process-mode.
 	// pprof must still emit frames for the workload's mapping.
 	out := filepath.Join(t.TempDir(), "profile.pb.gz")
-	cmd, cleanup := spawnBinaryAsWorkload(t, stripped)
+	cmd, cleanup := spawnBinaryAsWorkload(t, stripped, workloadRuntimeSecs)
 	defer cleanup()
-	agent := exec.Command(bin,
-		"--profile",
-		"--debuginfod-url", "http://localhost:8002",
-		"--symbol-cache-dir", cacheDir,
-		"--pid", strconv.Itoa(cmd.Process.Pid),
-		"--duration", "3s",
-		"--profile-output", out,
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run: %v", err)
+
+	workloadMappingOf := func(p *profile.Profile) *profile.Mapping {
+		for _, m := range p.Mapping {
+			if strings.Contains(m.File, "rust-workload") {
+				return m
+			}
+		}
+		return nil
 	}
 
-	p := parseProfile(t, out)
+	const window = 3 * time.Second
+	p, collected, report := collectProfileUntil(t,
+		"a profile with samples routed to the demoted rust-workload mapping",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, cmd, "rust-workload-stripped")
+			agent := exec.Command(bin,
+				"--profile",
+				"--debuginfod-url", "http://localhost:8002",
+				"--symbol-cache-dir", cacheDir,
+				"--pid", strconv.Itoa(cmd.Process.Pid),
+				"--duration", window.String(),
+				"--profile-output", out,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run: %v", err)
+			}
+			return readProfile(out)
+		},
+		func(p *profile.Profile) bool {
+			return len(p.Sample) > 0 && workloadMappingOf(p) != nil
+		})
+	if !collected {
+		t.Fatal(report)
+	}
 	if len(p.Sample) == 0 {
-		t.Fatalf("no samples in pprof — agent crashed or got 0 frames")
+		t.Fatalf("no samples in pprof — agent crashed or got 0 frames; %s", describeProfile(p))
 	}
 	// At least one sample's leaf should fall in the workload's mapping
 	// (even if unsymbolized).
-	var workloadMapping *profile.Mapping
-	for _, m := range p.Mapping {
-		if strings.Contains(m.File, "rust-workload") {
-			workloadMapping = m
-			break
-		}
-	}
-	if workloadMapping == nil {
-		t.Fatalf("no rust-workload mapping in pprof — agent didn't see the binary")
+	if workloadMappingOf(p) == nil {
+		t.Fatalf("no rust-workload mapping in pprof — agent didn't see the binary; %s", describeProfile(p))
 	}
 }
 
@@ -2417,7 +2774,7 @@ func TestStrippedSidecarUnreachableSymbolicPath(t *testing.T) {
 	stripWorkload(t, rustSrc, stripped)
 	waitForDebuginfodReady(t, buildID)
 
-	cmd, cleanup := spawnBinaryAsWorkload(t, stripped)
+	cmd, cleanup := spawnBinaryAsWorkload(t, stripped, workloadRuntimeSecs)
 	defer cleanup()
 
 	// Delete the binary from disk; the running process keeps it alive
@@ -2428,35 +2785,43 @@ func TestStrippedSidecarUnreachableSymbolicPath(t *testing.T) {
 
 	out := filepath.Join(t.TempDir(), "profile.pb.gz")
 	cacheDir := filepath.Join(t.TempDir(), "symbol-cache")
-	agent := exec.Command(bin,
-		"--profile",
-		"--debuginfod-url", "http://localhost:8002",
-		"--symbol-cache-dir", cacheDir,
-		"--pid", strconv.Itoa(cmd.Process.Pid),
-		"--duration", "6s",
-		"--profile-output", out,
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run: %v", err)
-	}
 
-	p := parseProfile(t, out)
+	const window = 6 * time.Second
+	p, collected, report := collectProfileUntil(t,
+		"a profile of the deleted-on-disk workload carrying map_files-resolved symbols",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, cmd, "rust-workload-stripped(deleted)")
+			agent := exec.Command(bin,
+				"--profile",
+				"--debuginfod-url", "http://localhost:8002",
+				"--symbol-cache-dir", cacheDir,
+				"--pid", strconv.Itoa(cmd.Process.Pid),
+				"--duration", window.String(),
+				"--profile-output", out,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run: %v", err)
+			}
+			return readProfile(out)
+		},
+		func(p *profile.Profile) bool {
+			return hasFunctionContaining(p, "rust_workload::cpu_intensive_work")
+		})
+	if !collected {
+		t.Logf("WARN: %s", report)
+	}
+	require.NotNil(t, p, "no readable profile after the collect-until budget: %s", report)
+
 	got := map[string]bool{}
 	for _, fn := range p.Function {
 		got[fn.Name] = true
 	}
 	// Assert symbol resolved through map_files-derived path.
-	found := false
-	for name := range got {
-		if strings.Contains(name, "rust_workload::cpu_intensive_work") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("sidecar-style profiling didn't resolve symbols; got: %v", sortedKeys(got))
+	if !hasFunctionContaining(p, "rust_workload::cpu_intensive_work") {
+		t.Errorf("sidecar-style profiling didn't resolve symbols; %s; got: %v", describeProfile(p), sortedKeys(got))
 	}
 	// Assert Mapping.BuildID is populated (i.e., Resolver.populate read
 	// it via map_files since the symbolic path is gone).
@@ -2492,23 +2857,53 @@ func TestOffBoxLibcResolution(t *testing.T) {
 	if _, err := os.Stat(rustSrc); err != nil {
 		t.Skipf("rust workload not built: %v", err)
 	}
-	cmd, cleanup := spawnBinaryAsWorkload(t, rustSrc)
+	cmd, cleanup := spawnBinaryAsWorkload(t, rustSrc, workloadRuntimeSecs)
 	defer cleanup()
 
 	out := filepath.Join(t.TempDir(), "profile.pb.gz")
 	cacheDir := filepath.Join(t.TempDir(), "symbol-cache")
-	agent := exec.Command(bin,
-		"--profile",
-		"--debuginfod-url", "http://localhost:8002",
-		"--symbol-cache-dir", cacheDir,
-		"--pid", strconv.Itoa(cmd.Process.Pid),
-		"--duration", "6s",
-		"--profile-output", out,
-	)
-	agent.Stdout = os.Stdout
-	agent.Stderr = os.Stderr
-	if err := agent.Run(); err != nil {
-		t.Fatalf("perf-agent run: %v", err)
+
+	// This test's only hard assertion is a NEGATIVE one — "libc was not
+	// fetched from debuginfod" — and a capture that sampled nothing
+	// symbolizes nothing, fetches nothing, and satisfies it vacuously.
+	// So collect until symbolization demonstrably ran end to end against
+	// the target (its own symbols resolved), and only then ask whether
+	// libc was fetched.
+	//
+	// The precondition is the workload's symbols, not libc's: the test
+	// documents libc frames as environment-dependent and only logs when
+	// they are absent, so requiring them here would invent a
+	// requirement the test deliberately does not make. That leaves a
+	// residual gap — a run that resolved rust_workload but never
+	// sampled a libc PC still passes without exercising the libc path —
+	// which is narrower than the vacuous pass it replaces, but not zero.
+	const window = 6 * time.Second
+	p, collected, report := collectProfileUntil(t,
+		"a profile in which the workload's own symbols resolved (proving symbolization ran)",
+		window,
+		func(int) (*profile.Profile, error) {
+			requireWorkloadAlive(t, cmd, "rust-workload")
+			agent := exec.Command(bin,
+				"--profile",
+				"--debuginfod-url", "http://localhost:8002",
+				"--symbol-cache-dir", cacheDir,
+				"--pid", strconv.Itoa(cmd.Process.Pid),
+				"--duration", window.String(),
+				"--profile-output", out,
+			)
+			agent.Stdout = os.Stdout
+			agent.Stderr = os.Stderr
+			if err := agent.Run(); err != nil {
+				t.Fatalf("perf-agent run: %v", err)
+			}
+			return readProfile(out)
+		},
+		func(p *profile.Profile) bool {
+			return len(p.Sample) > 0 && hasFunctionContaining(p, "rust_workload::")
+		})
+	if !collected {
+		t.Fatalf("symbolization never resolved a workload symbol, so the "+
+			"\"libc was not fetched\" assertion below would pass vacuously: %s", report)
 	}
 
 	// libc should NOT have been fetched via debuginfod — it was resolvable
@@ -2521,7 +2916,6 @@ func TestOffBoxLibcResolution(t *testing.T) {
 
 	// libc functions should appear in the pprof (best-effort — on hosts
 	// without libc debuginfo this assertion is a soft log).
-	p := parseProfile(t, out)
 	got := map[string]bool{}
 	for _, fn := range p.Function {
 		got[fn.Name] = true


### PR DESCRIPTION
Addresses #42.

The suite sampled a live workload for a fixed 3–10 s window at 99 Hz and asserted on
whatever landed. A cpu-clock sample only fires while the target is *on CPU*, so against an
I/O-bound workload on a contended runner that is a coin toss — which is why the same
commit produced three different symptoms and one pass.

### The harness

`test/collect_until.go`: one *attempt* is a complete collection against the still-running
workload, repeated until a precondition holds or a budget expires. 24 call sites converted.

The precondition is a **data-sufficiency** gate, never the correctness property. At 15 of
24 sites the timeout only logs a warning and the original assertion decides; the 9 fatal
sites gate on a precondition the assertion does not restate. That distinction is the whole
design: looping on the property under test would retry a real regression into a pass.

An earlier revision of this branch got that wrong at three sites — `RealMappings >= 1` was
in the loop condition while `assertPprofFidelity`'s predicate is `real >= 1`, so the
post-loop check could not fail. Caught in review and fixed. `UserFrames > 0` is *also*
wrong as a precondition, for a subtler reason: a located frame's mapping appears in the
mapping table, so it implies `RealMappings >= 1` just as surely. The gate is
`profileFidelityJudgeable` — `Samples >= degenerateSampleFloor && userSpaceFrames > 0`,
counting unmapped frames — reusing the floor `isDegenerateProfile` already applies, so
retry policy and tolerance policy cannot disagree.
`TestUserSpacePreconditionDoesNotImplyRealMapping` and
`TestSymptomThreeIsJudgedNotRetried` pin both directions.

### Budget

A package-wide 3-minute re-collection allowance. The first attempt of every loop is free;
once the allowance is spent, later loops run one attempt and let their own assertions
decide, degrading to pre-#42 behaviour rather than overrunning. Worst case is
`baseline + 3 min + one window` ≈ 8.5 min, independent of how many tests degrade, and it
is charged by *elapsed* time so unmeasured agent-startup cost sits inside the bound. CI's
limit is `-timeout 15m`.

### Diagnostics

Half the value of this change. `assertPprofFidelity` now prints the frame split and a
reading that separates the two causes a failure can have:

```
%d frame(s) carried a user-space PC that resolved to no binary mapping —
mapping resolution (procmap/blazesym) is the suspect
all %d sampled frames were kernel-side and none were user-side —
the target was never on-CPU in user space during this window
nothing was sampled at all, so this says nothing about mapping resolution
```

An empty profile now fails as `EMPTY (0 bytes): the agent collected 0 samples in this
window` rather than a bare `EOF`. The mapping table renders as fields, not Go pointers —
the old `%+v` on a slice printed heap addresses that looked like captured PCs and were not.

### What this does not fix

**Symptom 3 is not retried, deliberately.** That capture had ≥20 samples with every frame
on the default anonymous mapping and zero kernel frames — a mapping-resolution failure
shape, not a starved window. It is judged on the first capture and fails loudly. Retrying
it would have produced a 94% pass rate over a possible profiler bug. Filed as #56 with the
full derivation.

### Found along the way

`TestStrippedCachedHitNoFetch` was **passing vacuously on `main`**: `runStripped` ran one
3 s window with no check that a debuginfod fetch happened, so a sample-less window left the
cache empty, run 2 also fetched nothing, `delta == 0`, and the test passed having proved
nothing about cache hits. That is a worse defect than the flakiness this issue is about.
`TestOffBoxLibcResolution` had the same shape and is now gated too.

Also: `degenerateSampleFloor` lived in a `_test.go` file and was invisible to the non-test
harness file — caught by `go build`, which `vet` and `test -c` do not catch.

Related: #55 (`||` between testify assertions), #56 (the unresolved capture).
