### PR TITLE
gpu: make the producer wait for its CFI tables instead of racing them

### DIFF
--- a/.superpowers/sdd/issue-49-report.md
+++ b/.superpowers/sdd/issue-49-report.md
@@ -1,0 +1,494 @@
+# Issue #49 — the CFI tables now exist before the probe fires
+
+Branch `fix/gpu-eager-cfi`. One commit. **Not verified on hardware:** this machine has
+`CapEff: 0`, no BPF attach and no GPU, so `TestStubDrivesThePipelineToPprofWithoutAGPU`
+skips and no CUDA run was possible. Every number in §5 is a prediction derived from the
+mechanism, stated before any run.
+
+---
+
+## 1. The premise, checked
+
+The issue's framing is correct and the measurement is where it says it is.
+
+`gpuprobe/consumer.go` registers eagerly and synchronously only when `Config.PID != 0`.
+For `Config.PID == 0` — which `cmd/gpu-cuda-profile` passes, because the CUDA process
+does not exist at `Attach` time — nothing was registered until `applyBatch` saw the first
+batch from a PID and queued a compile on the registry's worker goroutine.
+
+The reason that is unfixable in userspace-observation terms: **the stack walk happens in
+the kernel, inside `walk_step` (`bpf/unwind_common.h`), at the instant the uprobe traps.**
+`walk_step` unwinds by CFI only for a PC it can find in `pid_mappings`; a miss is silent
+and falls through to the frame-pointer chain, which in a CUDA process dies in the vendor
+libraries. So any trigger a consumer can observe — a first batch, an mmap notification,
+an exec notification — is by construction late: the sample that triggered it was already
+walked without tables, and so is everything arriving during the compile. libcuda alone is
+135 805 CFI entries at ~73 ms against a ~540 ms workload, which is why the loss is ~38%
+and not a rounding error.
+
+Two arithmetic checks on the reported numbers, both of which hold and both of which
+constrain the prediction in §5:
+
+- `StacksWalkedDWARF + StacksWalkedNoTables == 500` in every run (308 + 192, 313 + 187).
+  Combined with the existing invariant `DWARF + FPOnly == sampled`, that means
+  `FPOnly == NoTables` exactly: **there were no FP-only walks that had tables.** Every
+  walk that had tables used them.
+- `StacksProfilerOnly == StacksWalkedNoTables` in every run: the tableless walks are
+  precisely the ones the #39 guard refused. So the lost population and the tableless
+  population are the same set, and removing one removes the other.
+
+---
+
+## 2. The mechanism: the producer waits
+
+The producer has a point in its life that provably precedes every launch, and the
+consumer does not. So the producer is the one that waits.
+
+**`shim/core/enroll.{h,cc}` — the producer half.** At initialisation, and only when the
+sampled-launch probe's semaphore says a consumer is attached, the shim connects to an
+abstract `AF_UNIX` socket and blocks for one status byte.
+
+**`gpuprobe/enroll.go` — the consumer half.** `Attach` binds that socket *before* it
+creates the `uprobe_multi` link. It accepts one producer at a time, takes the peer's PID
+from `SO_PEERCRED`, checks that PID actually maps the shim inode it attached to,
+registers its CFI tables **synchronously**, and only then writes the byte.
+
+The address is derived independently on both sides from the shim's own device and inode:
+
+```
+\0perfagent-gpu-enroll.v1.<dev_major>.<dev_minor>.<inode>
+```
+
+The producer reads its own `dev:inode` out of `/proc/self/maps` (the mapping containing
+`enroll_with_consumer`'s own address, which is linked into the shim); the consumer reads
+the same two numbers from `stat(2)` on `Config.ShimPath`. The inode is the right key
+because it is exactly what a uprobe attaches to: a producer whose probes this consumer
+armed maps that inode by construction. No environment variable, no path agreement, no
+cooperation from whoever launched the process, and two consumers watching two copies of a
+shim (the gate makes a private copy per run precisely so concurrent runs cannot collide)
+get two different addresses for free.
+
+### Why this closes the window rather than narrowing it
+
+For a CUDA process the call sequence is fixed by the driver:
+
+```
+cuInit
+  └── dlopen(CUDA_INJECTION64_PATH)      libcuda, libcupti, libcudart, the app: all mapped
+  └── InitializeInjection()
+        ├── open_log()
+        ├── enroll_with_consumer()  <-- blocks here until the tables are in
+        ├── cuptiSubscribe(on_callback)
+        └── cuptiActivityEnable(...)
+  ...
+cudaLaunchKernel  ->  on_callback  ->  gpu_launch_sampled_v1 probe  ->  walk_step
+```
+
+The rendezvous sits **before `cuptiSubscribe`**, not after. Subscribing is what makes
+`on_callback` reachable, and `on_callback` is the only thing in the adapter that fires a
+probe. So at the moment the reply is written, this process has fired no probe of any
+kind — not even from another thread already inside a CUDA call — and cannot until
+`InitializeInjection` returns.
+
+There is therefore no launch, so no probe, so no walk, until `AttachAllMappings` has
+returned. That is a synchronisation point, not a shorter race: making the compile faster
+would not change the argument and slowing it down would not break it.
+
+The stub takes the identical shape — the call is the first statement of
+`perfagent_stub_run`, before its launch loop.
+
+### It does not touch the event path
+
+The compile runs on the `enrollListener`'s own goroutine. The ringbuf drain goroutine is
+unchanged, and `Consumer.applyBatch` still does only O(1) map and list work. No batch can
+even arrive from the enrolling PID during its compile, because that process is blocked in
+its own initialisation; other PIDs drain normally throughout. `SequenceGaps` and
+`KernelDropped` have no new exposure.
+
+The accept loop is serial on purpose. N producers starting at once interleave into the
+same total I/O either way, and serial makes the ordering property trivially true: the
+reply for a producer goes out after that producer's tables are installed, with nothing
+else half-installed at the time.
+
+---
+
+## 3. What it does not cover
+
+Stated plainly, because the fix is a mechanism with a scope, not a blanket.
+
+1. **A process that was already running when the consumer attached.** Its
+   `InitializeInjection` ran with the semaphore at zero; it never reaches the rendezvous.
+   Its first batch triggers lazy registration exactly as before, and everything sampled
+   during that compile is walked without tables. **This is the genuine residual of #49**,
+   and it is visible as `StacksWalkedNoTables > 0` with `StacksNoTablesAfterEnroll == 0`.
+   Closing it needs the process stopped or its launches suppressed from outside, which
+   nothing here does.
+2. **A producer in a different network namespace.** Abstract sockets are netns-scoped. A
+   containerised CUDA process whose netns differs from the profiler's cannot reach the
+   address and falls back to lazy. Host-network and same-netns cases are fine. A
+   filesystem-path socket would trade this for a mount-namespace and cleanup problem;
+   neither is free, and the abstract one has no stale-file failure mode.
+3. **Libraries mapped after `cuInit`.** The tables cover what was mapped when the
+   rendezvous ran. Something dlopened later and landing on the launch path would produce a
+   per-frame mapping or CFI miss, not a "no tables for this PID" — a different counter
+   (`StacksWalkedCFIMiss`, `StackWalkAbandoned`) and a different fix (an mmap watcher),
+   out of scope here. The measured launch path — app → libcudart → libcupti → the adapter
+   → the probe — is entirely mapped before `InitializeInjection` runs.
+4. **A shim built before this change**, or one where `PERFAGENT_GPU_ENROLL_TIMEOUT_MS=0`:
+   no rendezvous, lazy path, pre-#49 behaviour.
+5. **A second consumer on the same shim inode.** Only one can bind; the second reports
+   `UnwindEnrollListening == false` and registers lazily for everything.
+6. **Non-CUPTI backends.** The rendezvous lives in `shim/core`, so any future vendor
+   adapter gets it by calling one function at init — but each has to call it.
+7. **A producer refused by the rate limiter.** More than 32 enrolments per second from one
+   uid (or 96 across the listener) fall back to the lazy path. That is far past any real
+   workload, and `UnwindEnrollThrottled` says when it happens, but it is a documented
+   ceiling rather than an unbounded promise.
+
+It is *not* limited to the case where the profiler spawns the target. A genuine
+system-wide attach covers every CUDA process that starts afterwards in the same netns,
+which is the deployment shape `cmd/gpu-cuda-profile` and the gate both use.
+
+---
+
+## 4. Failure and fallback
+
+Every path falls through to today's behaviour. Registration remains best-effort and
+nothing here can fail an attach or fail a run.
+
+| what fails | producer | consumer |
+|---|---|---|
+| no consumer attached (semaphore 0) | never connects; zero cost | — |
+| address unbindable (already held, no abstract sockets) | `no-listener`, runs immediately | `Attach` continues, `UnwindEnrollListening=false`, reason in `UnwindEnrollLastError` |
+| peer credentials unreadable / peer does not map the shim / wrong PID on a per-PID attach | reads `'X'`, runs | `UnwindEnrollRefused++`, no compile at all |
+| registration installs nothing | reads `'X'`, runs | `UnwindEnrollFailed++`, PID marked enrolled so its walks are counted as the contradiction they are |
+| consumer closes mid-rendezvous | reads EOF, runs | `close()` releases the producer; it is never left parked |
+| consumer too slow | `PERFAGENT_GPU_ENROLL_TIMEOUT_MS` (default 2000 ms) expires, runs | reply write has its own 5 s deadline so a slow compile still gets its answer out |
+| listener saturated (rate limit) | reads `'X'`, runs | `UnwindEnrollThrottled++`, no /proc read and no compile |
+| `enroll_with_consumer` cannot find its own mapping | `no-address`, runs | — |
+| connect interrupted by a signal after it completed | `EISCONN` is treated as connected, not as an error, so a rendezvous that really connected is not thrown away | — |
+
+**The budget is one deadline for the whole rendezvous**, connect and reply together, taken
+from `CLOCK_MONOTONIC` on entry and re-applied as *remaining* time before every blocking
+call. Two things made the first draft of this wrong, and both were measured on a harness
+against the real `enroll.cc`:
+
+- A per-syscall `SO_RCVTIMEO` is re-armed from zero on every `EINTR`, so a signal arriving
+  faster than the budget makes the wait never expire — 500 ms budget, `SIGALRM` every
+  100 ms, still blocked past **25 s** with no upper bound. That is not exotic: a Go runtime
+  sending `SIGURG`/`SIGPROF` in a cgo CUDA host, a JVM, `setitimer`, or a second profiler
+  all produce it, and the result was the profiled application hanging inside `cuInit`
+  forever. In a design whose premise is blocking the profiled process, an unbounded stall
+  is the one outcome that must be impossible.
+- `SO_SNDTIMEO` on the connect *plus* `SO_RCVTIMEO` on the read is two budgets, so the real
+  worst case was 2× the documented one.
+
+The signal-storm case in `shim/core/enroll_test.cc` pins both: it fires `SIGALRM` every
+50 ms (with `SA_RESTART` off, so the read really returns `EINTR`) against a 300 ms budget
+and asserts the call returns timed-out in under a second, and a companion case asserts a
+200 ms budget is not spent twice. Reverting `arm()` to a fixed per-call timeout makes the
+first one fail — verified by building that variant.
+
+The 2 s default is ~10× the measured need (libcuda 73 ms plus libcupti, libcudart, libc and
+the workload). A process mapping something libLLVM-sized could exceed it and fall back;
+`PERFAGENT_GPU_ENROLL_TIMEOUT_MS` is the dial, and `0` turns the rendezvous off.
+
+**Abuse.** The address is reachable by anything in the netns. Authorisation is the shim
+mapping, checked in order: `SO_PEERCRED` → per-PID filter → `procMapsHaveInode` → *then*
+enrol. An arbitrary PID cannot be registered.
+
+`Ucred.Uid` is **not** a blanket authorisation check. A root profiler legitimately profiles
+other users' processes, so requiring `uid == euid` unconditionally would refuse the real
+producer in the commonest production shape and silently restore the pre-#49 loss.
+
+There is a strictly additive version, and it is now in: when the consumer's euid is non-zero
+**and** it holds no `CAP_SYS_PTRACE`, the listener serves only its own uid. Such a consumer
+could not read another user's `/proc/<pid>/maps` anyway, so this refuses nothing it could
+have done — and it closes the rendezvous to every other local user on a multi-user box.
+Privileged consumers keep the inode check alone. `enrollRequiredUID` checks Permitted as
+well as Effective, for the same reason `perfagent.hasCapSysPtrace` does: a setcap'd binary
+has not promoted Permitted yet and would otherwise be misread as unprivileged.
+
+Otherwise the uid is the accounting key for the rate limiter and a name in the error string.
+
+What remains is resource exhaustion, and `enrollAdmission` bounds it: a token bucket per
+peer uid (32 burst, 32/s) and one for the listener as a whole (96/96), with the per-uid
+table itself capped at 64 entries so the defence cannot become the exhaustion. Entries that
+have refilled completely — i.e. uids idle for a full window — are reclaimed when the table
+is full, so a spray of one-shot uids cannot pin it and push real producers onto the shared
+bucket alone. Refusal is
+instantaneous, happens before any `/proc` read, and is counted in `UnwindEnrollThrottled`.
+A throttled producer is released and takes the lazy path — a worse profile, never a
+stalled application. (The compile is largely amortised anyway: `TableStore` keys on
+build-id, so a thousand processes mapping the same libLLVM pay for one.)
+
+**TOCTOU, accepted and documented.** `SO_PEERCRED` is stamped at connect but
+`/proc/<pid>/maps` is read afterwards, so a peer that disconnects immediately could in
+principle allow a PID recycle. The peer is normally blocked on the socket for the whole
+window, and losing the race is benign: the maps read and the registration use the *same*
+later `/proc` read, so the tables installed are correct for whoever holds that PID now, not
+stale ones for the process that connected — and that new process must itself map the shim
+inode or the check refuses it, which makes it a legitimate producer. The cost is a wasted
+compile and an LRU slot, never a wrong stack. A pidfd dance would not be atomic against
+exec either.
+
+---
+
+## 4b. A shared-table race this change would otherwise have introduced
+
+Before this commit the `PID == 0` path had exactly one caller of
+`pidRegistrar.Register`: the registry's worker goroutine. The rendezvous adds a second (the
+listener goroutine), and that made a latent bug in `unwind/ehmaps` reachable.
+
+`TableStore.AcquireBinary` returned "already installed" as soon as the refcount exceeded
+one — which is true from the instant the **first** caller bumped it, before that caller had
+compiled anything or written a single row. With two CUDA processes mapping the same binary:
+A's enrolment is compiling libc, B's registration gets `rc = 2` and returns immediately,
+`recordLocked` marks B `pidReady`, and B's walks consult a half-populated table.
+
+The symptom is the worst kind: those walks *have* mappings, so they never count as
+`NoTables`. They surface as CFI misses or FP-only-with-tables — a different symptom with a
+different suspect, and invisible to the counter meant to detect exactly this.
+
+Fixed in `unwind/ehmaps/store.go` by separating "who holds this table" (the refcount) from
+"this table is in the maps" (`installed`), with an `inflight` set and a `sync.Cond` so a
+second caller **waits for** the install rather than assuming it finished. `installed` is set
+only after both populates succeed, so a failed compile leaves the next caller free to retry
+instead of inheriting rows that were never written. `ReleaseBinary` holds `instMu` across
+both the forget *and* the map deletions, so eviction is atomic with respect to
+`beginInstall`: an acquirer either sees the table before the eviction starts, or compiles it
+again — it is never told "installed" for rows that are about to be deleted. The barrier is
+per-table, so one slow libcuda compile does not serialise every other binary.
+
+### The claim leak that first version shipped, and how it got through
+
+`AcquireBinary` uses named return values. Every failure path after the claim returns
+`0, false, err`, which **assigns** the named `tableID` before the deferred `endInstall`
+runs — so the defer released the claim on table 0 and left the real tableID marked in flight
+**forever**, with no timeout and no cancellation for the next caller.
+
+The blast radius was the serious part, and it had nothing to do with GPUs.
+`ehcompile.Compile` returns `ErrNoEHFrame` for any ELF without `.eh_frame` — an *expected*
+case that `AttachAllMappings` already logs and skips. So the first process mapping such a
+library poisoned its tableID and the second wedged in `beginInstall`. In `perf_dwarf` and
+`offcpu_dwarf` the wedged caller is the `PIDTracker.Run` goroutine, which also services exit
+events and `Detach`, so mmap tracking and PID teardown would stop with it; `pidRegistry.close`'s
+`wg.Wait()` would hang `Consumer.Close`. Reachable on any system-wide DWARF run. The
+pre-existing code had no such path, because the old `rc > 1` early return took no claim.
+
+The fix is one line (`claimed := tableID` before the defer), but **the test gap is the real
+finding**. This passed five new tests and `-race -count=4` because
+`store_install_test.go` exercised `beginInstall`/`endInstall` directly and never went
+through `AcquireBinary` — testing the primitives while the bug lived in the caller.
+`TestASecondAcquireAfterAFailedInstallDoesNotWedge` now drives the real entry point through
+both failure arms: an `objcopy`-stripped ELF that has a build-id (so the claim *is* taken)
+but no `.eh_frame`, and a successful compile whose populate then fails. It asserts both that
+`inflight` is empty and that a second `AcquireBinary` returns within 5 s. Reverting the
+defer to close over the named `tableID` fails it — verified.
+
+Six internal tests in `unwind/ehmaps/store_install_test.go` pin the rest: a second installer
+waits, a failed install is retryable, an evicted table is recompiled, distinct tables do not
+block each other, and under 16-way contention exactly one caller compiles and **zero**
+callers are told the table is ready before it is written.
+
+`SetOnCompile`'s hook runs inside the install claim, so a hook that re-entered the store for
+the same binary would wait on itself; that is now documented at both the field and the
+setter.
+
+---
+
+## 5. Predicted counters on the RTX 3090, and the derivation
+
+500 sampled launches, `cmd/gpu-cuda-profile` defaults, one workload.
+
+```
+StacksWalkedDWARF          500      (was mean 308)
+StacksWalkedNoTables         0      (was mean ~192)
+StacksWalkedFPOnly           0
+StacksProfilerOnly           0      (was == NoTables)
+StacksNoTablesAfterEnroll    0
+UnwindEnrollListening     true
+UnwindEnrollRequests         1
+UnwindEnrollConfirmed        1
+UnwindEnrollRefused          0
+UnwindEnrollFailed           0
+UnwindEnrollThrottled        0
+UnwindEnrolledPIDsEvicted    0
+UnwindEnrolledMarksDropped   0
+UnwindPIDsRegistered         1
+SequenceGaps                 0      (unchanged)
+```
+
+Derivation, step by step:
+
+1. `StacksWalkedNoTables == 0`. It is incremented only for an FP-only walk from a PID the
+   registry does not have as `pidReady`. The single producer reaches `pidReady` before
+   `InitializeInjection` returns, and `InitializeInjection` returns before `cuptiSubscribe`
+   runs, which is before any callback can fire a probe. So no walk can happen from a
+   not-ready PID.
+2. `StacksWalkedFPOnly == 0`, hence `StacksWalkedDWARF == 500`. The existing invariant
+   `DWARF + FPOnly == sampled` holds unconditionally. In the twelve baseline runs
+   `FPOnly == NoTables` exactly, i.e. **there was never an FP-only walk that had tables**
+   — the walk from the adapter's callback out to the application crosses libcupti and
+   libcudart, which are FP-less, so with tables present it always sets `DWARF_USED`.
+   With `NoTables == 0` that forces `FPOnly == 0` and `DWARF == 500`.
+3. `StacksProfilerOnly == 0`. It equalled `NoTables` in every baseline run: the refused
+   stacks were exactly the tableless ones, because those are the walks that die in the
+   adapter's own frame. With no tableless walks there is nothing for the #39 guard to
+   refuse. This is the number that says the *attribution* was recovered, not just the
+   walk — 500 launches now reach the profile with a real application call path.
+4. `UnwindEnrollRequests == UnwindEnrollConfirmed == 1`. One workload process, one
+   `InitializeInjection`, one connection that passes both identity checks. One connection
+   cannot exceed a 32-per-uid-per-second bucket, so `UnwindEnrollThrottled == 0`; one PID
+   against a 128-PID bound cannot be evicted, so `UnwindEnrolledPIDsEvicted == 0` and
+   `UnwindEnrolledMarksDropped == 0`. The workload runs as the same user as the profiler
+   here, and the profiler is privileged, so the uid gate is inert either way.
+5. `SequenceGaps == 0`. Nothing was added to the drain path.
+
+Also expected, not asserted: the workload's `cuInit` gains roughly 150–250 ms (the
+compile of libcuda, libcupti, libcudart, libc and the workload binary) before its first
+launch; the adapter logs `enroll=confirmed` on its `PERFAGENT_GPU_LOG` line.
+
+**What would falsify this.** `UnwindEnrollListening == false` means the address could not
+be bound and the run is entirely on the old path. `UnwindEnrollRefused > 0` means the
+identity check rejected the process the uprobes fired in, which cannot be true and would
+mean the `/proc` inode match is wrong. `StacksWalkedNoTables > 0` with
+`UnwindEnrollConfirmed == 1` means a walk happened before the reply, i.e. the ordering
+argument in §2 is false. `StacksNoTablesAfterEnroll > 0` **while `UnwindEnrollFailed` and
+`UnwindEnrolledPIDsEvicted` are both zero** means the rendezvous reported success it did
+not deliver. Any of these is a real defect, not a timing transient — which is the
+difference from the pre-#49 code, where a non-zero `NoTables` was expected.
+
+---
+
+## 6. Counters
+
+Six defects on this project were counters reading green when things were worst, so:
+
+- **`StacksWalkedNoTables` is untouched and still counts every tableless walk**, enrolled
+  or not. Nothing in this change can make it read zero except tables genuinely being
+  present. There is a regression test for exactly that
+  (`TestATablelessWalkAfterAnEnrollIsCountedSeparately` asserts *both* counters at 1).
+- **`StacksNoTablesAfterEnroll`** is the new race counter: the subset of the above whose
+  process completed the rendezvous. It has exactly two benign explanations, each with its
+  own counter beside it — registration ran and installed nothing (`UnwindEnrollFailed`), or
+  the PID was evicted from the bounded set afterwards (`UnwindEnrolledPIDsEvicted`). It is
+  **non-zero with both of those at zero** that has no benign reading: it means a walk
+  happened before the reply went out. The earlier draft of this report claimed the
+  unqualified form, which contradicted the code's own doc; the code doc now enumerates all
+  three and this does too.
+- **The enrolled mark deliberately outlives eviction.** It used to live only on the
+  registry entry, and eviction deletes the entry — so after an eviction the flag was gone,
+  `StacksNoTablesAfterEnroll` read zero and `StacksWalkedNoTables` climbed. Green exactly
+  when things were worst, inside the counter added to prevent that. `pidRegistry` now keeps
+  a bounded FIFO of evicted-but-enrolled PIDs, and `note()`/`registerNow()` carry the mark
+  forward when such a PID comes back. The bound means a PID evicted long ago is forgotten
+  (a false negative, the safe direction) and a recycled PID can be miscredited (a false
+  positive, cross-checked by `UnwindEnrolledPIDsEvicted`).
+- **`UnwindEnrolledPIDsEvicted`** names the second benign case on its own: the capacity
+  bound biting on exactly the processes the rendezvous exists to protect.
+- **`UnwindEnrolledMarksDropped`** closes the last hole in the chain. The mark set is
+  bounded, so a mark can age out and `StacksNoTablesAfterEnroll` then under-reports for that
+  PID — a silent under-report in the counter that exists to prevent silent under-reports.
+  Every dropped mark is now counted, and the set is sized at 4× the PID capacity rather than
+  1×: it is fed once per enrolment *and* again when an enrolled PID is evicted, so at 1× it
+  churned against the LRU and aged marks out roughly twice as fast as evictions happened.
+  `TestTheEnrolledMarkSetOutlivesTheEvictionItMustWitness` pins that, and the bounds test
+  asserts the books balance (`dropped + held == enrolments`).
+- **`UnwindEnrollThrottled`** makes the rate limiter visible. Non-zero on a machine that is
+  not under attack means a legitimate burst exceeded the per-uid bucket and those producers
+  fell back to the lazy path — the limiter causing a small version of the loss it protects.
+- **`UnwindEnrollListening`** exists because a run that lost the rendezvous and a run that
+  never needed one are otherwise indistinguishable, and the first is the one that loses
+  ~38% of its stacks.
+- `UnwindEnrollRequests` / `Confirmed` / `Refused` / `Failed` / `LastError` split the
+  outcomes so a shortfall names its own cause.
+- The producer reports its own half on stderr (`enroll=confirmed|no-listener|timed-out|…`).
+  A producer that never reached the socket is invisible to every consumer-side counter —
+  it would simply never appear — so the gate checks both ends.
+
+---
+
+## 7. Tests, and why each is falsifiable
+
+Go (`gpuprobe/enroll_test.go`, `gpuprobe/unwindtables_test.go`) — no caps, no GPU:
+
+| test | fails if |
+|---|---|
+| `TestTheProducerIsNotReleasedUntilItsTablesAreInstalled` | the reply is written before `Register` returns (the registrar is wedged on a channel and the test asserts no byte arrives) |
+| `TestTheCppProducerAndTheGoListenerAgreeOnTheWire` | the two ends spell the socket name differently, or the reply byte changes on one side. Builds a real producer from `shim/core/enroll.cc`, runs it against a real listener, asserts it prints `confirmed` and that the *peer's* PID was registered |
+| `TestTheRendezvousAddressIsTheShimsDeviceAndInode` | the address stops being a pure function of the shim's identity; pins the exact spelling |
+| `TestASecondRendezvousDoesNotRecompile` | a repeat connection duplicates `pid_mappings` rows and CFI table references |
+| `TestABatchArrivingMidEnrollDoesNotQueueASecondRegistration` | `enroll` claims its registry entry after the compile instead of before, letting the lazy path register the same PID again |
+| `TestAFailedRegistrationStillReleasesTheProducer` | a failed compile parks the producer instead of releasing it |
+| `TestAPeerThatDoesNotMapTheShimIsRefused` / `TestAPerPIDConsumerRefusesEveryOtherPID` | the identity checks stop biting |
+| `TestCloseReleasesAWaitingProducer` | teardown leaves a producer parked |
+| `TestASecondListenerForTheSameShimIsRefused` | a second consumer silently shadows the first |
+| `TestProcMapsInodeMatchIsDeviceAware` | the hex device field in `/proc` is read as decimal, which would refuse every genuine producer while looking like a working check |
+| `TestATablelessWalkAfterAnEnrollIsCountedSeparately` / `…WithoutAnEnrollIsNotCountedAsADefect` | the new counter nets out of the honest total, or fires on ordinary startup transients |
+| `TestAnEnrolledPIDEvictedFromTheBoundKeepsItsMark` / `…ComesBackLazily` / `TestATablelessWalkAfterAnEnrolledEvictionIsCounted` | the enrolled mark dies with the evicted entry, so a broken promise reads as an ordinary transient |
+| `TestTheEnrolledShadowSetIsBounded` | the anti-blindness set grows with a profiled machine's process churn, or drops marks without counting them |
+| `TestTheEnrolledMarkSetOutlivesTheEvictionItMustWitness` | the mark set is sized at the PID capacity and ages a mark out before the eviction it exists to witness |
+| `TestOnlyAnUnprivilegedConsumerIsPinnedToItsOwnUID` / `TestAPeerOfAnotherUIDIsRefusedByAnUnprivilegedConsumer` | the uid gate becomes unconditional (refusing a root profiler's non-root target) or disappears |
+| `TestIdlePerUIDEntriesAreReclaimed` | one-shot uids permanently occupy the rate limiter's table |
+| `TestOneUIDCannotMonopoliseTheRendezvous` / `TestManyUIDsTogetherAreStillBounded` / `TestThePerUIDTableIsBounded` / `TestALegitimateBurstOfProducersIsNotThrottled` / `TestAThrottledPeerIsReleasedAndCountedNotServed` | the rate limiter is absent, escapable across uids, unbounded in its own bookkeeping, tight enough to throttle a real workload, or parks the peer it refuses |
+| `TestAPeerIsAuthorisedByTheShimItMapsNotByItsUID` | authorisation drifts onto the uid, which would refuse a root profiler's non-root target |
+
+`unwind/ehmaps/store_install_test.go` (internal, no BPF): `TestASecondInstallerWaitsForThe
+FirstInsteadOfAssumingItFinished`, `TestAFailedInstallLetsTheNextCallerTryAgain`,
+`TestAnEvictedTableIsNoLongerConsideredInstalled`,
+`TestInstallsOfDifferentTablesDoNotBlockEachOther`,
+`TestExactlyOneCallerInstallsUnderContention`,
+`TestASecondAcquireAfterAFailedInstallDoesNotWedge` — see §4b. The last one is the
+important one: it drives `AcquireBinary` itself, which is where the bug the other five
+could not see actually lived.
+
+C++ (`shim/core/enroll_test.cc`, in `make -C shim test`): name derivation against a maps
+fixture (including the anonymous-mapping and no-match cases), `'K'`/`'X'`, no listener, a
+listener that accepts and never answers (must time out, not hang), **a signal storm that
+must not extend the budget**, **both phases sharing one budget rather than each getting
+it**, oversized and empty names, and the `PERFAGENT_GPU_ENROLL_TIMEOUT_MS` parse where an
+explicit `0` means off rather than "use the default".
+
+Gate (`TestStubDrivesThePipelineToPprofWithoutAGPU`), which still runs GPU-free with
+`PID: 0` and the target not yet running — the shape is unchanged, the producer is still
+launched after `Attach`, and the assertions were **tightened, not relaxed**:
+
+- `assert.Less(StacksWalkedNoTables, 63)` → `assert.Zero(StacksWalkedNoTables)`. The old
+  comment called zero "the trap in the shape of an obvious assertion" and it was right at
+  the time; it is no longer, because the producer no longer races the compile.
+- added: `StacksNoTablesAfterEnroll == 0`, `UnwindEnrollListening`,
+  `UnwindEnrollConfirmed == 1`, `UnwindEnrollRefused == 0`, `UnwindEnrollFailed == 0`,
+  `UnwindEnrollThrottled == 0`, `UnwindEnrolledPIDsEvicted == 0`,
+  `StacksWalkedDWARF == 63`, and `stubErr` contains `enroll=confirmed`.
+
+Predicted gate counters, against the §5.2 table of `issue-45-report.md`: everything there
+is unchanged except that the "62/1" DWARF/FP-only split — which that report explicitly
+left unasserted as timing-dependent — becomes 63/0. `StackWalkReachedRoot ==
+StacksWalkedDWARF` still holds, now at 63, and `StackWalkAbandoned`,
+`StackWalkFPExhausted`, `StackWalkFPNonMonotonic`, `StackWalkRootDisagreement` and
+`StacksWalkedCFIMiss` all stay zero.
+
+---
+
+## 8. Verification actually run
+
+```
+go build ./... && go vet ./...                                        pass
+go test ./gpu/ ./gpuprobe/ ./internal/... ./unwind/... -count=1        pass
+go test ./gpu/ ./gpuprobe/ ./unwind/ehmaps/ -race -count=4             pass
+golangci-lint run --timeout=5m                                        0 issues
+make -C shim test                                                     pass (incl. enroll_test)
+make -C shim perfagent-gpu-stub perfagent-gpu-fpless check-fpless      pass
+make -C shim nvidia                                                   builds; exports only InitializeInjection
+```
+
+**Cannot verify:** `CapEff: 0` on this machine. No BPF object could be loaded, no uprobe
+attached, and no CUDA device is present, so `TestStubDrivesThePipelineToPprofWithoutAGPU`
+skips and no RTX 3090 run was made. Nothing in §5 has been observed; it is derived, and
+the tightened gate assertions are unproven against real BPF. In particular, the claim that
+the uprobe reference-count semaphore is already armed when `InitializeInjection` runs
+(kernel `uprobe_mmap` / delayed-uprobe handling at `dlopen`) is read from the kernel's
+contract, not measured here — if it were false, the producer would skip the rendezvous
+and the run would simply look like the pre-#49 baseline, with `UnwindEnrollRequests == 0`
+saying so.

--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -65,6 +65,15 @@ func main() {
 		// yet, so the attachment has to be system-wide. The semaphore the
 		// uprobe refcount maintains is what arms the probes in it once the
 		// driver maps the .so.
+		//
+		// Attach also binds the startup rendezvous before it creates the
+		// uprobe link, which is what keeps the workload's first sampled
+		// launches from being walked before their CFI tables exist: the
+		// adapter blocks in InitializeInjection - during cuInit, after
+		// libcuda is mapped and before any kernel can be launched - until
+		// this consumer has installed them. See gpuprobe/enroll.go. Nothing
+		// is needed here for that, and nothing here may set
+		// PERFAGENT_GPU_ENROLL_TIMEOUT_MS to 0, which turns it off.
 		PID:        0,
 		Backend:    gpu.BackendCUPTI,
 		Sink:       timeline,

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -624,6 +624,21 @@ type Stats struct {
 	// released and their later walks degrade to frame pointers, counted in
 	// StacksWalkedNoTables. Attribution loss, never record loss.
 	UnwindPIDsEvicted uint64
+	// UnwindEnrolledPIDsEvicted is the subset of the above that had completed
+	// the startup rendezvous: producers that were released on the promise
+	// that their tables were installed, and then had them taken back to make
+	// room. Non-zero means the capacity bound is biting on exactly the
+	// processes the rendezvous exists to protect, and is the benign
+	// explanation to check first when StacksNoTablesAfterEnroll is non-zero.
+	UnwindEnrolledPIDsEvicted uint64
+	// UnwindEnrolledMarksDropped counts rendezvous marks that aged out of the
+	// bounded set pidRegistry keeps so the mark can outlive an eviction. Each
+	// one is a PID whose later tableless walks will NOT be counted in
+	// StacksNoTablesAfterEnroll even though they should be - an under-report,
+	// which is the direction this counter exists to keep visible. Non-zero
+	// means the set is small relative to how many distinct producers enrolled;
+	// Config.UnwindPIDCapacity sizes both.
+	UnwindEnrolledMarksDropped uint64
 	// UnwindRequestsDropped counts registration or release requests the
 	// worker queue could not accept. A dropped registration means the PID
 	// is forgotten and retried on its next batch; a dropped release means
@@ -638,6 +653,85 @@ type Stats struct {
 	// holding right now, registered or still being compiled. Bounded by
 	// Config.UnwindPIDCapacity.
 	UnwindPIDsTracked int
+	// UnwindEnrollListening says whether the startup rendezvous (enroll.go)
+	// is open for this consumer. False means the address could not be bound
+	// - another consumer already holds it for this shim inode, or abstract
+	// sockets are unavailable - and every producer therefore falls back to
+	// lazy registration, i.e. exactly the pre-#49 behaviour, with the
+	// startup window it implies. UnwindEnrollLastError says why.
+	//
+	// It is a flag rather than a silent fallback because a run that lost the
+	// rendezvous and a run that never needed it are otherwise
+	// indistinguishable from the counters, and the first is the one that
+	// loses ~38% of its stacks.
+	UnwindEnrollListening bool
+	// UnwindEnrollRequests counts producers that reached the rendezvous and
+	// passed both identity checks (SO_PEERCRED, and actually mapping this
+	// consumer's shim inode), so registration was attempted for them.
+	UnwindEnrollRequests uint64
+	// UnwindEnrollConfirmed counts producers released with "your tables are
+	// installed". Each one is a process whose FIRST sampled launch was
+	// walked with CFI, which is the entire point of issue #49. Compare it
+	// against the number of distinct producers a run had: a shortfall means
+	// some producer took the lazy path.
+	UnwindEnrollConfirmed uint64
+	// UnwindEnrollRefused counts connections turned away without any
+	// registration: no peer credentials, a PID other than Config.PID on a
+	// per-PID attach, or a peer that does not map the shim. The last is the
+	// interesting one - it is a process on this machine reaching the
+	// rendezvous address for a shim it has not loaded.
+	UnwindEnrollRefused uint64
+	// UnwindEnrollThrottled counts connections refused by the rendezvous rate
+	// limiter before any check or /proc read. The listener serves one
+	// producer at a time, so a fork loop of shim-mapping processes could
+	// otherwise monopolise it and expire genuine producers' budgets; see
+	// enrollAdmission. A throttled producer is released instantly and runs on
+	// the lazy path, so this is attribution loss, never a stalled
+	// application. Non-zero on a machine that is not under attack means the
+	// burst is genuinely larger than enrollUIDBurst per second.
+	UnwindEnrollThrottled uint64
+	// UnwindEnrollFailed counts producers whose registration was attempted
+	// and installed nothing. They are released rather than parked, so they
+	// run with frame-pointer stacks; every stack they go on to take is
+	// counted in both StacksWalkedNoTables and StacksNoTablesAfterEnroll.
+	UnwindEnrollFailed uint64
+	// UnwindEnrollLastError is the most recent reason a rendezvous did not
+	// end in a confirmation, including a failure to bind the address at all.
+	UnwindEnrollLastError string
+	// StacksNoTablesAfterEnroll is the counter that says the fix stopped
+	// working.
+	//
+	// It is the subset of StacksWalkedNoTables whose process DID complete the
+	// startup rendezvous. The rendezvous is meant to make that impossible:
+	// the producer is blocked in its own initialisation until the tables are
+	// installed, so a walk from it should never find them missing.
+	//
+	// There are exactly three ways it can be non-zero, and they are not
+	// equally alarming - read it together with the two counters that name the
+	// benign ones:
+	//
+	//   - the rendezvous ran and registration installed nothing. The producer
+	//     was released anyway (a degraded profile beats a stalled process)
+	//     and its walks are honestly tableless. Also counted in
+	//     UnwindEnrollFailed.
+	//   - the PID was evicted from the bounded set afterwards, so the tables
+	//     were taken back. Also counted in UnwindEnrolledPIDsEvicted.
+	//   - neither of those, in which case the ordering argument the whole fix
+	//     rests on is false: a walk happened before the reply went out, or
+	//     registration reported success it had not delivered. THAT has no
+	//     benign reading.
+	//
+	// The enrolled mark deliberately outlives eviction (pidRegistry's
+	// wasEnrolled set): if it did not, the second case above would leave this
+	// counter reading zero while StacksWalkedNoTables climbed - green exactly
+	// when things were worst, in the counter added to prevent that. The set
+	// is bounded, so a PID evicted long ago can be forgotten (a false
+	// negative, the safe direction) and a recycled PID can be miscredited (a
+	// false positive, which UnwindEnrolledPIDsEvicted cross-checks).
+	//
+	// Deliberately NOT a way to make StacksWalkedNoTables read zero: that
+	// counter still counts every tableless walk, enrolled or not.
+	StacksNoTablesAfterEnroll uint64
 	// StackMapFull counts captures the BPF side could not park because
 	// gpu_stacks was full (gpuStackCapacity live entries). Read from the
 	// `walk_errors` map.
@@ -915,6 +1009,14 @@ type Consumer struct {
 	// It has its own lock and is safe to use under c.mu; none of the methods
 	// c.mu-holding code calls does I/O or blocks. See pidRegistry.
 	unwind *pidRegistry
+	// enroll serves the startup rendezvous that makes those tables exist
+	// before the first probe fires. Nil when the address could not be bound,
+	// which is not fatal: producers then register lazily on their first
+	// batch, exactly as before issue #49. See enroll.go.
+	enroll *enrollListener
+	// enrollErr is why there is no listener, surfaced as
+	// Stats.UnwindEnrollLastError. Written once in Attach, read under mu.
+	enrollErr string
 
 	mu          sync.Mutex
 	seqByStream map[seqKey]uint64
@@ -1054,7 +1156,25 @@ func Attach(cfg Config) (c *Consumer, err error) {
 	}
 	// For a system-wide attach (cfg.PID == 0) there is nothing to register
 	// yet — the target may not even be running, which is exactly the gate's
-	// shape. Registration happens on first sight of a PID, in applyBatch.
+	// shape. What closes that window is the startup rendezvous below: the
+	// producer blocks in its own initialisation until its tables are in.
+	// Registration on first sight of a PID (applyBatch -> note) remains as
+	// the fallback for a producer that never reached it.
+
+	// Bound BEFORE the link, for the same reason registration is: creating
+	// the uprobe_multi link is what arms the shim's semaphores, and an armed
+	// semaphore is what makes a producer try the rendezvous at all. A
+	// listener bound after the link would miss a producer that started in
+	// between.
+	//
+	// Best-effort, never fatal, for the same reason as everything else here:
+	// a consumer with no rendezvous still profiles, registers lazily, and
+	// says so in Stats.UnwindEnrollListening.
+	if el, eerr := newEnrollListener(cfg, c.unwind); eerr != nil {
+		c.enrollErr = eerr.Error()
+	} else {
+		c.enroll = el
+	}
 
 	var ex *link.Executable
 	if ex, err = link.OpenExecutable(cfg.ShimPath); err != nil {
@@ -1590,6 +1710,13 @@ func (c *Consumer) resolveStackLocked(pid uint32, stackID int32) ([]pp.Frame, bo
 		// construction: a DWARF walk proves tables existed.
 		if !c.unwind.ready(pid) {
 			c.stats.StacksWalkedNoTables++
+			if c.unwind.enrolled(pid) {
+				// The producer blocked in its own initialisation waiting for
+				// exactly these tables and was told to go. Finding them
+				// missing now is a contradiction, not a startup transient -
+				// see Stats.StacksNoTablesAfterEnroll.
+				c.stats.StacksNoTablesAfterEnroll++
+			}
 		}
 	}
 	if flags&walkerFlagCFIMiss != 0 {
@@ -1953,9 +2080,22 @@ func (c *Consumer) Stats() Stats {
 	out.UnwindPIDsFailed = uw.failed
 	out.UnwindLastError = uw.lastErr
 	out.UnwindPIDsEvicted = uw.evicted
+	out.UnwindEnrolledPIDsEvicted = uw.enrolledEvicted
+	out.UnwindEnrolledMarksDropped = uw.enrolledMarksDropped
 	out.UnwindRequestsDropped = uw.requestsDropped
 	out.UnwindReleaseFailed = uw.releaseFailed
 	out.UnwindPIDsTracked = tracked
+	en := c.enroll.snapshot()
+	out.UnwindEnrollListening = c.enroll != nil
+	out.UnwindEnrollRequests = en.requests
+	out.UnwindEnrollConfirmed = en.confirmed
+	out.UnwindEnrollRefused = en.refused
+	out.UnwindEnrollThrottled = en.throttled
+	out.UnwindEnrollFailed = en.failed
+	out.UnwindEnrollLastError = en.lastErr
+	if out.UnwindEnrollLastError == "" {
+		out.UnwindEnrollLastError = c.enrollErr
+	}
 	// Gauges, read fresh: what the two side tables are holding right now.
 	out.PendingStacks = c.pending.len()
 	out.PendingLaunches = c.deferred.len()
@@ -2029,6 +2169,14 @@ func (c *Consumer) Close() error {
 	// descriptors. Outside mu because Stats takes mu and the wait can last a
 	// whole compile. Idempotent, and a no-op on a nil registry, so a
 	// half-built consumer from a failed Attach is safe.
+	// The rendezvous goes down before the registry: it is the only other
+	// thing that calls into the registrar, and closing it first means the
+	// wait below is the last compile there can be. A producer blocked on an
+	// accepted connection is released by the close (it reads EOF and takes
+	// the lazy path), never left parked on a consumer that has gone.
+	if err := c.enroll.close(); err != nil {
+		errs = append(errs, err)
+	}
 	c.unwind.close()
 	// The links and objects come down under mu so Stats, which reads the
 	// `dropped` map, cannot be looking at c.objs while it is being closed.

--- a/gpuprobe/enroll.go
+++ b/gpuprobe/enroll.go
@@ -1,0 +1,596 @@
+package gpuprobe
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+)
+
+// The consumer half of the startup rendezvous. shim/core/enroll.h is the
+// producer half and carries the full rationale; the short version is that the
+// stack walk happens in the kernel, inside walk_step, at the instant the
+// uprobe traps, so the CFI tables have to be in the BPF maps before the probe
+// can fire. Nothing a consumer observes in userspace - a first batch, an mmap
+// notification, an exec notification - happens before that, so registration
+// driven by any of them is definitionally late: the sample that triggered it
+// was already walked without tables, and so is everything that arrives during
+// the compile. On an RTX 3090 that compile is ~73ms for libcuda's 135805 CFI
+// entries against a ~540ms workload, which is the ~38% of sampled stacks
+// issue #49 measured as lost.
+//
+// So the producer waits instead. A CUDA process's adapter is dlopened by the
+// driver during cuInit, which is after libcuda and the application are mapped
+// and before any kernel launch, and it blocks there until this listener has
+// installed its tables. The window is closed rather than narrowed: there is
+// no launch, therefore no probe, therefore no walk, until the reply goes out.
+//
+// # The address
+//
+// An abstract AF_UNIX name both ends derive independently from the shim's own
+// device and inode:
+//
+//	@perfagent-gpu-enroll.v1.<dev_major>.<dev_minor>.<inode>
+//
+// The inode is the key because it is what a uprobe attaches to: a producer
+// whose probes this consumer armed maps that inode by construction, and two
+// consumers watching two different copies of the shim - the gate makes a
+// private copy per run precisely so concurrent runs cannot collide - get two
+// different names for free. No environment variable, no path agreement, and
+// no cooperation from whoever launched the profiled process.
+//
+// # What it will not do
+//
+// The peer's PID comes from SO_PEERCRED, which the kernel fills in and no
+// payload can forge, and the request is refused unless that PID actually maps
+// the shim inode this consumer attached to. An arbitrary local process
+// therefore cannot make a root profiler compile CFI for a PID of its
+// choosing; the most it can do is re-enroll a process that is already being
+// profiled, which costs a map lookup because pidRegistry.enroll never
+// recompiles a PID that already holds tables.
+//
+// That leaves resource exhaustion rather than misdirection: the address is
+// reachable by any local user who can read and map the shim, serve() is
+// serial, and each admitted enrolment costs a /proc/<pid>/maps read plus a
+// pid_mappings population - a fork loop of such processes could occupy the
+// listener, expire genuine producers' budgets and churn the registry's
+// bounded LRU. (The compile itself is largely amortised: TableStore keys on
+// build-id, so a thousand processes mapping the same libLLVM pay for one.)
+// enrollAdmission bounds it: a token bucket per peer uid and one for the
+// listener as a whole, both refilled continuously, with refusal being
+// instantaneous and counted in Stats.UnwindEnrollThrottled. A throttled
+// producer is released immediately and takes the lazy path - the failure mode
+// is a worse profile, never a stalled application.
+//
+// # The TOCTOU, and why it is benign
+//
+// SO_PEERCRED is stamped at connect time, but /proc/<pid>/maps is read
+// afterwards, so in principle the peer could exit and its PID be recycled in
+// between. In practice the peer is blocked reading the socket for the whole
+// window, and even when it is not, the consequence is bounded: the maps read
+// and the registration use the SAME later /proc read, so the tables installed
+// are correct for whoever holds that PID now, not stale ones for the process
+// that connected. Worse, that new process must ITSELF map the shim inode or
+// the check refuses it - which makes it a legitimate producer. The cost of
+// losing this race is therefore a wasted compile and an LRU slot, never a
+// wrong stack. Accepted and documented rather than papered over with a
+// pidfd dance that would still not be atomic against exec.
+//
+// # It is never fatal
+//
+// If the address cannot be bound - another consumer already has it, or
+// abstract sockets are unavailable - Attach continues without a listener and
+// every producer falls back to lazy registration, i.e. exactly the pre-#49
+// behaviour. Stats.UnwindEnrollListening says which of the two a run had, so
+// a degraded run is legible rather than silent.
+
+// enrollReply is the single status byte the producer waits for.
+const (
+	enrollReplyOK      = 'K' // the walker has this PID's tables
+	enrollReplyRefused = 'X' // it does not, and will not before you run
+)
+
+// enrollReplyTimeout bounds the reply write, and nothing else.
+//
+// Deliberately not a deadline over the whole handler: registration is a CFI
+// compile, and a deadline set before it would expire during a legitimately
+// slow one (a process mapping something libLLVM-sized) and then swallow the
+// reply that the compile had just earned. The producer's own budget
+// (PERFAGENT_GPU_ENROLL_TIMEOUT_MS, default 2s) is what bounds how long it
+// waits; this end always tries to answer.
+//
+// One byte into a socket whose peer is blocked reading it cannot actually
+// block, so this only ever fires for a producer that has already given up and
+// gone - which is exactly when the accept loop must not be held.
+const enrollReplyTimeout = 5 * time.Second
+
+// The admission bucket. Sized so that a legitimate burst is never throttled
+// and a fork loop is: 32 distinct CUDA processes started by one user inside a
+// second is already far past any real workload, and an attacker's loop does
+// thousands. A throttled producer is refused instantly and runs on the lazy
+// path, so the cost of being wrong in the tight direction is a worse profile
+// for that process, not a stalled one.
+const (
+	enrollUIDBurst    = 32
+	enrollUIDRefill   = 32 // tokens per second
+	enrollTotalBurst  = 96
+	enrollTotalRefill = 96
+	// enrollUIDTrackMax bounds the per-uid table itself, so the defence
+	// cannot become the exhaustion. Beyond it, everything falls back to the
+	// listener-wide bucket alone.
+	enrollUIDTrackMax = 64
+)
+
+// enrollAdmission is a continuously refilled token bucket, one per peer uid
+// plus one for the listener as a whole. Not safe for concurrent use; serve()
+// is serial and calls it from one goroutine.
+type enrollAdmission struct {
+	now func() time.Time
+
+	total    float64
+	totalAt  time.Time
+	perUID   map[uint32]*enrollBucket
+	burst    float64
+	refill   float64
+	uidBurst float64
+	uidFill  float64
+}
+
+type enrollBucket struct {
+	tokens float64
+	at     time.Time
+}
+
+func newEnrollAdmission(now func() time.Time) *enrollAdmission {
+	if now == nil {
+		now = time.Now
+	}
+	return &enrollAdmission{
+		now:      now,
+		total:    enrollTotalBurst,
+		totalAt:  now(),
+		perUID:   map[uint32]*enrollBucket{},
+		burst:    enrollTotalBurst,
+		refill:   enrollTotalRefill,
+		uidBurst: enrollUIDBurst,
+		uidFill:  enrollUIDRefill,
+	}
+}
+
+// admit spends one token from the uid's bucket and one from the listener's,
+// and reports whether both had one. Neither is charged unless both could pay,
+// so a uid that is already throttled cannot drain the shared bucket.
+func (a *enrollAdmission) admit(uid uint32) bool {
+	now := a.now()
+	a.total = refillTokens(a.total, a.totalAt, now, a.refill, a.burst)
+	a.totalAt = now
+
+	b, tracked := a.perUID[uid]
+	if !tracked {
+		if len(a.perUID) >= enrollUIDTrackMax {
+			// Reclaim first. A bucket that has refilled to its burst has not
+			// been spent for a full window, so it is indistinguishable from
+			// one that was never created: dropping it forgets nothing.
+			// Without this, sixty-four one-shot uids would pin the table
+			// forever and push every later producer - including the real one
+			// - onto the shared bucket alone.
+			a.sweepIdle(now)
+		}
+		if len(a.perUID) >= enrollUIDTrackMax {
+			// Still full: every tracked uid is actively spending. Fall back
+			// to the listener-wide bucket rather than growing without bound
+			// or refusing outright.
+			if a.total < 1 {
+				return false
+			}
+			a.total--
+			return true
+		}
+		b = &enrollBucket{tokens: a.uidBurst, at: now}
+		a.perUID[uid] = b
+	}
+	b.tokens = refillTokens(b.tokens, b.at, now, a.uidFill, a.uidBurst)
+	b.at = now
+
+	if a.total < 1 || b.tokens < 1 {
+		return false
+	}
+	a.total--
+	b.tokens--
+	return true
+}
+
+// sweepIdle drops every per-uid bucket that has refilled completely, i.e.
+// every uid that has not spent a token for a full window. Their state carries
+// no information a fresh bucket would not have.
+func (a *enrollAdmission) sweepIdle(now time.Time) {
+	for uid, b := range a.perUID {
+		if refillTokens(b.tokens, b.at, now, a.uidFill, a.uidBurst) >= a.uidBurst {
+			delete(a.perUID, uid)
+		}
+	}
+}
+
+func refillTokens(tokens float64, since, now time.Time, perSec, max float64) float64 {
+	if d := now.Sub(since); d > 0 {
+		tokens += d.Seconds() * perSec
+	}
+	if tokens > max {
+		tokens = max
+	}
+	return tokens
+}
+
+// enrollAddress is the rendezvous name for shimPath. Both ends compute it
+// from the same two numbers the kernel reports for the file, so they agree
+// without exchanging anything.
+func enrollAddress(shimPath string) (string, error) {
+	var st unix.Stat_t
+	if err := unix.Stat(shimPath, &st); err != nil {
+		return "", fmt.Errorf("stat shim %s: %w", shimPath, err)
+	}
+	dev := uint64(st.Dev) //nolint:unconvert // st.Dev is uint64 on amd64, uint32-widened elsewhere
+	return fmt.Sprintf("@perfagent-gpu-enroll.v1.%d.%d.%d",
+		unix.Major(dev), unix.Minor(dev), st.Ino), nil
+}
+
+// enrollStats is the listener's slice of gpuprobe.Stats, under its own lock.
+type enrollStats struct {
+	requests  uint64
+	confirmed uint64
+	refused   uint64
+	throttled uint64
+	failed    uint64
+	lastErr   string
+}
+
+// enrollListener serves the producer-side rendezvous for one consumer.
+type enrollListener struct {
+	ln  *net.UnixListener
+	reg *pidRegistry
+	// pid mirrors Config.PID: non-zero means this consumer's uprobes are
+	// filtered to one process, so an enrollment from any other PID is
+	// refused. The socket name is not PID-scoped and cannot be.
+	pid uint32
+	// dev and ino identify the shim image a peer must have mapped. Read once
+	// at construction: the file the uprobes are attached to cannot change
+	// identity underneath a live link.
+	dev, ino uint64
+	// procRoot is "/proc" in production; tests point it at a fixture.
+	procRoot string
+	// requireUID, when set, is the only peer uid this listener will serve.
+	// Nil for a privileged consumer, which legitimately profiles other
+	// users' processes. See enrollRequiredUID.
+	requireUID *uint32
+	// admit bounds how fast one peer uid, and the listener as a whole, may
+	// spend the single serving goroutine. Touched only from serve().
+	admit *enrollAdmission
+
+	wg sync.WaitGroup
+
+	mu    sync.Mutex
+	stats enrollStats
+}
+
+// newEnrollListener binds the rendezvous for cfg's shim and starts serving.
+//
+// Must be called BEFORE the uprobe_multi link is created. Creating the link
+// is what arms the shim's semaphores, and an armed semaphore is what makes a
+// producer attempt the rendezvous; binding afterwards would leave a window in
+// which a producer starts, finds nothing listening, and takes the lazy path -
+// which is the bug.
+func newEnrollListener(cfg Config, reg *pidRegistry) (*enrollListener, error) {
+	l, err := buildEnrollListener(cfg, reg)
+	if err != nil {
+		return nil, err
+	}
+	l.start()
+	return l, nil
+}
+
+// buildEnrollListener binds without serving. Split out so a test can settle
+// state that serve() alone is allowed to touch afterwards - `admit` has no
+// lock precisely because only the serving goroutine reaches it, and a test
+// that reached in while it ran would be racing the code it is checking.
+func buildEnrollListener(cfg Config, reg *pidRegistry) (*enrollListener, error) {
+	addr, err := enrollAddress(cfg.ShimPath)
+	if err != nil {
+		return nil, err
+	}
+	var st unix.Stat_t
+	if err := unix.Stat(cfg.ShimPath, &st); err != nil {
+		return nil, fmt.Errorf("stat shim %s: %w", cfg.ShimPath, err)
+	}
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: addr, Net: "unix"})
+	if err != nil {
+		return nil, fmt.Errorf("bind %s: %w", addr, err)
+	}
+	l := &enrollListener{
+		ln:         ln,
+		reg:        reg,
+		pid:        uint32(cfg.PID),
+		dev:        uint64(st.Dev), //nolint:unconvert // see enrollAddress
+		ino:        st.Ino,
+		procRoot:   "/proc",
+		admit:      newEnrollAdmission(nil),
+		requireUID: enrollRequiredUID(),
+	}
+	return l, nil
+}
+
+// start begins accepting. Separate from construction so buildEnrollListener's
+// caller can finish arranging the listener before any peer can reach it.
+func (l *enrollListener) start() {
+	l.wg.Add(1)
+	go l.serve()
+}
+
+// serve accepts one producer at a time.
+//
+// Serial on purpose. Each connection's work is a CFI compile, and the
+// registry's own worker goroutine may be doing another; ehmaps' store and
+// tracker are mutex-protected so concurrency would be safe, but it would not
+// be useful - the cost is I/O-bound on reading .eh_frame, and N producers
+// starting at once would only interleave into the same total. Serial keeps
+// the ordering property this file exists for trivially true: the reply for a
+// producer goes out after that producer's tables are installed, and nothing
+// else can be half-installed at the time.
+func (l *enrollListener) serve() {
+	defer l.wg.Done()
+	for {
+		conn, err := l.ln.AcceptUnix()
+		if err != nil {
+			// The only expected error is the listener being closed.
+			return
+		}
+		l.handle(conn)
+	}
+}
+
+// handle registers one producer and then releases it. Every early return
+// leaves the producer released (the deferred Close is an EOF the producer
+// reads as "no promise"), because a producer parked on a consumer that fell
+// over is worse than a producer with frame-pointer stacks.
+func (l *enrollListener) handle(conn *net.UnixConn) {
+	defer func() { _ = conn.Close() }()
+
+	pid, uid, err := enrollPeerCreds(conn)
+	if err != nil {
+		// No credentials means no PID to register and none to refuse by
+		// name. Counted as a refusal so the connection is never invisible.
+		l.refuse(conn, "peer credentials: "+err.Error())
+		return
+	}
+	// Cheapest check first, and before any /proc I/O: a caller that has
+	// exhausted its budget must not be able to spend the listener's time on
+	// the checks either.
+	if !l.admit.admit(uid) {
+		l.mu.Lock()
+		l.stats.throttled++
+		l.stats.lastErr = fmt.Sprintf("uid %d throttled at pid %d; enrolment rate exceeded", uid, pid)
+		l.mu.Unlock()
+		l.reply(conn, enrollReplyRefused)
+		return
+	}
+	if l.requireUID != nil && uid != *l.requireUID {
+		l.refuse(conn, fmt.Sprintf("pid %d has uid %d; this consumer is unprivileged and serves only uid %d",
+			pid, uid, *l.requireUID))
+		return
+	}
+	// Two independent reasons to refuse, both of which mean "this is not a
+	// process whose stacks this consumer walks".
+	if l.pid != 0 && pid != l.pid {
+		l.refuse(conn, fmt.Sprintf("pid %d (uid %d) is not the attached pid %d", pid, uid, l.pid))
+		return
+	}
+	mapped, err := procMapsHaveInode(l.procRoot, pid, l.dev, l.ino)
+	if err != nil {
+		l.refuse(conn, fmt.Sprintf("read maps for pid %d: %v", pid, err))
+		return
+	}
+	if !mapped {
+		l.refuse(conn, fmt.Sprintf("pid %d (uid %d) does not map the shim (dev %d:%d ino %d)",
+			pid, uid, unix.Major(l.dev), unix.Minor(l.dev), l.ino))
+		return
+	}
+
+	l.mu.Lock()
+	l.stats.requests++
+	l.mu.Unlock()
+
+	// The compile. The producer is blocked in its own init for the whole of
+	// it, which is the point: nothing it does can reach a probe until the
+	// reply below goes out.
+	outcome, rerr := l.reg.enroll(pid)
+	switch outcome {
+	case enrollInstalled, enrollAlreadyHeld:
+		l.mu.Lock()
+		l.stats.confirmed++
+		l.mu.Unlock()
+		l.reply(conn, enrollReplyOK)
+	default:
+		// The rendezvous happened and the tables still are not there. The
+		// producer is released rather than parked - see the file comment -
+		// and every stack it goes on to take is counted twice, once in
+		// StacksWalkedNoTables and once in StacksNoTablesAfterEnroll.
+		msg := "registration installed nothing"
+		if rerr != nil {
+			msg = rerr.Error()
+		}
+		l.mu.Lock()
+		l.stats.failed++
+		l.stats.lastErr = msg
+		l.mu.Unlock()
+		l.reply(conn, enrollReplyRefused)
+	}
+}
+
+// refuse turns a connection away without registering anything: it is not a
+// producer this consumer is responsible for, or it could not be identified.
+func (l *enrollListener) refuse(conn *net.UnixConn, reason string) {
+	l.mu.Lock()
+	l.stats.refused++
+	l.stats.lastErr = reason
+	l.mu.Unlock()
+	l.reply(conn, enrollReplyRefused)
+}
+
+// reply hands the producer its status byte. A failed write is not worth
+// retrying: the producer's own timeout releases it either way.
+func (l *enrollListener) reply(conn *net.UnixConn, b byte) {
+	_ = conn.SetWriteDeadline(time.Now().Add(enrollReplyTimeout))
+	_, _ = conn.Write([]byte{b})
+}
+
+// snapshot copies the counters out for Stats.
+func (l *enrollListener) snapshot() enrollStats {
+	if l == nil {
+		return enrollStats{}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.stats
+}
+
+// close stops accepting and waits for the goroutine. Safe on a nil listener
+// (Attach could not bind one) and idempotent.
+func (l *enrollListener) close() error {
+	if l == nil {
+		return nil
+	}
+	err := l.ln.Close()
+	l.wg.Wait()
+	if errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+// enrollRequiredUID returns the single peer uid this consumer will serve, or
+// nil when it will serve any.
+//
+// The uid is deliberately NOT a blanket authorisation check. A root profiler
+// legitimately profiles processes belonging to other users - refusing
+// anything but its own euid would turn the rendezvous off in the commonest
+// production shape and silently restore the pre-#49 loss. What authorises a
+// peer in general is procMapsHaveInode: it maps the very inode this
+// consumer's uprobes are attached to.
+//
+// The exception is strictly additive. A consumer running as a non-root user
+// WITHOUT CAP_SYS_PTRACE cannot read another user's /proc/<pid>/maps at all,
+// so it could never have served that producer: pinning it to its own uid
+// refuses nothing it could have done, and closes the rendezvous to every
+// other local user on a multi-user box. Privileged consumers - root, or
+// setcap'd with CAP_SYS_PTRACE - keep the inode check alone.
+//
+// Permitted as well as Effective, for the same reason perfagent's
+// hasCapSysPtrace checks both: a setcap'd binary has not promoted Permitted
+// yet, and gating on Effective alone would misread it as unprivileged.
+func enrollRequiredUID() *uint32 {
+	if os.Geteuid() == 0 {
+		return nil
+	}
+	if caps := cap.GetProc(); caps != nil {
+		for _, flag := range []cap.Flag{cap.Permitted, cap.Effective} {
+			if have, err := caps.GetFlag(flag, cap.SYS_PTRACE); err == nil && have {
+				return nil
+			}
+		}
+	}
+	uid := uint32(os.Geteuid())
+	return &uid
+}
+
+// enrollPeerCreds reads the connecting process's PID and uid out of
+// SO_PEERCRED. The kernel stamps both at connect time from the peer's own
+// task, so neither can be forged by anything the peer sends.
+//
+// The uid is the accounting key for the rate limiter, a name in the error
+// string when something is refused, and - only for an unprivileged consumer -
+// the check in enrollRequiredUID.
+func enrollPeerCreds(conn *net.UnixConn) (pid, uid uint32, err error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return 0, 0, err
+	}
+	var ucred *unix.Ucred
+	var inner error
+	if cerr := raw.Control(func(fd uintptr) {
+		ucred, inner = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	}); cerr != nil {
+		return 0, 0, cerr
+	}
+	if inner != nil {
+		return 0, 0, inner
+	}
+	if ucred == nil || ucred.Pid <= 0 {
+		return 0, 0, errors.New("no peer pid")
+	}
+	return uint32(ucred.Pid), ucred.Uid, nil
+}
+
+// procMapsHaveInode reports whether pid maps the file identified by dev and
+// ino. This is the same identity a uprobe attaches to, so it answers exactly
+// the question that matters: is this a process whose probes this consumer
+// armed?
+//
+// procRoot is a parameter so the parsing can be tested against a fixture
+// without a live process of a known layout.
+func procMapsHaveInode(procRoot string, pid uint32, dev, ino uint64) (bool, error) {
+	f, err := os.Open(fmt.Sprintf("%s/%d/maps", procRoot, pid))
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+	wantMaj, wantMin := unix.Major(dev), unix.Minor(dev)
+	sc := bufio.NewScanner(f)
+	// A CUDA process's maps is a few hundred lines; the default 64KiB token
+	// limit is far past the longest of them.
+	for sc.Scan() {
+		// 7fc9a0a00000-7fc9a0a21000 r-xp 00001000 08:02 4242 /lib/libshim.so
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 5 {
+			continue
+		}
+		gotIno, err := strconv.ParseUint(fields[4], 10, 64)
+		// Inode 0 is an anonymous mapping - the stack, the heap, a private
+		// arena. No uprobe can be attached to one, so it can never be the
+		// shim, and matching it would turn "the shim is not mapped" into
+		// "the shim is mapped" for any caller that passed a zero inode.
+		if err != nil || gotIno == 0 || gotIno != ino {
+			continue
+		}
+		maj, min, ok := parseMapsDev(fields[3])
+		if !ok || maj != wantMaj || min != wantMin {
+			continue
+		}
+		return true, nil
+	}
+	return false, sc.Err()
+}
+
+// parseMapsDev splits the "major:minor" field of a /proc/<pid>/maps line,
+// which is hex, into the decimal numbers unix.Major/unix.Minor produce.
+func parseMapsDev(field string) (uint32, uint32, bool) {
+	maj, min, ok := strings.Cut(field, ":")
+	if !ok {
+		return 0, 0, false
+	}
+	mj, err := strconv.ParseUint(maj, 16, 32)
+	if err != nil {
+		return 0, 0, false
+	}
+	mn, err := strconv.ParseUint(min, 16, 32)
+	if err != nil {
+		return 0, 0, false
+	}
+	return uint32(mj), uint32(mn), true
+}

--- a/gpuprobe/enroll_test.go
+++ b/gpuprobe/enroll_test.go
@@ -1,0 +1,606 @@
+package gpuprobe
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/sys/unix"
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+)
+
+// The rendezvous is tested against a real socket and this test binary's own
+// process, not against a mock of either. That is deliberate: the property
+// under test - "the reply does not go out until the tables are installed" -
+// lives in the ordering of two real operations, and the identity check it
+// depends on (does the peer map the shim inode?) is exactly the kind of thing
+// a mock would agree with while the real /proc parser disagreed.
+//
+// The trick that makes it possible without CAP_BPF or a GPU: point the
+// listener at /proc/self/exe. The test binary genuinely maps that inode, so
+// the peer check passes for real, and the registrar behind the registry is
+// the same fake the rest of gpuprobe's unwind tests use.
+
+// selfExe is the shim path a test listener attaches to: this process's own
+// executable, which this process therefore provably maps.
+func selfExe(t *testing.T) string {
+	t.Helper()
+	p, err := os.Readlink("/proc/self/exe")
+	require.NoError(t, err)
+	return p
+}
+
+// testEnrollListener binds a listener over a fake registrar and tears both
+// down with the test, so a leaked goroutine or a leaked abstract address
+// fails the next run rather than this one.
+func testEnrollListener(t *testing.T, shimPath string, pid int, reg pidRegistrar) (*enrollListener, *pidRegistry) {
+	t.Helper()
+	r := newPIDRegistry(reg, 0)
+	t.Cleanup(r.close)
+	l, err := newEnrollListener(Config{ShimPath: shimPath, PID: pid}, r)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.close() })
+	return l, r
+}
+
+// dialEnroll connects to a listener the way the shim does and returns the
+// status byte, or 0 if the connection was closed without one.
+func dialEnroll(t *testing.T, shimPath string) byte {
+	t.Helper()
+	addr, err := enrollAddress(shimPath)
+	require.NoError(t, err)
+	conn, err := net.DialTimeout("unix", addr, 2*time.Second)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	require.NoError(t, conn.SetDeadline(time.Now().Add(5*time.Second)))
+	var b [1]byte
+	n, err := conn.Read(b[:])
+	if err != nil || n != 1 {
+		return 0
+	}
+	return b[0]
+}
+
+// The address is a pure function of the shim's identity on disk, which is
+// what lets the two ends agree without exchanging anything - and what keeps
+// two consumers watching two copies of the same shim apart. The gate makes a
+// private copy of the stub per run for exactly that reason.
+func TestTheRendezvousAddressIsTheShimsDeviceAndInode(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "shim-a")
+	b := filepath.Join(dir, "shim-b")
+	require.NoError(t, os.WriteFile(a, []byte("a"), 0o600))
+	require.NoError(t, os.WriteFile(b, []byte("b"), 0o600))
+
+	addrA, err := enrollAddress(a)
+	require.NoError(t, err)
+	addrB, err := enrollAddress(b)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, addrA, addrB,
+		"two copies of a shim must not share a rendezvous: a consumer would then release a producer whose tables it never installed")
+
+	again, err := enrollAddress(a)
+	require.NoError(t, err)
+	assert.Equal(t, addrA, again, "the address must be stable for one file")
+
+	// The exact spelling is an ABI with shim/core/enroll.cc, which builds it
+	// from the decimal major/minor and inode it reads out of
+	// /proc/self/maps. Pin it here so a change on this side cannot silently
+	// stop matching the producer.
+	var st unix.Stat_t
+	require.NoError(t, unix.Stat(a, &st))
+	dev := uint64(st.Dev) //nolint:unconvert // matches enrollAddress
+	assert.Equal(t,
+		"@perfagent-gpu-enroll.v1."+itoa(uint64(unix.Major(dev)))+"."+itoa(uint64(unix.Minor(dev)))+"."+itoa(st.Ino),
+		addrA)
+
+	_, err = enrollAddress(filepath.Join(dir, "not-there"))
+	assert.Error(t, err, "an unstattable shim has no address, and Attach must hear about it")
+}
+
+// The property the whole change rests on: the producer is not released until
+// its tables are installed. A registrar that has not returned cannot have
+// been followed by a reply.
+func TestTheProducerIsNotReleasedUntilItsTablesAreInstalled(t *testing.T) {
+	shim := selfExe(t)
+	fake := newFakeRegistrar()
+	fake.gate = make(chan struct{})
+	l, _ := testEnrollListener(t, shim, 0, fake)
+
+	replied := make(chan byte, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		replied <- dialEnroll(t, shim)
+	}()
+
+	// The registrar is wedged, so no reply may have gone out.
+	select {
+	case b := <-replied:
+		t.Fatalf("released with %q while registration was still running", b)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(fake.gate)
+	select {
+	case b := <-replied:
+		assert.Equal(t, byte(enrollReplyOK), b)
+	case <-time.After(5 * time.Second):
+		t.Fatal("never released after registration finished")
+	}
+	wg.Wait()
+
+	assert.Equal(t, []uint32{uint32(os.Getpid())}, fake.registeredPIDs(),
+		"the PID registered must be the one SO_PEERCRED reported, not one the peer sent")
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.requests)
+	assert.Equal(t, uint64(1), st.confirmed)
+	assert.Zero(t, st.refused)
+	assert.Zero(t, st.failed)
+}
+
+// A second rendezvous for a PID that already holds tables must not recompile
+// them. ehmaps.PIDTracker.Attach appends mappings and takes a table reference
+// every call, so a repeat would duplicate both - and the rendezvous address
+// is reachable by anything on the machine, so "a repeat" is not hypothetical.
+func TestASecondRendezvousDoesNotRecompile(t *testing.T) {
+	shim := selfExe(t)
+	fake := newFakeRegistrar()
+	l, r := testEnrollListener(t, shim, 0, fake)
+
+	assert.Equal(t, byte(enrollReplyOK), dialEnroll(t, shim))
+	assert.Equal(t, byte(enrollReplyOK), dialEnroll(t, shim))
+
+	assert.Len(t, fake.registeredPIDs(), 1,
+		"the second rendezvous recompiled: mappings and table references would both be duplicated")
+	assert.Equal(t, uint64(2), l.snapshot().confirmed,
+		"both producers were still told the tables are there, because they are")
+	assert.True(t, r.ready(uint32(os.Getpid())))
+}
+
+// A registration that installs nothing releases the producer anyway - a
+// degraded profile is never turned into no profile - and says so, both in the
+// reply byte and in the counters.
+func TestAFailedRegistrationStillReleasesTheProducer(t *testing.T) {
+	shim := selfExe(t)
+	fake := newFakeRegistrar()
+	fake.binaries = 0 // registers, installs nothing
+	l, r := testEnrollListener(t, shim, 0, fake)
+
+	assert.Equal(t, byte(enrollReplyRefused), dialEnroll(t, shim))
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.requests)
+	assert.Equal(t, uint64(1), st.failed)
+	assert.Zero(t, st.confirmed)
+	assert.NotEmpty(t, st.lastErr)
+
+	// And the PID is marked enrolled even though it has no tables, which is
+	// what makes StacksNoTablesAfterEnroll count this case instead of
+	// letting it hide in the ordinary startup population.
+	pid := uint32(os.Getpid())
+	assert.True(t, r.enrolled(pid))
+	assert.False(t, r.ready(pid))
+}
+
+// The identity check: a peer that does not map the shim this consumer
+// attached to is refused without any registration at all. Without it, any
+// local process could make a root profiler compile CFI for a PID of its
+// choosing.
+func TestAPeerThatDoesNotMapTheShimIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "some-other-shim")
+	require.NoError(t, os.WriteFile(shim, []byte("not mapped by anyone"), 0o600))
+
+	fake := newFakeRegistrar()
+	l, _ := testEnrollListener(t, shim, 0, fake)
+
+	assert.Equal(t, byte(enrollReplyRefused), dialEnroll(t, shim))
+	assert.Empty(t, fake.registeredPIDs(), "a refused peer must cost no compile at all")
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.refused)
+	assert.Zero(t, st.requests)
+	assert.Contains(t, st.lastErr, "does not map the shim")
+}
+
+// A per-PID attach filters its uprobes to one process; the rendezvous address
+// cannot be filtered the same way, so the listener has to do it.
+func TestAPerPIDConsumerRefusesEveryOtherPID(t *testing.T) {
+	shim := selfExe(t)
+	fake := newFakeRegistrar()
+	// Some PID that is not ours.
+	l, _ := testEnrollListener(t, shim, os.Getpid()+1, fake)
+
+	assert.Equal(t, byte(enrollReplyRefused), dialEnroll(t, shim))
+	assert.Empty(t, fake.registeredPIDs())
+	assert.Contains(t, l.snapshot().lastErr, "is not the attached pid")
+}
+
+// Closing the consumer releases a producer that is still waiting, rather than
+// leaving it parked on a socket nobody serves.
+func TestCloseReleasesAWaitingProducer(t *testing.T) {
+	shim := selfExe(t)
+	fake := newFakeRegistrar()
+	fake.gate = make(chan struct{})
+	l, _ := testEnrollListener(t, shim, 0, fake)
+
+	got := make(chan byte, 1)
+	go func() { got <- dialEnroll(t, shim) }()
+
+	// Let the handler reach the wedged registrar, then let it through and
+	// close underneath the reply.
+	time.Sleep(100 * time.Millisecond)
+	close(fake.gate)
+	require.NoError(t, l.close())
+
+	select {
+	case <-got:
+		// Either a status byte or a 0 for "closed without one"; both mean
+		// the producer is running again, which is the requirement.
+	case <-time.After(5 * time.Second):
+		t.Fatal("a producer stayed parked after the consumer closed")
+	}
+}
+
+// Two consumers cannot both own one shim's rendezvous. The second is told so
+// rather than silently shadowing the first, because a consumer that thinks it
+// has a rendezvous and does not is the failure mode #49 is about.
+func TestASecondListenerForTheSameShimIsRefused(t *testing.T) {
+	shim := selfExe(t)
+	testEnrollListener(t, shim, 0, newFakeRegistrar())
+
+	r := newPIDRegistry(newFakeRegistrar(), 0)
+	t.Cleanup(r.close)
+	_, err := newEnrollListener(Config{ShimPath: shim}, r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bind")
+}
+
+// The /proc/<pid>/maps parser, against a fixture: the device is hex in /proc
+// and decimal in every other API, and getting that wrong would refuse every
+// genuine producer while looking like a working identity check.
+func TestProcMapsInodeMatchIsDeviceAware(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "77"), 0o755))
+	maps := "" +
+		"55e0d0a00000-55e0d0a01000 r--p 00000000 fd:01 100 /bin/thing\n" +
+		"7fc9a0a00000-7fc9a0a21000 r-xp 00001000 08:02 4242 /lib/libshim.so\n" +
+		"7ffd00000000-7ffd00021000 rw-p 00000000 00:00 0 [stack]\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, "77", "maps"), []byte(maps), 0o600))
+
+	dev := func(maj, min uint32) uint64 { return unix.Mkdev(maj, min) }
+
+	ok, err := procMapsHaveInode(root, 77, dev(8, 2), 4242)
+	require.NoError(t, err)
+	assert.True(t, ok, "08:02 in /proc is major 8 minor 2, not 8 and 2 read as decimal from elsewhere")
+
+	ok, err = procMapsHaveInode(root, 77, dev(253, 1), 100)
+	require.NoError(t, err)
+	assert.True(t, ok, "fd:01 is major 253 minor 1")
+
+	// Right inode, wrong device: two filesystems can each have inode 4242.
+	ok, err = procMapsHaveInode(root, 77, dev(9, 2), 4242)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	ok, err = procMapsHaveInode(root, 77, dev(8, 2), 4243)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// The anonymous line must never match inode 0 for a shim that is not
+	// there.
+	ok, err = procMapsHaveInode(root, 77, dev(0, 0), 0)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	_, err = procMapsHaveInode(root, 78, dev(8, 2), 4242)
+	assert.Error(t, err, "a process that has exited must be an error, not a silent false")
+}
+
+// itoa without importing strconv into the assertion above, kept local so the
+// pinned address string reads as one expression.
+func itoa(v uint64) string {
+	if v == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for v > 0 {
+		i--
+		b[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(b[i:])
+}
+
+// The one seam neither side's own tests can cover: the wire.
+//
+// The rendezvous has no negotiation in it. The producer computes the socket
+// name from /proc/self/maps in C++ (shim/core/enroll.cc) and the consumer
+// computes it from stat(2) in Go (enrollAddress), and if the two spellings
+// ever diverge every producer silently takes the pre-#49 lazy path - with no
+// error anywhere, because "nobody is listening" is also what an unprofiled
+// process sees. The same goes for the reply byte.
+//
+// So this builds a real producer out of shim/core, points a real listener at
+// it, and runs it. It needs no BPF, no GPU and no privilege: the producer
+// calls the rendezvous directly instead of waiting for a probe semaphore to
+// arm it.
+func TestTheCppProducerAndTheGoListenerAgreeOnTheWire(t *testing.T) {
+	cxx, err := exec.LookPath("c++")
+	if err != nil {
+		t.Skip("no c++ in PATH; this test builds the shim's producer half")
+	}
+	core, err := filepath.Abs(filepath.Join("..", "shim", "core"))
+	require.NoError(t, err)
+	if _, err := os.Stat(filepath.Join(core, "enroll.cc")); err != nil {
+		t.Skipf("shim/core not present: %v", err)
+	}
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "producer.cc")
+	require.NoError(t, os.WriteFile(src, []byte(`
+#include "enroll.h"
+#include <cstdio>
+int main() {
+    // Unconditional: in a real producer this is gated on the sampled-launch
+    // probe's semaphore, which needs a live uprobe to arm.
+    printf("%s\n", perfagent::enroll_result_name(
+        perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(5000))));
+    return 0;
+}
+`), 0o600))
+	// Built where the test runs, not in /tmp only, so the binary's device and
+	// inode are ordinary ones; the address embeds both.
+	bin := filepath.Join(dir, "producer")
+	build := exec.Command(cxx, "-std=c++17", "-O2", "-fvisibility=hidden",
+		"-I", core, "-o", bin, src, filepath.Join(core, "enroll.cc"))
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Skipf("could not build the producer half: %v\n%s", err, out)
+	}
+
+	fake := newFakeRegistrar()
+	l, r := testEnrollListener(t, bin, 0, fake)
+
+	run := exec.Command(bin)
+	out, err := run.Output()
+	require.NoError(t, err, "producer failed: %s", out)
+
+	assert.Equal(t, "confirmed\n", string(out),
+		"the producer did not get a confirmation. Either the two ends spell the socket name differently - C++ builds it from /proc/self/maps, Go from stat(2) - or the reply byte changed on one side only")
+
+	// And the consumer registered the process that was waiting, not some
+	// other one: the PID came from SO_PEERCRED, and the producer sent no
+	// payload at all.
+	pids := fake.registeredPIDs()
+	require.Len(t, pids, 1)
+	assert.Equal(t, uint64(1), l.snapshot().confirmed)
+	assert.True(t, r.ready(pids[0]))
+	assert.True(t, r.enrolled(pids[0]))
+	assert.NotEqual(t, uint32(os.Getpid()), pids[0],
+		"the registered PID is the test's own: the peer lookup is not reading the peer")
+}
+
+// The rendezvous serves one producer at a time, so the cost of admitting one
+// is the cost of blocking every other. Any local user who can map the shim
+// could otherwise fork-loop enrolments, occupy the single goroutine, and
+// expire genuine producers' budgets - which puts them back on the pre-#49
+// lazy path, i.e. it is an attack on the fix itself.
+func TestOneUIDCannotMonopoliseTheRendezvous(t *testing.T) {
+	now := time.Now()
+	a := newEnrollAdmission(func() time.Time { return now })
+
+	admitted := 0
+	for range enrollUIDBurst * 4 {
+		if a.admit(1000) {
+			admitted++
+		}
+	}
+	assert.Equal(t, enrollUIDBurst, admitted,
+		"one uid spent more than its burst without any time passing")
+
+	// A different uid is unaffected: the throttled one must not have drained
+	// the shared bucket on requests it was never granted.
+	assert.True(t, a.admit(1001),
+		"a second uid was refused because the first exhausted itself")
+
+	// And the bucket refills with time rather than resetting on a boundary.
+	now = now.Add(time.Second)
+	refilled := 0
+	for range enrollUIDBurst * 2 {
+		if a.admit(1000) {
+			refilled++
+		}
+	}
+	assert.Equal(t, enrollUIDBurst, refilled)
+}
+
+// The listener-wide bucket bounds a spray across many uids, which one per-uid
+// bucket alone cannot.
+func TestManyUIDsTogetherAreStillBounded(t *testing.T) {
+	now := time.Now()
+	a := newEnrollAdmission(func() time.Time { return now })
+	admitted := 0
+	for uid := uint32(0); uid < 200; uid++ {
+		for range 4 {
+			if a.admit(uid) {
+				admitted++
+			}
+		}
+	}
+	assert.LessOrEqual(t, admitted, enrollTotalBurst,
+		"a spray across uids escaped the listener-wide bound")
+	assert.Positive(t, admitted)
+}
+
+// The defence must not become the exhaustion: the per-uid table is bounded
+// too, and past the bound everything falls back to the shared bucket.
+func TestThePerUIDTableIsBounded(t *testing.T) {
+	now := time.Now()
+	a := newEnrollAdmission(func() time.Time { return now })
+	for uid := uint32(0); uid < 10_000; uid++ {
+		a.admit(uid)
+	}
+	assert.LessOrEqual(t, len(a.perUID), enrollUIDTrackMax,
+		"the rate limiter's own bookkeeping grew without bound")
+}
+
+// A legitimate burst - several CUDA processes starting together - must not be
+// throttled, or the rate limit would cause the loss it exists to prevent.
+func TestALegitimateBurstOfProducersIsNotThrottled(t *testing.T) {
+	now := time.Now()
+	a := newEnrollAdmission(func() time.Time { return now })
+	for range 16 {
+		require.True(t, a.admit(1000),
+			"16 processes starting at once is an ordinary workload, not an attack")
+	}
+}
+
+// End to end over a real socket: a throttled peer is refused instantly, told
+// so, and costs no /proc read or compile at all.
+func TestAThrottledPeerIsReleasedAndCountedNotServed(t *testing.T) {
+	shim := selfExe(t)
+	fake := newFakeRegistrar()
+	r := newPIDRegistry(fake, 0)
+	t.Cleanup(r.close)
+	// Built but not yet serving: the buckets are drained before any peer can
+	// reach the listener, so nothing touches `admit` except serve().
+	l, err := buildEnrollListener(Config{ShimPath: shim}, r)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.close() })
+	for l.admit.admit(uint32(os.Getuid())) { //nolint:revive // drain until empty
+	}
+	l.start()
+
+	assert.Equal(t, byte(enrollReplyRefused), dialEnroll(t, shim),
+		"a throttled producer must still be released, not left parked")
+	assert.Empty(t, fake.registeredPIDs(), "a throttled peer must cost no compile")
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.throttled)
+	assert.Zero(t, st.requests)
+	assert.Zero(t, st.refused, "throttling is its own outcome, not an identity refusal")
+	assert.Contains(t, st.lastErr, "throttled")
+}
+
+// The per-uid table must not be permanently occupiable by one-shot uids: 64
+// of them would otherwise pin it forever and push every later producer -
+// including the real one - onto the shared bucket alone.
+func TestIdlePerUIDEntriesAreReclaimed(t *testing.T) {
+	now := time.Now()
+	a := newEnrollAdmission(func() time.Time { return now })
+	for uid := uint32(0); uid < enrollUIDTrackMax; uid++ {
+		require.True(t, a.admit(uid))
+	}
+	require.Len(t, a.perUID, enrollUIDTrackMax)
+
+	// A window later every one of those buckets has refilled, so none of them
+	// carries information a fresh bucket would not.
+	now = now.Add(2 * time.Second)
+	require.True(t, a.admit(9999))
+	assert.LessOrEqual(t, len(a.perUID), enrollUIDTrackMax)
+	b, ok := a.perUID[9999]
+	require.True(t, ok, "a new uid was not tracked because the table was full of idle entries")
+	assert.Less(t, b.tokens, float64(enrollUIDBurst),
+		"the new uid must be charged against its own bucket, not waved through")
+
+	// A uid that is ACTIVELY spending is not reclaimed out from under itself.
+	now = now.Add(time.Millisecond)
+	for range enrollUIDBurst {
+		a.admit(7)
+	}
+	spent := a.perUID[7]
+	require.NotNil(t, spent)
+	for uid := uint32(1000); uid < 1000+enrollUIDTrackMax; uid++ {
+		a.admit(uid)
+	}
+	if still, ok := a.perUID[7]; ok {
+		assert.Less(t, still.tokens, float64(enrollUIDBurst),
+			"an actively throttled uid had its bucket reset by the sweep")
+	}
+}
+
+// An unprivileged consumer cannot read another user's /proc/<pid>/maps, so it
+// could never have served that producer; pinning it to its own uid refuses
+// nothing it could have done and closes the rendezvous to every other local
+// user. A privileged one must NOT be pinned, or it would refuse the target in
+// the commonest production shape - root profiler, application as its own user
+// - and silently reinstate the loss #49 is about.
+func TestOnlyAnUnprivilegedConsumerIsPinnedToItsOwnUID(t *testing.T) {
+	got := enrollRequiredUID()
+	if os.Geteuid() == 0 || hasPtraceCap() {
+		assert.Nil(t, got,
+			"a privileged consumer must serve any uid: it legitimately profiles other users' processes")
+		return
+	}
+	require.NotNil(t, got,
+		"an unprivileged consumer must serve only its own uid; it cannot read anyone else's maps anyway")
+	assert.Equal(t, uint32(os.Geteuid()), *got)
+}
+
+// A peer whose uid the listener will not serve is refused before any /proc
+// read, and released.
+func TestAPeerOfAnotherUIDIsRefusedByAnUnprivilegedConsumer(t *testing.T) {
+	shim := selfExe(t)
+	fake := newFakeRegistrar()
+	r := newPIDRegistry(fake, 0)
+	t.Cleanup(r.close)
+	l, err := buildEnrollListener(Config{ShimPath: shim}, r)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.close() })
+	// Force the unprivileged shape regardless of how this test is run.
+	other := uint32(os.Geteuid()) + 1
+	l.requireUID = &other
+	l.start()
+
+	assert.Equal(t, byte(enrollReplyRefused), dialEnroll(t, shim))
+	assert.Empty(t, fake.registeredPIDs(), "a uid-refused peer must cost no compile")
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.refused)
+	assert.Zero(t, st.requests)
+	assert.Contains(t, st.lastErr, "serves only uid")
+}
+
+// hasPtraceCap mirrors enrollRequiredUID's own probe so the test above states
+// the same condition the code does rather than a paraphrase of it.
+func hasPtraceCap() bool {
+	caps := cap.GetProc()
+	if caps == nil {
+		return false
+	}
+	for _, flag := range []cap.Flag{cap.Permitted, cap.Effective} {
+		if have, err := caps.GetFlag(flag, cap.SYS_PTRACE); err == nil && have {
+			return true
+		}
+	}
+	return false
+}
+
+// The uid is an accounting key, not an authorisation check. A root profiler
+// legitimately profiles other users' processes; refusing anything but its own
+// euid would turn the rendezvous off in the commonest production shape.
+func TestAPeerIsAuthorisedByTheShimItMapsNotByItsUID(t *testing.T) {
+	shim := selfExe(t)
+	fake := newFakeRegistrar()
+	testEnrollListener(t, shim, 0, fake)
+
+	// This test process shares the listener's uid, so the uid path cannot
+	// prove much on its own; what it can prove is that the identity that got
+	// the peer in was the shim mapping, by taking the shim away.
+	assert.Equal(t, byte(enrollReplyOK), dialEnroll(t, shim))
+	require.Len(t, fake.registeredPIDs(), 1)
+
+	other := filepath.Join(t.TempDir(), "other-shim")
+	require.NoError(t, os.WriteFile(other, []byte("x"), 0o600))
+	l2, _ := testEnrollListener(t, other, 0, newFakeRegistrar())
+	assert.Equal(t, byte(enrollReplyRefused), dialEnroll(t, other),
+		"same uid, same everything except the mapped inode: that is what must decide")
+	assert.Equal(t, uint64(1), l2.snapshot().refused)
+}

--- a/gpuprobe/gate_test.go
+++ b/gpuprobe/gate_test.go
@@ -186,22 +186,23 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	// has nothing to do with the capture path. Holding the producer open
 	// until the consumer has counted every sampled launch removes the race
 	// instead of papering over it with a longer sleep.
-	// period_us is 1000, not the 200 this gate used through Phase 4a. In
+	// period_us is 1000, not the 200 this gate used through Phase 4a. That
+	// was a workaround for the startup window issue #49 has since closed: in
 	// system-wide mode (Config.PID == 0, which this gate uses because the
-	// producer does not exist at Attach time) the walker's CFI tables for a
-	// process are compiled on the first batch the consumer sees FROM that
-	// process, on a worker goroutine, and that compile takes tens of
-	// milliseconds - it reads .eh_frame out of the producer, libstdc++, libm
-	// and libc. Sampled launches taken before it finishes are walked with no
-	// tables at all and land in StacksWalkedNoTables, which is correct
-	// behaviour and NOT asserted zero below.
+	// producer does not exist at Attach time) the walker's CFI tables used to
+	// be compiled on the first batch the consumer saw FROM that process, so
+	// every launch sampled during the compile was walked with no tables. At
+	// 200us the whole 500-launch run lasted ~100ms against a ~50ms compile
+	// and the split was a coin toss; 1000us stretched the run to ~500ms so
+	// that most captures landed on the right side of it.
 	//
-	// At 200us the whole 500-launch run lasted ~100ms, the same order as the
-	// compile, so the share of launches that got a DWARF walk was a coin
-	// toss. At 1000us the run lasts ~500ms against a ~50ms compile, so the
-	// large majority of the 63 sampled launches are walked with tables
-	// present. Nothing else depends on the period: the sampler is counting
-	// launches, not time, so the 63 below is unchanged.
+	// The producer now blocks in perfagent_stub_run, before its first launch,
+	// until the consumer has installed its tables (shim/core/enroll.h), so
+	// the split is no longer timing-dependent at all and StacksWalkedNoTables
+	// is asserted zero below. The period is left at 1000 anyway: nothing
+	// depends on it - the sampler counts launches, not time, so the 63 below
+	// is unchanged either way - and a slower run is the more demanding one
+	// for every other counter here.
 	cmd := exec.Command(stub, "500", "1000", "8", "10000")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -377,21 +378,58 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	assert.Equal(t, uint64(wantSampled), stats.StacksWalkedDWARF+stats.StacksWalkedFPOnly,
 		"every non-empty capture is counted exactly once as either a DWARF walk or an FP-only walk; a shortfall means captures went uncounted")
 
-	// Deliberately NOT asserted zero, and this is the trap in the shape of
-	// an obvious assertion: in system-wide mode the CFI tables for a process
-	// are compiled after the consumer sees that process's first batch, so
-	// the first sampled launches from a newly-seen producer are legitimately
-	// walked before its tables exist. A small non-zero count here is correct
-	// behaviour. What would be wrong is ALL of them, which is what the
-	// bound below says - and which StacksWalkedDWARF > 0 already implies,
-	// stated separately so the intent survives a future edit.
-	assert.Less(t, stats.StacksWalkedNoTables, uint64(wantSampled),
-		"every single capture was walked without CFI tables: registration never completed for the producer. last registration error: %q",
+	// ---- issue #49: the tables exist before the first probe fires --------
+	//
+	// This assertion was `Less(NoTables, wantSampled)` through Phase 4b, with
+	// a comment calling zero a trap: in system-wide mode the tables were
+	// compiled after the consumer saw the producer's first batch, so the
+	// first sampled launches were legitimately walked before they existed. On
+	// the RTX 3090 that cost ~38% of all sampled stacks (issue #49), and here
+	// it was one or two of the 63.
+	//
+	// It is zero now because the producer no longer races the compile: it
+	// blocks in perfagent_stub_run, before its first launch and therefore
+	// before its first probe, until this consumer has installed its tables
+	// (shim/core/enroll.h, gpuprobe/enroll.go). There is no launch, so no
+	// probe, so no walk, until that is done - so a non-zero count here does
+	// not mean "the timing was unlucky", it means the rendezvous did not
+	// happen or did not do its job, and the counters below say which.
+	assert.Zero(t, stats.StacksWalkedNoTables,
+		"a capture was walked with no CFI tables even though the producer waits for them before it launches anything. enroll: listening=%v requests=%d confirmed=%d refused=%d failed=%d err=%q; registration err=%q",
+		stats.UnwindEnrollListening, stats.UnwindEnrollRequests, stats.UnwindEnrollConfirmed,
+		stats.UnwindEnrollRefused, stats.UnwindEnrollFailed, stats.UnwindEnrollLastError,
 		stats.UnwindLastError)
+	assert.Zero(t, stats.StacksNoTablesAfterEnroll,
+		"the producer was released on a promise that its tables were installed, and a later walk found none: the rendezvous is reporting success it did not deliver")
+	assert.True(t, stats.UnwindEnrollListening,
+		"the rendezvous address could not be bound, so the producer had nothing to wait on and fell back to the pre-#49 lazy path: %q",
+		stats.UnwindEnrollLastError)
+	assert.Equal(t, uint64(1), stats.UnwindEnrollConfirmed,
+		"exactly one producer runs against this private stub copy, and it must have been told its tables are in. requests=%d refused=%d failed=%d err=%q",
+		stats.UnwindEnrollRequests, stats.UnwindEnrollRefused, stats.UnwindEnrollFailed,
+		stats.UnwindEnrollLastError)
+	assert.Zero(t, stats.UnwindEnrollRefused,
+		"a connection was turned away: either the peer credentials were unreadable or the producer did not map the inode this consumer attached to, which cannot be true of the process the uprobes fired in. %q",
+		stats.UnwindEnrollLastError)
+	assert.Zero(t, stats.UnwindEnrollFailed,
+		"the rendezvous ran and installed no tables: %q", stats.UnwindEnrollLastError)
+	assert.Zero(t, stats.UnwindEnrollThrottled,
+		"one producer cannot exceed the rendezvous rate limit; if this fires the limiter is refusing legitimate traffic: %q",
+		stats.UnwindEnrollLastError)
+	assert.Zero(t, stats.UnwindEnrolledPIDsEvicted,
+		"one producer against the default 128-PID bound cannot be evicted, so its tables cannot have been taken back")
+	// The producer's own account of the same exchange, from its stderr. A
+	// consumer-side counter cannot see a producer that never reached the
+	// socket - it would simply never appear - so both ends are checked.
+	assert.Contains(t, stubErr, "enroll=confirmed",
+		"the producer did not get a confirmation before it started launching; it ran on the pre-#49 lazy path")
 	assert.Positive(t, stats.UnwindPIDsRegistered,
 		"the consumer never registered the producer's PID with the walker, so no capture could have had tables to use")
 	assert.Zero(t, stats.UnwindPIDsFailed,
 		"a registration that installed nothing: %q", stats.UnwindLastError)
+	assert.Equal(t, uint64(wantSampled), stats.StacksWalkedDWARF,
+		"every capture should now be a DWARF walk: the tables were installed before the producer launched anything, and the two FP-less bridge frames force the walker onto the CFI path. fp-only=%d no-tables=%d",
+		stats.StacksWalkedFPOnly, stats.StacksWalkedNoTables)
 
 	// StackWalkAbandoned means "the walk stopped because it could not
 	// proceed". Through issue #44 it read 62 here alongside dwarf == 62 -

--- a/gpuprobe/unwindtables.go
+++ b/gpuprobe/unwindtables.go
@@ -2,6 +2,7 @@ package gpuprobe
 
 import (
 	"container/list"
+	"errors"
 	"sync"
 
 	"github.com/dpsoft/perf-agent/unwind/ehmaps"
@@ -104,6 +105,13 @@ type pidRegEntry struct {
 	pid   uint32
 	state pidRegState
 	elem  *list.Element
+	// enrolled records that this PID came through the startup rendezvous
+	// (enrollListener), i.e. that the producer blocked in its own init
+	// waiting for these tables. It exists so a walk that still found no
+	// tables can be told apart from one whose process never enrolled at
+	// all - see Stats.StacksNoTablesAfterEnroll, which is zero by
+	// construction unless the handshake failed to do its job.
+	enrolled bool
 }
 
 // pidWork is one unit of registrar I/O, handed to the worker goroutine.
@@ -117,14 +125,35 @@ type pidWork struct {
 // unwindStats is the registry's slice of gpuprobe.Stats. Kept separate so the
 // registry can be snapshotted under its own lock.
 type unwindStats struct {
-	registered       uint64
-	failed           uint64
-	evicted          uint64
-	requestsDropped  uint64
-	releaseFailed    uint64
-	binariesAttached uint64
-	lastErr          string
+	registered           uint64
+	failed               uint64
+	evicted              uint64
+	enrolledEvicted      uint64
+	enrolledMarksDropped uint64
+	requestsDropped      uint64
+	releaseFailed        uint64
+	binariesAttached     uint64
+	lastErr              string
 }
+
+// enrollOutcome is what the rendezvous decided for one connecting producer.
+type enrollOutcome uint8
+
+const (
+	// enrollInstalled: the tables were compiled and installed by this call.
+	enrollInstalled enrollOutcome = iota
+	// enrollAlreadyHeld: the walker already had tables for this PID, so
+	// nothing was recompiled. ehmaps.PIDTracker.Attach accumulates mappings
+	// and takes a table reference every time it is called, so a second
+	// registration for the same PID would duplicate both.
+	enrollAlreadyHeld
+	// enrollInFlight: another path (the lazy worker) is registering this PID
+	// right now. The producer is released without a promise, because the
+	// registry cannot honestly make one.
+	enrollInFlight
+	// enrollFailed: registration ran and installed nothing.
+	enrollFailed
+)
 
 // pidRegistry decides which PIDs get CFI tables, and bounds the set.
 //
@@ -134,11 +163,25 @@ type unwindStats struct {
 //     so the tables are in place before the probe can fire even once. This is
 //     the eager path, and it is what unwind/dwarfagent does for a per-PID
 //     profiler (mode is forced to ModeEager there for the same reason).
+//
 //   - Config.PID == 0 (system-wide, the documented default). The target
 //     process may not exist at Attach time - the gate's stub is launched after
 //     Attach, because the shim only emits once the uprobe's semaphore says
-//     someone is listening. A PID becomes interesting the first time any batch
-//     arrives from it, and note() requests registration then.
+//     someone is listening. Two things can feed the registry here, and only
+//     one of them is in time:
+//
+//     enroll(), from the startup rendezvous (enroll.go). The producer blocks
+//     in its own initialisation - before its first launch, and therefore
+//     before its first probe - until this call has installed its tables. This
+//     is the #49 fix, and it is the only path that puts tables in the maps
+//     before the kernel-side walk needs them.
+//
+//     note(), on the first batch from a PID. The fallback, for a producer
+//     that never reached the rendezvous (it was already running when the
+//     consumer attached, or the socket was unavailable). Everything sampled
+//     during the compile it starts is walked without tables; that is the
+//     ~38% loss issue #49 measured, and it is what Stats.StacksWalkedNoTables
+//     still counts, truthfully.
 //
 // Registration is NOT done on the caller's goroutine in the lazy case. It is
 // ehcompile.Compile per binary, and that is not free: measured on this branch,
@@ -163,11 +206,37 @@ type pidRegistry struct {
 	work     chan pidWork
 	wg       sync.WaitGroup
 
-	mu     sync.Mutex
-	byPID  map[uint32]*pidRegEntry
-	lru    *list.List // front = most recently seen
-	stats  unwindStats
-	closed bool
+	mu    sync.Mutex
+	byPID map[uint32]*pidRegEntry
+	lru   *list.List // front = most recently seen
+	// wasEnrolled remembers PIDs that completed the startup rendezvous and
+	// were later evicted from byPID.
+	//
+	// Without it the enrolled mark dies with the entry, and the one case
+	// StacksNoTablesAfterEnroll exists to catch - "we promised a producer its
+	// tables and then took them back" - reads as zero while
+	// StacksWalkedNoTables climbs. That is this project's signature defect
+	// (a counter green exactly when things are worst) inside the counter
+	// added to prevent it.
+	//
+	// Bounded FIFO, same order of size as the registry itself, so it cannot
+	// grow with a profiled machine's process churn. The bound's cost is a
+	// false NEGATIVE for a PID whose mark has aged out, counted in
+	// Stats.UnwindEnrolledMarksDropped so the under-report is never silent;
+	// PID recycling can produce a false POSITIVE, which UnwindEnrolledPIDsEvicted
+	// is the cross-check for. See rememberEnrolledLocked for why it fills per
+	// enrolment rather than per eviction.
+	wasEnrolled     map[uint32]struct{}
+	wasEnrolledFIFO *list.List
+	// wasEnrolledCap bounds it. Deliberately larger than the registry's own
+	// capacity: the set is fed once per ENROLMENT and once per eviction of an
+	// enrolled PID, so sizing it equal to the LRU made the two churn against
+	// each other and aged marks out roughly twice as fast as evictions
+	// happened. A multiple leaves an evicted PID's mark comfortably alive
+	// while it is the thing the counter needs to see.
+	wasEnrolledCap int
+	stats          unwindStats
+	closed         bool
 }
 
 const (
@@ -180,6 +249,14 @@ const (
 	// shared CFI table, so the real memory is dominated by the distinct
 	// binaries, which PIDs share.
 	defaultUnwindPIDCapacity = 128
+
+	// enrolledMarkOvercommit sizes the evicted-enrolment memory relative to
+	// the PID capacity. See pidRegistry.wasEnrolledCap: at 1x the set churned
+	// against the LRU itself and dropped marks about twice as fast as
+	// evictions occurred, which is under-reporting in the one counter that
+	// must not under-report silently. Four PIDs' worth of marks per tracked
+	// PID is a few kilobytes at the default capacity.
+	enrolledMarkOvercommit = 4
 
 	// unwindWorkDepth is the registrar work queue. Requests are one per
 	// distinct PID, not one per record, so this is deep enough to absorb a
@@ -195,11 +272,14 @@ func newPIDRegistry(reg pidRegistrar, capacity int) *pidRegistry {
 		capacity = defaultUnwindPIDCapacity
 	}
 	r := &pidRegistry{
-		reg:      reg,
-		capacity: capacity,
-		work:     make(chan pidWork, unwindWorkDepth),
-		byPID:    map[uint32]*pidRegEntry{},
-		lru:      list.New(),
+		reg:             reg,
+		capacity:        capacity,
+		work:            make(chan pidWork, unwindWorkDepth),
+		byPID:           map[uint32]*pidRegEntry{},
+		lru:             list.New(),
+		wasEnrolled:     map[uint32]struct{}{},
+		wasEnrolledFIFO: list.New(),
+		wasEnrolledCap:  capacity * enrolledMarkOvercommit,
 	}
 	r.wg.Add(1)
 	go r.run()
@@ -229,7 +309,7 @@ func (r *pidRegistry) note(pid uint32) bool {
 	if r.closed {
 		return false
 	}
-	e := &pidRegEntry{pid: pid, state: pidPending}
+	e := &pidRegEntry{pid: pid, state: pidPending, enrolled: r.wasEnrolledLocked(pid)}
 	e.elem = r.lru.PushFront(e)
 	r.byPID[pid] = e
 	r.evictLocked()
@@ -259,6 +339,14 @@ func (r *pidRegistry) evictLocked() {
 		}
 		delete(r.byPID, ve.pid)
 		r.stats.evicted++
+		if ve.enrolled {
+			// A producer we released on the promise that its tables were
+			// installed, whose tables we are now taking back. Counted, and
+			// remembered, so its next tableless walk is not read as an
+			// ordinary startup transient.
+			r.stats.enrolledEvicted++
+			r.rememberEnrolledLocked(ve.pid)
+		}
 		// Only a PID that actually holds tables has anything to release. A
 		// pending one is handled by the worker, which finds it gone and
 		// releases whatever it just installed (see run).
@@ -297,13 +385,144 @@ func (r *pidRegistry) registerNow(pid uint32) (int, error) {
 	defer r.mu.Unlock()
 	e, ok := r.byPID[pid]
 	if !ok {
-		e = &pidRegEntry{pid: pid, state: pidPending}
+		e = &pidRegEntry{pid: pid, state: pidPending, enrolled: r.wasEnrolledLocked(pid)}
 		e.elem = r.lru.PushFront(e)
 		r.byPID[pid] = e
 	}
 	r.recordLocked(e, n, err)
 	r.evictLocked()
 	return n, err
+}
+
+// wasEnrolledLocked reports whether pid completed the rendezvous before it was
+// evicted. Caller holds mu.
+func (r *pidRegistry) wasEnrolledLocked(pid uint32) bool {
+	_, ok := r.wasEnrolled[pid]
+	return ok
+}
+
+// rememberEnrolledLocked records a PID's rendezvous so the mark can outlive
+// its registry entry. Bounded FIFO. Caller holds mu.
+//
+// Note that it fills once per ENROLMENT, not once per eviction: enroll()
+// records the PID before it starts compiling, because that entry can be
+// evicted while its tables are still being built and the mark has to survive
+// that. So the set holds the last `capacity` enrolled PIDs, and a mark ages
+// out after `capacity` further enrolments rather than after `capacity`
+// evictions. Every mark that falls off the end is counted
+// (Stats.UnwindEnrolledMarksDropped): the consequence is that
+// StacksNoTablesAfterEnroll under-reports for that PID, and a silent
+// under-report in this particular counter is exactly the failure it exists
+// to prevent.
+func (r *pidRegistry) rememberEnrolledLocked(pid uint32) {
+	if _, ok := r.wasEnrolled[pid]; ok {
+		return
+	}
+	r.wasEnrolled[pid] = struct{}{}
+	r.wasEnrolledFIFO.PushFront(pid)
+	for r.wasEnrolledFIFO.Len() > r.wasEnrolledCap {
+		back := r.wasEnrolledFIFO.Back()
+		if back == nil {
+			return
+		}
+		r.wasEnrolledFIFO.Remove(back)
+		if old, ok := back.Value.(uint32); ok {
+			delete(r.wasEnrolled, old)
+			r.stats.enrolledMarksDropped++
+		}
+	}
+}
+
+// enroll installs pid's tables for the startup rendezvous and reports what it
+// found. Called on the enrollListener's goroutine, with a producer blocked in
+// its own initialisation waiting for the answer, which is the whole point:
+// the compile happens while nothing has launched yet.
+//
+// Not the same call as registerNow, for two reasons that both bite:
+//
+//   - It claims the registry entry BEFORE the compile, so a batch that
+//     arrives mid-compile (Consumer.applyBatch -> note) sees a known PID and
+//     does not queue a second registration for it. Two registrations for one
+//     PID would duplicate its pid_mappings rows and double the reference it
+//     holds on every shared CFI table.
+//   - It never recompiles a PID the walker already has tables for. Repeat
+//     connections - a producer that re-enrolls, or anything else that reaches
+//     the socket - therefore cost a map lookup, not a libcuda compile.
+//
+// The entry is marked enrolled either way, so a later walk that still finds
+// no tables is counted as the contradiction it is.
+func (r *pidRegistry) enroll(pid uint32) (enrollOutcome, error) {
+	if r == nil || pid == 0 {
+		return enrollFailed, errors.New("gpuprobe: no unwind registry")
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return enrollFailed, errors.New("gpuprobe: consumer is closing")
+	}
+	if e, ok := r.byPID[pid]; ok {
+		e.enrolled = true
+		r.lru.MoveToFront(e.elem)
+		state := e.state
+		r.mu.Unlock()
+		switch state {
+		case pidReady:
+			return enrollAlreadyHeld, nil
+		case pidPending:
+			return enrollInFlight, nil
+		default:
+			return enrollFailed, errors.New("gpuprobe: registration already failed for this pid")
+		}
+	}
+	e := &pidRegEntry{pid: pid, state: pidPending, enrolled: true}
+	e.elem = r.lru.PushFront(e)
+	r.byPID[pid] = e
+	// Recorded before the compile, not after: this entry can be evicted while
+	// its tables are still being built, and the mark has to outlive it.
+	r.rememberEnrolledLocked(pid)
+	r.evictLocked()
+	r.mu.Unlock()
+
+	n, err := r.reg.Register(pid)
+
+	r.mu.Lock()
+	cur := r.byPID[pid]
+	r.recordLocked(cur, n, err)
+	// The bound pushed this PID out while its tables were being compiled;
+	// same hazard, and same remedy, as the worker's evictedMidFlight arm.
+	evictedMidFlight := cur == nil && err == nil && n > 0
+	r.mu.Unlock()
+	if evictedMidFlight {
+		if uerr := r.reg.Unregister(pid); uerr != nil {
+			r.mu.Lock()
+			r.stats.releaseFailed++
+			r.mu.Unlock()
+		}
+		return enrollFailed, errors.New("gpuprobe: pid evicted while its tables were compiling")
+	}
+	if err != nil {
+		return enrollFailed, err
+	}
+	if n == 0 {
+		return enrollFailed, errors.New("gpuprobe: no binary with usable .eh_frame")
+	}
+	return enrollInstalled, nil
+}
+
+// enrolled reports whether pid went through the startup rendezvous. Used only
+// to make StacksNoTablesAfterEnroll mean what it says; see pidRegEntry.
+func (r *pidRegistry) enrolled(pid uint32) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.byPID[pid]; ok {
+		return e.enrolled
+	}
+	// Not tracked right now, but it may have been evicted after a successful
+	// rendezvous - which is precisely the case this counter must not miss.
+	return r.wasEnrolledLocked(pid)
 }
 
 // recordLocked folds one registration outcome into the entry and the counters.
@@ -382,6 +601,17 @@ func (r *pidRegistry) ready(pid uint32) bool {
 	defer r.mu.Unlock()
 	e, ok := r.byPID[pid]
 	return ok && e.state == pidReady
+}
+
+// snapshotTracked is the tracked-PID gauge on its own, for tests that need to
+// observe the moment an entry is claimed.
+func (r *pidRegistry) snapshotTracked() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.byPID)
 }
 
 // snapshot returns the registry's counters plus the current tracked-PID gauge.

--- a/gpuprobe/unwindtables_test.go
+++ b/gpuprobe/unwindtables_test.go
@@ -28,9 +28,23 @@ func newFakeRegistrar() *fakeRegistrar {
 	return &fakeRegistrar{binaries: 3}
 }
 
+// blockFrom makes every subsequent Register wait, so a test can pin the exact
+// moment a registration is still in flight. Safe to call while the registry's
+// worker is running, which is the point: `gate` is read under the same lock.
+func (f *fakeRegistrar) blockFrom() chan struct{} {
+	g := make(chan struct{})
+	f.mu.Lock()
+	f.gate = g
+	f.mu.Unlock()
+	return g
+}
+
 func (f *fakeRegistrar) Register(pid uint32) (int, error) {
-	if f.gate != nil {
-		<-f.gate
+	f.mu.Lock()
+	g := f.gate
+	f.mu.Unlock()
+	if g != nil {
+		<-g
 	}
 	f.mu.Lock()
 	f.registered = append(f.registered, pid)
@@ -346,4 +360,266 @@ func TestAConsumerWithNoRegistryReportsNoTables(t *testing.T) {
 	st := c.Stats()
 	assert.Equal(t, uint64(1), st.StacksWalkedNoTables)
 	assert.Zero(t, st.UnwindPIDsTracked)
+}
+
+// --- Issue #49: the rendezvous path through the registry.
+
+// The rendezvous claims the entry before it starts compiling, so a batch that
+// arrives mid-compile does not queue a second registration for the same PID.
+// Two registrations for one PID would append its mappings twice and take two
+// references on every shared CFI table.
+func TestABatchArrivingMidEnrollDoesNotQueueASecondRegistration(t *testing.T) {
+	f := newFakeRegistrar()
+	f.gate = make(chan struct{})
+	r := testRegistry(t, f, 8)
+
+	done := make(chan enrollOutcome, 1)
+	go func() {
+		o, _ := r.enroll(555)
+		done <- o
+	}()
+
+	// The enroll goroutine is inside Register. note() must see a known PID.
+	require.Eventually(t, func() bool { return r.snapshotTracked() == 1 },
+		2*time.Second, time.Millisecond,
+		"enroll must claim the registry entry before it compiles, not after")
+	assert.False(t, r.note(555),
+		"the PID has no tables yet, and note must say so rather than guess")
+
+	close(f.gate)
+	assert.Equal(t, enrollInstalled, <-done)
+	// Give any wrongly-queued work a chance to run before counting.
+	require.Eventually(t, func() bool { return r.ready(555) }, 2*time.Second, time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, []uint32{555}, f.registeredPIDs(),
+		"the lazy path registered the same PID a second time")
+}
+
+// A PID the walker already has tables for is never recompiled, whichever path
+// asked. This is what makes a repeat rendezvous cost a map lookup rather than
+// a libcuda compile.
+func TestEnrollDoesNotRecompileAPIDThatAlreadyHasTables(t *testing.T) {
+	f := newFakeRegistrar()
+	r := testRegistry(t, f, 8)
+	_, err := r.registerNow(555)
+	require.NoError(t, err)
+
+	o, err := r.enroll(555)
+	require.NoError(t, err)
+	assert.Equal(t, enrollAlreadyHeld, o)
+	assert.Len(t, f.registeredPIDs(), 1)
+	assert.True(t, r.enrolled(555),
+		"the eager path did not mark it; a later tableless walk would then hide in the ordinary startup population")
+}
+
+// A registration that installs nothing still marks the PID enrolled: the
+// producer was released on the strength of this call, so a later tableless
+// walk from it is a contradiction and must be countable as one.
+func TestAFailedEnrollStillMarksThePID(t *testing.T) {
+	f := newFakeRegistrar()
+	f.err = errors.New("no /proc")
+	r := testRegistry(t, f, 8)
+
+	o, err := r.enroll(555)
+	require.Error(t, err)
+	assert.Equal(t, enrollFailed, o)
+	assert.True(t, r.enrolled(555))
+	assert.False(t, r.ready(555))
+}
+
+// enrolled() is only ever true for a PID that went through the rendezvous.
+// A PID registered lazily must NOT be marked, or StacksNoTablesAfterEnroll
+// would count ordinary startup transients as defects.
+func TestALazilyRegisteredPIDIsNotMarkedEnrolled(t *testing.T) {
+	f := newFakeRegistrar()
+	r := testRegistry(t, f, 8)
+	r.note(555)
+	require.Eventually(t, func() bool { return r.ready(555) }, 2*time.Second, time.Millisecond)
+	assert.False(t, r.enrolled(555))
+	assert.False(t, r.enrolled(556), "an unknown PID never enrolled")
+}
+
+// A closing consumer refuses the rendezvous rather than compiling into maps
+// that are about to be closed. The producer is released, not parked.
+func TestEnrollOnAClosedRegistryIsRefused(t *testing.T) {
+	f := newFakeRegistrar()
+	r := newPIDRegistry(f, 8)
+	r.close()
+
+	o, err := r.enroll(555)
+	assert.Equal(t, enrollFailed, o)
+	assert.Error(t, err)
+	assert.Empty(t, f.registeredPIDs())
+}
+
+// The counter that says the fix stopped working: a tableless walk from a PID
+// that DID complete the rendezvous. It is a strict subset of
+// StacksWalkedNoTables, which must keep counting every tableless walk.
+func TestATablelessWalkAfterAnEnrollIsCountedSeparately(t *testing.T) {
+	sink := &recordingSink{}
+	c, sm, _ := stackConsumer(t, sink, Config{})
+	f := newFakeRegistrar()
+	f.err = errors.New("process exited")
+	c.unwind = testRegistry(t, f, 8)
+	_, err := c.unwind.enroll(555)
+	require.Error(t, err)
+
+	walkWithFlags(t, c, sm, 555, 1, 0)
+
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.StacksWalkedNoTables,
+		"the enrolled subset must never be netted out of the honest total")
+	assert.Equal(t, uint64(1), st.StacksNoTablesAfterEnroll,
+		"the producer was released on a promise the registry could not keep, and nothing said so")
+}
+
+// The same walk from a PID that never enrolled is an ordinary startup
+// transient, and must not read as a defect.
+func TestATablelessWalkWithoutAnEnrollIsNotCountedAsADefect(t *testing.T) {
+	sink := &recordingSink{}
+	c, sm, _ := stackConsumer(t, sink, Config{})
+	f := newFakeRegistrar()
+	f.gate = make(chan struct{})
+	c.unwind = newPIDRegistry(f, 8)
+	defer func() {
+		close(f.gate)
+		c.unwind.close()
+	}()
+
+	walkWithFlags(t, c, sm, 555, 1, 0)
+
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.StacksWalkedNoTables)
+	assert.Zero(t, st.StacksNoTablesAfterEnroll)
+}
+
+// Eviction is the one benign way the rendezvous promise gets broken, and it
+// used to be invisible: the enrolled flag lived on the registry entry, and
+// eviction deleted the entry. StacksNoTablesAfterEnroll then read zero while
+// StacksWalkedNoTables climbed - green exactly when things were worst, in the
+// counter added to prevent that.
+func TestAnEnrolledPIDEvictedFromTheBoundKeepsItsMark(t *testing.T) {
+	f := newFakeRegistrar()
+	r := testRegistry(t, f, 1) // room for exactly one PID
+
+	_, err := r.enroll(555)
+	require.NoError(t, err)
+	require.True(t, r.ready(555))
+
+	// A second PID pushes the first out.
+	_, err = r.enroll(556)
+	require.NoError(t, err)
+
+	assert.False(t, r.ready(555), "555 was evicted; its tables are gone")
+	assert.True(t, r.enrolled(555),
+		"the mark died with the entry, so a tableless walk from 555 now reads as an ordinary startup transient")
+
+	st, _ := r.snapshot()
+	assert.Equal(t, uint64(1), st.evicted)
+	assert.Equal(t, uint64(1), st.enrolledEvicted,
+		"the eviction of a PID we had promised must be nameable on its own")
+}
+
+// And the mark survives the PID coming back through the lazy path, which is
+// how it actually returns: note() re-creates the entry on the next batch.
+func TestAnEvictedEnrolledPIDIsStillMarkedWhenItComesBackLazily(t *testing.T) {
+	f := newFakeRegistrar()
+	f.gate = make(chan struct{})
+	r := newPIDRegistry(f, 1)
+	defer func() { close(f.gate); r.close() }()
+
+	go func() { _, _ = r.enroll(555) }()
+	require.Eventually(t, func() bool { return r.enrolled(555) }, 2*time.Second, time.Millisecond)
+
+	// Evict it while its compile is still in flight.
+	r.note(556)
+
+	assert.False(t, r.ready(555))
+	assert.True(t, r.note(555) == false && r.enrolled(555),
+		"555 came back through the lazy path and lost the fact that it had been promised tables")
+}
+
+// The bound on the shadow set is a bound: it must not grow with a profiled
+// machine's process churn.
+func TestTheEnrolledShadowSetIsBounded(t *testing.T) {
+	f := newFakeRegistrar()
+	r := testRegistry(t, f, 2)
+	for pid := uint32(1); pid <= 40; pid++ {
+		_, err := r.enroll(pid)
+		require.NoError(t, err)
+	}
+	r.mu.Lock()
+	n := len(r.wasEnrolled)
+	fifo := r.wasEnrolledFIFO.Len()
+	bound := r.wasEnrolledCap
+	r.mu.Unlock()
+	assert.LessOrEqual(t, n, bound, "the shadow set grew past its bound with process churn")
+	assert.Equal(t, n, fifo, "the map and the FIFO must not drift apart")
+	// The oldest is forgotten, the newest is not: a false negative for an
+	// ancient PID is the safe direction.
+	assert.False(t, r.enrolled(1))
+	assert.True(t, r.enrolled(40))
+
+	// Every forgotten mark is counted, and the books balance: a mark is
+	// either still held or was counted on the way out. An aged-out mark makes
+	// StacksNoTablesAfterEnroll under-report for that PID, and a silent
+	// under-report is precisely what that counter exists to prevent.
+	st, _ := r.snapshot()
+	assert.Equal(t, uint64(40), st.enrolledMarksDropped+uint64(n),
+		"marks vanished without being counted: dropped=%d held=%d of 40 enrolments",
+		st.enrolledMarksDropped, n)
+	assert.Positive(t, st.enrolledMarksDropped, "40 enrolments against a %d-entry set must drop some", bound)
+}
+
+// The mark set is sized ABOVE the PID capacity on purpose: it is fed once per
+// enrolment and again when an enrolled PID is evicted, so at 1x it churned
+// against the LRU and aged marks out about twice as fast as evictions
+// happened - under-reporting the very thing it exists to report.
+func TestTheEnrolledMarkSetOutlivesTheEvictionItMustWitness(t *testing.T) {
+	f := newFakeRegistrar()
+	r := testRegistry(t, f, 2)
+	for pid := uint32(1); pid <= 4; pid++ {
+		_, err := r.enroll(pid)
+		require.NoError(t, err)
+	}
+	// 1 and 2 have been evicted from the registry by now...
+	assert.False(t, r.ready(1))
+	assert.False(t, r.ready(2))
+	// ...and both must still be known to have enrolled, or the walk that
+	// notices their missing tables reads as an ordinary startup transient.
+	assert.True(t, r.enrolled(1), "the mark aged out before the eviction it had to witness")
+	assert.True(t, r.enrolled(2))
+	st, _ := r.snapshot()
+	assert.Zero(t, st.enrolledMarksDropped, "nothing should have aged out this early")
+}
+
+// A tableless walk from a PID whose tables were evicted after a successful
+// rendezvous must be counted as the broken promise it is.
+func TestATablelessWalkAfterAnEnrolledEvictionIsCounted(t *testing.T) {
+	sink := &recordingSink{}
+	c, sm, _ := stackConsumer(t, sink, Config{})
+	f := newFakeRegistrar()
+	c.unwind = testRegistry(t, f, 1)
+	_, err := c.unwind.enroll(555)
+	require.NoError(t, err)
+	_, err = c.unwind.enroll(556) // evicts 555
+	require.NoError(t, err)
+
+	// applyBatch calls note(), which queues a lazy re-registration of 555 on
+	// the worker. Wedge it so the walk below is counted while 555 genuinely
+	// has no tables - otherwise the worker sometimes wins and the test is
+	// asserting a scheduling outcome instead of the counter.
+	gate := f.blockFrom()
+	defer close(gate)
+
+	walkWithFlags(t, c, sm, 555, 1, 0)
+
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.StacksWalkedNoTables)
+	assert.Equal(t, uint64(1), st.StacksNoTablesAfterEnroll)
+	// Not an exact count: re-admitting 555 through note() pushes 556 out in
+	// turn, and both evictions are of enrolled PIDs. What matters is that the
+	// benign explanation for the counter above is readable next to it.
+	assert.Positive(t, st.UnwindEnrolledPIDsEvicted,
+		"an enrolled PID lost its tables to the capacity bound and nothing said so")
 }

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -21,7 +21,7 @@ NVCC ?= $(CUDA_HOME)/bin/nvcc
 # sm_86 is the RTX 3090 this adapter was proven on.
 CUDA_ARCH ?= sm_86
 
-CORE_SRC := core/batch.cc core/clock.cc core/drain.cc core/sampler.cc
+CORE_SRC := core/batch.cc core/clock.cc core/drain.cc core/enroll.cc core/sampler.cc
 CORE_OBJ := $(CORE_SRC:.cc=.o)
 
 .PHONY: all test test-tsan nvidia nvidia-workload clean
@@ -140,10 +140,11 @@ nvidia/testdata/cuda_workload: nvidia/testdata/cuda_workload.cu
 # _Static_asserts are the test. Compiling it only as C++ leaves the C11 spelling
 # unguarded -- which is how the header's validity broke earlier in this branch,
 # when a C++ translation unit included it for the first time.
-test: core/batch_test.cc core/clock_test.cc core/drain_test.cc core/usdt_abi_test.c core/sampler_test.cc core/probe_args_test.cc $(CORE_SRC)
+test: core/batch_test.cc core/clock_test.cc core/drain_test.cc core/enroll_test.cc core/usdt_abi_test.c core/sampler_test.cc core/probe_args_test.cc $(CORE_SRC)
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/batch_test core/batch_test.cc core/batch.cc && /tmp/batch_test
 	$(CXX) -std=c++17 -I core -o /tmp/clock_test core/clock_test.cc core/clock.cc && /tmp/clock_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/drain_test core/drain_test.cc core/drain.cc && /tmp/drain_test
+	$(CXX) -std=c++17 -pthread -I core -o /tmp/enroll_test core/enroll_test.cc core/enroll.cc && /tmp/enroll_test
 	$(CC) -std=c11 -Wall -Werror -I core -o /tmp/usdt_abi_test core/usdt_abi_test.c && /tmp/usdt_abi_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/sampler_test core/sampler_test.cc core/sampler.cc && /tmp/sampler_test
 	$(CXX) -std=c++17 -O2 -Wall -Werror -I core -o /tmp/probe_args_test core/probe_args_test.cc && /tmp/probe_args_test

--- a/shim/core/enroll.cc
+++ b/shim/core/enroll.cc
@@ -1,0 +1,228 @@
+#include "enroll.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+namespace perfagent {
+
+const char *enroll_result_name(EnrollResult r) {
+    switch (r) {
+        case kEnrollDisabled:   return "disabled";
+        case kEnrollNoAddress:  return "no-address";
+        case kEnrollNoListener: return "no-listener";
+        case kEnrollConfirmed:  return "confirmed";
+        case kEnrollRefused:    return "refused";
+        case kEnrollTimedOut:   return "timed-out";
+        case kEnrollError:      return "error";
+    }
+    return "unknown";
+}
+
+bool enroll_name_from_maps(const char *maps_path, unsigned long addr,
+                           char *out, size_t outsz) {
+    if (!out || outsz == 0) return false;
+    out[0] = '\0';
+    FILE *f = fopen(maps_path, "re");
+    if (!f) return false;
+    char line[4096];
+    bool ok = false;
+    while (fgets(line, sizeof(line), f)) {
+        unsigned long lo = 0, hi = 0, off = 0, ino = 0;
+        unsigned maj = 0, min = 0;
+        char perms[8] = {0};
+        // 7fc9a0a00000-7fc9a0a21000 r-xp 00000000 fd:01 1234567  /path/to.so
+        // The device is hex in /proc, and the consumer spells it as the
+        // decimal major/minor of the same st_dev, so it is converted here
+        // rather than passed through.
+        if (sscanf(line, "%lx-%lx %7s %lx %x:%x %lu",
+                   &lo, &hi, perms, &off, &maj, &min, &ino) != 7) {
+            continue;
+        }
+        if (addr < lo || addr >= hi) continue;
+        // An anonymous mapping has nothing the consumer's uprobe could have
+        // attached to, so there is no name to agree on.
+        if (ino == 0) break;
+        const int n = snprintf(out, outsz, "perfagent-gpu-enroll.v1.%u.%u.%lu",
+                               maj, min, ino);
+        ok = n > 0 && (size_t)n < outsz;
+        if (!ok) out[0] = '\0';
+        break;
+    }
+    fclose(f);
+    return ok;
+}
+
+namespace {
+
+// The budget is ONE absolute deadline for the whole rendezvous - connect and
+// reply together - not a per-syscall timeout.
+//
+// Two bugs live in the obvious alternative, and both were measured:
+//
+//   1. A per-call SO_RCVTIMEO is re-armed from zero on every retry. EINTR is
+//      not exotic in a profiled process - a Go runtime's SIGURG, a JVM, a
+//      setitimer, a second profiler - and a signal arriving faster than the
+//      budget makes the wait NEVER expire. With a 500ms budget and SIGALRM
+//      every 100ms, a producer sat blocked past 25s with no upper bound. In a
+//      design whose whole premise is blocking the profiled application inside
+//      cuInit, an unbounded stall is the one outcome that must be impossible.
+//   2. SO_SNDTIMEO on the connect plus SO_RCVTIMEO on the read is TWO budgets,
+//      so the real worst case was 2x what the documentation claimed.
+//
+// So: read the clock once, and before every blocking call set the socket
+// timeout to what is left of it. Zero or less means give up now - never "wait
+// forever", which is what a zero struct timeval would mean to the kernel.
+struct deadline {
+    long ms;  // CLOCK_MONOTONIC milliseconds
+
+    static long now_ms() {
+        struct timespec t;
+        clock_gettime(CLOCK_MONOTONIC, &t);
+        return (long)t.tv_sec * 1000L + t.tv_nsec / 1000000L;
+    }
+    static deadline in(unsigned budget_ms) {
+        return deadline{now_ms() + (long)budget_ms};
+    }
+    // Remaining budget, floored at zero.
+    long left() const {
+        const long d = ms - now_ms();
+        return d > 0 ? d : 0;
+    }
+};
+
+// Arms both socket timeouts at the remaining budget. Returns false when the
+// budget is spent, which the caller must treat as a timeout rather than as a
+// blocking call.
+bool arm(int fd, const deadline &dl) {
+    const long left = dl.left();
+    if (left <= 0) return false;
+    struct timeval tv;
+    tv.tv_sec = (time_t)(left / 1000);
+    tv.tv_usec = (suseconds_t)((left % 1000) * 1000);
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) != 0) return false;
+    return setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) == 0;
+}
+
+}  // namespace
+
+EnrollResult enroll_connect(const char *name, unsigned timeout_ms) {
+    if (!name || !*name) return kEnrollNoAddress;
+    const size_t nlen = strlen(name);
+    struct sockaddr_un sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sun_family = AF_UNIX;
+    // Abstract namespace: a leading NUL, then the name, and the address
+    // length says where it ends. No filesystem entry, so nothing to clean up
+    // if either end dies.
+    if (nlen + 1 > sizeof(sa.sun_path)) return kEnrollNoAddress;
+    memcpy(sa.sun_path + 1, name, nlen);
+    const socklen_t salen =
+        (socklen_t)(offsetof(struct sockaddr_un, sun_path) + 1 + nlen);
+
+    const int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) return kEnrollError;
+
+    const deadline dl = deadline::in(timeout_ms);
+    EnrollResult res = kEnrollError;
+    for (;;) {
+        // Re-armed from the REMAINING budget before every attempt, so a
+        // stream of signals cannot extend the total wait. See `deadline`.
+        if (!arm(fd, dl)) {
+            res = kEnrollTimedOut;
+            break;
+        }
+        if (connect(fd, (struct sockaddr *)&sa, salen) == 0) {
+            res = kEnrollConfirmed;  // provisional; the reply decides
+            break;
+        }
+        // A connect interrupted by a signal may already have completed, and
+        // the retry then reports EISCONN. That is success, not failure -
+        // treating it as an error would throw away a rendezvous that had
+        // actually connected, and put the producer back on the lazy path for
+        // no reason.
+        if (errno == EISCONN) {
+            res = kEnrollConfirmed;
+            break;
+        }
+        if (errno == EINTR) continue;
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINPROGRESS) {
+            // The listener's backlog is full and SO_SNDTIMEO expired. The
+            // consumer is alive but saturated; treat it as a timeout rather
+            // than reconnecting into the same queue.
+            res = kEnrollTimedOut;
+            break;
+        }
+        // ECONNREFUSED is what an unbound abstract address gives back, and
+        // it is the ordinary case: no profiler is listening for this shim.
+        res = (errno == ECONNREFUSED || errno == ENOENT) ? kEnrollNoListener
+                                                         : kEnrollError;
+        break;
+    }
+    if (res != kEnrollConfirmed) {
+        close(fd);
+        return res;
+    }
+
+    // One status byte. The consumer writes it only after the walker's tables
+    // are installed, so the read returning is the synchronisation point this
+    // whole file exists for.
+    char b = 0;
+    for (;;) {
+        if (!arm(fd, dl)) {
+            res = kEnrollTimedOut;
+            break;
+        }
+        const ssize_t n = read(fd, &b, 1);
+        if (n == 1) {
+            res = (b == 'K') ? kEnrollConfirmed : kEnrollRefused;
+            break;
+        }
+        if (n == 0) {
+            // The consumer closed without answering: it went away mid-
+            // registration. Not a timeout, and not our problem to retry.
+            res = kEnrollError;
+            break;
+        }
+        if (errno == EINTR) continue;
+        res = (errno == EAGAIN || errno == EWOULDBLOCK) ? kEnrollTimedOut
+                                                        : kEnrollError;
+        break;
+    }
+    close(fd);
+    return res;
+}
+
+unsigned enroll_timeout_ms(unsigned dflt) {
+    const char *v = getenv("PERFAGENT_GPU_ENROLL_TIMEOUT_MS");
+    if (!v || !*v) return dflt;
+    char *end = nullptr;
+    errno = 0;
+    const long n = strtol(v, &end, 10);
+    if (errno != 0 || end == v || *end != '\0' || n < 0 || n > 600000) return dflt;
+    return (unsigned)n;
+}
+
+EnrollResult enroll_with_consumer(unsigned timeout_ms) {
+    if (timeout_ms == 0) return kEnrollDisabled;
+    char name[sizeof(((struct sockaddr_un *)nullptr)->sun_path)];
+    // Our own address, not a caller-supplied one: this translation unit is
+    // linked into the shim itself, so the mapping that contains it is the
+    // mapping the consumer's uprobes are attached to. Taking a caller's
+    // function address instead would risk a PLT entry in another object.
+    const void *self = (const void *)&enroll_with_consumer;
+    if (!enroll_name_from_maps("/proc/self/maps", (unsigned long)self, name,
+                               sizeof(name))) {
+        return kEnrollNoAddress;
+    }
+    return enroll_connect(name, timeout_ms);
+}
+
+}  // namespace perfagent

--- a/shim/core/enroll.h
+++ b/shim/core/enroll.h
@@ -1,0 +1,117 @@
+// The startup rendezvous: the producer waits, once, for the consumer to
+// install its unwind tables before it emits a single sampled launch.
+//
+// # Why this exists in the producer and not in the consumer
+//
+// A sampled launch's CPU stack is walked IN THE KERNEL, inside walk_step
+// (bpf/unwind_common.h), at the instant the uprobe traps. The walker unwinds
+// by CFI only for frames whose PC it can find in `pid_mappings`; a miss is
+// silent and falls through to the frame-pointer chain, which in a CUDA
+// process dies in the vendor libraries. So the tables have to be in the BPF
+// maps BEFORE the probe fires -- not "sooner", before.
+//
+// Nothing the consumer can observe in userspace happens before the probe
+// fires. Registration driven by the first batch, by an mmap notification, or
+// by an exec notification all share the same defect: the event that triggers
+// them is delivered after the sample that would have needed the tables, and
+// everything arriving during the compile is walked without them too. On an
+// RTX 3090, libcuda alone is 135805 CFI entries and ~73ms to compile against
+// a ~540ms workload, which is why issue #49 measured ~38% of sampled stacks
+// lost rather than a rounding error.
+//
+// The producer, on the other hand, has a point in its life that provably
+// precedes every launch: the vendor adapter's init. The CUDA driver dlopens
+// the adapter through CUDA_INJECTION64_PATH during cuInit, so by the time
+// InitializeInjection runs, libcuda and the application are mapped, and no
+// kernel can have been launched yet. Blocking there until the consumer says
+// "your tables are in" closes the window instead of narrowing it.
+//
+// # The channel
+//
+// An abstract AF_UNIX stream socket whose name both ends compute
+// independently from the shim's own device and inode:
+//
+//	\0perfagent-gpu-enroll.v1.<dev_major>.<dev_minor>.<inode>
+//
+// The inode is the right key because it is exactly what a uprobe attaches
+// to: a producer whose probes this consumer armed necessarily maps the same
+// inode, and two consumers watching two different shim copies (a CI machine
+// running two gate copies at once, say) can never collide. The producer
+// reads its own dev:inode out of /proc/self/maps, so no path resolution, no
+// environment variable, and no cooperation from whoever launched the process
+// is involved.
+//
+// The producer sends nothing. The consumer takes the peer's PID from
+// SO_PEERCRED -- kernel-supplied, unspoofable -- installs that PID's tables
+// synchronously, and only then writes one status byte:
+//
+//	'K'  tables are installed; go
+//	'X'  registration was refused or installed nothing; go anyway
+//
+// # Every failure falls through to today's behaviour
+//
+// No consumer attached (the semaphore reads zero), nothing bound the
+// address, the connect failed, the reply never came: the producer proceeds
+// immediately and the consumer registers lazily on the first batch exactly
+// as before. A degraded profile is never turned into no profile, and an
+// unprofiled process pays nothing at all -- the caller checks its probe
+// semaphore before it ever gets here.
+#ifndef PERFAGENT_ENROLL_H
+#define PERFAGENT_ENROLL_H
+
+#include <cstddef>
+
+namespace perfagent {
+
+// How the rendezvous ended. Only kEnrollConfirmed means the consumer's
+// walker has this process's CFI tables; every other value means the run
+// continues on the pre-#49 lazy path.
+enum EnrollResult {
+    kEnrollDisabled = 0, // timeout of 0: the caller turned it off
+    kEnrollNoAddress,    // /proc/self/maps had no file-backed line for us
+    kEnrollNoListener,   // nobody bound the address
+    kEnrollConfirmed,    // 'K': the tables are in
+    kEnrollRefused,      // 'X': the consumer would not, or could not
+    kEnrollTimedOut,     // connected, but no reply inside the budget
+    kEnrollError,        // socket, connect or read failed
+};
+
+// A stable short name for logs. Never null.
+const char *enroll_result_name(EnrollResult r);
+
+// Builds the rendezvous name (without the leading NUL of the abstract
+// namespace) for the mapping that contains `addr`, reading `maps_path` in
+// the /proc/<pid>/maps format. Separated from the socket work so the name
+// derivation is testable against a fixture.
+bool enroll_name_from_maps(const char *maps_path, unsigned long addr,
+                           char *out, size_t outsz);
+
+// Connects to `name` in the abstract namespace and waits for the consumer's
+// status byte.
+//
+// `timeout_ms` is ONE budget for the whole rendezvous - the connect and the
+// reply together - measured against a CLOCK_MONOTONIC deadline taken on
+// entry. It is not a per-syscall timeout: a signal that interrupts either
+// call cannot extend the total, and the two phases cannot each spend the full
+// budget. This is a hard bound on how long the profiled application is held
+// inside its own initialisation, so it is stated as one.
+EnrollResult enroll_connect(const char *name, unsigned timeout_ms);
+
+// The whole rendezvous for the image this function is linked into: derive
+// the name from our own mapping, connect, wait. `timeout_ms` of 0 disables
+// it outright.
+//
+// Blocks the calling thread for at most `timeout_ms` in total, signals
+// included. Call it only when a consumer is attached -- i.e. under the
+// sampled-launch probe's semaphore -- so a process nobody is profiling never
+// touches a socket.
+EnrollResult enroll_with_consumer(unsigned timeout_ms);
+
+// The rendezvous budget, from PERFAGENT_GPU_ENROLL_TIMEOUT_MS, or `dflt`
+// when unset or unparseable. An explicit 0 disables the rendezvous, which is
+// why this is not shim/core's usual "non-positive means default" parse.
+unsigned enroll_timeout_ms(unsigned dflt);
+
+}  // namespace perfagent
+
+#endif

--- a/shim/core/enroll_test.cc
+++ b/shim/core/enroll_test.cc
@@ -1,0 +1,235 @@
+// The producer half of the #49 startup rendezvous, without a consumer: a
+// hand-rolled abstract-socket server stands in for gpuprobe's listener.
+#include "enroll.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include <atomic>
+#include <csignal>
+#include <ctime>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+using perfagent::enroll_connect;
+using perfagent::enroll_name_from_maps;
+using perfagent::enroll_result_name;
+using perfagent::enroll_timeout_ms;
+using perfagent::enroll_with_consumer;
+using perfagent::EnrollResult;
+using perfagent::kEnrollTimedOut;
+
+namespace {
+
+std::atomic<int> g_signals{0};
+void count_signal(int) { g_signals.fetch_add(1); }
+
+long mono_ms() {
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return (long)t.tv_sec * 1000L + t.tv_nsec / 1000000L;
+}
+
+int bind_abstract(const char *name) {
+    const int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    assert(fd >= 0);
+    struct sockaddr_un sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sun_family = AF_UNIX;
+    const size_t nlen = strlen(name);
+    memcpy(sa.sun_path + 1, name, nlen);
+    const socklen_t salen =
+        (socklen_t)(offsetof(struct sockaddr_un, sun_path) + 1 + nlen);
+    assert(bind(fd, (struct sockaddr *)&sa, salen) == 0);
+    assert(listen(fd, 8) == 0);
+    return fd;
+}
+
+// Accepts one connection and answers with `reply`, or, when `reply` is 0,
+// holds the connection open without answering at all.
+std::thread serve_once(int lfd, char reply, unsigned hold_ms) {
+    return std::thread([lfd, reply, hold_ms] {
+        const int cfd = accept(lfd, nullptr, nullptr);
+        if (cfd < 0) return;
+        if (reply) {
+            const ssize_t n = write(cfd, &reply, 1);
+            (void)n;
+        } else {
+            usleep(hold_ms * 1000u);
+        }
+        close(cfd);
+    });
+}
+
+std::string temp_maps(const char *body) {
+    char path[] = "/tmp/perfagent_enroll_mapsXXXXXX";
+    const int fd = mkstemp(path);
+    assert(fd >= 0);
+    const ssize_t n = write(fd, body, strlen(body));
+    assert(n == (ssize_t)strlen(body));
+    close(fd);
+    return std::string(path);
+}
+
+}  // namespace
+
+int main() {
+    // ---- the name is derived from the mapping that contains the address --
+    {
+        const std::string p = temp_maps(
+            "55e0d0a00000-55e0d0a01000 r--p 00000000 fd:01 100 /bin/thing\n"
+            "7fc9a0a00000-7fc9a0a21000 r-xp 00001000 08:02 4242 /lib/libshim.so\n"
+            "7ffd00000000-7ffd00021000 rw-p 00000000 00:00 0 [stack]\n");
+        char name[128];
+        assert(enroll_name_from_maps(p.c_str(), 0x7fc9a0a10000UL, name, sizeof(name)));
+        assert(std::string(name) == "perfagent-gpu-enroll.v1.8.2.4242");
+
+        // A different image in the same file gives a different name, which is
+        // what keeps two consumers watching two shim copies apart.
+        assert(enroll_name_from_maps(p.c_str(), 0x55e0d0a00100UL, name, sizeof(name)));
+        assert(std::string(name) == "perfagent-gpu-enroll.v1.253.1.100");
+
+        // An anonymous mapping has no inode a uprobe could have attached to.
+        assert(!enroll_name_from_maps(p.c_str(), 0x7ffd00000100UL, name, sizeof(name)));
+        // An address in no mapping at all.
+        assert(!enroll_name_from_maps(p.c_str(), 0x10UL, name, sizeof(name)));
+        // A missing maps file is a clean false, not a crash.
+        assert(!enroll_name_from_maps("/nonexistent/maps", 0x10UL, name, sizeof(name)));
+        unlink(p.c_str());
+    }
+
+    // ---- 'K' means the tables are in ------------------------------------
+    {
+        const char *n = "perfagent-gpu-enroll.test.confirm";
+        const int lfd = bind_abstract(n);
+        std::thread t = serve_once(lfd, 'K', 0);
+        assert(enroll_connect(n, 2000) == perfagent::kEnrollConfirmed);
+        t.join();
+        close(lfd);
+    }
+
+    // ---- 'X' means the consumer would not, and the producer still runs ---
+    {
+        const char *n = "perfagent-gpu-enroll.test.refuse";
+        const int lfd = bind_abstract(n);
+        std::thread t = serve_once(lfd, 'X', 0);
+        assert(enroll_connect(n, 2000) == perfagent::kEnrollRefused);
+        t.join();
+        close(lfd);
+    }
+
+    // ---- nobody listening: the ordinary unprofiled case ------------------
+    assert(enroll_connect("perfagent-gpu-enroll.test.nobody-at-all", 2000) ==
+           perfagent::kEnrollNoListener);
+
+    // ---- a consumer that accepts and never answers must not hang us ------
+    {
+        const char *n = "perfagent-gpu-enroll.test.silent";
+        const int lfd = bind_abstract(n);
+        std::thread t = serve_once(lfd, 0, 400);
+        assert(enroll_connect(n, 60) == perfagent::kEnrollTimedOut);
+        t.join();
+        close(lfd);
+    }
+
+    // ---- a signal storm must not extend the budget -----------------------
+    //
+    // The regression test for the one outcome this design cannot tolerate: an
+    // unbounded stall inside the profiled application's cuInit. A per-syscall
+    // SO_RCVTIMEO is re-armed from zero on every EINTR, so a signal arriving
+    // faster than the budget makes the wait never expire -- measured at 25s
+    // and climbing against a 500ms budget. A profiled process producing
+    // periodic signals is the normal case, not a corner: a Go runtime's
+    // SIGURG, a JVM, setitimer, another profiler.
+    //
+    // SA_RESTART is deliberately NOT set, because that is what makes the read
+    // return EINTR rather than being restarted by the kernel.
+    {
+        const char *n = "perfagent-gpu-enroll.test.signals";
+        const int lfd = bind_abstract(n);
+        std::thread t = serve_once(lfd, 0, 3000);
+
+        struct sigaction sa;
+        memset(&sa, 0, sizeof(sa));
+        sa.sa_handler = count_signal;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        struct sigaction old_sa;
+        assert(sigaction(SIGALRM, &sa, &old_sa) == 0);
+        struct itimerval it;
+        memset(&it, 0, sizeof(it));
+        it.it_interval.tv_usec = 50000;  // every 50ms, well inside the budget
+        it.it_value.tv_usec = 50000;
+        assert(setitimer(ITIMER_REAL, &it, nullptr) == 0);
+
+        const long t0 = mono_ms();
+        const EnrollResult r = enroll_connect(n, 300);
+        const long elapsed = mono_ms() - t0;
+
+        memset(&it, 0, sizeof(it));
+        setitimer(ITIMER_REAL, &it, nullptr);
+        sigaction(SIGALRM, &old_sa, nullptr);
+
+        assert(g_signals.load() >= 2 && "the timer never fired; the test proves nothing");
+        assert(r == kEnrollTimedOut);
+        // The budget is 300ms; anything past a second means EINTR is
+        // re-arming the wait rather than eating into one deadline.
+        assert(elapsed < 1000 && "a signal storm extended the rendezvous past its budget");
+        t.join();
+        close(lfd);
+    }
+
+    // ---- the two phases share one budget, they do not each get it --------
+    //
+    // A listener that accepts and never answers spends the whole budget in
+    // the read. A connect that also spent one would double the worst case,
+    // which is what SO_SNDTIMEO plus SO_RCVTIMEO used to do.
+    {
+        const char *n = "perfagent-gpu-enroll.test.onebudget";
+        const int lfd = bind_abstract(n);
+        std::thread t = serve_once(lfd, 0, 2000);
+        const long t0 = mono_ms();
+        assert(enroll_connect(n, 200) == kEnrollTimedOut);
+        const long elapsed = mono_ms() - t0;
+        assert(elapsed < 400 && "the rendezvous spent more than its stated budget");
+        t.join();
+        close(lfd);
+    }
+
+    // ---- an empty or oversized name is refused, not truncated ------------
+    assert(enroll_connect("", 100) == perfagent::kEnrollNoAddress);
+    {
+        const std::string huge(200, 'x');
+        assert(enroll_connect(huge.c_str(), 100) == perfagent::kEnrollNoAddress);
+    }
+
+    // ---- the budget ------------------------------------------------------
+    unsetenv("PERFAGENT_GPU_ENROLL_TIMEOUT_MS");
+    assert(enroll_timeout_ms(2000) == 2000);
+    setenv("PERFAGENT_GPU_ENROLL_TIMEOUT_MS", "150", 1);
+    assert(enroll_timeout_ms(2000) == 150);
+    // An explicit zero is "off", not "use the default" -- which is why this
+    // is not shim/core's usual non-positive-means-default parse.
+    setenv("PERFAGENT_GPU_ENROLL_TIMEOUT_MS", "0", 1);
+    assert(enroll_timeout_ms(2000) == 0);
+    assert(enroll_with_consumer(0) == perfagent::kEnrollDisabled);
+    setenv("PERFAGENT_GPU_ENROLL_TIMEOUT_MS", "not-a-number", 1);
+    assert(enroll_timeout_ms(2000) == 2000);
+    unsetenv("PERFAGENT_GPU_ENROLL_TIMEOUT_MS");
+
+    // ---- the self address resolves in a real process ---------------------
+    // No consumer is bound for this test binary's own inode, so the only
+    // correct answer is "nobody listening" -- and reaching that answer proves
+    // the /proc/self/maps lookup found this image.
+    assert(enroll_with_consumer(200) == perfagent::kEnrollNoListener);
+
+    assert(std::string(enroll_result_name(perfagent::kEnrollConfirmed)) == "confirmed");
+    printf("enroll_test OK\n");
+    return 0;
+}

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -12,6 +12,7 @@
 #include "batch.h"
 #include "clock.h"
 #include "drain.h"
+#include "enroll.h"
 #include "kernelnames.h"
 #include "sampler.h"
 #include "usdt_abi.h"
@@ -479,6 +480,29 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
 
     open_log();
 
+    // The #49 startup rendezvous, and this is the one place in a CUDA process
+    // where it can be done: the driver dlopened us during cuInit, so libcuda,
+    // libcupti and the application are all mapped, and NO kernel has been
+    // launched yet. Blocking here until the consumer has installed this
+    // process's CFI tables is what makes the kernel-side walk of the first
+    // sampled launch -- and of every launch during what would otherwise be a
+    // ~73ms libcuda compile -- find tables instead of falling through to the
+    // frame-pointer path.
+    //
+    // BEFORE cuptiSubscribe, not after: subscribing is what makes on_callback
+    // reachable, and on_callback is the only thing that fires a probe. Doing
+    // the rendezvous first means no probe of any kind can have fired from
+    // this process before it completes -- not even from another thread
+    // already inside a CUDA call.
+    //
+    // Only when a consumer is attached (the semaphore is what says so, and it
+    // was armed by the kernel when this library was mapped), bounded by
+    // PERFAGENT_GPU_ENROLL_TIMEOUT_MS, and never fatal: see core/enroll.h.
+    perfagent::EnrollResult enrolled = perfagent::kEnrollDisabled;
+    if (gpu_launch_sampled_v1_enabled()) {
+        enrolled = perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(2000));
+    }
+
     // Leaked on purpose, never deleted: CUPTI worker threads keep calling
     // buffer_completed during process teardown, and a destroyed Batch or
     // Sampler under them is a use-after-free in somebody else's process.
@@ -514,7 +538,8 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
     atexit(at_exit_handler);
 
     logf("perfagent-cupti: initialized pid=%d sample_period=%u drain_ms=%u "
-         "clock_offset_ns=%lld\n",
-         (int)getpid(), g_sampler->period(), drain_ms, (long long)g_clock.offset_ns());
+         "clock_offset_ns=%lld enroll=%s\n",
+         (int)getpid(), g_sampler->period(), drain_ms, (long long)g_clock.offset_ns(),
+         perfagent::enroll_result_name(enrolled));
     return 1;
 }

--- a/shim/stub/stub.cc
+++ b/shim/stub/stub.cc
@@ -4,6 +4,7 @@
 #include "batch.h"
 #include "clock.h"
 #include "drain.h"
+#include "enroll.h"
 #include "kernelnames.h"
 #include "sampler.h"
 #include "usdt_abi.h"
@@ -47,6 +48,16 @@ static uint64_t mono_ns() {
 // whatever process it's injected into.
 extern "C" __attribute__((visibility("default"))) void
 perfagent_stub_run(unsigned launches, unsigned period_us, unsigned sample_period) {
+    // The #49 startup rendezvous, before the first launch and therefore
+    // before the first probe: wait for the consumer to install this
+    // process's CFI tables, so the kernel-side walk of every sampled launch
+    // has them. Only when a consumer is actually attached -- the semaphore
+    // is what says so -- and never fatal: see core/enroll.h.
+    perfagent::EnrollResult enrolled = perfagent::kEnrollDisabled;
+    if (gpu_launch_sampled_v1_enabled()) {
+        enrolled = perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(2000));
+    }
+
     perfagent::Batch<gpu_launch_v1, 32> lb(gpu_launch_v1_emit, gpu_launch_v1_enabled);
     perfagent::Batch<gpu_exec_v1, 32> eb(gpu_exec_v1_emit, gpu_exec_v1_enabled);
     perfagent::Sampler sampler(sample_period);
@@ -124,10 +135,11 @@ perfagent_stub_run(unsigned launches, unsigned period_us, unsigned sample_period
     eb.flush();
     drainer.stop();
     fprintf(stderr, "stub: launches=%u observed=%llu sampled=%llu period=%u "
-                    "launch_dropped=%llu exec_dropped=%llu\n",
+                    "launch_dropped=%llu exec_dropped=%llu enroll=%s\n",
             launches, (unsigned long long)sampler.observed(),
             (unsigned long long)sampler.sampled(), sampler.period(),
-            (unsigned long long)lb.dropped(), (unsigned long long)eb.dropped());
+            (unsigned long long)lb.dropped(), (unsigned long long)eb.dropped(),
+            perfagent::enroll_result_name(enrolled));
 }
 
 // linger keeps this process alive after its records are flushed, until the

--- a/unwind/ehmaps/store.go
+++ b/unwind/ehmaps/store.go
@@ -72,9 +72,39 @@ type TableStore struct {
 
 	rc *RefcountTable
 
+	// The refcount says who HOLDS a table. It does not say the table is in
+	// the BPF maps yet, and those are different facts.
+	//
+	// AcquireBinary used to return "already installed" the moment the
+	// refcount exceeded one - which is true from the instant the FIRST caller
+	// bumped it, before that caller had compiled anything or written a single
+	// row. With two concurrent registrations of two processes that map the
+	// same binary (the gpuprobe startup rendezvous running alongside the lazy
+	// worker, for instance) the second one returned instantly, its PID was
+	// marked ready, and its stack walks consulted a half-populated table.
+	//
+	// That failure is invisible in the obvious place: those walks have
+	// mappings, so they never count as "no tables". They surface as CFI
+	// misses or as an FP-only walk with tables, which is a different symptom
+	// with a different suspect.
+	//
+	// installed/inflight close it. A caller that finds an install in flight
+	// waits for it; a caller that finds one finished returns without
+	// recompiling; and only the caller that claims `inflight` compiles.
+	// Guarded by instMu, with instCond to wake waiters.
+	instMu    sync.Mutex
+	instCond  *sync.Cond
+	installed map[uint64]struct{}
+	inflight  map[uint64]struct{}
+
 	// onCompile, if non-nil, is invoked after each successful first-time
 	// compile in AcquireBinary. Nil means no observation. Set via
 	// SetOnCompile after construction.
+	//
+	// It runs INSIDE the install claim for that table (see beginInstall), so
+	// a hook that called back into this store for the same binary would wait
+	// on itself forever. Hooks are for observation - timing, logging,
+	// metrics - and must not re-enter.
 	onCompile func(path, buildID string, ehFrameBytes int, dur time.Duration)
 }
 
@@ -82,19 +112,74 @@ type TableStore struct {
 // (typically from the agent's perf_dwarf program load). The caller owns
 // the maps; TableStore does not close them.
 func NewTableStore(cfi, cfiLen, cls, clsLen *ebpf.Map) *TableStore {
-	return &TableStore{
+	s := &TableStore{
 		CFIRules:          cfi,
 		CFILengths:        cfiLen,
 		CFIClassification: cls,
 		CFIClassLengths:   clsLen,
 		rc:                NewRefcountTable(),
+		installed:         map[uint64]struct{}{},
+		inflight:          map[uint64]struct{}{},
 	}
+	s.instCond = sync.NewCond(&s.instMu)
+	return s
+}
+
+// beginInstall claims the right to compile and populate tableID, waiting out
+// any install already in flight for it. Returns false when the table is
+// already in the maps and the caller has nothing to do.
+//
+// Broadcast rather than a per-table channel: an install finishing is rare
+// (once per distinct binary) and the waiters re-check their own key, so the
+// spurious wakeups cost a map lookup and the store keeps no per-table state
+// it would have to garbage-collect.
+func (s *TableStore) beginInstall(tableID uint64) bool {
+	s.instMu.Lock()
+	defer s.instMu.Unlock()
+	for {
+		if _, ok := s.installed[tableID]; ok {
+			return false
+		}
+		if _, ok := s.inflight[tableID]; !ok {
+			s.inflight[tableID] = struct{}{}
+			return true
+		}
+		s.instCond.Wait()
+	}
+}
+
+// endInstall releases the claim. installed is set only when the table is
+// actually in the maps, so a failed compile leaves the next caller free to
+// try again rather than inheriting a table that was never written.
+func (s *TableStore) endInstall(tableID uint64, ok bool) {
+	s.instMu.Lock()
+	delete(s.inflight, tableID)
+	if ok {
+		s.installed[tableID] = struct{}{}
+	}
+	s.instMu.Unlock()
+	s.instCond.Broadcast()
+}
+
+// forgetInstall drops the "this table is in the maps" fact, for a table that
+// has just been evicted from them. ReleaseBinary does the same thing inline,
+// under a lock it holds across the map deletions as well; this is the
+// standalone spelling the barrier tests drive.
+func (s *TableStore) forgetInstall(tableID uint64) {
+	s.instMu.Lock()
+	delete(s.installed, tableID)
+	s.instMu.Unlock()
+	s.instCond.Broadcast()
 }
 
 // SetOnCompile installs an observer callback that fires after each
 // successful CFI compile in AcquireBinary. Pass nil to disable.
 // Not safe to call concurrently with AcquireBinary; set once at
 // construction time.
+//
+// The callback runs while this store holds the install claim for the table
+// it just compiled, so it MUST NOT call back into the store - AcquireBinary
+// for the same binary from inside the hook deadlocks against itself.
 func (s *TableStore) SetOnCompile(fn func(path, buildID string, ehFrameBytes int, dur time.Duration)) {
 	s.onCompile = fn
 }
@@ -120,9 +205,31 @@ func (s *TableStore) AcquireBinary(binPath, openPath string, pid uint32) (tableI
 		return 0, false, fmt.Errorf("build-id %s: %w", binPath, err)
 	}
 	tableID = TableIDForBuildID(buildID)
-	if rc := s.rc.Acquire(tableID, pid); rc > 1 {
-		return tableID, false, nil // already installed
+	s.rc.Acquire(tableID, pid)
+	// NOT `if rc > 1 { return }`: the refcount rises before the first holder
+	// has written anything, so that test returned "installed" for a table
+	// that was still being compiled. See the instMu/installed comment on
+	// TableStore. beginInstall waits for the install in flight instead.
+	if !s.beginInstall(tableID) {
+		return tableID, false, nil // already in the maps, and finished
 	}
+	// `claimed`, not the named result. Every failure path below returns
+	// `0, false, err`, which ASSIGNS the named tableID before this defer
+	// runs - so a defer closing over `tableID` would release the claim on
+	// table 0 and leave the real one marked in-flight forever. The next
+	// AcquireBinary for that build-id would then block in beginInstall with
+	// no timeout and no cancellation.
+	//
+	// That is not a corner case: ehcompile.Compile returns ErrNoEHFrame for
+	// any ELF without .eh_frame, which AttachAllMappings expects and skips,
+	// so the first process mapping such a library would poison its tableID
+	// and the second would wedge - taking the PIDTracker.Run goroutine
+	// (mmap tracking AND PID teardown) down with it on any system-wide DWARF
+	// run. TestASecondAcquireAfterAFailedInstallDoesNotWedge covers it.
+	claimed := tableID
+	installOK := false
+	defer func() { s.endInstall(claimed, installOK) }()
+
 	// First reference for this tableID — compile + install.
 	t0 := time.Now()
 	entries, classifications, ehFrameBytes, err := ehcompile.Compile(openPath)
@@ -148,6 +255,7 @@ func (s *TableStore) AcquireBinary(binPath, openPath string, pid uint32) (tableI
 		s.rc.Release(tableID, pid)
 		return 0, false, fmt.Errorf("populate classification: %w", err)
 	}
+	installOK = true
 	return tableID, true, nil
 }
 
@@ -158,6 +266,19 @@ func (s *TableStore) ReleaseBinary(tableID uint64, pid uint32) error {
 	if rc := s.rc.Release(tableID, pid); rc > 0 {
 		return nil
 	}
+	// instMu is held across BOTH the forget and the deletes, not just the
+	// forget. Dropping it in between leaves a window in which the rows are
+	// still in the maps and `installed` no longer says so - harmless - and,
+	// worse, a window in which an acquirer that arrived a moment earlier was
+	// told "installed" for rows that are about to be deleted. Holding it
+	// makes eviction atomic with respect to beginInstall: an acquirer either
+	// sees the table before the eviction starts, or compiles it again.
+	s.instMu.Lock()
+	defer func() {
+		s.instMu.Unlock()
+		s.instCond.Broadcast()
+	}()
+	delete(s.installed, tableID)
 	// Evict. Deleting from the outer HASH_OF_MAPS drops the kernel's
 	// reference to the inner map, which the kernel then frees.
 	var firstErr error

--- a/unwind/ehmaps/store_install_test.go
+++ b/unwind/ehmaps/store_install_test.go
@@ -1,0 +1,246 @@
+package ehmaps
+
+import (
+	"debug/elf"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The refcount says who HOLDS a table; `installed` says the table is in the
+// maps. Conflating them is a real defect with a misleading symptom: a second
+// caller was told "already installed" the instant the first caller bumped the
+// refcount, i.e. before a single row had been written, and its PID's stack
+// walks then consulted a half-populated table. Those walks have mappings, so
+// they never surface as "no tables" - they look like CFI misses instead.
+//
+// These are internal tests because the barrier is internal: AcquireBinary
+// itself needs a real ELF and real BPF maps, and the property under test is
+// the ordering, not the compile.
+
+func TestASecondInstallerWaitsForTheFirstInsteadOfAssumingItFinished(t *testing.T) {
+	s := NewTableStore(nil, nil, nil, nil)
+	const tid uint64 = 0x1234
+
+	if !s.beginInstall(tid) {
+		t.Fatal("the first caller must be the one that installs")
+	}
+
+	second := make(chan bool, 1)
+	go func() { second <- s.beginInstall(tid) }()
+
+	select {
+	case got := <-second:
+		t.Fatalf("a second caller returned %v while the install was still in flight; "+
+			"it would go on to use a table with no rows in it", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	s.endInstall(tid, true)
+	select {
+	case got := <-second:
+		if got {
+			t.Fatal("the second caller recompiled a table that was already installed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the second caller was never woken")
+	}
+}
+
+func TestAFailedInstallLetsTheNextCallerTryAgain(t *testing.T) {
+	s := NewTableStore(nil, nil, nil, nil)
+	const tid uint64 = 0x1234
+
+	if !s.beginInstall(tid) {
+		t.Fatal("first caller")
+	}
+	s.endInstall(tid, false) // compile or populate failed
+
+	if !s.beginInstall(tid) {
+		t.Fatal("a table whose install FAILED must not be recorded as present: " +
+			"the next caller would inherit rows that were never written")
+	}
+	s.endInstall(tid, true)
+}
+
+func TestAnEvictedTableIsNoLongerConsideredInstalled(t *testing.T) {
+	s := NewTableStore(nil, nil, nil, nil)
+	const tid uint64 = 0x1234
+
+	if !s.beginInstall(tid) {
+		t.Fatal("first caller")
+	}
+	s.endInstall(tid, true)
+	if s.beginInstall(tid) {
+		t.Fatal("an installed table must not be recompiled")
+	}
+
+	s.forgetInstall(tid) // what ReleaseBinary does once the refcount hits zero
+	if !s.beginInstall(tid) {
+		t.Fatal("after eviction the rows are gone from the maps; the next acquire must compile again")
+	}
+	s.endInstall(tid, true)
+}
+
+// Distinct tables never block each other: the barrier is per-table, so one
+// slow libcuda compile must not serialize every other binary in the process.
+func TestInstallsOfDifferentTablesDoNotBlockEachOther(t *testing.T) {
+	s := NewTableStore(nil, nil, nil, nil)
+	if !s.beginInstall(1) {
+		t.Fatal("table 1")
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if !s.beginInstall(2) {
+			t.Error("table 2 was refused while table 1 was installing")
+		}
+		s.endInstall(2, true)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("an install of one table blocked an install of another")
+	}
+	s.endInstall(1, true)
+}
+
+// Under contention exactly one caller compiles, and nobody proceeds early.
+func TestExactlyOneCallerInstallsUnderContention(t *testing.T) {
+	s := NewTableStore(nil, nil, nil, nil)
+	const tid uint64 = 0x1234
+	const n = 16
+
+	var mu sync.Mutex
+	installs := 0
+	finishedBeforeInstall := 0
+	installDone := false
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if s.beginInstall(tid) {
+				mu.Lock()
+				installs++
+				mu.Unlock()
+				time.Sleep(20 * time.Millisecond) // stand in for the compile
+				mu.Lock()
+				installDone = true
+				mu.Unlock()
+				s.endInstall(tid, true)
+				return
+			}
+			mu.Lock()
+			if !installDone {
+				finishedBeforeInstall++
+			}
+			mu.Unlock()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if installs != 1 {
+		t.Fatalf("%d callers compiled the same table; the barrier is not exclusive", installs)
+	}
+	if finishedBeforeInstall != 0 {
+		t.Fatalf("%d callers were told the table was ready before it was written", finishedBeforeInstall)
+	}
+}
+
+// The bug the barrier tests above could not see, because they drive the
+// primitives and it lives in the caller.
+//
+// AcquireBinary uses named return values, and every failure path after the
+// claim returns `0, false, err` - which ASSIGNS the named tableID before the
+// deferred endInstall runs. A defer closing over that name therefore released
+// the claim on table 0 and left the real tableID marked in flight forever,
+// with no timeout and no cancellation on the next caller.
+//
+// The trigger is not exotic. ehcompile.Compile returns ErrNoEHFrame for any
+// ELF without .eh_frame - a case AttachAllMappings expects, logs and skips -
+// so the first process mapping such a library poisoned its tableID and the
+// second wedged. In perf_dwarf and offcpu_dwarf the wedged caller is the
+// PIDTracker.Run goroutine, which also services exit events and Detach, so
+// mmap tracking and PID teardown stop with it. Reachable on any system-wide
+// DWARF run, GPU or not.
+func TestASecondAcquireAfterAFailedInstallDoesNotWedge(t *testing.T) {
+	// Both failure arms, because the clobber is on every return after the
+	// claim: the first fails in ehcompile, the second gets past a successful
+	// compile and fails in the populate (the store's maps are nil).
+	for _, tc := range []struct{ name, path string }{
+		{name: "compile fails (no .eh_frame)", path: elfWithoutEHFrame(t)},
+		{name: "populate fails after a good compile", path: "../ehcompile/testdata/hello"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewTableStore(nil, nil, nil, nil)
+
+			if _, _, err := s.AcquireBinary(tc.path, "", 1); err == nil {
+				t.Fatalf("expected the first acquire to fail; the test proves nothing otherwise")
+			}
+
+			// The claim must be gone. Asserting on the internals as well as on
+			// the behaviour, because "the second call returned" could also be
+			// true for the wrong reason.
+			s.instMu.Lock()
+			inflight := len(s.inflight)
+			s.instMu.Unlock()
+			if inflight != 0 {
+				t.Fatalf("%d table(s) still claimed after a failed install; the next acquire for that build-id blocks forever", inflight)
+			}
+
+			done := make(chan error, 1)
+			go func() {
+				_, _, err := s.AcquireBinary(tc.path, "", 2)
+				done <- err
+			}()
+			select {
+			case <-done:
+				// Errors again, which is correct - what matters is that it returned.
+			case <-time.After(5 * time.Second):
+				t.Fatal("a second acquire for the same binary never returned: the failed install left its table claimed")
+			}
+		})
+	}
+}
+
+// elfWithoutEHFrame builds a real ELF that has a build-id (so ReadBuildID
+// succeeds and the claim IS taken) but no .eh_frame (so ehcompile fails).
+// That is the shape of a stripped vendor library, and it is the realistic
+// trigger for the clobber above.
+func elfWithoutEHFrame(t *testing.T) string {
+	t.Helper()
+	objcopy, err := exec.LookPath("objcopy")
+	if err != nil {
+		t.Skip("no objcopy; cannot build an ELF without .eh_frame")
+	}
+	src := "../ehcompile/testdata/hello"
+	if _, err := os.Stat(src); err != nil {
+		t.Skipf("testdata: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "no_eh_frame")
+	cmd := exec.Command(objcopy, "--remove-section=.eh_frame",
+		"--remove-section=.eh_frame_hdr", src, out)
+	if o, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("objcopy: %v\n%s", err, o)
+	}
+	f, err := elf.Open(out)
+	if err != nil {
+		t.Skipf("open stripped elf: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if f.Section(".eh_frame") != nil {
+		t.Skip("objcopy did not remove .eh_frame")
+	}
+	if _, err := ReadBuildID(out); err != nil {
+		t.Skipf("the fixture has no build-id, so no claim would be taken: %v", err)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #49.

~38% of sampled GPU stacks were walked before their CFI tables existed, walked with frame
pointers instead, landed in perf-agent's own callback, and were refused by the attribution
guard. Refused, not misattributed — but those launches got no CPU stack.

### Why the obvious fix cannot work

The walk happens in `walk_step`, **in the kernel, at trap time**. So any registration
triggered by observing an event in userspace is late by definition: the sample that
triggered it was already walked without tables, and so is everything arriving during the
compile. `cmd/gpu-cuda-profile` passes `PID: 0`, taking the lazy path, and libcuda alone is
135,805 CFI entries at ~73 ms against a ~540 ms run.

### The producer waits

`shim/core/enroll.{h,cc}` connects to an abstract `AF_UNIX` socket and blocks for one status
byte. `gpuprobe/enroll.go` binds it *before* creating the uprobe link, takes the peer PID
from `SO_PEERCRED`, verifies that PID maps the shim inode, registers CFI synchronously, then
replies. The address is derived independently on both sides from the shim's own `dev:inode`
— no env var, no path agreement, and two consumers on two shim copies cannot collide.

The call sits at the top of `InitializeInjection`, before `cuptiSubscribe` — after
libcuda/libcupti/libcudart and the app are mapped, before `on_callback` is reachable. No
launch → no probe → no walk until the tables are in. A synchronisation point, not a shorter
race.

**An unattached shim costs nothing.** The rendezvous is behind the same semaphore gate as
the probes: semaphore 0 → zero syscalls, measured at 0.0 ms.

### Bounded, and measured

Every failure path releases the producer, measured against the real `enroll.cc`: no listener
0.0 ms, bound-never-accept 507 ms, accept-never-reply 858 ms, backlog full 760 ms, consumer
closed mid-rendezvous 201 ms, consumer `SIGKILL`ed 402 ms, registrar wedged 747 ms.

One `CLOCK_MONOTONIC` deadline covers connect *and* read, re-armed from the remaining budget
before each blocking call and bailing at zero — never arming a zero `timeval`, which the
kernel reads as *no timeout*. An earlier revision re-armed from zero on each `EINTR` retry:
with `SIGALRM` every 100 ms against a 500 ms budget it was still blocked at 25 s. Any
periodic signal — Go's `SIGURG`/`SIGPROF` in a cgo host, a JVM, `setitimer` — would have hung
the application inside `cuInit` forever.

### `unwind/ehmaps` — shipped-code change, deliberate

`TableStore.AcquireBinary` returned "already installed" as soon as the refcount exceeded 1,
**before the first caller had run `PopulateCFI`**. Any second concurrent acquirer of the same
binary walked against a half-populated table. That was reachable in `perf_dwarf` and
`offcpu_dwarf` too, and surfaced as CFI misses or FP-only-with-tables — never as `NoTables`,
so the counter meant to detect it structurally could not.

`TableStore` now separates *who holds a table* (refcount) from *the table is in the maps*
(`installed`), with an `inflight` set and a `sync.Cond` so a later caller waits for the
install. Per-table, so a slow libcuda compile does not serialise unrelated installs.

That barrier introduced a permanent deadlock, caught in the second review pass: named return
values meant the deferred `endInstall(tableID, …)` saw `tableID = 0` on every error path,
clearing `inflight[0]` while the real table stayed claimed forever. Reachable via
`ErrNoEHFrame`, which `AttachAllMappings` treats as routine, and it would have taken
`PIDTracker.Run` — mmap tracking and PID teardown — down with it on any system-wide DWARF
run. Fixed by capturing the id before the defer.

It passed five new tests and `-race -count=4`, because they exercised `beginInstall` /
`endInstall` directly and never `AcquireBinary`. The regression test now drives
`AcquireBinary` through both failure arms.

### Admission and authorisation

Authorisation is "the peer maps the shim inode", checked after `SO_PEERCRED` and before any
registration. Deliberately **not** `uid == euid` unconditionally: a root profiler legitimately
profiles other users' processes, and that check would refuse the real producer while looking
healthy. It applies only when the consumer is itself unprivileged (euid ≠ 0 and no
`CAP_SYS_PTRACE` in Permitted or Effective) — which cannot legitimately serve another user
anyway. Plus a per-uid token bucket (32 burst, 32/s), a listener-wide bucket, refusal before
any `/proc` read, and a throttled peer degrading to the lazy path.

### Not covered

A process already running when the consumer attaches — the genuine residual of #49. Also: a
producer in a different netns, libraries `dlopen`ed after `cuInit`, an old shim, and
`PERFAGENT_GPU_ENROLL_TIMEOUT_MS=0`. It is *not* limited to profiler-spawned targets: a real
system-wide attach covers every CUDA process starting afterwards in the same netns.

### Prediction

`StacksWalkedDWARF = 500`, `NoTables = 0`, `FPOnly = 0`, `ProfilerOnly = 0`,
`UnwindEnrollRequests = Confirmed = 1`, throttled and marks-dropped 0. The 500 follows from
the baseline regularity `FPOnly == NoTables` — no FP-only walk ever had tables — so
`NoTables = 0` forces `DWARF = 500` under the existing `DWARF + FPOnly == sampled` invariant.
Empirical, not structural, and stated as such. Gate assertions were tightened, not relaxed:
`Less(NoTables, 63)` → `Zero`.
