### PR TITLE
gpu: surface the timeline join counters to the operator

### DIFF
--- a/.superpowers/sdd/issue-51-report.md
+++ b/.superpowers/sdd/issue-51-report.md
@@ -1,0 +1,218 @@
+# Issue #51 — Timeline join counters were computed and never surfaced
+
+Branch `fix/surface-join-stats`, worktree `.worktrees/surface-join-stats`.
+
+New: `gpu/joinhealth.go` (`gpu.JoinHealth(Snapshot) []string`) plus `gpu/joinhealth_test.go`.
+Wired into `cmd/gpu-cuda-profile/main.go` and `cmd/gpu-stub-profile/main.go` — three lines
+each, immediately after the existing `c.Stats()` log. No counter's computation changed.
+
+## 1. Rendered output
+
+Produced by `go test ./gpu/ -run TestJoinHealthRenderedOutput -v -count=1`, which renders
+three real `Snapshot` values through the shipped code path. Reproduced verbatim; in the
+drivers each line arrives through its own `log.Print`, so each carries a timestamp prefix.
+
+### Healthy — 512 executions all joined exactly, nothing evicted
+
+```
+gpu join: 512 executions, all exact; 256 launches, all matched; cache 256 live; no anomalies
+```
+
+One line. No zero-valued field appears anywhere in it.
+
+### Anomalous — the same run with every counter the timeline can raise
+
+```
+gpu join: 512 executions (470 exact, 22 heuristic, 20 unmatched); 260 launches (240 matched, 20 unmatched); cache 250 live; pc samples 900 attributed, 12 pending; 13 anomalies
+gpu join ANOMALY: 20 of 512 executions unmatched — GPU time arrived with no launch to attach it to; it is in the profile under [gpu:launch unsampled] carrying no CPU stack
+gpu join ANOMALY: 22 of 512 executions joined heuristically — matched on queue, kernel name and timing rather than vendor correlation; the CPU stack may be another launch's
+gpu join ANOMALY: 4 heuristic joins flagged ambiguous — more than one launch qualified and one was chosen; these are the least trustworthy stacks in the profile
+gpu join ANOMALY: 7 of the unmatched executions had a candidate launch just outside LaunchEventJoinWindowNs — widen that window or snapshot more often
+gpu join ANOMALY: launch cache evicted 47 launches at capacity (250 live) — too small for the launch rate, so their executions cannot join; raise TimelineConfig.LaunchCache.Capacity
+gpu join ANOMALY: launch cache evicted 3 launches past HorizonNs — they aged out before their execution arrived; raise the horizon if kernels sit queued that long
+gpu join ANOMALY: launch cache replaced 2 live entries — the same correlation ID came back while still live; the earlier launch and its stack are gone
+gpu join ANOMALY: 1 launch carried an out-of-range timestamp — the producer's clock is suspect and horizon eviction is running against a clamped anchor
+gpu join ANOMALY: 128 PC samples evicted while waiting for their execution — never attributed, so the stall detail on those kernels is under-reported
+gpu join ANOMALY: 9 executions evicted from the timeline ring before this snapshot — that GPU time is missing from the profile entirely; snapshot more often or raise the capacity
+gpu join ANOMALY: 11 timeline events evicted before this snapshot — raise TimelineConfig.EventCapacity
+gpu join ANOMALY: 1 module evicted before this snapshot — kernels from evicted modules resolve to bare addresses
+gpu join ANOMALY: sink dropped 64 PC samples at admission (60 full, 4 invalid, 0 downstream) — they never reached the timeline, so no join counter above accounts for them
+```
+
+### Empty snapshot — the degenerate worst case
+
+```
+gpu join: no executions; no launches; cache 0 live; 1 anomaly
+gpu join ANOMALY: no executions in this snapshot — nothing was attributed at all; check the probe attachment and the sink before reading anything below
+```
+
+### Counters that do not reconcile with the executions present
+
+```
+gpu join: 512 executions (500 exact, 0 heuristic, 0 unmatched); 256 launches, all matched; cache 256 live; 1 anomaly
+gpu join ANOMALY: join outcomes sum to 500 but the snapshot holds 512 executions — the join counters disagree with what is actually present; treat every figure below as unreliable
+```
+
+Without this condition the first line prints on its own, a breakdown that quietly does not
+add up and that reads exactly as authoritative as a correct one.
+
+## 2. Design reasoning
+
+**Why not `%+v`.** The obvious fix — add `join=%+v launch_cache=%+v` next to the existing
+`stats=%+v` — is what created the problem it is supposed to solve. `JoinStats` has eight
+fields, `LaunchCacheStats` five, `TimelineDropStats` four; on a healthy run seventeen of
+those print as `Field:0`. A line that is a wall of zeros on every good run is a line the
+reader learns to skip, and it is then skipped on the one run where
+`UnmatchedExecutionCount` was not zero. So the healthy case is one short sentence
+containing no zero-valued field at all, and the anomalous case is *longer* — length itself
+is the signal. Grepping `gpu join ANOMALY` finds every bad run in a log directory.
+
+**Anomalies get their own line, with a consequence attached.** `EvictedCapacity: 47` says
+nothing to someone who has not read `launchcache.go`. Each anomaly line is
+`<count and what was counted> — <what it costs, and the knob>`, capped at one line. The
+unmatched-executions line names `[gpu:launch unsampled]` because that is the frame the
+reader will find those samples under in the resulting pprof, which is the fastest way to
+confirm the counter against the artifact.
+
+**The one derived figure, and what it reads at both ends.** The summary ends with
+`no anomalies` / `N anomalies`. It is a count of raised conditions, not a ratio:
+
+- **Normal:** `no anomalies` — and it can only print that when *every* condition is
+  unraised, including "no executions in this snapshot".
+- **Worst:** it grows. Nothing arrived → 1 (the empty-snapshot condition). Everything went
+  wrong → 13, as above. There is no input on which it reads `no anomalies` while a counter
+  it covers is non-zero; `TestJoinHealthSummaryCountMatchesTheLinesBelowIt` asserts the
+  number equals `len(lines)-1` for all three fixtures.
+
+The trap this deliberately avoids is the ratio form. A "join success rate" would print
+`100%` for a snapshot with zero executions — green precisely when the profiler produced
+nothing — which is the exact shape of the seven defects already found on this project.
+`TestJoinHealthEmptySnapshotIsAnAnomalyNotAllExact` pins that: an empty `Snapshot` must
+not say "all exact".
+
+**Executions are counted from `len(snap.Executions)`, not from a `JoinStats` field, and
+the renderer checks the sum.** The three outcomes are mutually exclusive and every
+execution takes exactly one of them, so they must sum to the slice length. Quoting the
+slice gives a denominator that does not come from the counters being audited — but leaving
+the comparison to the reader's arithmetic is not surfacing it. A breakdown that fails to
+add up is not something anyone spots by eye, and unchecked it makes every figure beside it
+look authoritative while being wrong. So the mismatch is its own anomaly, carrying both
+figures so the discrepancy is legible rather than computed, and it is raised **first** —
+before the conditions whose numbers it casts doubt on — because it decides whether the rest
+of the line can be believed at all. It fires in both directions (under- and over-reporting)
+and stays silent on all three reconciling fixtures.
+
+**`UnmatchedLaunchCount` is in the summary but is not an anomaly.** A launch whose
+execution has not landed yet is the normal state at any snapshot boundary. Raising it would
+fire on every healthy periodic snapshot and devalue the word ANOMALY for the counters that
+do mean something. It is still printed whenever it is non-zero.
+
+**`SinkStats` is included even though both drivers leave it zero.** They pass the
+`Timeline` as the sink directly, so nothing populates it today — but it is a field of
+`Snapshot`, and a renderer that silently ignored a populated one would be a fresh instance
+of this same bug the moment the wiring uses `CountingSink.SnapshotWith`. Being zero, it
+costs nothing on the healthy line.
+
+**Scope boundary, stated in the doc comment.** `JoinHealth` sees only what `Snapshot`
+knows. Loss upstream of the sink — `gpuprobe.Stats.KernelDropped`, `SequenceGaps`,
+`Malformed`, `ZeroCorrelation` — is invisible to it, which is why both drivers keep their
+existing `c.Stats()` line and why `no anomalies` is phrased under a `gpu join:` prefix: it
+means the join is clean, not that nothing was lost reaching it.
+
+**Time scales differ and are documented.** `JoinStats` is per-snapshot (`Timeline` resets
+`launchesSinceSnapshot` on every `Snapshot` call); `LaunchCacheStats` and
+`TimelineDropStats` are cumulative over the `Timeline`'s life. Both drivers snapshot
+exactly once at the end, so the two coincide there. A periodic caller must read the
+eviction figures as running totals — noted in the `JoinHealth` doc comment so the eventual
+exporter wiring does not mix them.
+
+## 3. Exported-metric recommendation (`metrics/exporter.go`)
+
+`metrics.MetricsSnapshot` today is `{Timestamp, SystemWide, Processes map[uint32]*ProcessMetrics}`
+and `Exporter` is `Export(ctx, *MetricsSnapshot) error` / `Name() string`. GPU is not wired
+into `perfagent/` at all yet. Recommendation for when it is:
+
+**Add a process-independent `GPU *GPUMetrics` field to `MetricsSnapshot`, not a per-PID
+one.** The join happens in one `Timeline` shared across every profiled process; the launch
+cache is process-qualified internally (issue #36) but its eviction counters are not
+attributable to a PID. Forcing these into `ProcessMetrics` would require inventing a
+per-process split that the code does not have.
+
+**Export as counters (monotonic), converted to per-interval deltas by the exporter, with
+one gauge.** Concretely:
+
+| Field | Kind | Why it must be exported |
+|---|---|---|
+| `ExecutionsExact` | counter | the denominator every other join figure is read against |
+| `ExecutionsHeuristic` | counter | attribution quality; rising means stacks are guesses |
+| `ExecutionsUnmatched` | counter | **the alarm.** GPU time with no CPU stack |
+| `HeuristicAmbiguous` | counter | subset of heuristic; the least trustworthy stacks |
+| `OutOfWindowDrops` | counter | subset of unmatched with a specific, fixable cause |
+| `LaunchCacheEvictedCapacity` | counter | **the alarm.** joins dropped because the cache is undersized |
+| `LaunchCacheEvictedHorizon` | counter | joins dropped because launches aged out |
+| `LaunchCacheReplaced` | counter | correlation-ID reuse while live; a launch's stack was overwritten |
+| `LaunchCacheAnomalousTimestamp` | counter | producer clock fault; poisons horizon eviction |
+| `PendingSamplesEvicted` | counter | PC samples that will never be attributed |
+| `TimelineEvictedExecutions` | counter | GPU time never reaching the profile at all |
+| `LaunchCacheLive` | gauge | capacity headroom; the thing `EvictedCapacity` is a symptom of |
+
+Deliberately **not** exported: `LaunchCount` / `MatchedLaunchCount` / `UnmatchedLaunchCount`
+(unmatched-at-boundary is normal and would alert constantly; the ratio is recoverable from
+the execution counters), and `TimelineEvictedEvents` / `TimelineEvictedModules` (raw
+syscall traffic and symbol tables — real losses, but they degrade detail rather than
+attribution, and belong in logs). `SinkStats` should be exported too, but as part of
+whatever wires `CountingSink`, since it is ingestion rather than join.
+
+**Two rules the wiring must inherit:**
+
+1. **Export counters, never a success rate.** Any exporter-side "join health %" must be
+   computed by the *consumer* of the metrics from the exported counters, so that the
+   zero-traffic case shows as `executions_total == 0` rather than as `100%`. A ratio
+   computed inside `perf-agent` and exported as a single number is the failure mode this
+   issue exists to prevent, one abstraction layer up.
+2. **The alert is on the delta, not the level.** `ExecutionsUnmatched` is cumulative;
+   alerting on its absolute value fires forever after one bad minute. Alert on
+   `rate(ExecutionsUnmatched) > 0` alongside `rate(ExecutionsExact) > 0`, so a stopped
+   pipeline (both rates zero) is distinguishable from a healthy one.
+
+`metrics/console.go` should render them the same way `JoinHealth` does — compact when
+clean, expanded per anomaly — rather than a table of zeros.
+
+## 4. Cannot verify
+
+**No GPU run was performed and none is possible here.** `CapEff: 0` — no `CAP_BPF`, no
+`CAP_PERFMON`, so `gpuprobe.Attach` cannot load or attach anything, and there is no NVIDIA
+device reachable from this environment. Consequently:
+
+- Neither `cmd/gpu-cuda-profile` nor `cmd/gpu-stub-profile` was executed. Their two added
+  call sites (`for _, line := range gpu.JoinHealth(snap) { log.Print(line) }`) are verified
+  only by `go build` / `go vet` / `golangci-lint`, not by observing their output.
+- Every rendering in §1 comes from `Snapshot` values constructed in the test, four of them
+  hand-built and one produced by a real `gpu.Timeline`
+  (`TestJoinHealthAgainstARealTimelineSnapshot`). The *renderer* is exercised end to end;
+  the *counter values* a real CUDA run would produce are not, so the specific numbers above
+  are illustrative, not measured.
+- The claim "these lines appear after the `wrote …` line in a real run" is inferred from
+  the call-site position, not observed.
+
+**Not verified either:** that the counters are computed correctly. This change is
+surfacing-only, as the issue scopes it. Reading `Timeline.Snapshot` while writing the
+renderer surfaced no counter that reads green when things are worst — `UnmatchedExecutionCount`
+is incremented on both miss paths, `OutOfWindowDropCount` is a strict subset of it, and
+`MatchedLaunchCount` is `len(matched)` over a set, so it cannot exceed `LaunchCount` and the
+subtraction guarding `UnmatchedLaunchCount` is already conditional. No defect to report. The
+reconciliation anomaly added above is a check on the numbers being surfaced, not a change to
+how any of them is computed, so it stays inside #51's scope — and it is the mechanism that
+would make such a defect visible if one is ever introduced.
+
+## 5. Verification performed
+
+```
+go build ./...                                        OK
+go vet ./...                                          OK
+go test ./gpu/ ./gpuprobe/ ./internal/... -count=1     all ok
+~/go/bin/golangci-lint run --timeout=5m                0 issues
+gofmt -l gpu cmd                                       clean
+```
+
+(with `CGO_CFLAGS` / `CGO_LDFLAGS` / `LD_LIBRARY_PATH` pointing at blazesym as in CLAUDE.md)

--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -164,4 +164,12 @@ func main() {
 	st := c.Stats()
 	log.Printf("wrote %s: %d samples, launches=%d expected_sampled=%d stats=%+v",
 		*out, len(samples), launches, wantSampled, st)
+	// c.Stats() above is ingestion: what arrived off the ringbuf. This is
+	// attribution: what the timeline could join it to, and what it evicted
+	// trying. A run can be perfect on the first and quietly useless on the
+	// second, so both are printed - one line when the join is clean, one
+	// extra line per anomaly when it is not (see gpu.JoinHealth).
+	for _, line := range gpu.JoinHealth(snap) {
+		log.Print(line)
+	}
 }

--- a/cmd/gpu-stub-profile/main.go
+++ b/cmd/gpu-stub-profile/main.go
@@ -132,4 +132,12 @@ func main() {
 		log.Fatalf("close gpu-stub.pb.gz: %v", err)
 	}
 	log.Printf("wrote gpu-stub.pb.gz: %d samples, stats=%+v", len(samples), c.Stats())
+	// c.Stats() above is ingestion: what arrived off the ringbuf. This is
+	// attribution: what the timeline could join it to, and what it evicted
+	// trying. A run can be perfect on the first and quietly useless on the
+	// second, so both are printed - one line when the join is clean, one
+	// extra line per anomaly when it is not (see gpu.JoinHealth).
+	for _, line := range gpu.JoinHealth(snap) {
+		log.Print(line)
+	}
 }

--- a/gpu/joinhealth.go
+++ b/gpu/joinhealth.go
@@ -1,0 +1,241 @@
+package gpu
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	joinHealthPrefix  = "gpu join"
+	joinAnomalyPrefix = "gpu join ANOMALY"
+)
+
+// plural renders "1 launch" / "2 launches". These lines are read by a person
+// under time pressure, and "1 launches" reads like a formatting bug in a
+// line whose entire job is to be believed.
+func plural(n uint64, one, many string) string {
+	if n == 1 {
+		return "1 " + one
+	}
+	return strconv.FormatUint(n, 10) + " " + many
+}
+
+// JoinHealth renders a Snapshot's join and loss counters as operator-facing
+// lines: element 0 is always a one-line summary, and every element after it
+// is one anomaly that the summary's trailing count agrees with. Callers log
+// them one per line (see cmd/gpu-stub-profile, cmd/gpu-cuda-profile).
+//
+// The shape is deliberate. Printing the whole counter set on every run - the
+// obvious `%+v` - is what makes a rising UnmatchedExecutionCount invisible:
+// a line that is a wall of zeros on every healthy run trains the reader to
+// skip it, and then it is skipped on the one run that mattered. So the
+// healthy case collapses to a single short sentence with no zero-valued
+// fields in it at all, and anything anomalous is spelled out on its own
+// line, each with a few words of what the number means when it is bad. The
+// anomalous case is *longer* than the healthy case, which is the property
+// that makes it noticed.
+//
+// The summary's trailing "no anomalies" / "N anomalies" is the only derived
+// figure here, and it is derived so that it cannot read green when things
+// are worst: it is a count of raised conditions, so it reads 0 only when
+// every condition is unraised, and it grows monotonically as more go wrong.
+// The degenerate worst case - nothing arrived at all - is itself one of the
+// conditions ("no executions in this snapshot"), so an empty snapshot
+// reports an anomaly rather than the vacuous "all exact" that a ratio-based
+// health figure would print for 0/0.
+//
+// Scope. This covers what Snapshot knows: the join, the launch cache, the
+// timeline's own bounded stores, and (when the caller populated it via
+// CountingSink.SnapshotWith) admission. It cannot see loss upstream of the
+// sink - a full ringbuf, a batch the BPF program could not deliver - which
+// is gpuprobe.Stats's business and is logged separately by both drivers.
+// "no anomalies" therefore means the join is clean, not that nothing was
+// lost on the way to it.
+//
+// Time scales differ between the fields quoted here and are labelled as
+// such: JoinStats is per-snapshot (Timeline resets its launch counter on
+// every Snapshot call), while LaunchCacheStats and TimelineDropStats are
+// cumulative over the Timeline's life. Both drivers snapshot exactly once,
+// at the end, so the two coincide there; a caller that snapshots
+// periodically should read the eviction counters as running totals.
+func JoinHealth(snap Snapshot) []string {
+	anomalies := joinAnomalies(snap)
+	return append([]string{joinSummary(snap, len(anomalies))}, anomalies...)
+}
+
+// joinSummary is the always-printed line. len(snap.Executions), not a
+// JoinStats field, is the execution total: the three join outcomes are
+// mutually exclusive and sum to it, so quoting the slice length keeps the
+// parenthesised breakdown checkable against a figure that does not come
+// from the same counters it is auditing. joinAnomalies performs that check
+// rather than leaving it to the reader's arithmetic.
+func joinSummary(snap Snapshot, anomalies int) string {
+	js := snap.JoinStats
+	execs := uint64(len(snap.Executions))
+
+	var b strings.Builder
+	b.WriteString(joinHealthPrefix + ": ")
+	switch {
+	case execs == 0:
+		b.WriteString("no executions")
+	case js.ExactExecutionJoinCount == execs:
+		fmt.Fprintf(&b, "%s, all exact", plural(execs, "execution", "executions"))
+	default:
+		fmt.Fprintf(&b, "%s (%d exact, %d heuristic, %d unmatched)",
+			plural(execs, "execution", "executions"), js.ExactExecutionJoinCount,
+			js.HeuristicExecutionJoinCount, js.UnmatchedExecutionCount)
+	}
+
+	switch {
+	case js.LaunchCount == 0:
+		b.WriteString("; no launches")
+	case js.UnmatchedLaunchCount == 0:
+		fmt.Fprintf(&b, "; %s, all matched", plural(js.LaunchCount, "launch", "launches"))
+	default:
+		fmt.Fprintf(&b, "; %s (%d matched, %d unmatched)",
+			plural(js.LaunchCount, "launch", "launches"),
+			js.MatchedLaunchCount, js.UnmatchedLaunchCount)
+	}
+
+	fmt.Fprintf(&b, "; cache %d live", snap.LaunchCache.Live)
+
+	// PC samples are optional on this pipeline (CUPTI's continuous mode
+	// emits them, the stub does not), so the clause appears only when there
+	// were any - a permanent "0 attributed, 0 pending" would be exactly the
+	// zero-valued noise this format exists to avoid.
+	if snap.AttributedPCSamples > 0 || snap.PendingSamples > 0 {
+		fmt.Fprintf(&b, "; pc samples %d attributed, %d pending",
+			snap.AttributedPCSamples, snap.PendingSamples)
+	}
+
+	switch anomalies {
+	case 0:
+		b.WriteString("; no anomalies")
+	case 1:
+		b.WriteString("; 1 anomaly")
+	default:
+		fmt.Fprintf(&b, "; %d anomalies", anomalies)
+	}
+	return b.String()
+}
+
+// joinAnomalies returns one line per raised condition, in severity order:
+// nothing arrived, then the counters disagreeing with the executions in
+// hand, then attribution the profile got wrong or guessed, then the
+// eviction paths that caused it, then admission loss underneath.
+//
+// UnmatchedLaunchCount is deliberately not a condition. A launch whose
+// execution has not landed yet is the normal state at any snapshot boundary
+// - it is in the summary line, where it is readable, but raising it would
+// fire on every healthy periodic snapshot and devalue the word "anomaly"
+// for the counters that do mean something is wrong.
+func joinAnomalies(snap Snapshot) []string {
+	js, lc, dr := snap.JoinStats, snap.LaunchCache, snap.Dropped
+	execs := uint64(len(snap.Executions))
+
+	var out []string
+	add := func(format string, args ...any) {
+		out = append(out, joinAnomalyPrefix+": "+fmt.Sprintf(format, args...))
+	}
+
+	if execs == 0 {
+		add("no executions in this snapshot — nothing was attributed at all; " +
+			"check the probe attachment and the sink before reading anything below")
+	}
+	// The three join outcomes are mutually exclusive and every execution
+	// takes exactly one of them, so they must sum to the number of
+	// executions actually in the snapshot. joinSummary deliberately takes
+	// its denominator from len(snap.Executions) rather than from these
+	// counters precisely so the two can be compared - but a breakdown that
+	// silently fails to add up is not something a reader spots by eye, and
+	// unchecked it would make every figure below look authoritative while
+	// being wrong. Raised first, because it is the condition that decides
+	// whether the rest of the line can be believed at all.
+	if outcomes := js.ExactExecutionJoinCount + js.HeuristicExecutionJoinCount +
+		js.UnmatchedExecutionCount; outcomes != execs {
+		add("join outcomes sum to %d but the snapshot holds %d executions — the join counters "+
+			"disagree with what is actually present; treat every figure below as unreliable",
+			outcomes, execs)
+	}
+	if js.UnmatchedExecutionCount > 0 {
+		add("%d of %d executions unmatched — GPU time arrived with no launch to attach it to; "+
+			"it is in the profile under %s carrying no CPU stack",
+			js.UnmatchedExecutionCount, execs, FrameLaunchUnsampled)
+	}
+	if js.HeuristicExecutionJoinCount > 0 {
+		add("%d of %d executions joined heuristically — matched on queue, kernel name and timing "+
+			"rather than vendor correlation; the CPU stack may be another launch's",
+			js.HeuristicExecutionJoinCount, execs)
+	}
+	if js.AmbiguousHeuristicMatchCount > 0 {
+		add("%s flagged ambiguous — more than one launch qualified and one was chosen; "+
+			"these are the least trustworthy stacks in the profile",
+			plural(js.AmbiguousHeuristicMatchCount, "heuristic join", "heuristic joins"))
+	}
+	if js.OutOfWindowDropCount > 0 {
+		add("%d of the unmatched executions had a candidate launch just outside "+
+			"LaunchEventJoinWindowNs — widen that window or snapshot more often",
+			js.OutOfWindowDropCount)
+	}
+	if lc.EvictedCapacity > 0 {
+		add("launch cache evicted %s at capacity (%d live) — too small for the launch rate, "+
+			"so their executions cannot join; raise TimelineConfig.LaunchCache.Capacity",
+			plural(lc.EvictedCapacity, "launch", "launches"), lc.Live)
+	}
+	if lc.EvictedHorizon > 0 {
+		add("launch cache evicted %s past HorizonNs — they aged out before their execution "+
+			"arrived; raise the horizon if kernels sit queued that long",
+			plural(lc.EvictedHorizon, "launch", "launches"))
+	}
+	if lc.Replaced > 0 {
+		add("launch cache replaced %s — the same correlation ID came back while still "+
+			"live; the earlier launch and its stack are gone",
+			plural(lc.Replaced, "live entry", "live entries"))
+	}
+	if lc.AnomalousTimestamp > 0 {
+		add("%s carried an out-of-range timestamp — the producer's clock is suspect and "+
+			"horizon eviction is running against a clamped anchor",
+			plural(lc.AnomalousTimestamp, "launch", "launches"))
+	}
+	if dr.EvictedPendingSamples > 0 {
+		add("%s evicted while waiting for their execution — never attributed, so the "+
+			"stall detail on those kernels is under-reported",
+			plural(dr.EvictedPendingSamples, "PC sample", "PC samples"))
+	}
+	if dr.EvictedExecutions > 0 {
+		add("%s evicted from the timeline ring before this snapshot — that GPU time is "+
+			"missing from the profile entirely; snapshot more often or raise the capacity",
+			plural(dr.EvictedExecutions, "execution", "executions"))
+	}
+	if dr.EvictedEvents > 0 {
+		add("%s evicted before this snapshot — raise TimelineConfig.EventCapacity",
+			plural(dr.EvictedEvents, "timeline event", "timeline events"))
+	}
+	if dr.EvictedModules > 0 {
+		add("%s evicted before this snapshot — kernels from evicted modules resolve to bare addresses",
+			plural(dr.EvictedModules, "module", "modules"))
+	}
+
+	for _, k := range []struct {
+		one, many string
+		stats     EventKindStats
+	}{
+		{"launch", "launches", snap.SinkStats.Launches},
+		{"execution", "executions", snap.SinkStats.Execs},
+		{"PC sample", "PC samples", snap.SinkStats.PCSamples},
+		{"module", "modules", snap.SinkStats.Modules},
+		{"timeline event", "timeline events", snap.SinkStats.Events},
+	} {
+		lost := k.stats.DroppedFull + k.stats.DroppedInvalid + k.stats.DroppedDownstream
+		if lost == 0 {
+			continue
+		}
+		add("sink dropped %s at admission (%d full, %d invalid, %d downstream) — they never "+
+			"reached the timeline, so no join counter above accounts for them",
+			plural(lost, k.one, k.many), k.stats.DroppedFull, k.stats.DroppedInvalid,
+			k.stats.DroppedDownstream)
+	}
+
+	return out
+}

--- a/gpu/joinhealth_test.go
+++ b/gpu/joinhealth_test.go
@@ -1,0 +1,244 @@
+package gpu
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// healthySnapshot is 512 executions all joined exactly, 256 launches all
+// matched, nothing evicted - what a clean CUPTI run looks like.
+func healthySnapshot() Snapshot {
+	return Snapshot{
+		Executions: make([]ExecutionView, 512),
+		JoinStats: JoinStats{
+			LaunchCount:             256,
+			MatchedLaunchCount:      256,
+			ExactExecutionJoinCount: 512,
+		},
+		LaunchCache: LaunchCacheStats{Live: 256},
+	}
+}
+
+// anomalousSnapshot is the same run gone wrong in every way the counters
+// can express, so one rendering exercises every branch.
+func anomalousSnapshot() Snapshot {
+	return Snapshot{
+		Executions: make([]ExecutionView, 512),
+		JoinStats: JoinStats{
+			LaunchCount:                  260,
+			MatchedLaunchCount:           240,
+			UnmatchedLaunchCount:         20,
+			ExactExecutionJoinCount:      470,
+			HeuristicExecutionJoinCount:  22,
+			AmbiguousHeuristicMatchCount: 4,
+			UnmatchedExecutionCount:      20,
+			OutOfWindowDropCount:         7,
+		},
+		LaunchCache: LaunchCacheStats{
+			Live:               250,
+			EvictedCapacity:    47,
+			EvictedHorizon:     3,
+			Replaced:           2,
+			AnomalousTimestamp: 1,
+		},
+		Dropped: TimelineDropStats{
+			EvictedExecutions:     9,
+			EvictedEvents:         11,
+			EvictedModules:        1,
+			EvictedPendingSamples: 128,
+		},
+		SinkStats: SinkStats{
+			PCSamples: EventKindStats{Accepted: 900, DroppedFull: 60, DroppedInvalid: 4},
+		},
+		AttributedPCSamples: 900,
+		PendingSamples:      12,
+		PendingCorrelations: 5,
+	}
+}
+
+func TestJoinHealthHealthyRunIsOneShortLine(t *testing.T) {
+	lines := JoinHealth(healthySnapshot())
+
+	require.Len(t, lines, 1, "a clean run must not print anything a reader learns to skip")
+	assert.Equal(t,
+		"gpu join: 512 executions, all exact; 256 launches, all matched; cache 256 live; no anomalies",
+		lines[0])
+}
+
+func TestJoinHealthAnomaliesEachGetTheirOwnLine(t *testing.T) {
+	lines := JoinHealth(anomalousSnapshot())
+
+	require.Greater(t, len(lines), 1)
+	for _, l := range lines[1:] {
+		assert.True(t, strings.HasPrefix(l, joinAnomalyPrefix+": "), "line %q", l)
+		assert.Contains(t, l, " — ", "every anomaly says what the number means when it is bad")
+	}
+
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"20 of 512 executions unmatched",
+		"22 of 512 executions joined heuristically",
+		"4 heuristic joins flagged ambiguous",
+		"7 of the unmatched executions had a candidate launch",
+		"launch cache evicted 47 launches at capacity",
+		"launch cache evicted 3 launches past HorizonNs",
+		"launch cache replaced 2 live entries",
+		"1 launch carried an out-of-range timestamp",
+		"128 PC samples evicted",
+		"9 executions evicted from the timeline ring",
+		"11 timeline events evicted",
+		"1 module evicted before this snapshot — kernels from evicted modules resolve",
+		"sink dropped 64 PC samples at admission",
+	} {
+		assert.Contains(t, joined, want)
+	}
+}
+
+// The summary's anomaly count is the one derived figure here; it must never
+// read green when things are worst.
+func TestJoinHealthSummaryCountMatchesTheLinesBelowIt(t *testing.T) {
+	for name, snap := range map[string]Snapshot{
+		"healthy":   healthySnapshot(),
+		"anomalous": anomalousSnapshot(),
+		"empty":     {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			lines := JoinHealth(snap)
+			switch n := len(lines) - 1; n {
+			case 0:
+				assert.Contains(t, lines[0], "; no anomalies")
+			case 1:
+				assert.Contains(t, lines[0], "; 1 anomaly")
+			default:
+				assert.Contains(t, lines[0], "; "+strconv.Itoa(n)+" anomalies")
+			}
+		})
+	}
+}
+
+// A snapshot with nothing in it is the degenerate worst case: every ratio a
+// health figure could compute is 0/0. It must read as an anomaly, not as a
+// clean run.
+func TestJoinHealthEmptySnapshotIsAnAnomalyNotAllExact(t *testing.T) {
+	lines := JoinHealth(Snapshot{})
+
+	require.Len(t, lines, 2)
+	assert.Equal(t, "gpu join: no executions; no launches; cache 0 live; 1 anomaly", lines[0])
+	assert.Contains(t, lines[1], "no executions in this snapshot")
+	assert.NotContains(t, lines[0], "all exact")
+}
+
+// A run whose executions all joined but whose cache was thrashing is the
+// case the summary line alone would call fine; the eviction lines are what
+// make it visible.
+func TestJoinHealthEvictionsAreRaisedEvenWhenEveryJoinWasExact(t *testing.T) {
+	snap := healthySnapshot()
+	snap.LaunchCache.EvictedCapacity = 47
+
+	lines := JoinHealth(snap)
+
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], "512 executions, all exact")
+	assert.Contains(t, lines[0], "; 1 anomaly")
+	assert.Contains(t, lines[1], "launch cache evicted 47 launches at capacity")
+	assert.Contains(t, lines[1], "TimelineConfig.LaunchCache.Capacity")
+}
+
+// The summary line quotes len(snap.Executions) as its denominator so the
+// breakdown beside it is checkable. Nothing checks it by eye, so the
+// renderer checks it: a counter that has drifted from the executions
+// actually present is exactly the condition an operator cannot spot.
+func TestJoinHealthRaisesWhenJoinOutcomesDoNotSumToExecutions(t *testing.T) {
+	snap := healthySnapshot()
+	snap.JoinStats.ExactExecutionJoinCount = 500 // 12 executions unaccounted for
+
+	lines := JoinHealth(snap)
+
+	require.Len(t, lines, 2)
+	assert.Equal(t,
+		"gpu join ANOMALY: join outcomes sum to 500 but the snapshot holds 512 executions — "+
+			"the join counters disagree with what is actually present; treat every figure below as unreliable",
+		lines[1],
+		"both figures belong in the message; the reader must not have to compute the discrepancy")
+	assert.Contains(t, lines[0], "; 1 anomaly")
+}
+
+// It has to fire in the other direction too - counters over-reporting is the
+// same defect and reads just as authoritative.
+func TestJoinHealthRaisesWhenJoinOutcomesExceedExecutions(t *testing.T) {
+	snap := healthySnapshot()
+	snap.JoinStats.HeuristicExecutionJoinCount = 3 // 515 outcomes over 512 executions
+
+	lines := JoinHealth(snap)
+
+	require.Len(t, lines, 3)
+	assert.Contains(t, lines[1], "join outcomes sum to 515 but the snapshot holds 512 executions")
+	assert.Contains(t, lines[2], "3 of 512 executions joined heuristically",
+		"the reconciliation line comes before the conditions it casts doubt on")
+}
+
+// The reconciliation check must not fire on snapshots that do add up, or it
+// becomes the noise it exists to prevent.
+func TestJoinHealthReconciliationStaysQuietWhenTheCountersAgree(t *testing.T) {
+	for name, snap := range map[string]Snapshot{
+		"healthy":   healthySnapshot(),
+		"anomalous": anomalousSnapshot(),
+		"empty":     {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.NotContains(t, strings.Join(JoinHealth(snap), "\n"), "join outcomes sum to")
+		})
+	}
+}
+
+// The two drivers snapshot a real Timeline, so the renderer has to hold up
+// against a Snapshot this package actually produced, not only hand-built
+// structs.
+func TestJoinHealthAgainstARealTimelineSnapshot(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	l := launch("a", 100)
+	require.NoError(t, tl.EmitLaunch(l))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		Correlation: l.Correlation,
+		KernelName:  l.KernelName,
+		StartNs:     200,
+		EndNs:       300,
+	}))
+	// An execution whose correlation never had a launch: the shape issue #36
+	// turned from a wrong exact join into an honest miss.
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "ghost"},
+		KernelName:  "k_ghost",
+		StartNs:     400,
+		EndNs:       500,
+	}))
+
+	lines := JoinHealth(tl.Snapshot())
+
+	require.Len(t, lines, 2)
+	assert.Equal(t,
+		"gpu join: 2 executions (1 exact, 0 heuristic, 1 unmatched); 1 launch, all matched; cache 1 live; 1 anomaly",
+		lines[0])
+	assert.Contains(t, lines[1], "1 of 2 executions unmatched")
+	assert.Contains(t, lines[1], FrameLaunchUnsampled)
+}
+
+// TestJoinHealthRenderedOutput prints both renderings verbatim so the text a
+// human will actually read can be reviewed with `go test -run
+// TestJoinHealthRenderedOutput -v ./gpu/`.
+func TestJoinHealthRenderedOutput(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		snap Snapshot
+	}{
+		{"healthy", healthySnapshot()},
+		{"anomalous", anomalousSnapshot()},
+		{"empty", Snapshot{}},
+	} {
+		t.Log(c.name + ":\n" + strings.Join(JoinHealth(c.snap), "\n"))
+	}
+}


### PR DESCRIPTION
Closes #51.

`Timeline`'s join counters were computed on every snapshot and thrown away.
`cmd/gpu-cuda-profile/main.go` logged `c.Stats()` — the Consumer counters — and never
`snap.JoinStats` or `snap.Stats.LaunchCache`. So `UnmatchedExecutionCount`,
`EvictedCapacity`, `Replaced` and the rest never reached a human.

That mattered concretely. Before #36 a cross-process collision was counted as an
`ExactExecutionJoinCount` — green while wrong. After #36 the same collision lands in
`UnmatchedExecutionCount` — correctly red. A real improvement in what the profiler
*knows*, and with nothing surfacing it the observable behaviour was unchanged.

### Not a struct dump

`join=%+v` would print seventeen `Field:0` on every healthy run, which is what trains
people to skip the line — the same failure this issue is about, reintroduced by the fix.

`gpu.JoinHealth(Snapshot) []string` returns a summary as element 0 and one anomaly per
element after it. The healthy case carries no zero-valued field:

```
gpu join: 512 executions, all exact; 256 launches, all matched; cache 256 live; no anomalies
```

Anomalies expand it, so length itself is the signal, and `gpu join ANOMALY` greps:

```
gpu join ANOMALY: 20 of 512 executions unmatched — GPU time arrived with no launch to
  attach it to; it is in the profile under [gpu:launch unsampled] carrying no CPU stack
gpu join ANOMALY: 22 of 512 executions joined heuristically — matched on queue, kernel
  name and timing rather than vendor correlation; the CPU stack may be another launch's
gpu join ANOMALY: launch cache evicted 47 launches at capacity (250 live) — too small for
  the launch rate, so their executions cannot join; raise TimelineConfig.LaunchCache.Capacity
```

Each says what the number *means* when it is bad, because `EvictedCapacity: 47` is not
actionable on its own.

### Three deliberate choices

**No join success rate.** It would read 100% for a zero-execution snapshot — green
precisely when the profiler produced nothing. "No executions in this snapshot" is instead
one of the anomaly conditions. The only derived figure is the trailing count of raised
conditions, which reads `no anomalies` only when every condition is unraised.

**`UnmatchedLaunchCount` is printed but never raised.** Unmatched-at-boundary is normal;
raising it would fire on every healthy periodic snapshot and train people to ignore the
line.

**Reconciliation.** The execution total comes from `len(snap.Executions)`, not a
`JoinStats` field, so the breakdown is checkable against a figure that does not come from
the counters being audited. And that check is now made rather than merely made possible:

```
gpu join ANOMALY: join outcomes sum to 500 but the snapshot holds 512 executions — the
  join counters disagree with what is actually present; treat every figure below as unreliable
```

Raised first, ahead of everything whose numbers it undermines. A drifted counter is
exactly the condition an operator cannot catch by eye, and without this the summary prints
a breakdown that quietly does not add up, reading as authoritative as a correct one.

`SinkStats` is rendered even though both drivers currently leave it zero, so wiring
`CountingSink.SnapshotWith` later does not reintroduce the same gap.

No counter's computation is changed. Reading `Timeline.Snapshot` while writing this
surfaced no green-when-worst counter.

### Exported metrics

Recommendation only, in the report — GPU is not yet wired into the main binary, so making
the call now means that wiring inherits it. Summary: a process-independent `GPU
*GPUMetrics` on `metrics.MetricsSnapshot` (the join is one shared `Timeline`; eviction
counters are not PID-attributable), 11 monotonic counters plus `LaunchCacheLive` as a
gauge, alarms on `ExecutionsUnmatched` and `LaunchCacheEvictedCapacity`. Two rules for the
wiring: never export a computed success rate, and alert on the delta with
`rate(ExecutionsExact) > 0` as a companion so a stopped pipeline is distinguishable from a
healthy one.
