### PR TITLE
flamegraph: emit a self-contained interactive HTML flame graph

### DIFF
--- a/.superpowers/sdd/flamegraph-html-report.md
+++ b/.superpowers/sdd/flamegraph-html-report.md
@@ -1,0 +1,414 @@
+# `--flamegraph-output`: a self-contained HTML flame graph
+
+Branch `feat/flamegraph-html`. One commit. Additive: two new packages, one new
+`cmd/`, plus flag/option/Stop wiring. Nothing in `gpu/`, `gpuprobe/`, `bpf/`,
+`unwind/` or `shim/` was touched.
+
+---
+
+## 1. What shipped
+
+| Piece | Path |
+|---|---|
+| pprof → folded stacks | `internal/foldedstacks/fold.go` |
+| Domain classifier | `internal/flamegraph/domain.go` |
+| HTML/SVG renderer | `internal/flamegraph/render.go`, `assets.go` |
+| Profile file → page | `internal/flamegraph/file.go` |
+| Offline CLI | `cmd/flamegraph/main.go` |
+| Agent wiring | `perfagent/options.go`, `perfagent/agent.go` |
+| Flag | `main.go` (`--flamegraph-output`) |
+
+`--flamegraph-output <path>|auto` sits beside `--profile-output` and
+`--offcpu-output`. `auto` follows the established convention exactly —
+`generateOutputName(pid, all, "on-cpu"|"off-cpu", "html")`, the same function
+`--pmu-output auto` calls. With `--profile` and `--offcpu` both on, an explicit
+path is rejected at flag-parse time: one path cannot name two graphs, and
+rendering one while silently dropping the other is the failure mode this whole
+feature is supposed to avoid.
+
+The renderer reads the `.pb.gz` back off disk after the agent writes it. That is
+deliberate: the page is a rendering of the artifact the user was actually
+handed, so a page that looks wrong is evidence about the file rather than about
+a second, parallel code path. The consequence is that `WithCPUProfileWriter`
+(stream-to-io.Writer) has no file to re-read; that case logs why no graph
+appeared rather than staying quiet.
+
+---
+
+## 2. What was salvaged from PR #10, and what changed
+
+**Kept:** the overall shape — build a tree from folded stacks, emit one `<g
+class="frame">` per node with `data-orig-x`/`data-orig-width`, rewrite `x`/`width`
+in JS to zoom, no d3, no CDN, one file. The click-to-zoom ancestor/descendant
+test, the `/`-to-search and Esc-clears-then-resets keybindings, and the
+breadcrumb/details/match-count toolbar are PR #10's design and survive.
+
+**Changed, with reasons:**
+
+1. **It could not read a pprof file.** PR #10 consumed folded text and nothing
+   in the repo produced it. That gap is why it never shipped; `internal/foldedstacks`
+   is the missing half.
+
+2. **The renderer no longer round-trips through text.** It consumes
+   `[]foldedstacks.Stack` directly. Folded text has no escape for `;`, a space,
+   or a newline inside a frame name, and C++ symbols contain spaces routinely
+   (`foo(float, int)`). PR #10's `strings.LastIndexByte(line, ' ')` parser
+   happens to survive that, but a `;` in a name would silently split one frame
+   into two. `WriteFolded` still exists (and `cmd/flamegraph -folded` exposes it)
+   but it *reports* how many names it had to substitute, and the structured path
+   the renderer uses keeps the originals.
+
+3. **An empty profile was an error.** `renderParsed` returned
+   `fmt.Errorf("no folded samples")`. Now a degenerate profile renders a page
+   that states the fact — see §5.
+
+4. **"samples" was hardcoded.** PR #10's UI said `N samples` for every value.
+   This repo's GPU and off-CPU profiles are nanoseconds; calling 5,987,854
+   nanoseconds "5,987,854 samples" is a straightforward lie. The page now
+   carries the profile's own `type/unit` and formats accordingly (ns/µs/ms/s),
+   in Go for the tooltips and in mirrored JS for the live readouts.
+
+5. **Colour was `fnv(name) % 360`.** Replaced with a domain classifier (§4).
+   A hash carries no information, and these profiles have real structure.
+
+6. **No synthetic root.** PR #10 laid out `root.children` side by side. Any
+   profile with more than one root frame — every system-wide profile, and the
+   verification profile itself, which has two disjoint roots — then had no
+   full-width frame to click, and no anchor for "% of total". Added an `all`
+   node.
+
+7. **Zoom did not re-fit labels.** Text was truncated server-side for the
+   original width and never recomputed, so a frame zoomed from 84px to 1264px
+   still read `cudaLau…`. `fit()` now re-truncates on every layout.
+
+8. **`fmt.Fprintf` returns were discarded** throughout (errcheck). Everything
+   goes through an `errWriter` that latches the first error.
+
+9. **One giant `Fprintf` format string** held the entire document, with
+   `%%`-escaped CSS percentages and positional `%d`s interleaved with content.
+   CSS and JS are now plain constants written with `io.WriteString`; no user
+   data is ever a format argument or lands inside `<style>`/`<script>`.
+
+10. **`RenderSVG` refuses a degenerate profile** rather than emitting a blank
+    canvas, because the standalone SVG has nowhere to put the explanation.
+
+11. Siblings are sorted by name and stacks are sorted before rendering, so two
+    runs over one profile produce byte-identical HTML (tested). PR #10's output
+    depended on input line order.
+
+---
+
+## 3. Stack order — the decision that was easiest to get silently wrong
+
+The pprof proto specifies `Sample.Location[0]` is the **leaf**. perf-agent does
+not follow that: `profile/profiler.go:236` and `offcpu/profiler.go:206` both
+call `pprof.Reverse` before building, and `gpu/projection.go` assembles frames
+root-first. In every profile this repo writes, `Location[0]` is the **root**.
+
+Folding with the wrong assumption does not fail. It draws a perfectly plausible
+flame graph upside down. So:
+
+- `foldedstacks.Options.StackOrder` is explicit, defaulting to `RootFirst`
+  (what perf-agent writes), with a `LeafFirst` mode for foreign profiles.
+- `cmd/flamegraph -stack-order` exposes it.
+- **The page always states which order it read**, in a header chip and in the
+  footer. If it guessed wrong, the reader can see that it guessed.
+
+---
+
+## 4. Colour: domain, not hash
+
+`Classify(name, module)` maps a frame to one of nine domains. Where the profile
+supplies a mapping file it is used (`[kernel]`, `libcuda*`, `libperfagent*`,
+`libc*`); otherwise the symbol name. The legend says the domain is *inferred*,
+and classification affects nothing but colour — every width and position comes
+from the measured value.
+
+On the verification profile every frame lands correctly (test:
+`TestClassifyCoversTheRealRTX3090Stack`):
+
+| Frames | Domain | Treatment |
+|---|---|---|
+| `_start`, `__libc_start_main_alias_1`, `__libc_start_call_main` | process startup / libc | red |
+| `main`, `__device_stub__Z14perfagent_axpy…` | application | pink |
+| `cudaLaunchKernel` | GPU runtime, CPU side | orange |
+| `0x7f2c958b71c6` … ×7 | unsymbolized | muted slate **+ hatch** |
+| `(anonymous namespace)::on_callback(…CUpti_CallbackDomain…)` | perf-agent's own shim | violet |
+| `[gpu:launch]` | CPU→GPU boundary | grey, outlined |
+| `[gpu:launch unsampled]` | GPU work with no CPU stack | pale grey **+ hatch** |
+| `[gpu:kernel:…]` | GPU kernel execution | green |
+
+Two of these are honesty features rather than decoration:
+
+- **Unsymbolized** frames are hatched because the depth is real and the *names*
+  are missing — a symbolization gap, not an unwinding one. 1,799 of 11,598 frame
+  slots in the verification profile.
+- **`[gpu:launch unsampled]`** must not be confusable with `[gpu:launch]`. One
+  means "GPU time we have a CPU stack for", the other "GPU time we do not". They
+  differ in fill, in stroke, and in hatching, and the legend spells out the
+  difference. A test asserts they cannot render identically.
+
+The shim domain requires *both* `on_callback` and a vendor callback type in the
+signature, so an application function innocently named `on_callback` is not
+billed to the profiler.
+
+The legend lists only domains actually present, so a CPU-only profile does not
+advertise a GPU layer it does not have.
+
+---
+
+## 5. Degenerate profiles
+
+`Fold` returns an empty profile as a `Result` with `Total == 0` and a populated
+`Warnings`, never as an error and never as a silent success. `RenderHTML` then
+emits **no `<svg>` and no `<script>`** and instead a panel:
+
+> **No flame graph was drawn.** The profile contains zero samples. An empty
+> flame graph would be indistinguishable from a flame graph of an idle process,
+> so none is drawn. […] This is the profile reporting on itself, not a rendering
+> failure.
+
+The all-zero-values case gets its own wording. The same warnings are echoed to
+the terminal by both `cmd/flamegraph` and the agent, so a pipeline sees it
+without opening a browser.
+
+Verified against a real file: `/tmp/fg/empty.pb.gz`, a valid gzipped pprof with
+a declared `cpu/nanoseconds` type and zero samples.
+
+```
+$ go run ./cmd/flamegraph -o /tmp/fg/empty.html /tmp/fg/empty.pb.gz
+wrote /tmp/fg/empty.html
+  axis     cpu/nanoseconds
+  total    0 ns across 0 samples in 0 distinct stacks
+  note     This profile contains no samples at all. Nothing was collected, so
+           there is nothing to draw. That is a fact about the profile, not a
+           statement that the target was idle.
+```
+
+The rendered page contains no `<svg class="flame">` and no `<script>` (asserted
+in `TestFromProfileFileWritesAPageForAnEmptyProfile`).
+
+---
+
+## 6. Sample-type choice
+
+`chooseSampleIndex`:
+
+1. `Profile.DefaultSampleType`, when it names a real type;
+2. otherwise the **last** sample type.
+
+"Last" matches `google/pprof`'s own driver. Every mode perf-agent ships today —
+`cpu`, `offcpu`, `gpu` — declares exactly one type, so this only bites the
+memory builder, where the two types are `alloc_objects/count` and
+`alloc_space/bytes` and "last" picks bytes, which is the useful axis. When a
+profile has more than one axis the page says which one it drew and names the
+ones it did not.
+
+**Negative values are refused, not drawn.** A negative value means a
+`-diff_base` differential profile. A flame graph has no negative rectangle, and
+clamping or absolute-valuing one would present a subtraction as a measurement.
+
+For the verification profile: one type, `gpu/nanoseconds`, index 0.
+
+---
+
+## 7. GPU labels — the decision, and its grounding in spec §8
+
+**Decision: labels stay out of the frames entirely. They are summarised beside
+the graph, and the two that qualify how much the graph can be trusted are
+promoted to warnings on the page.**
+
+### Why not in the frames
+
+§8 of `docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md` already
+ruled on this, and the ruling is not ambiguous:
+
+> - **Frames** — what should nest in the flame graph: real CPU stack, then
+>   `[gpu:launch]`, then the kernel name.
+> - **Labels** — what must not fragment aggregation: stall reason, PC, queue,
+>   device, correlation ID, cgroup, pod UID, container ID.
+
+and the reason:
+
+> Frames are stack identity, so `[gpu:pc:0x1a40]` as a frame produces one
+> flame-graph leaf per sampled instruction. […] this destroys aggregation.
+
+The verification profile makes the cost concrete. It has 4,000 samples and
+**4,000 distinct `gpu_correlation` values** — one per sample. Folding
+`gpu_correlation` into the path turns 3 folded stacks into 4,000, each 1/4000th
+of the width, and the flame graph stops being a flame graph. So the folder never
+puts a label in a frame, and a test asserts it
+(`TestFoldKeepsLabelsOutOfFramesAndSummarisesThemInstead`).
+
+### Why not simply dropped
+
+"Frames-only" cannot mean "labels vanish". The page therefore carries a
+**Sample labels (not in the graph)** table: key, sample count, distinct-value
+count, and the top values by value. For a label whose cardinality equals its
+sample count it says *"one distinct value per sample — nothing to aggregate,
+which is why this is a label and not a frame"* rather than listing eight
+arbitrary correlation IDs that would read as a top-N finding.
+
+### The two labels that change how the graph must be read
+
+Two labels are not merely context; they qualify the trustworthiness of the very
+frames being drawn. Leaving those to a table nobody scrolls to would be the
+"looks healthy exactly when it is worst" defect in visual form.
+
+**`gpu_join` / `gpu_ambiguous` → per-frame hatching.** `gpu/projection.go` sets
+`gpu_join` unconditionally to `exact`, `heuristic` or `unmatched`, with an
+explicit comment that "an ABSENT label must never be readable as 'exact'". A
+heuristic join means the CPU call path under `[gpu:launch]` was *guessed*; the
+tags it carries (pod_uid, container_id) may belong to the wrong container. So
+`Fold` accumulates a per-stack `Inexact` weight from those labels, the renderer
+hatches every affected frame with a distinct pattern, the tooltip says how much
+of that frame is inferred, and a warning states the share of the total. On the
+verification profile this is 0% — every join is `exact` — and correctly nothing
+is hatched for it.
+
+**`gpu_sample_period` → a warning about what the widths mean.** This is the one
+that would have misled a reader worst. On the verification profile the picture
+is:
+
+- `[gpu:launch unsampled]` — 5,590,723 ns, **93.4%** of the total
+- the joined 16-frame CPU stack — 397,131 ns, **6.6%**
+
+The naive reading is "only 6.6% of GPU time comes from this call path". That is
+wrong. `gpu/projection.go` samples launch *stacks* one-in-`SamplePeriod` (here
+8) while recording *every* execution, and deliberately refuses to scale either
+population, because "multiplying the sampled population by SamplePeriod would
+turn a measurement into an estimate and present it as fact". So the 6.6% is a
+sample of launches, not a share of GPU time. The page says so, in the notices
+box, in these words:
+
+> 93.4% of the total sits under [gpu:launch unsampled]: measured GPU time whose
+> launch was not one of the sampled ones, so it has no CPU caller and none is
+> borrowed from a sampled sibling.
+>
+> 257 samples carry gpu_sample_period=8: one launch in 8 contributed a CPU
+> stack. The call path beneath [gpu:launch] is therefore a sample of launches,
+> not a sample of GPU time - do not read its width as the share of GPU work that
+> call path is responsible for. Nothing here is scaled by 8; every value is a
+> measured duration.
+
+Nothing on the page is scaled by the period. The flame graph does not imply
+anything the profile does not say.
+
+---
+
+## 8. Verification against `/home/diego/gpu-cuda-45.pb.gz`
+
+### Totals
+
+| | `go tool pprof -raw` | `cmd/flamegraph` |
+|---|---:|---:|
+| total | 5,987,854 ns | 5,987,854 ns (`data-total="5987854"`, "5.99 ms") |
+| samples | 4,000 | 4,000 |
+| distinct stacks | 3 | 3 |
+| max depth | 16 | 16 |
+
+### Per-stack, exact
+
+`go tool pprof -raw`, summed per distinct location list, against the folded
+output — identical on all three:
+
+| stack | pprof `-raw` | folded | samples |
+|---|---:|---:|---:|
+| `[gpu:launch unsampled];[gpu:kernel:_Z15perfagent_scalePffi]` | 2,894,901 | 2,894,901 | 2,000 |
+| `[gpu:launch unsampled];[gpu:kernel:_Z14perfagent_axpyfPKfPfi]` | 2,695,822 | 2,695,822 | 1,743 |
+| `_start;…;[gpu:launch];[gpu:kernel:_Z14perfagent_axpyfPKfPfi]` (16 frames) | 397,131 | 397,131 | 257 |
+| **total** | **5,987,854** | **5,987,854** | **4,000** |
+
+`go tool pprof -traces` reproduces the same three stacks with the same sample
+counts (2,000 / 1,743 / 257). Its per-line values are printed rounded to three
+significant figures (`1.44us`), so summing its display text gives 5,987,350 —
+a 0.008% display artifact of `-traces`, not a discrepancy. `-raw` carries the
+unrounded integers and matches exactly.
+
+### Frame accounting
+
+- Frame slots: 1,743×2 + 2,000×2 + 257×16 = **11,598** — matches.
+- Unsymbolized: 257×7 hex frames = **1,799** (15.5%) — matches, and all seven
+  are hatched in the render.
+- Tree nodes: 1 root + 3 (unsampled branch) + 16 (joined chain) = **20** `g.frame`
+  elements in the SVG — matches.
+
+### The page itself
+
+Rendered to `/tmp/fg/gpu-cuda-45.html` (30 KB) and opened in Chrome from
+`file://`, light and dark, plus a headless driver that exercises the UI:
+
+- **Self-contained.** Zero `<script src>`, `<link>`, `@import`, `<img>`,
+  `fetch(`. The only `http://` in the whole document is
+  `http://www.w3.org/2000/svg`, the SVG XML namespace — an identifier, not a
+  fetch. Asserted by test, over the full URL set.
+- **Zoom.** Clicking `_start` (83.8px) expands it to the full 1264px plot,
+  hides the `[gpu:launch unsampled]` branch, sets focus to `_start`, breadcrumbs
+  to `all › _start`, and details to
+  `_start — 397.13 µs (6.63% of total) — process startup and libc`. The
+  descendant `[gpu:kernel:…]` at depth 16 scales to 1264px; the same-named node
+  at depth 2 in the other branch is hidden. `Reset zoom` restores 83.832px.
+- **Search.** `gpu:kernel` reports `3 frames, 5.99 ms` (2,695,822 + 2,894,901 +
+  397,131 = 5,987,854 ✓), marks the three matches, dims `_start`. `Esc` clears
+  the box, resets the count, and un-dims.
+- **Dark mode** renders correctly under `prefers-color-scheme: dark`.
+
+### Escaping
+
+Symbol names reach the page only as `html.EscapeString`-ed SVG attributes and
+`<title>` text, and are read back with `dataset`/`textContent`. Tested with
+`std::vector<Foo&Bar>::push_back("</title><script>alert(1)</script>")` and
+`</g></svg><script>evil()</script>` as frame names and a script-injecting page
+title: neither payload survives, and the document still contains exactly one
+`<script>`, one `</script>` and one `<style>`. A separate test asserts no
+profile-derived text ever appears inside `<style>` or `<script>`.
+
+---
+
+## 9. Cannot verify
+
+- **No live capture.** This environment has no BPF capabilities, so
+  `--flamegraph-output` was never exercised end to end through a real
+  `agent.Start()` / `agent.Stop()`. What *was* exercised: flag parsing and both
+  fatal validations against the built binary; `flamegraphPath` auto-naming
+  against `generateOutputName`; and `Agent.writeFlamegraph` /
+  `warnFlamegraphNeedsPath` directly, in `perfagent/flamegraph_test.go`, against
+  real `.pb.gz` files on disk. The call sites in `Stop()` are three lines each
+  and compile, but nothing has run them.
+- **No AMD/ROCm profile.** The domain classifier's `hip*`, `hsa_*`,
+  `rocprofiler*` and `libamdhip*` rules are written from the spec and from
+  `shim/`, not observed against a real ROCm capture.
+- **No kernel-stack profile.** The `[kernel]` mapping rule is unit-tested
+  against a synthetic mapping; `--kernel-stacks` output was never folded.
+- **No inlined-frame profile from this repo.** Multi-`Line` locations are
+  unit-tested (`TestFoldExpandsInlinedFramesCallerFirst`, which pins the
+  caller-first ordering the pprof proto specifies) but the verification profile
+  has none, so the ordering has not been checked against a real DWARF-inlined
+  stack.
+- **No off-CPU or multi-axis profile rendered.** Both paths are unit-tested;
+  neither has been run against a real file.
+- **Firefox and Safari untested.** Verified in Chrome only. The page uses no
+  APIs newer than `classList.toggle` and `dataset`, but that is reasoning, not
+  evidence.
+- **`isAddressOnly` is a name-shaped test.** Once a profile is written there is
+  no "unsymbolized" bit left in pprof to consult — perf-agent's symbolizer has
+  already turned the PC into the frame's *name*. A real symbol literally named
+  `0xabc` would be miscounted. No such symbol is known to exist.
+- **Domain classification is inferred, and says so.** Where the profile carries
+  no mapping (which is every GPU profile today, since the GPU builder emits one
+  empty mapping) the classifier reads symbol names. It could mislabel a frame.
+  The legend states this; nothing about a frame's value, width or position
+  depends on it.
+
+---
+
+## 10. Verification commands
+
+```
+$ go build ./... && go vet ./...            # clean
+$ go test ./... -count=1                    # all packages ok
+$ ~/go/bin/golangci-lint run --timeout=5m   # 0 issues
+```
+
+New tests: 23 in `internal/foldedstacks`, 30 in `internal/flamegraph`, 8 in
+`perfagent`, 3 in `main` — 64 in total.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,25 @@ For toolchains that don't speak pprof, add `--perf-data-output app.perf.data` to
 
 See [`docs/perf-data-output.md`](docs/perf-data-output.md) for the per-tool walkthrough.
 
+#### Built-in HTML flame graph
+
+`--flamegraph-output auto` writes an interactive flame graph beside the pprof file — one HTML file, no server, no CDN, no external script or font, correct opened straight off disk. Click a frame to zoom, `/` to search, `Esc` to clear then reset.
+
+```bash
+sudo ./perf-agent --pid 1234 --profile --flamegraph-output auto --duration 30s
+```
+
+To render a profile written earlier, or one from any other pprof producer:
+
+```bash
+go run ./cmd/flamegraph -o profile.html profile.pb.gz
+go run ./cmd/flamegraph -folded profile.pb.gz     # the a;b;c 123 text form
+```
+
+Colour encodes **domain** — application, libc/startup, GPU runtime, unsymbolized, perf-agent's own shim, the `[gpu:launch]` CPU→GPU boundary, GPU kernel — not a hash of the frame name, and the page carries a legend saying so.
+
+The page also states what it is *not* showing: the count of frames with no symbol, the share of GPU time sitting under `[gpu:launch unsampled]` with no CPU caller, the launch sampling period and what it does to the widths, and every per-sample label that is deliberately kept out of the tree. A profile with no samples renders a page that says so rather than an empty rectangle.
+
 ---
 
 ## Requirements
@@ -211,6 +230,7 @@ For Python workloads, see [docs/python-profiling.md](docs/python-profiling.md).
 | `--profile-output` | Output path for CPU profile | auto-named |
 | `--offcpu-output` | Output path for off-CPU profile | auto-named |
 | `--pmu-output` | Output path for PMU metrics (`auto` for auto-named) | stdout |
+| `--flamegraph-output` | Also write a self-contained interactive HTML flame graph of the profile (`auto` for auto-named). Requires `--profile` or `--offcpu`. | - |
 | `--perf-data-output` | Also emit a Linux kernel-format `perf.data` (consumable by `perf script`, FlameGraph, hotspot, AutoFDO `create_llvm_prof`, …). Requires `--profile`. | - |
 | `--inject-python` | Activate Python 3.12+ perf trampoline on the target before profiling | `false` |
 | `--tag key=value` | Add tag to profile (repeatable) | - |
@@ -235,6 +255,7 @@ Output files are auto-named by process name + timestamp + profile type:
 | `--profile` | `myapp-202604021430-on-cpu.pb.gz` | `202604021430-on-cpu.pb.gz` |
 | `--offcpu` | `myapp-202604021430-off-cpu.pb.gz` | `202604021430-off-cpu.pb.gz` |
 | `--pmu-output auto` | `myapp-202604021430-pmu.txt` | `202604021430-pmu.txt` |
+| `--flamegraph-output auto` | `myapp-202604021430-on-cpu.html` | `202604021430-on-cpu.html` |
 
 Process name comes from `/proc/<pid>/comm`. Override with `--profile-output` / `--offcpu-output`.
 

--- a/cmd/flamegraph/main.go
+++ b/cmd/flamegraph/main.go
@@ -1,0 +1,122 @@
+// Command flamegraph renders a pprof profile as a self-contained interactive
+// HTML flame graph, with no server, no CDN and no external script.
+//
+// It is the offline counterpart to perf-agent's --flamegraph-output flag:
+// the flag renders a profile the agent just wrote, this renders one written
+// earlier, by perf-agent or by anything else that emits pprof.
+//
+//	flamegraph -o out.html profile.pb.gz
+//	flamegraph -folded profile.pb.gz          # the a;b;c 123 text form
+//
+// Foreign profiles: perf-agent writes Sample.Location root-first, which is
+// the reverse of what the pprof proto specifies. -stack-order exists for
+// profiles from other producers; getting it wrong draws a plausible flame
+// graph upside down, so the page always states which order it assumed.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/dpsoft/perf-agent/internal/flamegraph"
+	"github.com/dpsoft/perf-agent/internal/foldedstacks"
+	"github.com/google/pprof/profile"
+)
+
+func main() {
+	var (
+		out        = flag.String("o", "", "HTML output path (default: <input>.html)")
+		title      = flag.String("title", "", "page title (default: the input file name)")
+		width      = flag.Int("width", 0, "graph width in pixels (default: 1280)")
+		folded     = flag.Bool("folded", false, "write folded stacks to stdout instead of HTML")
+		sampleIdx  = flag.Int("sample-index", -1, "which sample type to fold; -1 chooses automatically")
+		stackOrder = flag.String("stack-order", "root-first", "how the profile stores Sample.Location: root-first (perf-agent) | leaf-first (pprof proto)")
+	)
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: %s [flags] <profile.pb.gz>\n\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	in := flag.Arg(0)
+
+	order := foldedstacks.RootFirst
+	switch *stackOrder {
+	case "root-first":
+	case "leaf-first":
+		order = foldedstacks.LeafFirst
+	default:
+		fatalf("unknown -stack-order %q: want root-first or leaf-first", *stackOrder)
+	}
+
+	if *folded {
+		writeFolded(in, *sampleIdx, order)
+		return
+	}
+
+	dst := *out
+	if dst == "" {
+		dst = in + ".html"
+	}
+	res, err := flamegraph.FromProfileFile(in, dst, flamegraph.Options{
+		Title: *title,
+		Width: *width,
+	})
+	if err != nil {
+		fatalf("%v", err)
+	}
+	report(dst, res)
+}
+
+func writeFolded(in string, sampleIdx int, order foldedstacks.StackOrder) {
+	res := fold(in, sampleIdx, order)
+	n, err := res.WriteFolded(os.Stdout)
+	if err != nil {
+		fatalf("write folded: %v", err)
+	}
+	if n > 0 {
+		fmt.Fprintf(os.Stderr, "warning: %d frame names contained ';' or a newline and were substituted; the folded text form has no escape for them\n", n)
+	}
+	for _, w := range res.Warnings {
+		fmt.Fprintf(os.Stderr, "note: %s\n", w)
+	}
+}
+
+func fold(in string, sampleIdx int, order foldedstacks.StackOrder) *foldedstacks.Result {
+	f, err := os.Open(in)
+	if err != nil {
+		fatalf("open %s: %v", in, err)
+	}
+	defer func() { _ = f.Close() }()
+	p, err := profile.Parse(f)
+	if err != nil {
+		fatalf("parse %s: %v", in, err)
+	}
+	res, err := foldedstacks.Fold(p, foldedstacks.Options{SampleIndex: sampleIdx, StackOrder: order})
+	if err != nil {
+		fatalf("fold %s: %v", in, err)
+	}
+	return res
+}
+
+// report prints the same honest numbers the page carries, so a user running
+// this in a pipeline sees a degenerate profile without opening a browser.
+func report(dst string, res *foldedstacks.Result) {
+	fmt.Printf("wrote %s\n", dst)
+	fmt.Printf("  axis     %s/%s\n", res.SampleTypeName, res.Unit)
+	fmt.Printf("  total    %s across %d samples in %d distinct stacks\n",
+		flamegraph.FormatValue(res.Total, res.Unit), res.Samples, len(res.Stacks))
+	for _, w := range res.Warnings {
+		fmt.Printf("  note     %s\n", w)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -1,0 +1,268 @@
+package flamegraph
+
+// Everything in this file is inlined verbatim into the output page. Nothing
+// here may reference an external URL: the deliverable is one file that
+// renders correctly from file:// with no server and no network.
+//
+// No user- or symbol-derived text is ever placed inside <style> or <script>.
+// All profile data reaches the page through escaped SVG attributes and is
+// read back with dataset/textContent, so a mangled C++ name full of <, > and
+// & cannot inject markup or script.
+
+// svgDefs holds the hatch patterns. Hatching always means "the profile could
+// not fully account for this frame" — no symbol, or no measured caller.
+const svgDefs = `<defs>
+<pattern id="p-gap" width="6" height="6" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+<rect width="6" height="6" fill="none"/>
+<line x1="0" y1="0" x2="0" y2="6" stroke="rgba(20,20,20,.30)" stroke-width="2.2"/>
+</pattern>
+<pattern id="p-inferred" width="5" height="5" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
+<rect width="5" height="5" fill="none"/>
+<line x1="0" y1="0" x2="0" y2="5" stroke="rgba(10,10,10,.34)" stroke-width="1.6" stroke-dasharray="2 2"/>
+</pattern>
+</defs>
+`
+
+const toolbarHTML = `<section class="toolbar">
+<div class="row">
+<label class="search"><span>Search</span><input id="search" type="search" placeholder="frame name or substring" autocomplete="off" spellcheck="false"></label>
+<button id="clear-search" type="button">Clear</button>
+<button id="reset-zoom" type="button">Reset zoom</button>
+<span class="spacer"></span>
+<span class="stat"><b>matched</b><span id="match-count">&mdash;</span></span>
+<span class="stat"><b>focus</b><span id="zoom-state">all</span></span>
+</div>
+<div class="crumbs" id="breadcrumbs">all</div>
+<div class="detail" id="details">Hover a frame for its value. Click to zoom. Press / to search, Esc to clear then reset.</div>
+</section>
+`
+
+const styleSheet = `
+:root{
+  --bg:#fbf9f6; --panel:#fffefc; --ink:#1d1a17; --muted:#6b6259;
+  --line:#e2dad0; --accent:#b4522a; --warn-bg:#fff6e8; --warn-line:#e8c88a;
+  --fatal-bg:#fdecec; --fatal-line:#e0a3a3;
+}
+@media (prefers-color-scheme: dark){
+  :root{
+    --bg:#16151a; --panel:#1e1d23; --ink:#eceaf2; --muted:#a29caf;
+    --line:#332f3b; --accent:#ff9a6a; --warn-bg:#2b2313; --warn-line:#6d5722;
+    --fatal-bg:#2e1616; --fatal-line:#7a3232;
+  }
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+  font:14px/1.5 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+main{max-width:1360px;margin:0 auto;padding:20px 16px 48px}
+h1{font-size:20px;margin:0 0 2px;letter-spacing:-.01em}
+h2{font-size:13px;margin:0 0 8px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+code{font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.sub{margin:0 0 10px;color:var(--muted);font-size:12.5px;word-break:break-all}
+.muted{color:var(--muted)}
+.hdr{margin-bottom:14px}
+.chips{display:flex;flex-wrap:wrap;gap:6px}
+.chip{display:inline-flex;gap:6px;align-items:baseline;padding:3px 9px;border:1px solid var(--line);
+  border-radius:999px;background:var(--panel);font-size:12px}
+.chip b{font-weight:600;color:var(--muted);font-size:10.5px;text-transform:uppercase;letter-spacing:.06em}
+section{margin:0 0 14px}
+.notices,.nodata,.legend,.labels{border:1px solid var(--line);border-radius:10px;background:var(--panel);padding:12px 14px}
+.notices{background:var(--warn-bg);border-color:var(--warn-line)}
+.notices.fatal,.nodata{background:var(--fatal-bg);border-color:var(--fatal-line)}
+.notices ul{margin:0;padding-left:18px}
+.notices li{margin:3px 0;font-size:13px}
+.nodata h2{color:inherit}
+.nodata p{margin:0 0 8px;max-width:70ch}
+.toolbar{position:sticky;top:0;z-index:5;border:1px solid var(--line);border-radius:10px;
+  background:var(--panel);padding:10px 12px}
+.row{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+.search{display:inline-flex;gap:6px;align-items:center}
+.search span{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
+input,button{font:inherit;color:inherit;background:var(--bg);border:1px solid var(--line);
+  border-radius:7px;padding:5px 9px}
+input{min-width:260px}
+button{cursor:pointer}
+button:hover{border-color:var(--accent)}
+.spacer{flex:1}
+.stat{display:inline-flex;gap:6px;align-items:baseline;font-size:12px}
+.stat b{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
+.crumbs{margin-top:8px;font-size:12px;color:var(--muted);word-break:break-word;min-height:1.4em}
+.detail{margin-top:4px;font-size:12.5px;min-height:1.4em}
+.chart{margin:12px 0;overflow-x:auto;border:1px solid var(--line);border-radius:10px;background:var(--panel)}
+svg.flame{display:block}
+svg.flame text{font:11px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;fill:#14120f;pointer-events:none}
+@media (prefers-color-scheme: dark){svg.flame text{fill:#100f14}}
+g.frame{cursor:pointer}
+g.frame rect.bg{stroke:rgba(255,255,255,.55);stroke-width:.5}
+g.frame:hover rect.bg{stroke:var(--ink);stroke-width:1.4}
+g.frame.match rect.bg{stroke:#111;stroke-width:1.6}
+g.frame.dim{opacity:.15}
+.legend-list{list-style:none;margin:0;padding:0;display:grid;gap:5px;
+  grid-template-columns:repeat(auto-fit,minmax(330px,1fr))}
+.legend-list li{font-size:12.5px;line-height:1.45}
+.legend-list b{margin-right:4px}
+.sw{display:inline-block;width:14px;height:14px;border-radius:3px;margin-right:7px;
+  border:1px solid rgba(0,0,0,.3);vertical-align:-2px}
+.sw.hatched{background-image:repeating-linear-gradient(45deg,rgba(20,20,20,.34) 0 2px,transparent 2px 6px)}
+.sw.hatch{background:#c9c9c9;
+  background-image:repeating-linear-gradient(45deg,rgba(20,20,20,.45) 0 2px,transparent 2px 6px);
+  border-color:var(--muted)}
+.depth-note{margin:10px 0 0;max-width:90ch;font-size:12.5px}
+.labels table{border-collapse:collapse;width:100%;font-size:12.5px}
+.labels th,.labels td{text-align:left;padding:5px 10px 5px 0;border-bottom:1px solid var(--line);
+  vertical-align:top}
+.labels th{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
+.lv{display:inline-block;margin:0 8px 2px 0;white-space:nowrap}
+footer{color:var(--muted);font-size:11.5px;padding-top:6px}
+`
+
+const script = `
+(function(){
+"use strict";
+var svg=document.querySelector("svg.flame");
+if(!svg){return;}
+var frames=Array.prototype.slice.call(svg.querySelectorAll("g.frame"));
+var sidePad=parseFloat(svg.dataset.sidePad)||0;
+var plotWidth=parseFloat(svg.dataset.plotWidth)||1;
+var minText=parseFloat(svg.dataset.minText)||24;
+var textPad=parseFloat(svg.dataset.textPad)||4;
+var charWidth=parseFloat(svg.dataset.charWidth)||6.4;
+var unit=svg.dataset.unit||"";
+var total=Number(svg.dataset.total||"0");
+
+var details=document.getElementById("details");
+var crumbs=document.getElementById("breadcrumbs");
+var matchCount=document.getElementById("match-count");
+var zoomState=document.getElementById("zoom-state");
+var search=document.getElementById("search");
+var clearBtn=document.getElementById("clear-search");
+var resetBtn=document.getElementById("reset-zoom");
+var zoomTarget=null;
+var hintText=details.textContent;
+
+function num(el,key){return Number(el.dataset[key]||"0");}
+
+function grouped(n){
+  var s=String(Math.round(n)),out="",i;
+  for(i=0;i<s.length;i++){
+    if(i>0&&(s.length-i)%3===0){out+=",";}
+    out+=s.charAt(i);
+  }
+  return out;
+}
+/* Mirrors flamegraph.FormatValue: never invent a unit the profile did not
+   give, and never call nanoseconds "samples". */
+function fmt(v){
+  if(unit==="nanoseconds"){
+    if(v===0){return "0 ns";}
+    if(v<1e3){return grouped(v)+" ns";}
+    if(v<1e6){return (v/1e3).toFixed(2)+" µs";}
+    if(v<1e9){return (v/1e6).toFixed(2)+" ms";}
+    return (v/1e9).toFixed(3)+" s";
+  }
+  if(unit===""){return grouped(v);}
+  return grouped(v)+" "+unit;
+}
+function pct(v){
+  if(!total){return "0%";}
+  return (v/total*100).toFixed(2)+"%";
+}
+function fit(name,width){
+  var max=Math.floor((width-textPad*2)/charWidth);
+  if(max<=0){return "";}
+  var chars=Array.from(name);
+  if(chars.length<=max){return name;}
+  if(max<=2){return chars.slice(0,max).join("");}
+  return chars.slice(0,max-1).join("")+"…";
+}
+function place(el,x,width,visible){
+  el.style.display=visible?"":"none";
+  if(!visible){return;}
+  var rects=el.querySelectorAll("rect"),i;
+  for(i=0;i<rects.length;i++){
+    rects[i].setAttribute("x",x.toFixed(3));
+    rects[i].setAttribute("width",Math.max(0,width).toFixed(3));
+  }
+  var text=el.querySelector("text");
+  if(text){
+    if(width>=minText){
+      text.style.display="";
+      text.setAttribute("x",(x+textPad).toFixed(3));
+      text.textContent=fit(el.dataset.name,width);
+    }else{
+      text.style.display="none";
+    }
+  }
+}
+function describe(el){
+  var v=num(el,"value"),inexact=num(el,"inexact");
+  var s=el.dataset.name+" — "+fmt(v)+" ("+pct(v)+" of total) — "+el.dataset.domainLabel;
+  if(inexact>0){s+=" — "+fmt(inexact)+" of it attributed by inference, not measurement";}
+  return s;
+}
+function showPath(el){
+  crumbs.textContent=el?el.dataset.path:"all";
+}
+function select(el){
+  if(!el){details.textContent=hintText;showPath(zoomTarget);return;}
+  details.textContent=describe(el);
+  showPath(el);
+}
+function reset(){
+  zoomTarget=null;
+  zoomState.textContent="all";
+  frames.forEach(function(el){place(el,num(el,"origX"),num(el,"origWidth"),true);});
+  select(null);
+  applySearch(search.value);
+}
+function zoom(target){
+  var tx=num(target,"origX"),tw=num(target,"origWidth");
+  if(!(tw>0)){return;}
+  var tEnd=tx+tw,ratio=plotWidth/tw;
+  zoomTarget=target;
+  zoomState.textContent=target.dataset.name;
+  frames.forEach(function(el){
+    var x=num(el,"origX"),w=num(el,"origWidth"),end=x+w;
+    var ancestor=x<=tx&&end>=tEnd;
+    var descendant=x>=tx&&end<=tEnd;
+    if(ancestor){place(el,sidePad,plotWidth,true);return;}
+    if(descendant){place(el,sidePad+(x-tx)*ratio,w*ratio,true);return;}
+    place(el,x,w,false);
+  });
+  select(target);
+  applySearch(search.value);
+}
+function applySearch(query){
+  var q=(query||"").trim().toLowerCase();
+  var matched=0,matchedValue=0;
+  frames.forEach(function(el){
+    var visible=el.style.display!=="none";
+    var hit=q!==""&&el.dataset.name.toLowerCase().indexOf(q)!==-1;
+    el.classList.toggle("match",hit&&visible);
+    el.classList.toggle("dim",q!==""&&visible&&!hit);
+    if(hit&&visible){matched++;matchedValue+=num(el,"value");}
+  });
+  if(q===""){matchCount.textContent="—";return;}
+  matchCount.textContent=grouped(matched)+" frames, "+fmt(matchedValue);
+}
+
+frames.forEach(function(el){
+  el.addEventListener("click",function(evt){evt.stopPropagation();zoom(el);});
+  el.addEventListener("mouseenter",function(){select(el);});
+  el.addEventListener("mouseleave",function(){select(zoomTarget);});
+});
+svg.addEventListener("click",function(evt){if(evt.target===svg){reset();}});
+search.addEventListener("input",function(e){applySearch(e.target.value);});
+clearBtn.addEventListener("click",function(){search.value="";applySearch("");search.focus();});
+resetBtn.addEventListener("click",reset);
+document.addEventListener("keydown",function(evt){
+  if(evt.key==="/"&&document.activeElement!==search){
+    evt.preventDefault();search.focus();search.select();return;
+  }
+  if(evt.key==="Escape"){
+    if(search.value!==""){search.value="";applySearch("");}
+    else if(zoomTarget){reset();}
+  }
+});
+reset();
+})();
+`

--- a/internal/flamegraph/domain.go
+++ b/internal/flamegraph/domain.go
@@ -1,0 +1,270 @@
+package flamegraph
+
+import (
+	"path"
+	"strings"
+
+	"github.com/dpsoft/perf-agent/internal/foldedstacks"
+)
+
+// Domain is what a frame *is*, not how deep it sits or what its name hashes
+// to. A hashed palette carries no information; these profiles have real
+// structure worth showing — application code, the CPU path that initiates
+// GPU work, an explicit boundary marker, and the accelerator side — so the
+// palette carries that instead. (The idea of colouring a mixed CPU/GPU flame
+// graph by domain is Brendan Gregg's.)
+//
+// Two domains have no counterpart in that scheme and exist here because they
+// are honesty features rather than decoration:
+//
+//   - DomainUnsymbolized. These frames were unwound correctly; no symbol
+//     table could name them. That is a symbolization gap, not a hole in the
+//     stack, and the reader must be able to tell the difference at a glance.
+//   - DomainProfilerShim. perf-agent's own injected callback appears in
+//     perf-agent's own profile. Colouring it as ordinary CPU work would bill
+//     the profiler's overhead to the program being profiled.
+//
+// Classification is INFERRED — from the mapping file when the profile
+// supplies one, otherwise from the symbol name. The legend says so. It is a
+// reading aid layered on the graph, never a claim the profile itself makes;
+// nothing about a frame's value, width or position depends on it.
+type Domain int
+
+// Domains, in CPU→accelerator order. The order is also the legend order.
+const (
+	DomainRoot Domain = iota
+	DomainApplication
+	DomainSystem
+	DomainKernel
+	DomainVendorRuntime
+	DomainUnsymbolized
+	DomainProfilerShim
+	DomainBoundary
+	DomainBoundaryUnattributed
+	DomainGPUKernel
+	numDomains
+)
+
+// DomainInfo is everything the page needs to draw and explain a domain.
+type DomainInfo struct {
+	// Key is a stable machine name, emitted as data-domain.
+	Key string
+	// Label is the legend heading.
+	Label string
+	// Desc is the legend's one-line explanation.
+	Desc string
+	// Fill is a CSS colour.
+	Fill string
+	// Overlay names an SVG pattern painted over the fill, or "" for none.
+	// Patterns encode uncertainty: a hatched frame is one the profile
+	// could not fully account for.
+	Overlay string
+	// Stroke is an explicit outline colour, or "" for the default.
+	Stroke string
+}
+
+var domainInfo = [numDomains]DomainInfo{
+	DomainRoot: {
+		Key: "root", Label: "all", Fill: "hsl(30 8% 78%)",
+		Desc: "Synthetic root. Its width is the whole profile.",
+	},
+	DomainApplication: {
+		Key: "app", Label: "application", Fill: "hsl(336 62% 74%)",
+		Desc: "Your program's own code, and compiler-generated glue in its binary.",
+	},
+	DomainSystem: {
+		Key: "system", Label: "process startup and libc", Fill: "hsl(4 62% 67%)",
+		Desc: "The C runtime, dynamic loader and thread entry that get to main.",
+	},
+	DomainKernel: {
+		Key: "kernel", Label: "kernel", Fill: "hsl(48 82% 62%)",
+		Desc: "Kernel-mode frames, identified by the profile's [kernel] mapping.",
+	},
+	DomainVendorRuntime: {
+		Key: "vendor", Label: "GPU runtime, CPU side", Fill: "hsl(26 88% 64%)",
+		Desc: "CUDA/HIP/HSA runtime and driver frames: the CPU path that initiates GPU work.",
+	},
+	DomainUnsymbolized: {
+		Key: "unsym", Label: "unsymbolized", Fill: "hsl(214 10% 68%)", Overlay: "url(#p-gap)",
+		Desc: "Unwound correctly; no symbol table could name it. The depth here is real — the names are missing, usually because a stripped vendor library has no exported symbols.",
+	},
+	DomainProfilerShim: {
+		Key: "shim", Label: "perf-agent's own shim", Fill: "hsl(272 32% 70%)",
+		Desc: "The profiler observing itself: perf-agent's injected callback, not work your program asked for.",
+	},
+	DomainBoundary: {
+		Key: "boundary", Label: "CPU→GPU boundary", Fill: "hsl(0 0% 82%)", Stroke: "hsl(0 0% 42%)",
+		Desc: "[gpu:launch] — the launch this execution was joined to. Everything below it ran on the CPU; everything above it ran on the accelerator.",
+	},
+	DomainBoundaryUnattributed: {
+		Key: "boundary-unattributed", Label: "GPU work with no CPU stack", Fill: "hsl(0 0% 88%)", Overlay: "url(#p-gap)", Stroke: "hsl(0 0% 55%)",
+		Desc: "[gpu:launch unsampled] — measured GPU time whose launch was not one of the sampled ones, so no CPU call path exists for it. Its duration is measured; its caller is unknown, and is not borrowed from a sampled sibling.",
+	},
+	DomainGPUKernel: {
+		Key: "gpu-kernel", Label: "GPU kernel execution", Fill: "hsl(142 44% 55%)",
+		Desc: "The kernel that ran on the accelerator, and how long it ran for.",
+	},
+}
+
+// Info returns the domain's presentation.
+func (d Domain) Info() DomainInfo {
+	if d < 0 || d >= numDomains {
+		return domainInfo[DomainApplication]
+	}
+	return domainInfo[d]
+}
+
+// Classify assigns a frame to a domain. name is the symbol; module is the
+// mapping file, or "" when the profile does not say.
+//
+// Rule order matters: the accelerator-side names gpu/projection.go emits are
+// matched before anything name-shaped, then whatever the profile's mapping
+// tells us, then symbol-name rules, and application is the fallback.
+func Classify(name, module string) Domain {
+	switch {
+	// --- accelerator side ---
+	case name == "[gpu:launch]":
+		return DomainBoundary
+	case name == "[gpu:launch unsampled]":
+		return DomainBoundaryUnattributed
+	case strings.HasPrefix(name, "[gpu:"):
+		// [gpu:kernel:<name>], plus any other accelerator-side frame:
+		// green is the claim being made, and it is the right one.
+		return DomainGPUKernel
+
+	// --- module-derived, i.e. taken from the profile rather than guessed ---
+	case module == "[kernel]":
+		return DomainKernel
+	case isShimModule(module):
+		return DomainProfilerShim
+	case isVendorModule(module):
+		return DomainVendorRuntime
+	case isSystemModule(module):
+		return DomainSystem
+
+	// --- name-derived ---
+	case isUnsymbolized(name):
+		return DomainUnsymbolized
+	case isShimSymbol(name):
+		return DomainProfilerShim
+	case isVendorSymbol(name):
+		return DomainVendorRuntime
+	case isSystemSymbol(name):
+		return DomainSystem
+	default:
+		return DomainApplication
+	}
+}
+
+func base(module string) string {
+	if module == "" {
+		return ""
+	}
+	return path.Base(module)
+}
+
+// isShimModule matches the adapter perf-agent injects into the target
+// (shim/Makefile builds libperfagent-gpu-nvidia.so and -amd.so).
+func isShimModule(module string) bool {
+	return strings.HasPrefix(base(module), "libperfagent")
+}
+
+// isShimSymbol is the fallback for a shim frame in a profile whose mappings
+// are empty, which is every profile the GPU builder writes today. The CUPTI
+// and rocprofiler callback entry points are the only shim symbols that can
+// appear on a target's stack; requiring both halves keeps an application
+// function innocently named on_callback from being billed to the profiler.
+func isShimSymbol(name string) bool {
+	return strings.Contains(name, "on_callback") &&
+		(strings.Contains(name, "CallbackDomain") || strings.Contains(name, "rocprofiler"))
+}
+
+var vendorModulePrefixes = []string{
+	"libcuda", "libcudart", "libcupti", "libnvidia", "libnvperf",
+	"libamdhip", "libhsa-runtime", "librocprofiler", "libroctracer", "libhsakmt",
+}
+
+func isVendorModule(module string) bool {
+	b := base(module)
+	if b == "" {
+		return false
+	}
+	for _, p := range vendorModulePrefixes {
+		if strings.HasPrefix(b, p) {
+			return true
+		}
+	}
+	return false
+}
+
+var vendorSymbolPrefixes = []string{
+	"cuda", "cuda_", "cuLaunch", "cuMem", "cuStream", "cuModule", "cuCtx", "cuDevice",
+	"cupti", "cuptiActivity", "nvidia", "nvrtc",
+	"hip", "hsa_", "roctracer", "rocprofiler", "amd_",
+}
+
+func isVendorSymbol(name string) bool {
+	for _, p := range vendorSymbolPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	// cuFoo / cuBar: the CUDA driver API is "cu" + an uppercase letter.
+	if len(name) > 2 && strings.HasPrefix(name, "cu") && name[2] >= 'A' && name[2] <= 'Z' {
+		return true
+	}
+	return false
+}
+
+var systemModulePrefixes = []string{"ld-linux", "ld-musl", "libc.so", "libc-", "libpthread", "libdl.so", "libm.so", "librt.so"}
+
+func isSystemModule(module string) bool {
+	b := base(module)
+	if b == "" {
+		return false
+	}
+	for _, p := range systemModulePrefixes {
+		if strings.HasPrefix(b, p) {
+			return true
+		}
+	}
+	return false
+}
+
+var systemSymbols = map[string]bool{
+	"_start": true, "_start_c": true, "start_thread": true, "clone": true,
+	"clone3": true, "__clone": true, "__clone3": true, "abort": true,
+	"_exit": true, "exit": true, "syscall": true,
+}
+
+var systemSymbolPrefixes = []string{"__libc_", "__GI_", "_dl_", "__pthread_", "__nptl_", "_IO_"}
+
+func isSystemSymbol(name string) bool {
+	if systemSymbols[name] {
+		return true
+	}
+	for _, p := range systemSymbolPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// isUnsymbolized reports whether a frame name carries no symbol: a bare
+// address, or the placeholder the folder writes for a location with neither.
+func isUnsymbolized(name string) bool {
+	return name == foldedstacks.UnknownFrame || (strings.HasPrefix(name, "0x") && isHex(name[2:]))
+}
+
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/flamegraph/domain_test.go
+++ b/internal/flamegraph/domain_test.go
@@ -1,0 +1,89 @@
+package flamegraph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyCoversTheRealRTX3090Stack(t *testing.T) {
+	// Every frame below is taken verbatim from the CPU+GPU profile in
+	// /home/diego/gpu-cuda-45.pb.gz, root-first. If the classifier drifts,
+	// the colours stop meaning what the legend says they mean.
+	cases := []struct {
+		name   string
+		module string
+		want   Domain
+	}{
+		{"_start", "", DomainSystem},
+		{"__libc_start_main_alias_1", "", DomainSystem},
+		{"__libc_start_call_main", "", DomainSystem},
+		{"main", "", DomainApplication},
+		{"__device_stub__Z14perfagent_axpyfPKfPfi(float, float const*, float*, int)", "", DomainApplication},
+		{"cudaLaunchKernel", "", DomainVendorRuntime},
+		{"0x7f2c958b71c6", "", DomainUnsymbolized},
+		{"0x7f2c944de06b", "", DomainUnsymbolized},
+		{"(anonymous namespace)::on_callback(void*, CUpti_CallbackDomain, unsigned int, void const*)", "", DomainProfilerShim},
+		{"[gpu:launch]", "", DomainBoundary},
+		{"[gpu:launch unsampled]", "", DomainBoundaryUnattributed},
+		{"[gpu:kernel:_Z14perfagent_axpyfPKfPfi]", "", DomainGPUKernel},
+		{"[gpu:kernel:_Z15perfagent_scalePffi]", "", DomainGPUKernel},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, Classify(c.name, c.module), "frame %q", c.name)
+	}
+}
+
+func TestClassifyPrefersTheProfilesMappingOverTheSymbolName(t *testing.T) {
+	// The mapping is something the profile asserts; the name is something
+	// we infer from. When both are available the profile wins.
+	assert.Equal(t, DomainKernel, Classify("finish_task_switch.isra.0", "[kernel]"))
+	assert.Equal(t, DomainVendorRuntime, Classify("someInternalThing", "/usr/lib/libcuda.so.550.54.14"))
+	assert.Equal(t, DomainProfilerShim, Classify("emit_launch", "/opt/libperfagent-gpu-nvidia.so"))
+	assert.Equal(t, DomainSystem, Classify("memcpy", "/usr/lib64/libc.so.6"))
+}
+
+func TestClassifyDoesNotBillOrdinaryCallbacksToTheProfiler(t *testing.T) {
+	// "on_callback" alone is a name any program may use. Only the vendor
+	// callback signatures perf-agent's shim actually registers count.
+	assert.Equal(t, DomainApplication, Classify("myapp::on_callback(int)", ""))
+	assert.Equal(t, DomainProfilerShim, Classify("on_callback(void*, CUpti_CallbackDomain)", ""))
+	assert.Equal(t, DomainProfilerShim, Classify("on_callback(rocprofiler_record_t)", ""))
+}
+
+func TestClassifyUnknownFrame(t *testing.T) {
+	assert.Equal(t, DomainUnsymbolized, Classify("[unknown]", ""))
+	assert.Equal(t, DomainUnsymbolized, Classify("0xdeadbeef", ""))
+	assert.Equal(t, DomainApplication, Classify("0xNotHex", ""))
+	assert.Equal(t, DomainApplication, Classify("0x", ""))
+}
+
+func TestClassifyCUDADriverAPI(t *testing.T) {
+	assert.Equal(t, DomainVendorRuntime, Classify("cuLaunchKernel", ""))
+	assert.Equal(t, DomainVendorRuntime, Classify("cuMemcpyDtoH_v2", ""))
+	assert.Equal(t, DomainVendorRuntime, Classify("hipLaunchKernel", ""))
+	assert.Equal(t, DomainVendorRuntime, Classify("hsa_signal_wait_scacquire", ""))
+	// "cu" followed by lowercase is not the driver API; do not over-claim.
+	assert.Equal(t, DomainApplication, Classify("cutlass_gemm", ""))
+	assert.Equal(t, DomainApplication, Classify("current_thread", ""))
+}
+
+func TestEveryDomainHasAFillAndALegendEntry(t *testing.T) {
+	for d := Domain(0); d < numDomains; d++ {
+		info := d.Info()
+		assert.NotEmpty(t, info.Key, "domain %d", d)
+		assert.NotEmpty(t, info.Label, "domain %d", d)
+		assert.NotEmpty(t, info.Desc, "domain %d", d)
+		assert.NotEmpty(t, info.Fill, "domain %d", d)
+	}
+}
+
+func TestBoundaryAndUnattributedBoundaryLookDifferent(t *testing.T) {
+	// One means "GPU time we have a CPU stack for", the other "GPU time we
+	// do not". They must not be confusable at a glance.
+	a := DomainBoundary.Info()
+	b := DomainBoundaryUnattributed.Info()
+	assert.NotEqual(t, a.Fill, b.Fill)
+	assert.Empty(t, a.Overlay)
+	assert.NotEmpty(t, b.Overlay, "unattributed GPU time must be hatched")
+}

--- a/internal/flamegraph/file.go
+++ b/internal/flamegraph/file.go
@@ -1,0 +1,76 @@
+package flamegraph
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/pprof/profile"
+
+	"github.com/dpsoft/perf-agent/internal/foldedstacks"
+)
+
+// FromProfileFile reads a pprof profile (gzipped or not) and writes a
+// self-contained HTML flame graph.
+//
+// It reads the profile back off disk rather than tapping the builder in
+// memory. That is deliberate: it means the page is a rendering of the file
+// the user was actually given, so a page that looks wrong is evidence about
+// the artifact rather than about a second, parallel code path.
+//
+// The returned Result is the folding summary — sample counts, unsymbolized
+// frame counts, warnings — so a caller can echo the honest numbers to the
+// terminal alongside the file it just wrote. It is returned even when the
+// profile is degenerate; that case is not an error, and the page says so.
+func FromProfileFile(profilePath, htmlPath string, opts Options) (*foldedstacks.Result, error) {
+	f, err := os.Open(profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("open profile: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	p, err := profile.Parse(f)
+	if err != nil {
+		return nil, fmt.Errorf("parse profile %s: %w", profilePath, err)
+	}
+
+	res, err := foldedstacks.Fold(p, foldedstacks.Options{
+		SampleIndex: -1,
+		StackOrder:  foldedstacks.RootFirst,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fold %s: %w", profilePath, err)
+	}
+
+	if opts.Title == "" {
+		opts.Title = filepath.Base(profilePath)
+	}
+	if opts.Subtitle == "" {
+		opts.Subtitle = subtitleFor(profilePath, p)
+	}
+
+	out, err := os.Create(htmlPath)
+	if err != nil {
+		return nil, fmt.Errorf("create %s: %w", htmlPath, err)
+	}
+	if err := RenderHTML(out, res, opts); err != nil {
+		_ = out.Close()
+		return nil, fmt.Errorf("render %s: %w", htmlPath, err)
+	}
+	if err := out.Close(); err != nil {
+		return nil, fmt.Errorf("close %s: %w", htmlPath, err)
+	}
+	return res, nil
+}
+
+func subtitleFor(profilePath string, p *profile.Profile) string {
+	s := profilePath
+	if p.TimeNanos > 0 {
+		s += "  ·  collected " + time.Unix(0, p.TimeNanos).Format(time.RFC3339)
+	}
+	if p.DurationNanos > 0 {
+		s += "  ·  over " + time.Duration(p.DurationNanos).String()
+	}
+	return s
+}

--- a/internal/flamegraph/file_test.go
+++ b/internal/flamegraph/file_test.go
@@ -1,0 +1,151 @@
+package flamegraph
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/pprof/profile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeProfile serialises p to a gzipped pprof file, the same shape
+// perf-agent writes.
+func writeProfile(t *testing.T, p *profile.Profile) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "profile.pb.gz")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, p.Write(f))
+	require.NoError(t, f.Close())
+	return path
+}
+
+func fn(name string) *profile.Function { return &profile.Function{ID: 0, Name: name} }
+
+// gpuLikeProfile mirrors the structure of the real RTX 3090 profile: two
+// unsampled-launch stacks and one 16-frame joined stack carrying unsymbolized
+// vendor frames, root-first, one nanosecond value axis, gpu_* labels.
+func gpuLikeProfile(t *testing.T) *profile.Profile {
+	t.Helper()
+	m := &profile.Mapping{ID: 1}
+	p := &profile.Profile{
+		SampleType: []*profile.ValueType{{Type: "gpu", Unit: "nanoseconds"}},
+		PeriodType: &profile.ValueType{Type: "gpu", Unit: "nanoseconds"},
+		Period:     1,
+		Mapping:    []*profile.Mapping{m},
+	}
+	var id uint64
+	mk := func(name string) *profile.Location {
+		id++
+		f := fn(name)
+		f.ID = id
+		p.Function = append(p.Function, f)
+		l := &profile.Location{ID: id, Mapping: m, Line: []profile.Line{{Function: f}}}
+		p.Location = append(p.Location, l)
+		return l
+	}
+	unsampled := mk("[gpu:launch unsampled]")
+	axpy := mk("[gpu:kernel:_Z14perfagent_axpyfPKfPfi]")
+	scale := mk("[gpu:kernel:_Z15perfagent_scalePffi]")
+
+	var joined []*profile.Location
+	for _, name := range []string{
+		"_start", "__libc_start_main_alias_1", "__libc_start_call_main", "main",
+		"__device_stub__Z14perfagent_axpyfPKfPfi(float, float const*, float*, int)",
+		"cudaLaunchKernel",
+		"0x7f2c958b71c6", "0x7f2c945ace62", "0x7f2c945acc75", "0x7f2c945b2dfb",
+		"0x7f2c945b2c2b", "0x7f2c945bbf6f", "0x7f2c944de06b",
+		"(anonymous namespace)::on_callback(void*, CUpti_CallbackDomain, unsigned int, void const*)",
+		"[gpu:launch]",
+	} {
+		joined = append(joined, mk(name))
+	}
+	joined = append(joined, axpy)
+
+	label := func(join, corr string) map[string][]string {
+		return map[string][]string{"gpu_join": {join}, "gpu_correlation": {corr}}
+	}
+	p.Sample = []*profile.Sample{
+		{Location: []*profile.Location{unsampled, axpy}, Value: []int64{2695822}, Label: label("exact", "cupti:1")},
+		{Location: []*profile.Location{unsampled, scale}, Value: []int64{2894901}, Label: label("exact", "cupti:2")},
+		{Location: joined, Value: []int64{397131}, Label: label("exact", "cupti:3")},
+	}
+	return p
+}
+
+func TestFromProfileFileRendersARealGPUShapedProfile(t *testing.T) {
+	src := writeProfile(t, gpuLikeProfile(t))
+	dst := filepath.Join(t.TempDir(), "out.html")
+
+	res, err := FromProfileFile(src, dst, Options{})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(5987854), res.Total, "the folded total must equal the profile's own sum")
+	assert.Equal(t, 3, res.Samples)
+	assert.Len(t, res.Stacks, 3)
+	assert.Equal(t, "gpu", res.SampleTypeName)
+	assert.Equal(t, "nanoseconds", res.Unit)
+	assert.Equal(t, 16, res.MaxDepth)
+	assert.Equal(t, 20, res.Frames) // 2 + 2 + 16
+	assert.Equal(t, 7, res.AddressOnlyFrames)
+	assert.Zero(t, res.InexactTotal, "every join in this profile is exact")
+
+	html, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	page := string(html)
+	assert.Contains(t, page, "5.99 ms")
+	assert.Contains(t, page, "[gpu:kernel:_Z14perfagent_axpyfPKfPfi]")
+	assert.Contains(t, page, `data-domain="boundary-unattributed"`)
+	assert.Contains(t, page, `data-domain="shim"`)
+	assert.Contains(t, page, "gpu_correlation")
+	assert.Contains(t, page, "profile.pb.gz", "the page names the file it was rendered from")
+}
+
+func TestFromProfileFileWritesAPageForAnEmptyProfile(t *testing.T) {
+	// The deliberately empty case: a profile with a declared type and no
+	// samples at all must still produce a file, and that file must say why
+	// it is blank.
+	src := writeProfile(t, &profile.Profile{
+		SampleType: []*profile.ValueType{{Type: "cpu", Unit: "nanoseconds"}},
+		PeriodType: &profile.ValueType{Type: "cpu", Unit: "nanoseconds"},
+		Period:     1,
+	})
+	dst := filepath.Join(t.TempDir(), "empty.html")
+
+	res, err := FromProfileFile(src, dst, Options{})
+	require.NoError(t, err, "an empty profile is not a rendering failure")
+	assert.True(t, res.Degenerate())
+
+	page, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Contains(t, string(page), "No flame graph was drawn")
+	assert.Contains(t, string(page), "zero samples")
+	assert.NotContains(t, string(page), "<svg class=\"flame\"")
+}
+
+func TestFromProfileFileReportsAMissingOrCorruptInput(t *testing.T) {
+	_, err := FromProfileFile(filepath.Join(t.TempDir(), "nope.pb.gz"), filepath.Join(t.TempDir(), "o.html"), Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open profile")
+
+	bad := filepath.Join(t.TempDir(), "bad.pb.gz")
+	require.NoError(t, os.WriteFile(bad, []byte("not a profile"), 0o600))
+	_, err = FromProfileFile(bad, filepath.Join(t.TempDir(), "o.html"), Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse profile")
+}
+
+func TestFromProfileFileTitleAndSubtitleDefaultToProvenance(t *testing.T) {
+	src := writeProfile(t, gpuLikeProfile(t))
+	dst := filepath.Join(t.TempDir(), "out.html")
+	_, err := FromProfileFile(src, dst, Options{})
+	require.NoError(t, err)
+
+	page, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Contains(t, string(page), "<title>profile.pb.gz</title>")
+	assert.True(t, strings.Contains(string(page), src), "the subtitle names the source path")
+}

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -1,0 +1,584 @@
+// Package flamegraph renders folded stacks as a self-contained interactive
+// HTML page: one file, no network fetches, no external script or font, and
+// correct when opened straight off disk with file://.
+//
+// Colour encodes domain, not depth and not a hash of the name — see
+// domain.go. The honesty rules, because a flame graph is very good at
+// looking healthy when it is not:
+//
+//   - A degenerate profile (no samples, or nothing but zero values) renders
+//     a page that SAYS so. It never renders an empty rectangle, and it never
+//     renders a plausible-looking picture of nothing.
+//   - The value axis is labelled with the profile's own type and unit.
+//     Calling 5,987,854 nanoseconds "samples" is a lie this format invites.
+//   - Frames that carry no symbol are drawn, hatched, and counted. Dropping
+//     them would make the picture cleanest exactly when symbolization worked
+//     worst.
+//   - Frames whose CPU attribution came from an inferred GPU join are
+//     hatched and counted, so an inferred caller never reads as an observed
+//     one.
+//   - The legend names each layer for what it is.
+//   - Labels are summarised beside the graph rather than folded into it.
+//     See internal/foldedstacks.Fold for why.
+package flamegraph
+
+import (
+	"cmp"
+	"fmt"
+	"html"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/dpsoft/perf-agent/internal/foldedstacks"
+)
+
+const (
+	defaultWidth = 1280
+	frameHeight  = 18
+	topPad       = 8
+	bottomPad    = 8
+	sidePad      = 8
+	textPad      = 4
+	minTextWidth = 24
+	// charWidth approximates the advance of the 11px monospace label font.
+	charWidth = 6.4
+)
+
+// Options configures a render.
+type Options struct {
+	// Title names the page. Defaults to "Flame Graph".
+	Title string
+	// Subtitle is a one-line provenance string (source file, mode, host).
+	Subtitle string
+	// Width is the SVG width in CSS pixels. Defaults to 1280.
+	Width int
+	// Meta are extra header chips, rendered after the built-in ones.
+	Meta []MetaItem
+}
+
+// MetaItem is one header chip.
+type MetaItem struct {
+	Label string
+	Value string
+}
+
+type node struct {
+	name    string
+	module  string
+	modSet  bool
+	domain  Domain
+	value   int64
+	inexact int64
+
+	children []*node
+	index    map[string]*node
+
+	x, width float64
+	depth    int
+}
+
+// RenderHTML writes the standalone page.
+func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
+	opts = opts.withDefaults()
+	if res == nil {
+		return fmt.Errorf("flamegraph: nil result")
+	}
+	ew := &errWriter{w: w}
+
+	root, maxDepth := buildTree(res)
+	degenerate := res.Degenerate()
+
+	ew.s("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n")
+	ew.s("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<title>")
+	ew.esc(opts.Title)
+	ew.s("</title>\n<style>\n")
+	ew.s(styleSheet)
+	ew.s("</style>\n</head>\n<body>\n<main>\n")
+
+	writeHeader(ew, res, opts, degenerate)
+	writeNotices(ew, res, degenerate)
+
+	if degenerate {
+		writeNoData(ew, res)
+	} else {
+		writeToolbar(ew)
+		ew.s("<div class=\"chart\">\n")
+		if err := writeSVG(ew, root, maxDepth, res, opts); err != nil {
+			return err
+		}
+		ew.s("</div>\n")
+		writeLegend(ew, root)
+	}
+
+	writeLabels(ew, res)
+	writeFooter(ew, res)
+
+	ew.s("</main>\n")
+	if !degenerate {
+		ew.s("<script>\n")
+		ew.s(script)
+		ew.s("</script>\n")
+	}
+	ew.s("</body>\n</html>\n")
+	return ew.err
+}
+
+// RenderSVG writes just the graph, for embedding. It carries none of the
+// interactivity, none of the legend and none of the warning text, so it is
+// not a substitute for RenderHTML when the profile is degenerate: it returns
+// an error rather than emitting a blank canvas.
+func RenderSVG(w io.Writer, res *foldedstacks.Result, opts Options) error {
+	opts = opts.withDefaults()
+	if res == nil {
+		return fmt.Errorf("flamegraph: nil result")
+	}
+	if res.Degenerate() {
+		return fmt.Errorf("flamegraph: refusing to draw an SVG for a profile with no drawable samples (%d samples, total %d %s); use RenderHTML, which reports why",
+			res.Samples, res.Total, res.Unit)
+	}
+	root, maxDepth := buildTree(res)
+	ew := &errWriter{w: w}
+	if err := writeSVG(ew, root, maxDepth, res, opts); err != nil {
+		return err
+	}
+	return ew.err
+}
+
+func (o Options) withDefaults() Options {
+	if o.Width <= 0 {
+		o.Width = defaultWidth
+	}
+	if o.Title == "" {
+		o.Title = "Flame Graph"
+	}
+	return o
+}
+
+// buildTree folds the stacks into a tree under a synthetic "all" root.
+//
+// The synthetic root is not decoration: without it, a profile with several
+// disjoint root frames (which is every system-wide profile) has no
+// full-width frame to click for "zoom out", and no anchor for percentages.
+func buildTree(res *foldedstacks.Result) (*node, int) {
+	root := &node{name: "all", index: map[string]*node{}, domain: DomainRoot}
+	maxDepth := 1
+	for _, st := range res.Stacks {
+		if st.Value <= 0 {
+			continue
+		}
+		root.value += st.Value
+		root.inexact += st.Inexact
+		cur := root
+		for i, frame := range st.Frames {
+			mod := ""
+			if i < len(st.Modules) {
+				mod = st.Modules[i]
+			}
+			child := cur.index[frame]
+			if child == nil {
+				child = &node{
+					name:   frame,
+					module: mod,
+					modSet: true,
+					index:  map[string]*node{},
+					depth:  cur.depth + 1,
+				}
+				cur.index[frame] = child
+				cur.children = append(cur.children, child)
+			} else if child.module != mod {
+				// Two samples disagree about which object this frame came
+				// from. Rather than pick one, drop the module so the
+				// classifier falls back to the symbol name and the page
+				// never asserts a provenance the profile contradicts.
+				child.module = ""
+			}
+			child.value += st.Value
+			child.inexact += st.Inexact
+			cur = child
+			if cur.depth+1 > maxDepth {
+				maxDepth = cur.depth + 1
+			}
+		}
+	}
+	classify(root)
+	sortTree(root)
+	return root, maxDepth
+}
+
+func classify(n *node) {
+	if n.depth > 0 {
+		n.domain = Classify(n.name, n.module)
+	}
+	for _, c := range n.children {
+		classify(c)
+	}
+}
+
+// sortTree orders siblings by name so two renders of the same profile
+// produce byte-identical HTML and two flame graphs can be diffed.
+func sortTree(n *node) {
+	slices.SortFunc(n.children, func(a, b *node) int { return cmp.Compare(a.name, b.name) })
+	for _, c := range n.children {
+		sortTree(c)
+	}
+}
+
+func layout(n *node, x float64, scale float64) {
+	n.x = x
+	n.width = float64(n.value) * scale
+	childX := x
+	for _, c := range n.children {
+		layout(c, childX, scale)
+		childX += c.width
+	}
+}
+
+func writeSVG(ew *errWriter, root *node, maxDepth int, res *foldedstacks.Result, opts Options) error {
+	if root.value <= 0 {
+		return fmt.Errorf("flamegraph: tree total is %d", root.value)
+	}
+	plotWidth := float64(opts.Width - sidePad*2)
+	layout(root, float64(sidePad), plotWidth/float64(root.value))
+
+	height := topPad + bottomPad + maxDepth*frameHeight
+
+	ew.f(`<svg class="flame" width="%d" height="%d" viewBox="0 0 %d %d" `, opts.Width, height, opts.Width, height)
+	ew.f(`xmlns="http://www.w3.org/2000/svg" data-total="%d" data-inexact="%d" data-unit="%s" data-side-pad="%d" data-plot-width="%.2f" data-min-text="%d" data-text-pad="%d" data-char-width="%.2f">`+"\n",
+		root.value, root.inexact, html.EscapeString(res.Unit), sidePad, plotWidth, minTextWidth, textPad, charWidth)
+	ew.s(svgDefs)
+	writeNode(ew, root, maxDepth, res, "")
+	ew.s("</svg>\n")
+	return ew.err
+}
+
+func writeNode(ew *errWriter, n *node, maxDepth int, res *foldedstacks.Result, parentPath string) {
+	y := float64(topPad + (maxDepth-n.depth-1)*frameHeight)
+	path := n.name
+	if parentPath != "" {
+		path = parentPath + " › " + n.name
+	}
+	info := n.domain.Info()
+
+	cls := "frame"
+	if n.inexact > 0 {
+		cls += " inexact"
+	}
+
+	ew.f(`<g class="%s" data-name="%s" data-path="%s" data-domain="%s" data-domain-label="%s" data-value="%d" data-inexact="%d" data-orig-x="%.3f" data-orig-width="%.3f" data-depth="%d">`,
+		cls, html.EscapeString(n.name), html.EscapeString(path),
+		html.EscapeString(info.Key), html.EscapeString(info.Label),
+		n.value, n.inexact, n.x, n.width, n.depth)
+	ew.s("<title>")
+	ew.esc(tooltip(n, res))
+	ew.s("</title>")
+
+	stroke := ""
+	if info.Stroke != "" {
+		stroke = fmt.Sprintf(` stroke="%s" stroke-width="0.8"`, info.Stroke)
+	}
+	ew.f(`<rect class="bg" x="%.3f" y="%.1f" width="%.3f" height="%d" rx="2" fill="%s"%s/>`,
+		n.x, y, n.width, frameHeight-1, info.Fill, stroke)
+	if info.Overlay != "" {
+		ew.f(`<rect class="ov" x="%.3f" y="%.1f" width="%.3f" height="%d" rx="2" fill="%s"/>`,
+			n.x, y, n.width, frameHeight-1, info.Overlay)
+	}
+	if n.inexact > 0 {
+		ew.f(`<rect class="ov" x="%.3f" y="%.1f" width="%.3f" height="%d" rx="2" fill="url(#p-inferred)"/>`,
+			n.x, y, n.width, frameHeight-1)
+	}
+	if n.width >= minTextWidth {
+		maxChars := int((n.width - textPad*2) / charWidth)
+		if label := truncate(n.name, maxChars); label != "" {
+			ew.f(`<text x="%.3f" y="%.1f">`, n.x+textPad, y+float64(frameHeight)-5.5)
+			ew.esc(label)
+			ew.s("</text>")
+		}
+	}
+	ew.s("</g>\n")
+
+	for _, c := range n.children {
+		writeNode(ew, c, maxDepth, res, path)
+	}
+}
+
+func tooltip(n *node, res *foldedstacks.Result) string {
+	var b strings.Builder
+	b.WriteString(n.name)
+	b.WriteString("\n")
+	b.WriteString(FormatValue(n.value, res.Unit))
+	if res.Total > 0 {
+		fmt.Fprintf(&b, " (%.2f%% of total)", float64(n.value)/float64(res.Total)*100)
+	}
+	if n.depth > 0 {
+		b.WriteString("\ndomain: " + n.domain.Info().Label)
+	}
+	if n.module != "" {
+		b.WriteString("\nmodule: " + n.module)
+	}
+	if n.inexact > 0 {
+		fmt.Fprintf(&b, "\n%s of this is attributed by inference, not measurement", FormatValue(n.inexact, res.Unit))
+	}
+	if n.domain == DomainUnsymbolized {
+		b.WriteString("\nno symbol: the unwind found this frame, nothing could name it")
+	}
+	return b.String()
+}
+
+func truncate(label string, maxChars int) string {
+	if maxChars <= 0 {
+		return ""
+	}
+	r := []rune(label)
+	if len(r) <= maxChars {
+		return label
+	}
+	if maxChars <= 2 {
+		return string(r[:maxChars])
+	}
+	return string(r[:maxChars-1]) + "…"
+}
+
+// FormatValue renders a value in its profile unit. Nanosecond profiles get
+// human time; anything else gets a grouped integer plus the unit, so the
+// page never invents a unit it was not given.
+func FormatValue(v int64, unit string) string {
+	switch unit {
+	case "nanoseconds":
+		return formatDuration(v)
+	case "":
+		return group(v)
+	default:
+		return group(v) + " " + unit
+	}
+}
+
+func formatDuration(ns int64) string {
+	switch {
+	case ns == 0:
+		return "0 ns"
+	case ns < 1_000:
+		return fmt.Sprintf("%d ns", ns)
+	case ns < 1_000_000:
+		return fmt.Sprintf("%.2f µs", float64(ns)/1e3)
+	case ns < 1_000_000_000:
+		return fmt.Sprintf("%.2f ms", float64(ns)/1e6)
+	default:
+		return fmt.Sprintf("%.3f s", float64(ns)/1e9)
+	}
+}
+
+func group(v int64) string {
+	s := fmt.Sprintf("%d", v)
+	neg := strings.HasPrefix(s, "-")
+	s = strings.TrimPrefix(s, "-")
+	var b strings.Builder
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+		b.WriteRune(c)
+	}
+	if neg {
+		return "-" + b.String()
+	}
+	return b.String()
+}
+
+func writeHeader(ew *errWriter, res *foldedstacks.Result, opts Options, degenerate bool) {
+	ew.s("<header class=\"hdr\">\n<h1>")
+	ew.esc(opts.Title)
+	ew.s("</h1>\n")
+	if opts.Subtitle != "" {
+		ew.s("<p class=\"sub\">")
+		ew.esc(opts.Subtitle)
+		ew.s("</p>\n")
+	}
+	ew.s("<div class=\"chips\">\n")
+	chip(ew, "axis", res.SampleTypeName+"/"+res.Unit)
+	if degenerate {
+		chip(ew, "total", "nothing to draw")
+	} else {
+		chip(ew, "total", FormatValue(res.Total, res.Unit))
+	}
+	chip(ew, "samples", group(int64(res.Samples)))
+	chip(ew, "distinct stacks", group(int64(len(res.Stacks))))
+	chip(ew, "max depth", group(int64(res.MaxDepth)))
+	if res.Frames > 0 {
+		chip(ew, "unsymbolized frames", fmt.Sprintf("%s of %s", group(int64(res.AddressOnlyFrames)), group(int64(res.Frames))))
+	}
+	if res.InlinedFrames > 0 {
+		chip(ew, "inlined frames", group(int64(res.InlinedFrames)))
+	}
+	chip(ew, "stack order read as", res.StackOrder.String())
+	for _, m := range opts.Meta {
+		chip(ew, m.Label, m.Value)
+	}
+	ew.s("</div>\n</header>\n")
+}
+
+func chip(ew *errWriter, k, v string) {
+	ew.s("<span class=\"chip\"><b>")
+	ew.esc(k)
+	ew.s("</b>")
+	ew.esc(v)
+	ew.s("</span>\n")
+}
+
+func writeNotices(ew *errWriter, res *foldedstacks.Result, degenerate bool) {
+	if len(res.Warnings) == 0 {
+		return
+	}
+	cls := "notices"
+	if degenerate {
+		cls += " fatal"
+	}
+	ew.f("<section class=\"%s\">\n<h2>What this graph does not show</h2>\n<ul>\n", cls)
+	for _, warning := range res.Warnings {
+		ew.s("<li>")
+		ew.esc(warning)
+		ew.s("</li>\n")
+	}
+	ew.s("</ul>\n</section>\n")
+}
+
+func writeNoData(ew *errWriter, res *foldedstacks.Result) {
+	ew.s("<section class=\"nodata\">\n<h2>No flame graph was drawn</h2>\n<p>")
+	if res.Samples == 0 {
+		ew.s("The profile contains zero samples. An empty flame graph would be indistinguishable from a flame graph of an idle process, so none is drawn.")
+	} else {
+		ew.f("The profile contains %s samples, but every one of them carries the value 0 on the ", group(int64(res.Samples)))
+		ew.esc(res.SampleTypeName + "/" + res.Unit)
+		ew.s(" axis, so there is nothing with a width to draw.")
+	}
+	ew.s("</p>\n<p class=\"muted\">This is the profile reporting on itself, not a rendering failure. Check that the profiler attached, that the target was running, and that the collection window overlapped it.</p>\n</section>\n")
+}
+
+func writeToolbar(ew *errWriter) { ew.s(toolbarHTML) }
+
+// writeLegend emits only the domains actually present in this graph, so the
+// legend never advertises a layer the profile does not contain.
+func writeLegend(ew *errWriter, root *node) {
+	present := make([]bool, numDomains)
+	var walk func(*node)
+	walk = func(n *node) {
+		if n.depth > 0 {
+			present[n.domain] = true
+		}
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	walk(root)
+
+	ew.s("<section class=\"legend\">\n<h2>Colour means domain</h2>\n")
+	ew.s("<p class=\"muted\">Each colour is a layer of the CPU→GPU path, not a hash of the frame name. The domain is inferred — from the profile's mapping file where it has one, otherwise from the symbol name — and it affects nothing but the colour: every frame's width and position comes from its measured value.</p>\n<ul class=\"legend-list\">\n")
+	for d := Domain(0); d < numDomains; d++ {
+		if !present[d] {
+			continue
+		}
+		info := d.Info()
+		cls := "sw"
+		if info.Overlay != "" {
+			// The swatch is hatched exactly when the frames are, so the
+			// legend row and the graph read as the same thing.
+			cls += " hatched"
+		}
+		ew.f("<li><span class=\"%s\" style=\"background-color:%s\"", cls, info.Fill)
+		if info.Stroke != "" {
+			ew.f(";border-color:%s", info.Stroke)
+		}
+		ew.s("></span><b>")
+		ew.esc(info.Label)
+		ew.s("</b> ")
+		ew.esc(info.Desc)
+		ew.s("</li>\n")
+	}
+	if root.inexact > 0 {
+		ew.s("<li><span class=\"sw hatch\"></span><b>diagonal hatching</b> Either the frame has no symbol, or its CPU attribution was inferred rather than measured. Hover the frame for which.</li>\n")
+	} else {
+		ew.s("<li><span class=\"sw hatch\"></span><b>diagonal hatching</b> The frame has no symbol, or no CPU stack stands behind it. Hover the frame for which.</li>\n")
+	}
+	ew.s("</ul>\n")
+	if present[DomainGPUKernel] {
+		ew.s("<p class=\"muted depth-note\">A <code>[gpu:kernel:…]</code> frame is one kernel and its duration.</p>\n")
+	}
+	ew.s("</section>\n")
+}
+
+func writeLabels(ew *errWriter, res *foldedstacks.Result) {
+	ew.s("<section class=\"labels\">\n<h2>Sample labels (not in the graph)</h2>\n")
+	if len(res.Labels) == 0 {
+		ew.s("<p class=\"muted\">This profile carries no per-sample labels.</p>\n</section>\n")
+		return
+	}
+	ew.s(`<p class="muted">Frames are stack identity, so §8 of the GPU profiling v2 design keeps these out of the tree: folding a per-sample PC or correlation ID into the path would give every sample its own leaf and destroy the aggregation a flame graph exists to show. They are reported here instead, so nothing in the profile is silently discarded.</p>
+<table>
+<thead><tr><th>key</th><th>samples</th><th>distinct values</th><th>top values by value</th></tr></thead>
+<tbody>
+`)
+	for _, l := range res.Labels {
+		ew.s("<tr><td><code>")
+		ew.esc(l.Key)
+		ew.s("</code></td><td>")
+		ew.esc(group(int64(l.Count)))
+		ew.s("</td><td>")
+		ew.esc(group(int64(l.Distinct)))
+		ew.s("</td><td>")
+		if l.Count > 1 && l.Distinct >= l.Count {
+			// One value per sample. Listing eight arbitrary correlation IDs
+			// would look like a finding; the cardinality is the finding.
+			ew.s("<span class=\"muted\">one distinct value per sample — nothing to aggregate, which is why this is a label and not a frame</span>")
+		} else {
+			for i, v := range l.Top {
+				if i > 0 {
+					ew.s(" ")
+				}
+				ew.s("<span class=\"lv\"><code>")
+				ew.esc(v.Value)
+				ew.s("</code> &rarr; ")
+				ew.esc(FormatValue(v.Total, res.Unit))
+				ew.s("</span>")
+			}
+			if l.Distinct > len(l.Top) {
+				ew.f(" <span class=\"muted\">+%s more</span>", group(int64(l.Distinct-len(l.Top))))
+			}
+		}
+		ew.s("</td></tr>\n")
+	}
+	ew.s("</tbody>\n</table>\n</section>\n")
+}
+
+func writeFooter(ew *errWriter, res *foldedstacks.Result) {
+	ew.s("<footer>Rendered by perf-agent. Value axis: ")
+	ew.esc(res.SampleTypeName + "/" + res.Unit)
+	if len(res.SampleTypes) > 1 {
+		ew.s(" (of ")
+		ew.esc(strings.Join(res.SampleTypes, ", "))
+		ew.s(")")
+	}
+	ew.s(". Stack order read as ")
+	ew.esc(res.StackOrder.String())
+	ew.s(". No external resources are loaded.</footer>\n")
+}
+
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) s(str string) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = io.WriteString(e.w, str)
+}
+
+func (e *errWriter) esc(str string) { e.s(html.EscapeString(str)) }
+
+func (e *errWriter) f(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -1,0 +1,315 @@
+package flamegraph
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dpsoft/perf-agent/internal/foldedstacks"
+)
+
+func result(stacks ...foldedstacks.Stack) *foldedstacks.Result {
+	res := &foldedstacks.Result{
+		Stacks:         stacks,
+		SampleTypeName: "gpu",
+		Unit:           "nanoseconds",
+		StackOrder:     foldedstacks.RootFirst,
+	}
+	for _, s := range stacks {
+		res.Total += s.Value
+		res.InexactTotal += s.Inexact
+		res.Samples++
+		res.Frames += len(s.Frames)
+		if len(s.Frames) > res.MaxDepth {
+			res.MaxDepth = len(s.Frames)
+		}
+	}
+	return res
+}
+
+func renderString(t *testing.T, res *foldedstacks.Result, opts Options) string {
+	t.Helper()
+	var b strings.Builder
+	require.NoError(t, RenderHTML(&b, res, opts))
+	return b.String()
+}
+
+func TestRenderHTMLProducesAStandalonePage(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"main", "work"}, Value: 3000},
+		foldedstacks.Stack{Frames: []string{"main", "idle"}, Value: 1000},
+	), Options{Title: "GPU flame graph"})
+
+	for _, want := range []string{
+		"<!DOCTYPE html>", "<html lang=\"en\">", "<title>GPU flame graph</title>",
+		"<svg class=\"flame\"", "data-name=\"main\"", "data-name=\"work\"",
+		"id=\"search\"", "id=\"reset-zoom\"", "id=\"breadcrumbs\"", "id=\"match-count\"",
+		"function zoom(target)", "function applySearch(query)",
+	} {
+		assert.Contains(t, got, want)
+	}
+}
+
+// A "self-contained" page that quietly loads a CDN font is broken the moment
+// it is opened on a machine with no network, which is the machine profiling
+// usually happens on.
+func TestRenderHTMLFetchesNothing(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"main"}, Value: 10},
+	), Options{})
+
+	for _, forbidden := range []string{
+		"<script src", "<link ", "@import", "url(http", "url('http", "url(\"http",
+		"fonts.googleapis.com", "fonts.gstatic.com", "cdn.", "fetch(", "XMLHttpRequest",
+		"<img", "<iframe",
+	} {
+		assert.NotContains(t, got, forbidden, "the page must load nothing from the network")
+	}
+	// The one http:// in the document is the SVG XML namespace, which is an
+	// identifier, not a fetch.
+	for _, m := range regexp.MustCompile(`https?://[^\s"'<>)]+`).FindAllString(got, -1) {
+		assert.Equal(t, "http://www.w3.org/2000/svg", m)
+	}
+}
+
+// C++ templates and Go generics guarantee <, > and & in symbol names. A
+// mangled name must not be able to close a tag or open a script.
+func TestRenderHTMLEscapesHostileSymbolNames(t *testing.T) {
+	hostile := `std::vector<Foo&Bar>::push_back("</title><script>alert(1)</script>")`
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{hostile, "</g></svg><script>evil()</script>"}, Value: 100},
+	), Options{Title: `</title><script>alert("title")</script>`})
+
+	assert.NotContains(t, got, "<script>alert(1)</script>")
+	assert.NotContains(t, got, "<script>evil()</script>")
+	assert.NotContains(t, got, `<script>alert("title")</script>`)
+	assert.Contains(t, got, "&lt;/title&gt;&lt;script&gt;")
+	assert.Contains(t, got, "std::vector&lt;Foo&amp;Bar&gt;")
+
+	// Exactly the two <script> elements this renderer emits: none injected.
+	assert.Equal(t, 1, strings.Count(got, "<script>"))
+	assert.Equal(t, 1, strings.Count(got, "</script>"))
+	assert.Equal(t, 1, strings.Count(got, "<style>"))
+}
+
+func TestRenderHTMLKeepsProfileTextOutOfScriptAndStyle(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"SENTINEL_SYMBOL"}, Value: 5},
+	), Options{Title: "SENTINEL_TITLE"})
+
+	scriptBody := between(t, got, "<script>", "</script>")
+	styleBody := between(t, got, "<style>", "</style>")
+	for _, blob := range []string{scriptBody, styleBody} {
+		assert.NotContains(t, blob, "SENTINEL_SYMBOL")
+		assert.NotContains(t, blob, "SENTINEL_TITLE")
+	}
+}
+
+func between(t *testing.T, s, openTag, closeTag string) string {
+	t.Helper()
+	i := strings.Index(s, openTag)
+	require.GreaterOrEqual(t, i, 0)
+	j := strings.Index(s[i:], closeTag)
+	require.GreaterOrEqual(t, j, 0)
+	return s[i : i+j]
+}
+
+// The seven defects this project has found all share a shape: the output
+// looks healthy exactly when it is worst. A flame graph of nothing must
+// therefore be a page that says "nothing", not an empty rectangle.
+func TestRenderHTMLOnAnEmptyProfileSaysSoInsteadOfDrawingNothing(t *testing.T) {
+	empty := &foldedstacks.Result{
+		SampleTypeName: "cpu", Unit: "nanoseconds",
+		Warnings: []string{"This profile contains no samples at all."},
+	}
+	got := renderString(t, empty, Options{Title: "empty"})
+
+	assert.NotContains(t, got, "<svg class=\"flame\"", "no graph may be drawn")
+	assert.NotContains(t, got, "<script>", "no interactivity without a graph")
+	assert.Contains(t, got, "No flame graph was drawn")
+	assert.Contains(t, got, "zero samples")
+	assert.Contains(t, got, "This profile contains no samples at all.")
+	assert.Contains(t, got, "nothing to draw")
+}
+
+func TestRenderHTMLOnAnAllZeroProfileSaysSo(t *testing.T) {
+	res := &foldedstacks.Result{SampleTypeName: "gpu", Unit: "nanoseconds", Samples: 40}
+	got := renderString(t, res, Options{})
+
+	assert.NotContains(t, got, "<svg class=\"flame\"")
+	assert.Contains(t, got, "No flame graph was drawn")
+	assert.Contains(t, got, "every one of them carries the value 0")
+	assert.Contains(t, got, "gpu/nanoseconds")
+}
+
+func TestRenderSVGRefusesADegenerateProfile(t *testing.T) {
+	err := RenderSVG(&strings.Builder{}, &foldedstacks.Result{SampleTypeName: "cpu", Unit: "nanoseconds"}, Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no drawable samples")
+}
+
+func TestRenderHTMLNamesTheValueAxisRatherThanCallingEverythingSamples(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"k"}, Value: 5987854},
+	), Options{})
+
+	assert.Contains(t, got, "gpu/nanoseconds")
+	assert.Contains(t, got, "5.99 ms", "a nanosecond total must read as time")
+	assert.NotContains(t, got, "5,987,854 samples")
+	assert.Contains(t, got, `data-unit="nanoseconds"`)
+}
+
+func TestFormatValueHonoursTheProfilesUnit(t *testing.T) {
+	assert.Equal(t, "512 ns", FormatValue(512, "nanoseconds"))
+	assert.Equal(t, "1.54 µs", FormatValue(1537, "nanoseconds"))
+	assert.Equal(t, "5.99 ms", FormatValue(5987854, "nanoseconds"))
+	assert.Equal(t, "1.500 s", FormatValue(1500000000, "nanoseconds"))
+	assert.Equal(t, "4,096 bytes", FormatValue(4096, "bytes"))
+	assert.Equal(t, "17 count", FormatValue(17, "count"))
+	assert.Equal(t, "1,234", FormatValue(1234, ""))
+}
+
+func TestRenderHTMLConservesTheTotalOnTheSyntheticRoot(t *testing.T) {
+	// The root's width is the whole profile. If it disagreed with the fold
+	// total, every percentage on the page would be wrong.
+	res := result(
+		foldedstacks.Stack{Frames: []string{"a", "b"}, Value: 2695822},
+		foldedstacks.Stack{Frames: []string{"a", "c"}, Value: 2894901},
+		foldedstacks.Stack{Frames: []string{"d"}, Value: 397131},
+	)
+	got := renderString(t, res, Options{})
+	assert.Equal(t, int64(5987854), res.Total)
+	assert.Contains(t, got, `data-total="5987854"`)
+	assert.Contains(t, got, `data-name="all" data-path="all" data-domain="root" data-domain-label="all" data-value="5987854"`)
+}
+
+func TestRenderHTMLColoursByDomainNotByNameHash(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{
+			"_start", "main", "cudaLaunchKernel", "0xdeadbeef",
+			"[gpu:launch]", "[gpu:kernel:matmul]",
+		}, Value: 1000},
+		foldedstacks.Stack{Frames: []string{"[gpu:launch unsampled]", "[gpu:kernel:matmul]"}, Value: 500},
+	), Options{})
+
+	for _, want := range []string{
+		`data-domain="system"`, `data-domain="app"`, `data-domain="vendor"`,
+		`data-domain="unsym"`, `data-domain="boundary"`,
+		`data-domain="boundary-unattributed"`, `data-domain="gpu-kernel"`,
+	} {
+		assert.Contains(t, got, want)
+	}
+	// Same fill for every frame of a domain: colour is information, not
+	// decoration.
+	assert.Contains(t, got, DomainGPUKernel.Info().Fill)
+	assert.Contains(t, got, "url(#p-gap)", "unsymbolized frames must be hatched")
+}
+
+func TestRenderHTMLLegendOnlyNamesDomainsThatAreActuallyPresent(t *testing.T) {
+	cpuOnly := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"_start", "main"}, Value: 10},
+	), Options{})
+	assert.Contains(t, cpuOnly, DomainApplication.Info().Label)
+	assert.NotContains(t, cpuOnly, DomainGPUKernel.Info().Label,
+		"a CPU-only profile must not advertise a GPU layer it does not have")
+	assert.NotContains(t, cpuOnly, DomainBoundary.Info().Label)
+
+	withGPU := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"main", "[gpu:launch]", "[gpu:kernel:k]"}, Value: 10},
+	), Options{})
+	assert.Contains(t, withGPU, DomainGPUKernel.Info().Label)
+	assert.Contains(t, withGPU, "one kernel and its duration")
+}
+
+func TestRenderHTMLMarksInferredAttributionOnTheFramesItAffects(t *testing.T) {
+	res := result(
+		foldedstacks.Stack{Frames: []string{"main", "[gpu:launch]", "[gpu:kernel:k]"}, Value: 100, Inexact: 100},
+		foldedstacks.Stack{Frames: []string{"other"}, Value: 50},
+	)
+	got := renderString(t, res, Options{})
+
+	assert.Contains(t, got, `class="frame inexact"`)
+	assert.Contains(t, got, "url(#p-inferred)")
+	assert.Contains(t, got, `data-inexact="100"`)
+	assert.Contains(t, got, "attributed by inference, not measurement")
+	// The frame that was measured must not be marked.
+	assert.Regexp(t, regexp.MustCompile(`class="frame" data-name="other"`), got)
+}
+
+func TestRenderHTMLReportsLabelsWithoutFoldingThemIntoFrames(t *testing.T) {
+	res := result(foldedstacks.Stack{Frames: []string{"[gpu:kernel:k]"}, Value: 30})
+	res.Labels = []foldedstacks.LabelSummary{
+		{
+			Key: "gpu_join", Distinct: 2, Total: 30, Count: 4000,
+			Top: []foldedstacks.LabelValue{
+				{Value: "exact", Total: 25, Count: 3000},
+				{Value: "heuristic", Total: 5, Count: 1000},
+			},
+		},
+		{
+			Key: "gpu_queue", Distinct: 12, Total: 30, Count: 4000,
+			Top: []foldedstacks.LabelValue{{Value: "q0", Total: 20, Count: 2000}},
+		},
+	}
+	got := renderString(t, res, Options{})
+
+	assert.Contains(t, got, "Sample labels (not in the graph)")
+	assert.Contains(t, got, "gpu_join")
+	assert.Contains(t, got, "heuristic")
+	assert.Contains(t, got, "+11 more")
+	assert.NotContains(t, got, `data-name="gpu_join`, "a label must never become a frame")
+	assert.NotContains(t, got, `data-name="gpu_queue`)
+}
+
+func TestRenderHTMLDoesNotDressUpAHighCardinalityLabelAsAFinding(t *testing.T) {
+	// gpu_correlation is one value per sample. Listing eight arbitrary IDs
+	// would read as a top-N; the cardinality is the whole story, and it is
+	// also exactly why spec §8 keeps this out of the frames.
+	res := result(foldedstacks.Stack{Frames: []string{"[gpu:kernel:k]"}, Value: 30})
+	res.Labels = []foldedstacks.LabelSummary{{
+		Key: "gpu_correlation", Distinct: 4000, Total: 30, Count: 4000,
+		Top: []foldedstacks.LabelValue{{Value: "cupti:4294967301", Total: 1, Count: 1}},
+	}}
+	got := renderString(t, res, Options{})
+
+	assert.Contains(t, got, "one distinct value per sample")
+	assert.NotContains(t, got, "cupti:4294967301")
+}
+
+func TestRenderHTMLStatesTheStackOrderItAssumed(t *testing.T) {
+	// Reading the order wrong draws a plausible graph upside down, so the
+	// page always says which way it read the profile.
+	got := renderString(t, result(foldedstacks.Stack{Frames: []string{"a"}, Value: 1}), Options{})
+	assert.Contains(t, got, "stack order read as")
+	assert.Contains(t, got, "root-first")
+}
+
+func TestRenderHTMLIsDeterministic(t *testing.T) {
+	build := func() *foldedstacks.Result {
+		return result(
+			foldedstacks.Stack{Frames: []string{"z", "y"}, Value: 3},
+			foldedstacks.Stack{Frames: []string{"a", "b"}, Value: 5},
+			foldedstacks.Stack{Frames: []string{"a", "c"}, Value: 2},
+		)
+	}
+	first := renderString(t, build(), Options{Title: "t"})
+	for range 4 {
+		assert.Equal(t, first, renderString(t, build(), Options{Title: "t"}))
+	}
+}
+
+func TestTruncateNeverSplitsAMultibyteRune(t *testing.T) {
+	assert.Equal(t, "", truncate("abc", 0))
+	assert.Equal(t, "abc", truncate("abc", 3))
+	assert.Equal(t, "ab…", truncate("abcdef", 3))
+	assert.Equal(t, "日本…", truncate("日本語です", 3))
+	assert.Equal(t, "日", truncate("日本語", 1))
+}
+
+func TestRenderHTMLRejectsANilResult(t *testing.T) {
+	require.Error(t, RenderHTML(&strings.Builder{}, nil, Options{}))
+	require.Error(t, RenderSVG(&strings.Builder{}, nil, Options{}))
+}

--- a/internal/foldedstacks/fold.go
+++ b/internal/foldedstacks/fold.go
@@ -1,0 +1,663 @@
+// Package foldedstacks turns a pprof profile into folded stacks — the
+// `root;mid;leaf <value>` form a flame graph consumes.
+//
+// It exists because perf-agent writes pprof and nothing else, so every
+// flame graph previously required an out-of-tree shell pipeline
+// (`pprof -traces | awk ...`) that no test could cover and that silently
+// mangled C++ symbol names containing spaces.
+//
+// Two things in here are deliberate and easy to get wrong:
+//
+// Stack order. The pprof proto says Sample.Location[0] is the leaf.
+// perf-agent does not follow that: profile/profiler.go and
+// offcpu/profiler.go both call pprof.Reverse before handing the stack to
+// the builder, and gpu/projection.go builds its frames root-first, so in
+// every profile this repo writes Location[0] is the ROOT. Folding with the
+// wrong assumption does not fail — it draws a perfectly plausible flame
+// graph upside down. So the order is an explicit option, defaulting to
+// what this repo writes, and Result.StackOrder records the choice so the
+// renderer can state it on the page instead of leaving the reader to guess.
+//
+// Degeneracy. A profile with no samples, or whose samples all carry zero
+// at the chosen value index, folds to nothing. Fold returns that as a
+// Result with Total == 0 and a Warning, not as an error and never as a
+// silently empty success: the caller is expected to render the warning.
+package foldedstacks
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/google/pprof/profile"
+)
+
+// StackOrder describes how a profile stores frames within Sample.Location.
+type StackOrder int
+
+const (
+	// RootFirst means Location[0] is the outermost frame. Every profile
+	// perf-agent writes is RootFirst; see the package comment.
+	RootFirst StackOrder = iota
+	// LeafFirst means Location[0] is the innermost frame, which is what the
+	// pprof proto specifies and what foreign profiles (Go runtime, perf)
+	// use.
+	LeafFirst
+)
+
+func (o StackOrder) String() string {
+	if o == LeafFirst {
+		return "leaf-first"
+	}
+	return "root-first"
+}
+
+// UnknownFrame is the placeholder for a location that carries neither a
+// function name nor an address.
+const UnknownFrame = "[unknown]"
+
+// Options configures Fold.
+type Options struct {
+	// SampleIndex selects which of Profile.SampleType to fold. Negative
+	// means "choose automatically" — see chooseSampleIndex.
+	SampleIndex int
+
+	// StackOrder is how the profile stores Sample.Location. Defaults to
+	// RootFirst, which is what perf-agent writes.
+	StackOrder StackOrder
+
+	// InexactLabels marks samples whose stack attribution is not a
+	// measurement. Each entry is a label key and the set of values that
+	// mean "inexact"; an empty value set means "any value present".
+	// Fold sums the value of matching samples into Stack.Inexact so the
+	// renderer can say which part of the picture is inferred. Defaults to
+	// DefaultInexactLabels.
+	InexactLabels []InexactRule
+
+	// MaxLabelValues caps how many distinct values are retained per label
+	// key in the summary. Zero means DefaultMaxLabelValues.
+	MaxLabelValues int
+}
+
+// InexactRule flags samples whose stack is attributed by inference.
+type InexactRule struct {
+	Key string
+	// Values that mean "inexact". Empty means the key's mere presence does.
+	Values []string
+}
+
+// DefaultMaxLabelValues bounds the per-key value list in a label summary.
+const DefaultMaxLabelValues = 8
+
+// UnsampledLaunchFrame is the root frame gpu/projection.go emits for an
+// execution whose launch did not carry a sampled CPU stack. Its GPU time is
+// measured; it simply has no caller, and none is borrowed from a sampled
+// sibling. Fold reports the share of the profile sitting under it because a
+// reader looking at the graph would otherwise read "6.6% of GPU time comes
+// from this call path" when the truth is "this call path is the 1-in-N of
+// launches whose stack we kept".
+const UnsampledLaunchFrame = "[gpu:launch unsampled]"
+
+// SamplePeriodLabel is the launch sampling denominator gpu/projection.go
+// attaches to the sampled population only.
+const SamplePeriodLabel = "gpu_sample_period"
+
+// DefaultInexactLabels encodes gpu/projection.go's honesty contract:
+// gpu_join is written unconditionally as exactly "exact", "heuristic" or
+// "unmatched", and gpu_ambiguous appears only when the join picked one of
+// several candidates. A heuristic or unmatched join means the CPU call path
+// under [gpu:launch] was guessed or is absent — which is precisely the part
+// of a flame graph a reader would otherwise read as measured fact.
+func DefaultInexactLabels() []InexactRule {
+	return []InexactRule{
+		{Key: "gpu_join", Values: []string{"heuristic", "unmatched"}},
+		{Key: "gpu_ambiguous", Values: []string{"true"}},
+	}
+}
+
+// Stack is one folded stack.
+type Stack struct {
+	// Frames run root-first regardless of the input profile's order.
+	Frames []string
+	// Modules is parallel to Frames: the mapping file each frame came
+	// from, or "" when the profile does not say. perf-agent routes kernel
+	// frames through a "[kernel]" sentinel mapping and JIT frames through
+	// "[jit]", so this is the only channel that identifies those two
+	// classes from the profile itself rather than by guessing at a symbol
+	// name. Consumers must tolerate "" everywhere: the GPU builder emits
+	// a single empty mapping for every location.
+	Modules []string
+	// Value is the summed value at the chosen sample index.
+	Value int64
+	// Inexact is the part of Value contributed by samples matched by
+	// Options.InexactLabels. Always <= Value.
+	Inexact int64
+}
+
+// LabelValue is one observed value of a pprof label.
+type LabelValue struct {
+	Value string
+	Total int64
+	Count int
+}
+
+// LabelSummary aggregates one pprof label key across the whole profile.
+// Labels never enter the folded frames — see the Fold doc comment — so this
+// is the only place they survive into the rendered page.
+type LabelSummary struct {
+	Key string
+	// Distinct is the number of distinct values observed, which may exceed
+	// len(Top).
+	Distinct int
+	// Total is the summed sample value carrying this key.
+	Total int64
+	// Count is the number of profile samples carrying this key.
+	Count int
+	// Top holds the highest-Total values, capped by Options.MaxLabelValues
+	// and sorted descending.
+	Top []LabelValue
+}
+
+// Result is everything the renderer needs, including the reasons a picture
+// might be misleading.
+type Result struct {
+	Stacks []Stack
+
+	// Total is the sum of Stack.Value.
+	Total int64
+	// InexactTotal is the sum of Stack.Inexact.
+	InexactTotal int64
+	// UnsampledLaunchTotal is the part of Total whose stack begins at
+	// UnsampledLaunchFrame: measured GPU time with no CPU caller.
+	UnsampledLaunchTotal int64
+
+	// SampleTypeName and Unit describe the folded value axis, e.g.
+	// ("gpu", "nanoseconds"). The renderer must print these: labelling
+	// 5,987,854 nanoseconds as "samples" is a lie a flame graph makes very
+	// easy to tell.
+	SampleTypeName string
+	Unit           string
+	SampleIndex    int
+	// SampleTypes lists every type the profile offered, so a page can say
+	// which one it is not showing.
+	SampleTypes []string
+
+	StackOrder StackOrder
+
+	// Samples is the number of profile.Sample records read.
+	Samples int
+	// ZeroValueSamples were skipped: they carry 0 at the chosen index.
+	ZeroValueSamples int
+	// EmptyStackSamples carried a non-zero value but no locations; they are
+	// folded under UnknownFrame rather than dropped.
+	EmptyStackSamples int
+	// Frames is the number of frame slots emitted across all folded stacks.
+	Frames int
+	// AddressOnlyFrames is how many of those carry no symbol — a bare
+	// address, or UnknownFrame. A flame graph that quietly dropped these
+	// would look cleaner precisely when symbolization worked worst.
+	AddressOnlyFrames int
+	// InlinedFrames is how many frames came from a Location's second and
+	// later Line entries.
+	InlinedFrames int
+	// MaxDepth is the deepest folded stack.
+	MaxDepth int
+
+	Labels []LabelSummary
+
+	// Warnings are reader-facing statements about why the picture may be
+	// empty, partial or misleading. Never empty when Total == 0.
+	Warnings []string
+}
+
+// Degenerate reports whether there is nothing worth drawing.
+func (r *Result) Degenerate() bool { return r == nil || r.Total <= 0 || len(r.Stacks) == 0 }
+
+// Fold converts a pprof profile into folded stacks.
+//
+// Labels are deliberately NOT folded into frames. §8 of the GPU profiling
+// v2 design ("Output representation") rules that frames carry the real CPU
+// stack, then [gpu:launch], then the kernel name, and that everything which
+// would fragment that identity — stall reason, PC, queue, device,
+// correlation ID, cgroup, pod UID, container ID — is a label. Folding
+// gpu_correlation into the path would give this profile 4000 distinct
+// leaves instead of 3 and destroy the aggregation the flame graph exists to
+// show. They are summarised in Result.Labels instead, so they are visible
+// without being structural.
+func Fold(p *profile.Profile, opts Options) (*Result, error) {
+	if p == nil {
+		return nil, fmt.Errorf("foldedstacks: nil profile")
+	}
+	if len(p.SampleType) == 0 {
+		return nil, fmt.Errorf("foldedstacks: profile declares no sample types")
+	}
+
+	idx := opts.SampleIndex
+	if idx < 0 {
+		idx = chooseSampleIndex(p)
+	}
+	if idx >= len(p.SampleType) {
+		return nil, fmt.Errorf("foldedstacks: sample index %d out of range (profile has %d sample types)", idx, len(p.SampleType))
+	}
+	maxLabelValues := opts.MaxLabelValues
+	if maxLabelValues <= 0 {
+		maxLabelValues = DefaultMaxLabelValues
+	}
+	rules := opts.InexactLabels
+	if rules == nil {
+		rules = DefaultInexactLabels()
+	}
+
+	res := &Result{
+		SampleTypeName: p.SampleType[idx].Type,
+		Unit:           p.SampleType[idx].Unit,
+		SampleIndex:    idx,
+		StackOrder:     opts.StackOrder,
+		Samples:        len(p.Sample),
+	}
+	for _, st := range p.SampleType {
+		res.SampleTypes = append(res.SampleTypes, st.Type+"/"+st.Unit)
+	}
+
+	agg := make(map[string]*Stack, len(p.Sample))
+	var order []string
+	labels := make(map[string]map[string]*LabelValue)
+	labelTotals := make(map[string]*LabelSummary)
+
+	for _, s := range p.Sample {
+		if idx >= len(s.Value) {
+			return nil, fmt.Errorf("foldedstacks: sample carries %d values, need index %d", len(s.Value), idx)
+		}
+		v := s.Value[idx]
+		if v < 0 {
+			// A negative value is a diff profile ("pprof -diff_base").
+			// A flame graph has no way to draw a negative rectangle, and
+			// scaling or clamping it would present a subtraction as a
+			// measurement. Refuse rather than draw a confident lie.
+			return nil, fmt.Errorf("foldedstacks: sample has negative value %d at index %d; a flame graph cannot represent a differential profile", v, idx)
+		}
+
+		accumulateLabels(labels, labelTotals, s.Label, v)
+
+		if v == 0 {
+			res.ZeroValueSamples++
+			continue
+		}
+
+		frames, mods, stats := framesOf(s, opts.StackOrder)
+		if len(frames) == 0 {
+			res.EmptyStackSamples++
+			frames = []string{UnknownFrame}
+			mods = []string{""}
+			stats.addressOnly = 1
+		}
+		res.Frames += len(frames)
+		res.AddressOnlyFrames += stats.addressOnly
+		res.InlinedFrames += stats.inlined
+		if len(frames) > res.MaxDepth {
+			res.MaxDepth = len(frames)
+		}
+
+		key := strings.Join(frames, "\x00")
+		st := agg[key]
+		if st == nil {
+			st = &Stack{Frames: frames, Modules: mods}
+			agg[key] = st
+			order = append(order, key)
+		}
+		st.Value += v
+		if matchesInexact(s.Label, rules) {
+			st.Inexact += v
+		}
+	}
+
+	res.Stacks = make([]Stack, 0, len(order))
+	for _, k := range order {
+		st := agg[k]
+		res.Stacks = append(res.Stacks, *st)
+		res.Total += st.Value
+		res.InexactTotal += st.Inexact
+		if len(st.Frames) > 0 && st.Frames[0] == UnsampledLaunchFrame {
+			res.UnsampledLaunchTotal += st.Value
+		}
+	}
+	// Sort for a byte-stable rendering: two runs over the same profile must
+	// produce the same HTML, or nobody can diff two flame graphs.
+	slices.SortFunc(res.Stacks, func(a, b Stack) int {
+		return cmp.Compare(strings.Join(a.Frames, "\x00"), strings.Join(b.Frames, "\x00"))
+	})
+
+	res.Labels = summariseLabels(labels, labelTotals, maxLabelValues)
+	res.Warnings = buildWarnings(res, p)
+	return res, nil
+}
+
+type frameStats struct {
+	addressOnly int
+	inlined     int
+}
+
+// framesOf renders one sample's locations as root-first frame names, with a
+// parallel slice of the mapping file each frame came from.
+func framesOf(s *profile.Sample, order StackOrder) ([]string, []string, frameStats) {
+	var stats frameStats
+	if len(s.Location) == 0 {
+		return nil, nil, stats
+	}
+	out := make([]string, 0, len(s.Location))
+	mods := make([]string, 0, len(s.Location))
+
+	emit := func(loc *profile.Location) {
+		mod := ""
+		if loc != nil && loc.Mapping != nil {
+			mod = loc.Mapping.File
+		}
+		if loc == nil {
+			out = append(out, UnknownFrame)
+			mods = append(mods, mod)
+			stats.addressOnly++
+			return
+		}
+		if len(loc.Line) == 0 {
+			name := addressName(loc)
+			out = append(out, name)
+			mods = append(mods, mod)
+			stats.addressOnly++
+			return
+		}
+		// pprof: "the last entry represents the caller into which the
+		// preceding entries were inlined", so Line[0] is innermost. Walking
+		// backwards emits the inlined chain root-first, matching the frame
+		// order we produce for locations.
+		for i := len(loc.Line) - 1; i >= 0; i-- {
+			name := lineName(loc, loc.Line[i])
+			if isAddressOnly(name) {
+				stats.addressOnly++
+			}
+			if i != len(loc.Line)-1 {
+				stats.inlined++
+			}
+			out = append(out, name)
+			mods = append(mods, mod)
+		}
+	}
+
+	if order == LeafFirst {
+		for i := len(s.Location) - 1; i >= 0; i-- {
+			emit(s.Location[i])
+		}
+	} else {
+		for _, loc := range s.Location {
+			emit(loc)
+		}
+	}
+	return out, mods, stats
+}
+
+func lineName(loc *profile.Location, ln profile.Line) string {
+	if ln.Function != nil {
+		if n := strings.TrimSpace(ln.Function.Name); n != "" {
+			return n
+		}
+		if n := strings.TrimSpace(ln.Function.SystemName); n != "" {
+			return n
+		}
+		if f := strings.TrimSpace(ln.Function.Filename); f != "" {
+			if ln.Line > 0 {
+				return fmt.Sprintf("%s:%d", f, ln.Line)
+			}
+			return f
+		}
+	}
+	return addressName(loc)
+}
+
+func addressName(loc *profile.Location) string {
+	if loc != nil && loc.Address != 0 {
+		return fmt.Sprintf("0x%x", loc.Address)
+	}
+	if loc != nil && loc.Mapping != nil && loc.Mapping.File != "" {
+		return fmt.Sprintf("%s+0x%x", loc.Mapping.File, loc.Address)
+	}
+	return UnknownFrame
+}
+
+// isAddressOnly reports whether a frame name carries no symbol. perf-agent's
+// symbolizer already formats unresolved PCs as "0x7f2c945ace62" and missing
+// frames as "[unknown]", so a name-shaped test is the only way to count them
+// once the profile is written; there is no separate "unsymbolized" bit in
+// pprof to consult.
+func isAddressOnly(name string) bool {
+	if name == UnknownFrame || name == "" {
+		return true
+	}
+	if !strings.HasPrefix(name, "0x") || len(name) < 3 {
+		return false
+	}
+	for _, r := range name[2:] {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesInexact(labels map[string][]string, rules []InexactRule) bool {
+	for _, rule := range rules {
+		vals, ok := labels[rule.Key]
+		if !ok {
+			continue
+		}
+		if len(rule.Values) == 0 {
+			return true
+		}
+		for _, v := range vals {
+			if slices.Contains(rule.Values, v) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func accumulateLabels(byKey map[string]map[string]*LabelValue, totals map[string]*LabelSummary, labels map[string][]string, v int64) {
+	for k, vals := range labels {
+		sum := totals[k]
+		if sum == nil {
+			sum = &LabelSummary{Key: k}
+			totals[k] = sum
+			byKey[k] = make(map[string]*LabelValue)
+		}
+		sum.Total += v
+		sum.Count++
+		for _, val := range vals {
+			lv := byKey[k][val]
+			if lv == nil {
+				lv = &LabelValue{Value: val}
+				byKey[k][val] = lv
+			}
+			lv.Total += v
+			lv.Count++
+		}
+	}
+}
+
+func summariseLabels(byKey map[string]map[string]*LabelValue, totals map[string]*LabelSummary, maxValues int) []LabelSummary {
+	out := make([]LabelSummary, 0, len(totals))
+	for k, sum := range totals {
+		vals := make([]LabelValue, 0, len(byKey[k]))
+		for _, lv := range byKey[k] {
+			vals = append(vals, *lv)
+		}
+		slices.SortFunc(vals, func(a, b LabelValue) int {
+			if c := cmp.Compare(b.Total, a.Total); c != 0 {
+				return c
+			}
+			return cmp.Compare(a.Value, b.Value)
+		})
+		s := *sum
+		s.Distinct = len(vals)
+		if len(vals) > maxValues {
+			vals = vals[:maxValues]
+		}
+		s.Top = vals
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+func buildWarnings(res *Result, p *profile.Profile) []string {
+	var w []string
+	switch {
+	case res.Samples == 0:
+		w = append(w, "This profile contains no samples at all. Nothing was collected, so there is nothing to draw. That is a fact about the profile, not a statement that the target was idle.")
+	case res.Total == 0:
+		w = append(w, fmt.Sprintf("Every one of the %d samples carries the value 0 for %s/%s. There is nothing to draw.",
+			res.Samples, res.SampleTypeName, res.Unit))
+	}
+	if res.ZeroValueSamples > 0 && res.Total > 0 {
+		w = append(w, fmt.Sprintf("%d of %d samples carry the value 0 for %s/%s and are not drawn.",
+			res.ZeroValueSamples, res.Samples, res.SampleTypeName, res.Unit))
+	}
+	if res.EmptyStackSamples > 0 {
+		w = append(w, fmt.Sprintf("%d samples carry a value but no stack; they are folded under %s rather than dropped.",
+			res.EmptyStackSamples, UnknownFrame))
+	}
+	if res.AddressOnlyFrames > 0 {
+		w = append(w, fmt.Sprintf("%d of %d frame slots (%.1f%%) have no symbol and are drawn as a raw address or %s.",
+			res.AddressOnlyFrames, res.Frames, pct(int64(res.AddressOnlyFrames), int64(res.Frames)), UnknownFrame))
+	}
+	if res.InexactTotal > 0 {
+		w = append(w, fmt.Sprintf("%.1f%% of the total is attributed to its CPU call path by inference, not measurement (gpu_join is heuristic or unmatched, or the join was ambiguous). Those frames name a plausible caller, not an observed one.",
+			pct(res.InexactTotal, res.Total)))
+	}
+	if res.Total > 0 {
+		w = append(w, gpuSamplingWarnings(res)...)
+	}
+	if len(p.SampleType) > 1 {
+		w = append(w, fmt.Sprintf("This profile carries %d value axes (%s); only %s/%s is drawn.",
+			len(p.SampleType), strings.Join(res.SampleTypes, ", "), res.SampleTypeName, res.Unit))
+	}
+	return w
+}
+
+// gpuSamplingWarnings states what launch sampling does to a GPU flame
+// graph's shape, because the shape alone is actively misleading without it.
+//
+// gpu/projection.go samples launch STACKS (one launch in SamplePeriod carries
+// one) but records every execution. So the CPU call path under [gpu:launch]
+// is a sample of launches, while the width beside it under
+// [gpu:launch unsampled] is the rest of the measured GPU time with no caller.
+// A reader who takes the attributed width as "the share of GPU time this call
+// path is responsible for" is wrong by roughly the sampling period. And
+// neither population is scaled: multiplying by the period would turn a
+// measurement into an estimate and present it as fact, which is precisely
+// what that package refuses to do on the reader's behalf.
+func gpuSamplingWarnings(res *Result) []string {
+	var period string
+	var periodSamples int
+	for _, l := range res.Labels {
+		if l.Key == SamplePeriodLabel && len(l.Top) > 0 {
+			period = l.Top[0].Value
+			periodSamples = l.Count
+		}
+	}
+	if res.UnsampledLaunchTotal == 0 && period == "" {
+		return nil
+	}
+
+	var w []string
+	if res.UnsampledLaunchTotal > 0 {
+		w = append(w, fmt.Sprintf(
+			"%.1f%% of the total sits under %s: measured GPU time whose launch was not one of the sampled ones, so it has no CPU caller and none is borrowed from a sampled sibling.",
+			pct(res.UnsampledLaunchTotal, res.Total), UnsampledLaunchFrame))
+	}
+	if period != "" {
+		w = append(w, fmt.Sprintf(
+			"%d samples carry %s=%s: one launch in %s contributed a CPU stack. The call path beneath [gpu:launch] is therefore a sample of launches, not a sample of GPU time - do not read its width as the share of GPU work that call path is responsible for. Nothing here is scaled by %s; every value is a measured duration.",
+			periodSamples, SamplePeriodLabel, period, period, period))
+	}
+	return w
+}
+
+func pct(part, whole int64) float64 {
+	if whole == 0 {
+		return 0
+	}
+	return float64(part) / float64(whole) * 100
+}
+
+// chooseSampleIndex picks the value axis to fold.
+//
+// The rule, in order: honour Profile.DefaultSampleType when it names a real
+// type; otherwise take the LAST sample type, which is what google/pprof's
+// own driver does and which picks the meaningful axis for the two-axis
+// profiles this repo can emit (alloc_objects/count, alloc_space/bytes →
+// bytes). Every profiling mode perf-agent ships today — cpu, offcpu, gpu —
+// declares exactly one type, so this only matters for the memory builder
+// and for foreign profiles.
+func chooseSampleIndex(p *profile.Profile) int {
+	if p.DefaultSampleType != "" {
+		for i, st := range p.SampleType {
+			if st.Type == p.DefaultSampleType {
+				return i
+			}
+		}
+	}
+	return len(p.SampleType) - 1
+}
+
+// WriteFolded emits the classic `a;b;c 123` text form, one stack per line,
+// in Result order (which Fold has already sorted).
+//
+// The text form cannot carry Stack.Inexact, so a folded file loses the
+// distinction between a measured and an inferred call path. Anything that
+// needs that must read the Result. Frame names containing ';' or a newline
+// would corrupt the format — the folded format has no escape — so they are
+// substituted and reported in the returned count.
+func (r *Result) WriteFolded(w io.Writer) (substituted int, err error) {
+	bw := &countingWriter{w: w}
+	for _, st := range r.Stacks {
+		for i, f := range st.Frames {
+			clean := sanitizeFolded(f)
+			if clean != f {
+				substituted++
+			}
+			if i > 0 {
+				bw.writeString(";")
+			}
+			bw.writeString(clean)
+		}
+		bw.writeString(fmt.Sprintf(" %d\n", st.Value))
+	}
+	return substituted, bw.err
+}
+
+func sanitizeFolded(s string) string {
+	if !strings.ContainsAny(s, ";\n\r") {
+		return s
+	}
+	return foldedReplacer.Replace(s)
+}
+
+// foldedSemicolon (U+FF1B FULLWIDTH SEMICOLON) stands in for a literal ";"
+// inside a frame name, which would otherwise read as a frame separator.
+const foldedSemicolon = "\uFF1B"
+
+var foldedReplacer = strings.NewReplacer(";", foldedSemicolon, "\n", " ", "\r", " ")
+
+type countingWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (c *countingWriter) writeString(s string) {
+	if c.err != nil {
+		return
+	}
+	_, c.err = io.WriteString(c.w, s)
+}

--- a/internal/foldedstacks/fold_test.go
+++ b/internal/foldedstacks/fold_test.go
@@ -1,0 +1,352 @@
+package foldedstacks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/pprof/profile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loc builds a location whose Line entries carry the given function names,
+// in pprof's order (index 0 innermost).
+func loc(addr uint64, names ...string) *profile.Location {
+	l := &profile.Location{Address: addr}
+	for _, n := range names {
+		l.Line = append(l.Line, profile.Line{Function: &profile.Function{Name: n}})
+	}
+	return l
+}
+
+func sample(v int64, labels map[string][]string, locs ...*profile.Location) *profile.Sample {
+	return &profile.Sample{Location: locs, Value: []int64{v}, Label: labels}
+}
+
+func oneType(samples ...*profile.Sample) *profile.Profile {
+	return &profile.Profile{
+		SampleType: []*profile.ValueType{{Type: "gpu", Unit: "nanoseconds"}},
+		Sample:     samples,
+	}
+}
+
+func TestFoldRootFirstIsTheDefaultBecauseThatIsWhatPerfAgentWrites(t *testing.T) {
+	// perf-agent calls pprof.Reverse before building, so Location[0] is the
+	// root. Folding leaf-first would draw a correct-looking graph upside
+	// down, which is why this has its own test rather than an assumption.
+	p := oneType(sample(7, nil, loc(1, "root"), loc(2, "mid"), loc(3, "leaf")))
+
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	require.Len(t, res.Stacks, 1)
+	assert.Equal(t, []string{"root", "mid", "leaf"}, res.Stacks[0].Frames)
+	assert.Equal(t, int64(7), res.Total)
+	assert.Equal(t, RootFirst, res.StackOrder)
+	assert.Equal(t, "root-first", res.StackOrder.String())
+}
+
+func TestFoldLeafFirstReversesTheStack(t *testing.T) {
+	p := oneType(sample(7, nil, loc(1, "leaf"), loc(2, "mid"), loc(3, "root")))
+
+	res, err := Fold(p, Options{SampleIndex: -1, StackOrder: LeafFirst})
+	require.NoError(t, err)
+	require.Len(t, res.Stacks, 1)
+	assert.Equal(t, []string{"root", "mid", "leaf"}, res.Stacks[0].Frames)
+	assert.Equal(t, "leaf-first", res.StackOrder.String())
+}
+
+func TestFoldExpandsInlinedFramesCallerFirst(t *testing.T) {
+	// pprof: "the last entry represents the caller into which the preceding
+	// entries were inlined". Emitting Line in storage order would invert
+	// every inlined chain.
+	p := oneType(sample(3, nil,
+		loc(1, "caller"),
+		loc(2, "innermost_inlined", "middle_inlined", "outer"),
+	))
+
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]string{"caller", "outer", "middle_inlined", "innermost_inlined"},
+		res.Stacks[0].Frames)
+	assert.Equal(t, 2, res.InlinedFrames)
+	assert.Equal(t, 4, res.Frames)
+}
+
+func TestFoldRendersUnsymbolizedFramesRatherThanDroppingThem(t *testing.T) {
+	// A flame graph that drops what it cannot name looks cleanest exactly
+	// when symbolization worked worst.
+	noLines := &profile.Location{Address: 0x7f2c945ace62}
+	p := oneType(sample(5, nil, loc(1, "main"), noLines))
+
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"main", "0x7f2c945ace62"}, res.Stacks[0].Frames)
+	assert.Equal(t, 1, res.AddressOnlyFrames)
+	assert.Contains(t, strings.Join(res.Warnings, "\n"), "have no symbol")
+}
+
+func TestFoldCountsAlreadyHexNamedFramesAsUnsymbolized(t *testing.T) {
+	// perf-agent's symbolizer formats an unresolved PC as its own name, so
+	// there is no "unsymbolized" bit left in the written profile to consult.
+	p := oneType(sample(5, nil, loc(1, "main"), loc(2, "0x7f2c945ace62")))
+
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.AddressOnlyFrames)
+}
+
+func TestFoldFallsBackThroughEmptyFunctionNames(t *testing.T) {
+	sys := &profile.Location{Address: 9, Line: []profile.Line{
+		{Function: &profile.Function{Name: "", SystemName: "_ZN3fooEv"}},
+	}}
+	file := &profile.Location{Address: 10, Line: []profile.Line{
+		{Function: &profile.Function{Name: "  ", Filename: "a.cc"}, Line: 42},
+	}}
+	nameless := &profile.Location{Address: 11, Line: []profile.Line{{Function: &profile.Function{}}}}
+	nothing := &profile.Location{Line: []profile.Line{{}}}
+
+	p := oneType(sample(1, nil, sys, file, nameless, nothing))
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"_ZN3fooEv", "a.cc:42", "0xb", UnknownFrame}, res.Stacks[0].Frames)
+}
+
+func TestFoldCarriesTheMappingFilePerFrame(t *testing.T) {
+	kern := &profile.Mapping{File: "[kernel]"}
+	l := loc(1, "schedule")
+	l.Mapping = kern
+	p := oneType(sample(1, nil, loc(2, "main"), l))
+
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"", "[kernel]"}, res.Stacks[0].Modules)
+	assert.Len(t, res.Stacks[0].Modules, len(res.Stacks[0].Frames))
+}
+
+func TestFoldAggregatesIdenticalStacksAndSumsValues(t *testing.T) {
+	p := oneType(
+		sample(3, nil, loc(1, "a"), loc(2, "b")),
+		sample(4, nil, loc(1, "a"), loc(2, "b")),
+		sample(5, nil, loc(1, "a"), loc(3, "c")),
+	)
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	require.Len(t, res.Stacks, 2)
+	assert.Equal(t, int64(12), res.Total)
+	byPath := map[string]int64{}
+	for _, s := range res.Stacks {
+		byPath[strings.Join(s.Frames, ";")] = s.Value
+	}
+	assert.Equal(t, int64(7), byPath["a;b"])
+	assert.Equal(t, int64(5), byPath["a;c"])
+}
+
+func TestFoldKeepsLabelsOutOfFramesAndSummarisesThemInstead(t *testing.T) {
+	// Spec §8: frames are stack identity. Folding a per-sample correlation
+	// ID into the path would give every sample its own leaf.
+	p := oneType(
+		sample(10, map[string][]string{"gpu_correlation": {"cupti:1"}, "gpu_join": {"exact"}}, loc(1, "k")),
+		sample(20, map[string][]string{"gpu_correlation": {"cupti:2"}, "gpu_join": {"exact"}}, loc(1, "k")),
+	)
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+
+	require.Len(t, res.Stacks, 1, "labels must not fragment the folded stack")
+	assert.Equal(t, []string{"k"}, res.Stacks[0].Frames)
+	assert.Equal(t, int64(30), res.Total)
+
+	require.Len(t, res.Labels, 2)
+	assert.Equal(t, "gpu_correlation", res.Labels[0].Key)
+	assert.Equal(t, 2, res.Labels[0].Distinct)
+	assert.Equal(t, int64(30), res.Labels[0].Total)
+	assert.Equal(t, "gpu_join", res.Labels[1].Key)
+	assert.Equal(t, 1, res.Labels[1].Distinct)
+	assert.Equal(t, "exact", res.Labels[1].Top[0].Value)
+}
+
+func TestFoldMarksInferredGPUJoinsAsInexact(t *testing.T) {
+	// gpu/projection.go writes gpu_join unconditionally as exact/heuristic/
+	// unmatched. A heuristic join means the CPU call path under the launch
+	// was guessed; the graph must be able to say so.
+	p := oneType(
+		sample(10, map[string][]string{"gpu_join": {"exact"}}, loc(1, "a"), loc(2, "k")),
+		sample(30, map[string][]string{"gpu_join": {"heuristic"}}, loc(1, "a"), loc(2, "k")),
+		sample(5, map[string][]string{"gpu_join": {"exact"}, "gpu_ambiguous": {"true"}}, loc(1, "a"), loc(2, "k")),
+	)
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	require.Len(t, res.Stacks, 1)
+	assert.Equal(t, int64(45), res.Stacks[0].Value)
+	assert.Equal(t, int64(35), res.Stacks[0].Inexact)
+	assert.Equal(t, int64(35), res.InexactTotal)
+	assert.Contains(t, strings.Join(res.Warnings, "\n"), "by inference, not measurement")
+}
+
+func TestFoldExactJoinsAreNeverInexact(t *testing.T) {
+	p := oneType(sample(10, map[string][]string{"gpu_join": {"exact"}}, loc(1, "k")))
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Zero(t, res.InexactTotal)
+	assert.NotContains(t, strings.Join(res.Warnings, "\n"), "by inference")
+}
+
+func TestFoldOnAnEmptyProfileReportsRatherThanReturningNothing(t *testing.T) {
+	res, err := Fold(oneType(), Options{SampleIndex: -1})
+	require.NoError(t, err, "an empty profile is a fact to report, not an error to swallow")
+	assert.True(t, res.Degenerate())
+	assert.Zero(t, res.Total)
+	require.NotEmpty(t, res.Warnings)
+	assert.Contains(t, res.Warnings[0], "no samples at all")
+}
+
+func TestFoldOnAnAllZeroProfileSaysSo(t *testing.T) {
+	p := oneType(sample(0, nil, loc(1, "a")), sample(0, nil, loc(2, "b")))
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.True(t, res.Degenerate())
+	assert.Equal(t, 2, res.ZeroValueSamples)
+	assert.Contains(t, strings.Join(res.Warnings, "\n"), "carries the value 0")
+}
+
+func TestFoldRefusesADifferentialProfile(t *testing.T) {
+	p := oneType(sample(-5, nil, loc(1, "a")))
+	_, err := Fold(p, Options{SampleIndex: -1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "differential")
+}
+
+func TestFoldKeepsValuedSamplesThatHaveNoStack(t *testing.T) {
+	p := oneType(sample(9, nil))
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.EmptyStackSamples)
+	assert.Equal(t, []string{UnknownFrame}, res.Stacks[0].Frames)
+	assert.Equal(t, int64(9), res.Total)
+}
+
+func TestChooseSampleIndexPrefersDefaultSampleType(t *testing.T) {
+	p := &profile.Profile{
+		SampleType: []*profile.ValueType{
+			{Type: "alloc_objects", Unit: "count"},
+			{Type: "alloc_space", Unit: "bytes"},
+		},
+		DefaultSampleType: "alloc_objects",
+		Sample: []*profile.Sample{
+			{Location: []*profile.Location{loc(1, "a")}, Value: []int64{3, 4096}},
+		},
+	}
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.SampleIndex)
+	assert.Equal(t, "alloc_objects", res.SampleTypeName)
+	assert.Equal(t, int64(3), res.Total)
+}
+
+func TestChooseSampleIndexFallsBackToTheLastType(t *testing.T) {
+	// google/pprof's own driver treats the last sample type as the default,
+	// which for this repo's memory builder picks bytes over object counts.
+	p := &profile.Profile{
+		SampleType: []*profile.ValueType{
+			{Type: "alloc_objects", Unit: "count"},
+			{Type: "alloc_space", Unit: "bytes"},
+		},
+		Sample: []*profile.Sample{
+			{Location: []*profile.Location{loc(1, "a")}, Value: []int64{3, 4096}},
+		},
+	}
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.SampleIndex)
+	assert.Equal(t, "alloc_space", res.SampleTypeName)
+	assert.Equal(t, int64(4096), res.Total)
+	assert.Contains(t, strings.Join(res.Warnings, "\n"), "value axes")
+}
+
+func TestFoldRejectsAnOutOfRangeSampleIndex(t *testing.T) {
+	_, err := Fold(oneType(sample(1, nil, loc(1, "a"))), Options{SampleIndex: 4})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
+func TestFoldIsDeterministic(t *testing.T) {
+	build := func() *profile.Profile {
+		return oneType(
+			sample(1, nil, loc(1, "z"), loc(2, "y")),
+			sample(2, nil, loc(3, "a"), loc(4, "b")),
+			sample(3, nil, loc(5, "m")),
+		)
+	}
+	var first string
+	for range 5 {
+		res, err := Fold(build(), Options{SampleIndex: -1})
+		require.NoError(t, err)
+		var b strings.Builder
+		_, err = res.WriteFolded(&b)
+		require.NoError(t, err)
+		if first == "" {
+			first = b.String()
+			continue
+		}
+		assert.Equal(t, first, b.String(), "two folds of the same profile must be byte-identical")
+	}
+	assert.Equal(t, "a;b 2\nm 3\nz;y 1\n", first)
+}
+
+func TestWriteFoldedSubstitutesSeparatorsInsideFrameNames(t *testing.T) {
+	p := oneType(sample(1, nil, loc(1, "weird;name"), loc(2, "two\nlines")))
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+
+	var b strings.Builder
+	n, err := res.WriteFolded(&b)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "the caller must be told the text form was lossy")
+	assert.Equal(t, "weird；name;two lines 1\n", b.String())
+	assert.Equal(t, []string{"weird;name", "two\nlines"}, res.Stacks[0].Frames,
+		"the structured stacks the renderer consumes must keep the original name")
+}
+
+func TestFoldRejectsNilAndTypelessProfiles(t *testing.T) {
+	_, err := Fold(nil, Options{})
+	require.Error(t, err)
+
+	_, err = Fold(&profile.Profile{}, Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no sample types")
+}
+
+// The shape of a sampled-launch GPU profile is actively misleading without
+// this. gpu/projection.go samples launch STACKS one-in-N but records every
+// execution, so the attributed call path is narrow by roughly N while the
+// rest of the measured GPU time sits under [gpu:launch unsampled] with no
+// caller. A reader who takes the attributed width as "the share of GPU time
+// this path is responsible for" is wrong by that factor.
+func TestFoldExplainsWhatLaunchSamplingDoesToTheShape(t *testing.T) {
+	p := oneType(
+		sample(5590723, map[string][]string{"gpu_join": {"exact"}},
+			loc(1, UnsampledLaunchFrame), loc(2, "[gpu:kernel:k]")),
+		sample(397131, map[string][]string{"gpu_join": {"exact"}, SamplePeriodLabel: {"8"}},
+			loc(3, "main"), loc(4, "[gpu:launch]"), loc(2, "[gpu:kernel:k]")),
+	)
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(5590723), res.UnsampledLaunchTotal)
+	joined := strings.Join(res.Warnings, "\n")
+	assert.Contains(t, joined, "93.4% of the total sits under [gpu:launch unsampled]")
+	assert.Contains(t, joined, "one launch in 8 contributed a CPU stack")
+	assert.Contains(t, joined, "not a sample of GPU time")
+	assert.Contains(t, joined, "every value is a measured duration",
+		"the page must not let a reader think the widths were scaled up by the period")
+}
+
+func TestFoldSaysNothingAboutSamplingWhenThereIsNone(t *testing.T) {
+	p := oneType(sample(10, nil, loc(1, "main"), loc(2, "work")))
+	res, err := Fold(p, Options{SampleIndex: -1})
+	require.NoError(t, err)
+	assert.Zero(t, res.UnsampledLaunchTotal)
+	joined := strings.Join(res.Warnings, "\n")
+	assert.NotContains(t, joined, "launch")
+	assert.NotContains(t, joined, "sample of GPU time")
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,11 @@ var (
 	flagProfileOutput  = flag.String("profile-output", "", "Output path for CPU profile (default: auto-generated)")
 	flagOffcpuOutput   = flag.String("offcpu-output", "", "Output path for off-CPU profile (default: auto-generated)")
 	flagPMUOutput      = flag.String("pmu-output", "", "Output path for PMU metrics (default: stdout)")
+	flagFlamegraph     = flag.String("flamegraph-output", "",
+		"Also write a self-contained interactive HTML flame graph of the profile. "+
+			"Pass a path, or 'auto' to name it like the other outputs "+
+			"({process}-{timestamp}-{on-cpu|off-cpu}.html). With both --profile and "+
+			"--offcpu, only 'auto' is accepted: one path cannot name two graphs.")
 	flagPerfDataOutput = flag.String("perf-data-output", "",
 		"Write a kernel-format perf.data file alongside the pprof output. "+
 			"Consumable by perf script, perf report, create_llvm_prof (AutoFDO PGO), "+
@@ -165,12 +170,27 @@ func buildOptions() []perfagent.Option {
 		log.Fatal("At least one of --profile, --offcpu, or --pmu must be specified")
 	}
 
+	// --flamegraph-output names at most one file, so with both stack
+	// profiling modes on it can only be "auto". Silently rendering one mode
+	// and dropping the other would leave a plausible-looking graph that is
+	// missing half the run.
+	if *flagFlamegraph != "" && *flagFlamegraph != "auto" && *flagProfile && *flagOffCpu {
+		log.Fatal("--flamegraph-output with an explicit path cannot serve both --profile and --offcpu; use --flamegraph-output auto, or run one mode at a time")
+	}
+	if *flagFlamegraph != "" && !*flagProfile && !*flagOffCpu {
+		log.Fatal("--flamegraph-output requires --profile or --offcpu; there is no stack profile to render")
+	}
+
 	if *flagProfile {
 		outputPath := *flagProfileOutput
 		if outputPath == "" {
 			outputPath = generateOutputName(*flagPID, *flagAll, "on-cpu", "pb.gz")
 		}
 		opts = append(opts, perfagent.WithCPUProfile(outputPath))
+
+		if path := flamegraphPath(*flagFlamegraph, "on-cpu"); path != "" {
+			opts = append(opts, perfagent.WithCPUFlamegraph(path))
+		}
 
 		if *flagPerfDataOutput != "" {
 			opts = append(opts, perfagent.WithPerfDataOutput(*flagPerfDataOutput))
@@ -183,6 +203,10 @@ func buildOptions() []perfagent.Option {
 			outputPath = generateOutputName(*flagPID, *flagAll, "off-cpu", "pb.gz")
 		}
 		opts = append(opts, perfagent.WithOffCPUProfile(outputPath))
+
+		if path := flamegraphPath(*flagFlamegraph, "off-cpu"); path != "" {
+			opts = append(opts, perfagent.WithOffCPUFlamegraph(path))
+		}
 	}
 
 	if *flagPMU {
@@ -260,6 +284,21 @@ func buildOptions() []perfagent.Option {
 	}
 
 	return opts
+}
+
+// flamegraphPath resolves --flamegraph-output for one profiling mode.
+// "auto" follows the same naming convention as the other outputs, which is
+// also what --pmu-output auto does; an explicit path is used verbatim, and
+// buildOptions has already rejected the one case where that is ambiguous.
+func flamegraphPath(flagValue, suffix string) string {
+	switch flagValue {
+	case "":
+		return ""
+	case "auto":
+		return generateOutputName(*flagPID, *flagAll, suffix, "html")
+	default:
+		return flagValue
+	}
 }
 
 func generateOutputName(pid int, systemWide bool, suffix, ext string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlamegraphPathFollowsTheExistingAutoNamingConvention(t *testing.T) {
+	// --flamegraph-output auto must name its file exactly the way
+	// --pmu-output auto and the default profile names do, so the three
+	// artifacts of one run sort together.
+	oldPID, oldAll := *flagPID, *flagAll
+	t.Cleanup(func() { *flagPID, *flagAll = oldPID, oldAll })
+
+	*flagPID, *flagAll = 0, true
+	auto := flamegraphPath("auto", "on-cpu")
+	assert.True(t, strings.HasSuffix(auto, "-on-cpu.html"), "got %q", auto)
+	assert.Equal(t, generateOutputName(0, true, "on-cpu", "html"), auto)
+
+	*flagPID, *flagAll = 999999, false
+	perPID := flamegraphPath("auto", "off-cpu")
+	assert.True(t, strings.HasPrefix(perPID, "pid999999-"), "got %q", perPID)
+	assert.True(t, strings.HasSuffix(perPID, "-off-cpu.html"), "got %q", perPID)
+}
+
+func TestFlamegraphPathPassesAnExplicitPathThrough(t *testing.T) {
+	assert.Equal(t, "/tmp/x.html", flamegraphPath("/tmp/x.html", "on-cpu"))
+	assert.Equal(t, "", flamegraphPath("", "on-cpu"), "unset means no flame graph")
+}
+
+func TestGenerateOutputNameShapes(t *testing.T) {
+	assert.Regexp(t, `^\d{12}-on-cpu\.html$`, generateOutputName(0, true, "on-cpu", "html"))
+	assert.Regexp(t, `^pid1234-\d{12}-off-cpu\.pb\.gz$`, generateOutputName(1234, false, "off-cpu", "pb.gz"))
+}

--- a/perfagent/agent.go
+++ b/perfagent/agent.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"maps"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,6 +24,7 @@ import (
 	"github.com/dpsoft/perf-agent/cpu"
 	"github.com/dpsoft/perf-agent/inject/ptraceop"
 	"github.com/dpsoft/perf-agent/inject/python"
+	"github.com/dpsoft/perf-agent/internal/flamegraph"
 	"github.com/dpsoft/perf-agent/internal/k8slabels"
 	"github.com/dpsoft/perf-agent/internal/nspid"
 	"github.com/dpsoft/perf-agent/internal/perfdata"
@@ -634,9 +636,13 @@ func (a *Agent) Stop(ctx context.Context) error {
 				log.Printf("Failed to write CPU profile: %v", err)
 				lastErr = err
 			}
+			a.warnFlamegraphNeedsPath(a.config.CPUFlamegraphPath, "CPU")
 		} else {
 			if err := a.cpuProfiler.CollectAndWrite(a.config.CPUProfilePath); err != nil {
 				log.Printf("Failed to write CPU profile: %v", err)
+				lastErr = err
+			} else if err := a.writeFlamegraph(a.config.CPUProfilePath, a.config.CPUFlamegraphPath, "on-CPU"); err != nil {
+				log.Printf("Failed to write CPU flame graph: %v", err)
 				lastErr = err
 			}
 		}
@@ -649,9 +655,13 @@ func (a *Agent) Stop(ctx context.Context) error {
 				log.Printf("Failed to write off-CPU profile: %v", err)
 				lastErr = err
 			}
+			a.warnFlamegraphNeedsPath(a.config.OffCPUFlamegraphPath, "off-CPU")
 		} else {
 			if err := a.offcpuProfiler.CollectAndWrite(a.config.OffCPUProfilePath); err != nil {
 				log.Printf("Failed to write off-CPU profile: %v", err)
+				lastErr = err
+			} else if err := a.writeFlamegraph(a.config.OffCPUProfilePath, a.config.OffCPUFlamegraphPath, "off-CPU"); err != nil {
+				log.Printf("Failed to write off-CPU flame graph: %v", err)
 				lastErr = err
 			}
 		}
@@ -664,6 +674,54 @@ func (a *Agent) Stop(ctx context.Context) error {
 	}
 
 	return lastErr
+}
+
+// writeFlamegraph renders htmlPath from the pprof file just written to
+// profilePath. It is a no-op when no flame graph was requested.
+//
+// Every honest number the page carries is also echoed to the terminal. A
+// profile that folded to nothing still produces a page - one that says so -
+// and still logs why, because a silently empty flame graph is exactly the
+// failure this feature must not add.
+func (a *Agent) writeFlamegraph(profilePath, htmlPath, mode string) error {
+	if htmlPath == "" {
+		return nil
+	}
+	res, err := flamegraph.FromProfileFile(profilePath, htmlPath, flamegraph.Options{
+		Title: fmt.Sprintf("%s flame graph - %s", mode, filepath.Base(profilePath)),
+		Meta: []flamegraph.MetaItem{
+			{Label: "mode", Value: mode},
+			{Label: "target", Value: a.targetDescription()},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("Flame graph written to %s (%s across %d samples in %d distinct stacks)",
+		htmlPath, flamegraph.FormatValue(res.Total, res.Unit), res.Samples, len(res.Stacks))
+	for _, w := range res.Warnings {
+		log.Printf("Flame graph note: %s", w)
+	}
+	return nil
+}
+
+// warnFlamegraphNeedsPath says out loud why no flame graph appeared. The
+// writer-based options hand the profile to an io.Writer the agent cannot
+// re-read, so there is nothing to render from; staying quiet about it would
+// look identical to the flag having worked.
+func (a *Agent) warnFlamegraphNeedsPath(htmlPath, mode string) {
+	if htmlPath == "" {
+		return
+	}
+	log.Printf("No %s flame graph written to %s: this run streams the profile to a writer rather than a file, and the renderer reads the written profile back. Use the path-based profile option to get one.", mode, htmlPath)
+}
+
+// targetDescription is the header chip naming what was profiled.
+func (a *Agent) targetDescription() string {
+	if a.config.SystemWide {
+		return "system-wide"
+	}
+	return fmt.Sprintf("pid %d", a.config.PID)
 }
 
 // GetMetrics returns the current PMU metrics snapshot.

--- a/perfagent/flamegraph_test.go
+++ b/perfagent/flamegraph_test.go
@@ -1,0 +1,148 @@
+package perfagent
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/pprof/profile"
+)
+
+func writeTestProfile(t *testing.T, samples ...*profile.Sample) string {
+	t.Helper()
+	m := &profile.Mapping{ID: 1}
+	f1 := &profile.Function{ID: 1, Name: "main"}
+	f2 := &profile.Function{ID: 2, Name: "hot"}
+	p := &profile.Profile{
+		SampleType: []*profile.ValueType{{Type: "cpu", Unit: "nanoseconds"}},
+		PeriodType: &profile.ValueType{Type: "cpu", Unit: "nanoseconds"},
+		Period:     10101010,
+		Mapping:    []*profile.Mapping{m},
+		Function:   []*profile.Function{f1, f2},
+		Location: []*profile.Location{
+			{ID: 1, Mapping: m, Line: []profile.Line{{Function: f1}}},
+			{ID: 2, Mapping: m, Line: []profile.Line{{Function: f2}}},
+		},
+		Sample: samples,
+	}
+	for _, s := range p.Sample {
+		s.Location = []*profile.Location{p.Location[0], p.Location[1]}
+	}
+	path := filepath.Join(t.TempDir(), "prof.pb.gz")
+	fh, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Write(fh); err != nil {
+		t.Fatal(err)
+	}
+	if err := fh.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() { log.SetOutput(prevOut); log.SetFlags(prevFlags) })
+	return &buf
+}
+
+func TestWriteFlamegraphRendersFromTheProfileTheUserWasGiven(t *testing.T) {
+	src := writeTestProfile(t, &profile.Sample{Value: []int64{7000000}})
+	dst := filepath.Join(t.TempDir(), "graph.html")
+	a := &Agent{config: &Config{PID: 4321, CPUFlamegraphPath: dst}}
+	logs := captureLog(t)
+
+	if err := a.writeFlamegraph(src, dst, "on-CPU"); err != nil {
+		t.Fatalf("writeFlamegraph: %v", err)
+	}
+	page, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"<!DOCTYPE html>", "data-name=\"main\"", "data-name=\"hot\"", "pid 4321", "on-CPU"} {
+		if !strings.Contains(string(page), want) {
+			t.Errorf("page missing %q", want)
+		}
+	}
+	if !strings.Contains(logs.String(), "Flame graph written to "+dst) {
+		t.Errorf("the run must say where the graph went; got %q", logs.String())
+	}
+}
+
+func TestWriteFlamegraphIsANoOpWhenNotRequested(t *testing.T) {
+	a := &Agent{config: &Config{}}
+	if err := a.writeFlamegraph("nonexistent.pb.gz", "", "on-CPU"); err != nil {
+		t.Fatalf("an unset flame graph path must not be an error: %v", err)
+	}
+}
+
+func TestWriteFlamegraphEchoesTheProfilesOwnWarnings(t *testing.T) {
+	// A profile that folds to nothing must still produce a file, and the
+	// run must say why it is blank rather than looking like a success.
+	src := writeTestProfile(t)
+	dst := filepath.Join(t.TempDir(), "graph.html")
+	a := &Agent{config: &Config{SystemWide: true}}
+	logs := captureLog(t)
+
+	if err := a.writeFlamegraph(src, dst, "on-CPU"); err != nil {
+		t.Fatalf("an empty profile is not a rendering failure: %v", err)
+	}
+	if !strings.Contains(logs.String(), "Flame graph note:") ||
+		!strings.Contains(logs.String(), "no samples at all") {
+		t.Errorf("the empty profile must be reported, got %q", logs.String())
+	}
+	page, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(page), "No flame graph was drawn") {
+		t.Error("the page must say it drew nothing")
+	}
+	if strings.Contains(string(page), "<svg class=\"flame\"") {
+		t.Error("an empty profile must not produce a graph")
+	}
+}
+
+func TestWriteFlamegraphReportsAnUnreadableProfile(t *testing.T) {
+	a := &Agent{config: &Config{}}
+	err := a.writeFlamegraph(filepath.Join(t.TempDir(), "gone.pb.gz"), filepath.Join(t.TempDir(), "o.html"), "on-CPU")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+}
+
+func TestWarnFlamegraphNeedsPathExplainsTheWriterCase(t *testing.T) {
+	// The writer-based options stream the profile somewhere the agent
+	// cannot read back. Silence would be indistinguishable from the flag
+	// having worked.
+	a := &Agent{config: &Config{}}
+	logs := captureLog(t)
+	a.warnFlamegraphNeedsPath("wanted.html", "CPU")
+	if !strings.Contains(logs.String(), "No CPU flame graph written to wanted.html") {
+		t.Errorf("got %q", logs.String())
+	}
+
+	quiet := captureLog(t)
+	a.warnFlamegraphNeedsPath("", "CPU")
+	if quiet.String() != "" {
+		t.Errorf("no warning when no flame graph was asked for; got %q", quiet.String())
+	}
+}
+
+func TestTargetDescription(t *testing.T) {
+	if got := (&Agent{config: &Config{SystemWide: true}}).targetDescription(); got != "system-wide" {
+		t.Errorf("got %q", got)
+	}
+	if got := (&Agent{config: &Config{PID: 99}}).targetDescription(); got != "pid 99" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/perfagent/options.go
+++ b/perfagent/options.go
@@ -41,6 +41,20 @@ type Config struct {
 	// are written; off-CPU and PMU modes ignore this option.
 	PerfDataOutput string
 
+	// CPUFlamegraphPath is the path for a self-contained HTML flame graph
+	// rendered from the CPU profile this run writes. Empty disables it.
+	// Set via WithCPUFlamegraph.
+	//
+	// The renderer reads back the pprof file the agent just wrote, so it
+	// only runs when the profile went to a path. With CPUProfileWriter
+	// there is no file to re-read and the agent says so rather than
+	// quietly skipping.
+	CPUFlamegraphPath string
+
+	// OffCPUFlamegraphPath is the same for the off-CPU profile. Set via
+	// WithOffCPUFlamegraph.
+	OffCPUFlamegraphPath string
+
 	// EnablePMU enables PMU hardware counter monitoring.
 	EnablePMU bool
 
@@ -299,6 +313,22 @@ func WithOffCPUProfileWriter(w io.Writer) Option {
 // create_llvm_prof (AutoFDO PGO), FlameGraph, hotspot, etc.
 func WithPerfDataOutput(path string) Option {
 	return func(c *Config) { c.PerfDataOutput = path }
+}
+
+// WithCPUFlamegraph writes a self-contained interactive HTML flame graph of
+// the CPU profile, alongside the .pb.gz. One file, no external scripts or
+// fonts, correct when opened straight off disk.
+//
+// Requires CPU profiling to be writing to a path: the flame graph is
+// rendered from the profile file after it is written, not from a second
+// in-memory path, so what you look at is the artifact you were given.
+func WithCPUFlamegraph(path string) Option {
+	return func(c *Config) { c.CPUFlamegraphPath = path }
+}
+
+// WithOffCPUFlamegraph is WithCPUFlamegraph for the off-CPU profile.
+func WithOffCPUFlamegraph(path string) Option {
+	return func(c *Config) { c.OffCPUFlamegraphPath = path }
 }
 
 // WithDebuginfodURL appends a debuginfod server URL. Repeatable.

--- a/perfagent/options_test.go
+++ b/perfagent/options_test.go
@@ -55,3 +55,28 @@ func TestWithPerfDataOutput_SetsConfig(t *testing.T) {
 		t.Errorf("PerfDataOutput = %q, want %q", cfg.PerfDataOutput, "app.perf.data")
 	}
 }
+
+func TestWithCPUFlamegraph_SetsConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.CPUFlamegraphPath != "" {
+		t.Fatalf("CPUFlamegraphPath should default to off, got %q", cfg.CPUFlamegraphPath)
+	}
+	WithCPUFlamegraph("app-on-cpu.html")(cfg)
+	if cfg.CPUFlamegraphPath != "app-on-cpu.html" {
+		t.Errorf("CPUFlamegraphPath = %q, want %q", cfg.CPUFlamegraphPath, "app-on-cpu.html")
+	}
+	if cfg.OffCPUFlamegraphPath != "" {
+		t.Errorf("WithCPUFlamegraph must not touch the off-CPU path, got %q", cfg.OffCPUFlamegraphPath)
+	}
+}
+
+func TestWithOffCPUFlamegraph_SetsConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	WithOffCPUFlamegraph("app-off-cpu.html")(cfg)
+	if cfg.OffCPUFlamegraphPath != "app-off-cpu.html" {
+		t.Errorf("OffCPUFlamegraphPath = %q, want %q", cfg.OffCPUFlamegraphPath, "app-off-cpu.html")
+	}
+	if cfg.CPUFlamegraphPath != "" {
+		t.Errorf("WithOffCPUFlamegraph must not touch the CPU path, got %q", cfg.CPUFlamegraphPath)
+	}
+}


### PR DESCRIPTION
Adds `--flamegraph-output <path>|auto`, emitting a self-contained interactive HTML flame
graph from the pprof profile the agent just wrote. Also `cmd/flamegraph` for rendering an
existing `.pb.gz` offline.

The renderer is adapted from the one in closed draft PR #10; what changed and why is in the
report. Salvaged: the tree/zoom/search architecture and keybindings. Rewritten: it could not
read pprof at all, which is why it never shipped.

### Pieces

- **`internal/foldedstacks`** — pprof → folded. Expands inlined `Line` chains, renders
  unsymbolized frames as addresses, aggregates by path, and returns the honest counts
  (samples, zero-value samples, unsymbolized slots, inlined frames, label summaries,
  warnings) alongside the stacks rather than discarding them.
- **`internal/flamegraph`** — one HTML file. No server, no CDN, no external font: the only
  URL in a rendered document is the SVG namespace, and the single `<script>` is inline.
- **`cmd/flamegraph`** — `-o out.html`, or `-folded` for the text form.

### Three decisions

**Stack order.** The pprof proto says `Location[0]` is the leaf, but perf-agent calls
`pprof.Reverse` before building, so in every profile it writes it is the *root*. Getting
this wrong does not fail — it draws a plausible graph upside down. It is an explicit option
defaulting to what this repo writes, and the page states which order it assumed.

**Sample type.** `DefaultSampleType` when set, else the last type (what google/pprof's own
driver does). Every shipped mode has exactly one. Negative values — a `-diff_base` profile —
are refused rather than clamped.

**GPU labels: frames-only, per spec §8.** `gpu_correlation` has 4,000 distinct values across
4,000 samples; folding it into the path turns 3 stacks into 4,000. Labels are summarised
beside the graph. Two are promoted onto it, because they qualify how far the picture can be
trusted: `gpu_join` heuristic/unmatched hatches the affected frames, and
`gpu_sample_period` raises

> 257 samples carry `gpu_sample_period=8`: one launch in 8 contributed a CPU stack. The call
> path beneath `[gpu:launch]` is therefore a sample of launches, not a sample of GPU time —
> do not read its width as the share of GPU work that call path is responsible for. Nothing
> here is scaled by 8; every value is a measured duration.

That is a real misreading trap: the natural reading of that 6.6% column is wrong by roughly
the period.

### Honesty

A flame graph that renders a plausible picture from an empty profile is this project's
recurring defect in visual form. An empty profile produces no `<svg>` and no `<script>` — a
panel saying the profile has zero samples, and that this is the profile reporting on itself.
Unsymbolized frames are drawn hatched and counted (1,799 of 11,598 slots, 15.5%, in the
verification profile) rather than quietly rendered as ordinary frames.

Colour encodes **domain** — application, CPU, vendor-unsymbolized, perf-agent's own shim,
GPU — with a legend. PR #10 used `fnv(name) % 360`, which carries no information.

### Verified against a real profile

`/home/diego/gpu-cuda-45.pb.gz`, the RTX 3090 CPU+GPU capture. Total **5,987,854 ns** and all
three per-stack sums match `go tool pprof -raw` exactly: 2,894,901 (n=2000), 2,695,822
(n=1743), 397,131 (n=257). (`-traces` prints values rounded to 3 significant figures, so
summing its text gives 5,987,350 — a display artifact, not a discrepancy.) All seven hex
vendor frames render hatched. Opened from `file://` in light and dark; zoom, search and reset
driven headlessly.

Hostile symbol names are escaped — `std::vector<Foo&Bar>::push_back("</title><script>…")`
and a title carrying the same is pinned by test. C++ templates and Go generics make `<`, `>`
and `&` routine in this data.

64 new tests. `go build`, `go vet`, `go test ./... -count=1`, `golangci-lint` 0 issues.

### Not verified

`--flamegraph-output` has never run through a real `Start()`/`Stop()` — no BPF capabilities
in the build environment. Flag parsing, both fatal validations, auto-naming, and
`Agent.writeFlamegraph` were exercised directly against real `.pb.gz` files, but the
three-line call sites in `Stop()` are compiled, not run. Also untested against real data:
AMD/ROCm frames, kernel stacks, DWARF-inlined frames, off-CPU and multi-axis profiles, and
any browser other than Chrome. `isAddressOnly` is a name-shaped test — once a profile is
written there is no unsymbolized bit left in pprof to consult — so a symbol literally named
`0xabc` would be miscounted.
