### PR TITLE
shim: jitter the launch sampler so it cannot lock phase

### DIFF
--- a/.superpowers/sdd/issue-50-report.md
+++ b/.superpowers/sdd/issue-50-report.md
@@ -1,0 +1,303 @@
+# Issue #50 — the launch sampler aliased against periodic launch patterns
+
+Branch `fix/sampler-aliasing`. One commit. Not pushed, no PR.
+
+## Cannot verify (read this first)
+
+`CapEff: 0000000000000000` on this machine. `TestStubDrivesThePipelineToPprofWithoutAGPU`
+**skipped**, and no CUDA run was possible. So:
+
+- The end-to-end pipeline assertions in `gpuprobe/gate_test.go` — including the new
+  both-kernels-get-stacks assertion and the changed sampled count — **have not been
+  executed**. They compile and vet clean; that is all I can say about them.
+- The RTX 3090 numbers below are **predictions derived before any run**, from the
+  schedule itself. They are not measurements.
+
+What *was* executed: the whole C++ shim suite (`make -C shim test`, plus `test-tsan`),
+the new Go replica suite, `go build`, `go vet`, `go test ./gpu/ ./gpuprobe/
+./internal/...`, and `golangci-lint` (0 issues). The stub binary was run standalone to
+confirm its accounting line.
+
+## The scheme chosen: jittered stride, deterministic given a seed
+
+Option 1 from the issue, with the one addition that makes it keep everything the fixed
+stride was chosen for.
+
+After sampling launch `s`, the next sample is at `s + gap_at(s)`, where the gap is drawn
+uniformly from the `2k+1` consecutive integers centred on `period` (`k = period/2`):
+
+| period | gap band | mean gap |
+|---:|---|---:|
+| 1 | {1} | 1 (every launch) |
+| 2 | [1, 3] | 2 |
+| 3 | [2, 4] | 3 |
+| 8 | [4, 12] | 8 |
+| 64 | [32, 96] | 64 |
+
+The set is symmetric about `period`, so the mean gap is **exactly** `period` and the
+long-run rate is **exactly** `1/period` — the same rate the fixed stride had. Because the
+band always spans both parities for any period ≥ 2, the phase cannot lock: over a
+`c`-cycle every residue mod `c` is reached.
+
+The gap is **not** read from a running PRNG state. It is a pure function
+`gap_at(sample_point, period, seed)` — a splitmix64 finalizer of `seed ^ (seq * φ)`,
+mapped into the band by Lemire's multiply-shift. So the schedule `0, s1, s2, …` is a
+deterministic chain replayable from the seed alone.
+
+The seed defaults to a fixed constant (`Sampler::kDefaultSeed = 0x9E3779B97F4A7C15`)
+rather than being randomized per process. Reproducibility is why this sampler was
+deterministic in the first place, and a fixed seed is what keeps the phase gate's
+assertion an equality. `PERFAGENT_GPU_SAMPLE_SEED` (CUPTI adapter) buys per-process
+variation for anyone who wants to average several runs; both the adapter and the stub now
+print the seed they ran on, so any profile is auditable after the fact.
+
+### Why not Bernoulli
+
+Bernoulli is simpler, but the count over a run becomes a random variable with no fixed
+value, which turns three exact gate assertions into tolerance bands and makes
+`expected_sampled` an estimate. Jittered-with-a-seed gives the same phase-unlocking for
+the same hot-path cost while every count stays exact. There was no reason to pay for
+Bernoulli's simplicity with a weaker gate.
+
+## The pre-fix failure output
+
+The regression test was written first and run against the unfixed sampler. Verbatim:
+
+```
+  alternating 2-kernel at period 8: kernel_a=500 kernel_b=0
+  FAIL: the sampler locked phase against a 2-cycle: one kernel of the pair received every stack and the other received none
+prefix_sampler_test: /tmp/prefix_sampler_test.cc:76: int main(): Assertion `stacks[1] > 0' failed.
+EXIT=134
+```
+
+With the asserts removed so the sweep could run to completion, the unfixed sampler locked
+phase in **30** of the 33 (period, cycle) pairs tested:
+
+```
+  FAIL: period=2 locks phase against a 2-cycle: residue 1 never sampled
+  FAIL: period=4 locks phase against a 2-cycle: residue 1 never sampled
+  FAIL: period=6 locks phase against a 2-cycle: residue 1 never sampled
+  FAIL: period=8 locks phase against a 2-cycle: residue 1 never sampled
+  FAIL: period=10 locks phase against a 2-cycle: residue 1 never sampled
+  FAIL: period=12 locks phase against a 2-cycle: residue 1 never sampled
+  FAIL: period=3 locks phase against a 3-cycle: residue 1 never sampled
+  FAIL: period=3 locks phase against a 3-cycle: residue 2 never sampled
+  FAIL: period=6 locks phase against a 3-cycle: residue 1 never sampled
+  FAIL: period=6 locks phase against a 3-cycle: residue 2 never sampled
+  FAIL: period=9 locks phase against a 3-cycle: residue 1 never sampled
+  FAIL: period=9 locks phase against a 3-cycle: residue 2 never sampled
+  FAIL: period=12 locks phase against a 3-cycle: residue 1 never sampled
+  FAIL: period=12 locks phase against a 3-cycle: residue 2 never sampled
+  FAIL: period=2 locks phase against a 4-cycle: residue 1 never sampled
+  FAIL: period=2 locks phase against a 4-cycle: residue 3 never sampled
+  FAIL: period=4 locks phase against a 4-cycle: residue 1 never sampled
+  FAIL: period=4 locks phase against a 4-cycle: residue 2 never sampled
+  FAIL: period=4 locks phase against a 4-cycle: residue 3 never sampled
+  FAIL: period=6 locks phase against a 4-cycle: residue 1 never sampled
+  FAIL: period=6 locks phase against a 4-cycle: residue 3 never sampled
+  FAIL: period=8 locks phase against a 4-cycle: residue 1 never sampled
+  FAIL: period=8 locks phase against a 4-cycle: residue 2 never sampled
+  FAIL: period=8 locks phase against a 4-cycle: residue 3 never sampled
+  FAIL: period=10 locks phase against a 4-cycle: residue 1 never sampled
+  FAIL: period=10 locks phase against a 4-cycle: residue 3 never sampled
+  FAIL: period=12 locks phase against a 4-cycle: residue 1 never sampled
+  FAIL: period=12 locks phase against a 4-cycle: residue 2 never sampled
+  FAIL: period=12 locks phase against a 4-cycle: residue 3 never sampled
+```
+
+The rate block passed on the unfixed sampler (it always did — the rate was never the
+defect), which is the point: a rate check alone would never have found this.
+
+Post-fix, the same suite:
+
+```
+  alternating 2-kernel at period 8: kernel_a=255 kernel_b=250
+  rate at period  2: sampled=100069 expected=100000.0 err=+0.069%
+  rate at period  3: sampled=66561 expected=66666.7 err=-0.159%
+  rate at period  4: sampled=49943 expected=50000.0 err=-0.114%
+  rate at period  7: sampled=28596 expected=28571.4 err=+0.086%
+  rate at period  8: sampled=25054 expected=25000.0 err=+0.216%
+  rate at period 16: sampled=12517 expected=12500.0 err=+0.136%
+  rate at period 64: sampled=3124 expected=3125.0 err=-0.032%
+  schedule pin: 500 launches at period 8 -> 58 sampled
+  schedule pin: 4000 launches at period 8 -> 505 sampled
+sampler_test OK
+```
+
+## Did `sample_period`'s meaning change?
+
+**Yes, slightly, and it needs stating plainly.** It used to be an *exact* stride: a
+consumer could assert `launch_seq % sample_period == 0`. It is now the *mean* stride.
+
+What did **not** change:
+
+- The wire ABI. `gpu_launch_sampled_v1` is byte-for-byte identical; `sample_period` is
+  still the `uint32` at offset 44 and is still never 0. No consumer code needed changing,
+  and none was changed on the decode path.
+- The **rate** it names. Gaps are drawn from a set symmetric about `period`, so the
+  long-run rate is exactly `1/sample_period`, as before.
+- It is still **not a scale factor**. Confirmed below.
+
+The two comments that stated the old meaning are updated to state the new one:
+`shim/core/usdt_abi.h` (the field) and `gpu.LaunchContext.SamplePeriod` (the Go type).
+
+### What replaces `launch_seq % period == 0` as the consumer's check
+
+Two things, and between them the verifiability is stronger than before, not weaker:
+
+1. **Full replay.** `internal/gpuabi.SampleSchedule` / `SampledCount` are a Go replica of
+   `Sampler::gap_at()`. Given `(seed, period)` a consumer reproduces the exact set of
+   sampled ordinals. The two implementations are pinned to a shared vector —
+   `shim/core/sampler_test.cc`'s "schedule pin" block and
+   `TestTheGoReplicaMatchesTheShimSampler` assert the same ten gaps, the same first ten
+   sample points and the same two counts — so they cannot drift apart quietly.
+2. **A seedless invariant.** Consecutive sampled `launch_seq` values from one process must
+   differ by a gap inside `[period - period/2, period + period/2]`. That catches a broken
+   producer that the modulo check could not: a sampler that stopped, doubled up, or ran at
+   the wrong rate.
+
+## Durations are never scaled — confirmed
+
+Unchanged and re-checked end to end:
+
+- `Sampler::should_sample()` returns a bool and touches no timestamp. Its only callers
+  (`shim/stub/stub.cc`, `shim/nvidia/cupti_adapter.cc`) use it solely to decide whether to
+  fire `gpu_launch_sampled_v1`. `gpu_launch_v1` and `gpu_exec_v1` are emitted for **every**
+  launch and execution regardless.
+- `gpu/projection.go` still puts `sample_period` in a label only
+  (`gpu_sample_period`) and multiplies nothing by it; its comment explaining why scaling
+  would turn a measurement into an estimate is untouched.
+- The gate's conservation assertions — sample values summing to exactly `totalExecNs`, and
+  no sample exceeding its own execution's duration — are untouched (unrunnable here, but
+  unmodified).
+
+## The gate-assertion decision
+
+**No assertion was widened. Every exact count stayed exact.** That was the deciding
+constraint and it drove the choice of a seeded, pure-function schedule over Bernoulli.
+
+`gpuprobe/gate_test.go` changes, all localised (expect a trivial rebase under #58):
+
+- `wantSampled` 63 → **58**, and the two other hardcoded `63`s with it. 63 was
+  `ceil(500/8)`; 58 is the exact length of the default schedule over 500 launches. Still an
+  equality, still a magic number with its derivation in the comment, and now cross-checked
+  three ways: the stub's own `sampled=` line, the consumer's `Stats.SampledLaunches`, and
+  the pinned replica.
+- **One assertion added**, not relaxed: the stub alternates two kernel ids one per launch,
+  so its launch stream is exactly the 2-cycle this bug aliased against. The gate now
+  collects the kernel name of every stack-carrying launch and requires more than one
+  distinct name. Under the old sampler this would have **failed** — every sampled ordinal
+  was even, so `kernel_1111` took all 63 stacks and `kernel_2222` took none, in a run that
+  passed every other assertion in the file. That is the issue reproduced at the pipeline
+  level rather than the unit level.
+- **One assertion added**: the stub's stderr must carry `seed=0x9e3779b97f4a7c15`. Without
+  it the exact 58 above would describe a schedule the run did not use, and a seed change
+  would show up as a confusing count mismatch instead of a named cause.
+
+`cmd/gpu-cuda-profile`'s `expected_sampled` stays exact too: it is now
+`gpuabi.SampledCount(launches, period, DefaultSampleSeed)` rather than
+`ceil(launches/period)`. `cmd/gpu-stub-profile` had the same `2000/8` rounding and would
+have parked on its 30 s deadline waiting for a count that is never reached; it uses the
+replica now as well.
+
+## Cost — measured, not argued
+
+The header comment initially claimed the new path was *cheaper* (it drops a 64-bit
+division). I benchmarked it and that was **wrong**; the claim in the code is now the
+measurement. Single-threaded, `-O2`, period 8, 2×10⁸ calls, three runs:
+
+```
+old %period  4.377 / 4.332 / 4.319 ns/launch
+new jittered 4.887 / 4.818 / 4.881 ns/launch
+```
+
+**+0.5 ns/launch, +12%.** Both are dominated by the atomic increment; the extra acquire
+load costs a little more than the division saves. At the measured 393k launches/s ceiling
+that is 0.0002 s/s — 0.02% of one core, against the 1–2 µs uprobe trap each *sampled*
+launch already pays. No syscall, no lock, no allocation, and `gap_at()` runs only on the
+launches actually sampled.
+
+## What determinism survives concurrency (and what does not)
+
+Worth being explicit, because it is not obvious and the gate rests on it.
+
+`next_` walks the chain `0, s1, s2, …` whatever the thread interleaving, because each
+successor is derived from the value being replaced, not from how many threads raced for
+it. So the sampled **count** over L launches is exactly the number of chain points below
+L, thread-independently — asserted directly: an 8-trial 4-thread test that must land on
+the same count as a single-threaded run of the same length.
+
+What *can* shift under concurrent launches is **which** launch carries each stack: a
+thread whose ordinal is past a chain point claims that point, so a sampled `launch_seq`
+can be later than its chain point (never earlier). For a single-threaded launch stream —
+the stub, the CUDA validation workload, most real submission loops — the two coincide
+exactly, and only there is the gap-band invariant exact rather than approximate. Nothing
+in the accounting depends on it either way. Documented in `shim/core/sampler.h` and in the
+replica's package comment.
+
+`make -C shim test-tsan` is clean on the new CAS loop.
+
+## Prediction for the live RTX 3090 run
+
+Derived from the schedule, before any run. `cmd/gpu-cuda-profile` defaults: `iters=2000`
+→ **4000 launches**, `period=8`, default seed. The workload's loop is
+`launch_axpy(); launch_scale();`, and the adapter's `on_launch` fires only on kernel-launch
+cbids with no warm-up kernel, so **even ordinal = `perfagent_axpy`, odd = `perfagent_scale`**.
+
+Sampler level — exact, not approximate:
+
+| quantity | prediction |
+|---|---:|
+| adapter `sampled=` (and `expected_sampled=`) | **505** |
+| of which even ordinal → `perfagent_axpy` | **255** |
+| of which odd ordinal → `perfagent_scale` | **250** |
+| adapter line | `sample_period=8 sample_seed=0x9e3779b97f4a7c15` |
+
+Profile level: the run that produced `gpu-cuda-45.pb.gz` yielded 257 stack-carrying
+launches out of a nominal 500 sampled — roughly half — for reasons outside this change
+(walk/symbolize/eviction attrition), and I have no way to predict that yield here. So the
+robust prediction is the **split**, which is what issue #50 is about:
+
+- `perfagent_scale` must have a **non-zero** stack count. Under the old sampler it was
+  exactly 0, permanently.
+- The two kernels' stack counts should sit near **50.5% / 49.5%** (255:250). If the run
+  reproduces the same ~257 total stack yield, expect roughly **130 axpy / 127 scale**.
+- Anything near 100/0 in either direction means the fix did not take.
+- GPU-time totals and the join and conservation invariants should be **unchanged** — this
+  change touches attribution only.
+
+Re-derive for any other `-iters` with
+`gpuabi.SampledCount(iters*2, period, gpuabi.DefaultSampleSeed)`, or by splitting
+`gpuabi.SampleSchedule(...)` on ordinal parity.
+
+## Files changed
+
+| file | change |
+|---|---|
+| `shim/core/sampler.h` | the jittered schedule, `gap_at`, the seed, the CAS claim loop; header rewritten |
+| `shim/core/sampler_test.cc` | the regression test, the phase sweep, rate, determinism, seed, gap band, thread-independence, schedule pin |
+| `internal/gpuabi/sampler.go` | new: the Go replica of the schedule |
+| `internal/gpuabi/sampler_test.go` | new: the shared pin plus the consumer-side properties |
+| `shim/core/usdt_abi.h` | `sample_period` is the mean stride (comment only; layout untouched) |
+| `shim/stub/stub.cc` | reports `seed=` alongside `period=` |
+| `shim/nvidia/cupti_adapter.cc` | `PERFAGENT_GPU_SAMPLE_SEED`, logs the seed |
+| `gpu/types.go` | `SamplePeriod` doc |
+| `gpuprobe/gate_test.go` | 63 → 58; both-kernels assertion; seed assertion |
+| `cmd/gpu-cuda-profile/main.go` | exact `expected_sampled` from the replica; flag validation |
+| `cmd/gpu-stub-profile/main.go` | same, and it would otherwise have hung on its deadline |
+
+## Verification run here
+
+```
+make -C shim && make -C shim test        # batch/clock/drain/usdt_abi/sampler/probe_args all OK
+make -C shim test-tsan                   # clean
+make -C shim nvidia                      # the CUPTI adapter still builds
+make -C shim check-fpless                # OK
+go build ./... && go vet ./...           # clean
+go test ./gpu/ ./gpuprobe/ ./internal/... -count=1   # all ok
+golangci-lint run --timeout=5m           # 0 issues
+./shim/perfagent-gpu-stub 500 0 8 0
+  -> stub: launches=500 observed=500 sampled=58 period=8 seed=0x9e3779b97f4a7c15 ...
+```
+
+`TestStubDrivesThePipelineToPprofWithoutAGPU`: **SKIP** (CapEff 0). No CUDA run.

--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dpsoft/perf-agent/gpu"
 	"github.com/dpsoft/perf-agent/gpuprobe"
+	"github.com/dpsoft/perf-agent/internal/gpuabi"
 	"github.com/dpsoft/perf-agent/pprof"
 	"github.com/dpsoft/perf-agent/symbolize"
 )
@@ -93,11 +94,18 @@ func main() {
 		}
 	}()
 
-	// The sampler is deterministic one-in-N over every launch, and the
-	// workload launches exactly two kernels per iteration, so the expected
-	// count is exact rather than approximate.
+	// The sampler jitters each gap around the period so it cannot lock phase
+	// against the workload's alternating axpy/scale pair (issue #50), but the
+	// schedule is still a deterministic chain from (seed, period): replaying
+	// it gives the EXACT sampled count, not an estimate. The workload
+	// launches exactly two kernels per iteration and the adapter samples on
+	// every launch, attached or not, so this number is what the consumer must
+	// see before the workload may be released.
+	if *iters <= 0 || *period <= 0 {
+		log.Fatalf("iters and period must both be positive, got iters=%d period=%d", *iters, *period)
+	}
 	launches := *iters * 2
-	wantSampled := (launches + *period - 1) / *period
+	wantSampled := int(gpuabi.SampledCount(uint64(launches), uint32(*period), gpuabi.DefaultSampleSeed)) //nolint:gosec // both bounds-checked positive above
 
 	cmd := exec.Command(*workload,
 		fmt.Sprint(*iters), fmt.Sprint(*sleepUs), fmt.Sprint(*linger))

--- a/cmd/gpu-stub-profile/main.go
+++ b/cmd/gpu-stub-profile/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dpsoft/perf-agent/gpu"
 	"github.com/dpsoft/perf-agent/gpuprobe"
+	"github.com/dpsoft/perf-agent/internal/gpuabi"
 	"github.com/dpsoft/perf-agent/pprof"
 	"github.com/dpsoft/perf-agent/symbolize"
 )
@@ -55,7 +56,12 @@ func main() {
 	// the process (the previous CombinedOutput) meant every record still in
 	// the ringbuf at that moment resolved to bare hex addresses — an artifact
 	// that looks like a working profile and names nothing.
-	const wantSampled = 2000 / 8 // the sampler is deterministic at period 8
+	// The sampler jitters each gap around the period (issue #50), so this is
+	// not 2000/8; it is the exact length of the deterministic schedule the
+	// stub will follow, replayed here from the same seed the stub uses.
+	// Rounding it up to 250 would park this loop on its 30s deadline for a
+	// count that is never reached.
+	wantSampled := gpuabi.SampledCount(2000, 8, gpuabi.DefaultSampleSeed)
 	cmd := exec.Command(stub, "2000", "200", "8", "30000")
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	release, err := cmd.StdinPipe()

--- a/gpu/types.go
+++ b/gpu/types.go
@@ -250,6 +250,15 @@ type LaunchContext struct {
 	// with the stack rather than being reconstructed downstream, because
 	// the period can change between runs and even mid-run.
 	//
+	// It is the MEAN stride, not an exact one. The shim jitters each gap
+	// around SamplePeriod so the sampler cannot lock phase against a
+	// periodic launch pattern -- a fixed stride at an even period gave one
+	// kernel of an alternating pair every stack and the other none (issue
+	// #50). The rate is unchanged: gaps are drawn from a set of consecutive
+	// integers centred on SamplePeriod, so the long-run rate is exactly
+	// 1/SamplePeriod. The exact schedule is replayable from the shim's seed
+	// via internal/gpuabi.SampleSchedule.
+	//
 	// It is NOT a scale factor to multiply this launch's GPU time by.
 	// Sampling applies to stack *capture* only: every execution is still
 	// measured and joined, so durations stay exact and the sampled and

--- a/gpuprobe/gate_test.go
+++ b/gpuprobe/gate_test.go
@@ -173,8 +173,18 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	// before it ever reaches a probe. A consumer-side counter cannot see that
 	// loss — it happens in the producer, upstream of the ringbuf.
 	// sample_period=8 explicit (it also happens to be the stub's default):
-	// with 500 launches the sampler is deterministic and yields exactly 63
-	// sampled launches (n%8==0 for n in 0..499, i.e. ceil(500/8)).
+	// with 500 launches the sampler yields exactly 58 sampled launches.
+	//
+	// 58, not ceil(500/8)==63, since issue #50: the sampler no longer takes
+	// every 8th launch. It draws each gap uniformly from [4,12] -- mean
+	// exactly 8, so the RATE is unchanged -- from a hash of (seed, sample
+	// point), which is why this count is still an equality and not a
+	// tolerance band. The schedule is a deterministic chain from the stub's
+	// seed, and 58 is its exact length over 500 launches; it is pinned on
+	// both sides of the shim/consumer boundary by
+	// shim/core/sampler_test.cc's schedule pin and by
+	// TestTheGoReplicaMatchesTheShimSampler, so a change to the sampler
+	// fails there with a legible cause before it reaches this gate.
 	//
 	// The fourth argument is the linger: after flushing, the stub waits for
 	// EOF on stdin (up to 10s) before exiting. Start(), not Run(): the
@@ -200,7 +210,7 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	// until the consumer has installed its tables (shim/core/enroll.h), so
 	// the split is no longer timing-dependent at all and StacksWalkedNoTables
 	// is asserted zero below. The period is left at 1000 anyway: nothing
-	// depends on it - the sampler counts launches, not time, so the 63 below
+	// depends on it - the sampler counts launches, not time, so the 58 below
 	// is unchanged either way - and a slower run is the more demanding one
 	// for every other counter here.
 	cmd := exec.Command(stub, "500", "1000", "8", "10000")
@@ -218,9 +228,9 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	// Wait for the consumer to have OBSERVED every sampled launch, rather
 	// than sleeping and hoping. Stats is the right handle: SampledLaunches is
 	// incremented on the decode path, and stacks are symbolized on that same
-	// path, so once it reads 63 every symbolization has already happened —
+	// path, so once it reads 58 every symbolization has already happened —
 	// and happened while the stub was alive.
-	const wantSampled = 63
+	const wantSampled = 58
 	deadline := time.Now().Add(10 * time.Second)
 	var lastSampled uint64
 	for {
@@ -278,7 +288,10 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(500), stubObserved, "the sampler must see every one of the 500 launches")
 	assert.Equal(t, uint64(8), stubPeriod, "the stub was invoked with sample_period=8")
-	assert.Equal(t, uint64(63), stubSampled, "ceil(500/8): the sampler is deterministic at period 8 over 500 launches")
+	assert.Equal(t, uint64(58), stubSampled,
+		"the deterministic jittered schedule at period 8 over 500 launches is exactly 58 samples long")
+	assert.Contains(t, stubErr, "seed=0x9e3779b97f4a7c15",
+		"the stub ran on a seed other than the shim's default, so the exact count above describes a different schedule than the one asserted")
 
 	stats := c.Stats()
 	assert.Zero(t, stats.SequenceGaps, "no batch may be lost silently")
@@ -291,8 +304,8 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	// vary.
 	assert.Equal(t, stubSampled, stats.SampledLaunches,
 		"the producer's own sampled= count and the consumer's SampledLaunches must not disagree")
-	assert.Equal(t, uint64(63), stats.SampledLaunches,
-		"ceil(500/8) sampled launches, deterministic because the sampler is")
+	assert.Equal(t, uint64(wantSampled), stats.SampledLaunches,
+		"the sampler is deterministic given its seed, so this stays an exact count")
 	// Records is incremented *before* the sink call, so it alone does not
 	// prove the timeline accepted anything — every other loss counter has to
 	// be zero for the count above to mean what it looks like it means.
@@ -518,7 +531,7 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 			"execution for correlation %s has no kernel name", view.Exec.Correlation.Value)
 	}
 
-	// Sampled-stack accounting: exactly 63 of the 500 launches reached the
+	// Sampled-stack accounting: exactly 58 of the 500 launches reached the
 	// timeline with a non-empty CPUStack, and every one of those stacks
 	// names the function the probe fired in. perfagent_stub_run keeps its
 	// frame pointer (see shim/Makefile), so a failure on that one is the
@@ -547,6 +560,7 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	// why it is asserted by name rather than by depth: a deeper stack could
 	// come from anywhere, this name could not.
 	var sampledLaunches, sawFPLessCaller int
+	stackedKernels := map[string]int{}
 	for _, view := range snap.Executions {
 		require.NotNil(t, view.Launch,
 			"every execution joined its launch exactly (asserted above), so Launch must never be nil here")
@@ -554,6 +568,7 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 			continue
 		}
 		sampledLaunches++
+		stackedKernels[view.Exec.KernelName]++
 		var sawStubFrame, sawCaller bool
 		for _, f := range view.Launch.Launch.CPUStack {
 			if strings.Contains(f.Name, "perfagent_stub_run") {
@@ -570,8 +585,19 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 			sawFPLessCaller++
 		}
 	}
-	assert.Equal(t, 63, sampledLaunches,
-		"exactly 63 launches on the timeline must carry a non-empty CPUStack, matching Stats.SampledLaunches")
+	assert.Equal(t, wantSampled, sampledLaunches,
+		"exactly %d launches on the timeline must carry a non-empty CPUStack, matching Stats.SampledLaunches",
+		wantSampled)
+	// Issue #50, at the pipeline level rather than the unit level. The stub
+	// alternates two kernel ids, one per launch, so its launch stream is a
+	// 2-cycle -- the exact shape the fixed-stride sampler aliased against. At
+	// period 8 every sampled ordinal used to be even, so kernel_1111 took
+	// every stack on this producer and kernel_2222 took none, in a run that
+	// otherwise passed every assertion above. Both must now be represented.
+	assert.Greater(t, len(stackedKernels), 1,
+		"every stack-carrying launch on this producer names the same kernel (%v): the sampler locked phase against the stub's alternating 2-kernel stream, which is issue #50",
+		stackedKernels)
+	t.Logf("stacks per kernel: %v", stackedKernels)
 	assert.Positive(t, sawFPLessCaller,
 		"not one of the %d sampled stacks names perfagent_fpless_caller, which is only reachable by unwinding an FP-less frame through CFI: the walk never crossed one, or the symbolizer could not name it",
 		sampledLaunches)

--- a/internal/gpuabi/sampler.go
+++ b/internal/gpuabi/sampler.go
@@ -1,0 +1,86 @@
+package gpuabi
+
+// The consumer-side replica of the shim's launch sampler
+// (shim/core/sampler.h). It exists so that "the consumer can verify the
+// sampler" survives the move from a fixed stride to a jittered one
+// (issue #50).
+//
+// Under the old sampler a launch was sampled iff launch_seq%sample_period==0,
+// which any consumer could check with one modulo and no shared state. The
+// jittered sampler draws each gap from a pure function of (seed, period,
+// sample point), so the schedule is still a deterministic chain -- it just
+// takes this much arithmetic to replay instead of a modulo. Everything below
+// mirrors Sampler::gap_at() exactly, and TestTheGoReplicaMatchesTheShimSampler
+// pins it to the numbers shim/core/sampler_test.cc's schedule pin asserts on
+// the C++ side, so the two cannot drift apart quietly.
+//
+// What this replays is the chain of sample POINTS, which is thread-
+// independent, so SampledCount is exact for any launch stream. The launch
+// ordinal that actually carries each stack can be later than its chain point
+// when launches arrive concurrently on several threads (never earlier) --
+// see the concurrency note in shim/core/sampler.h. For a single-threaded
+// launch stream the two coincide exactly.
+//
+// None of this is on the decode path. It is for tools that need the exact
+// expected sampled count before a run (cmd/gpu-cuda-profile) and for anyone
+// auditing a profile's sampled population after one.
+
+// DefaultSampleSeed mirrors perfagent::Sampler::kDefaultSeed. The shim's seed
+// is a fixed constant so two runs of the same workload sample identically;
+// PERFAGENT_GPU_SAMPLE_SEED overrides it in the CUPTI adapter.
+const DefaultSampleSeed uint64 = 0x9E3779B97F4A7C15
+
+// SampleGap returns the number of launches from the sample point at seq to
+// the next one. Uniform over the 2k+1 integers centred on period (k =
+// period/2), so the mean gap is exactly period and the long-run rate is
+// exactly 1/period.
+func SampleGap(seq uint64, period uint32, seed uint64) uint64 {
+	if period <= 1 {
+		return 1
+	}
+	k := uint64(period / 2)
+	span := 2*k + 1
+	r := sampleMix(seed ^ (seq * 0x9E3779B97F4A7C15))
+	// Lemire's multiply-shift, matching the C++ side bit for bit: the top 32
+	// bits of the hash scaled into [0, span).
+	off := ((r >> 32) * span) >> 32
+	return uint64(period) - k + off
+}
+
+// SampleSchedule returns the launch ordinals the shim samples over the first
+// `launches` launches, in order. Ordinal 0 is always sampled.
+func SampleSchedule(launches uint64, period uint32, seed uint64) []uint64 {
+	if period == 0 {
+		period = 1 // the shim coerces 0 to 1 rather than dividing by zero
+	}
+	out := make([]uint64, 0, launches/uint64(period)+2)
+	for seq := uint64(0); seq < launches; seq += SampleGap(seq, period, seed) {
+		out = append(out, seq)
+	}
+	return out
+}
+
+// SampledCount is the exact number of launches that carry a CPU stack over
+// `launches` launches. Exact, not expected: the schedule is deterministic
+// given the seed, which is what keeps the phase gate's assertion an equality
+// rather than a tolerance band.
+func SampledCount(launches uint64, period uint32, seed uint64) uint64 {
+	if period == 0 {
+		period = 1
+	}
+	var n uint64
+	for seq := uint64(0); seq < launches; seq += SampleGap(seq, period, seed) {
+		n++
+	}
+	return n
+}
+
+// sampleMix is splitmix64's finalizer, mirroring Sampler::mix().
+func sampleMix(x uint64) uint64 {
+	x ^= x >> 30
+	x *= 0xBF58476D1CE4E5B9
+	x ^= x >> 27
+	x *= 0x94D049BB133111EB
+	x ^= x >> 31
+	return x
+}

--- a/internal/gpuabi/sampler_test.go
+++ b/internal/gpuabi/sampler_test.go
@@ -1,0 +1,114 @@
+package gpuabi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The shared pin. These are the same numbers shim/core/sampler_test.cc
+// asserts on the C++ side; the two implementations of the schedule have to
+// agree or "the consumer can verify the sampler" is a claim with nothing
+// behind it. A change to the hash, the seed or the gap band fails both
+// suites, which is the point.
+func TestTheGoReplicaMatchesTheShimSampler(t *testing.T) {
+	wantGaps8 := []uint64{11, 4, 9, 6, 4, 8, 4, 8, 9, 5}
+	wantGaps3 := []uint64{4, 2, 3, 2, 2, 3, 2, 3, 3, 2}
+	for seq := range uint64(10) {
+		assert.Equal(t, wantGaps8[seq], SampleGap(seq, 8, DefaultSampleSeed),
+			"gap at seq %d, period 8", seq)
+		assert.Equal(t, wantGaps3[seq], SampleGap(seq, 3, DefaultSampleSeed),
+			"gap at seq %d, period 3", seq)
+	}
+
+	sched := SampleSchedule(500, 8, DefaultSampleSeed)
+	require.GreaterOrEqual(t, len(sched), 10)
+	assert.Equal(t, []uint64{0, 11, 19, 31, 38, 43, 51, 62, 70, 77}, sched[:10],
+		"the first ten sample points of the default schedule at period 8")
+
+	// The two counts the phase gate and cmd/gpu-cuda-profile depend on. Exact,
+	// because the schedule is a deterministic chain from the seed.
+	assert.Equal(t, uint64(58), SampledCount(500, 8, DefaultSampleSeed),
+		"the phase gate's 500 launches at period 8")
+	assert.Equal(t, uint64(505), SampledCount(4000, 8, DefaultSampleSeed),
+		"the CUDA validation run's 4000 launches at period 8")
+	assert.Equal(t, uint64(len(sched)), SampledCount(500, 8, DefaultSampleSeed),
+		"SampleSchedule and SampledCount must not disagree")
+}
+
+// The property the whole fix exists for, stated on the consumer side: the
+// schedule reaches both residues of a 2-cycle. Under the fixed stride every
+// sample point at an even period had the same parity, so a workload
+// alternating two kernels gave one of them every stack and the other none
+// (issue #50, measured on an RTX 3090: perfagent_scale held 48% of GPU time
+// and appeared in zero sampled stacks).
+func TestTheScheduleDoesNotLockPhase(t *testing.T) {
+	for cycle := uint64(2); cycle <= 4; cycle++ {
+		for period := uint32(2); period <= 12; period++ {
+			hits := make([]int, cycle)
+			for _, seq := range SampleSchedule(20000, period, DefaultSampleSeed) {
+				hits[seq%cycle]++
+			}
+			for residue, n := range hits {
+				assert.Positivef(t, n,
+					"period %d never samples launch ordinals congruent to %d mod %d: "+
+						"a workload cycling %d kernels loses that one entirely",
+					period, residue, cycle, cycle)
+			}
+		}
+	}
+}
+
+// sample_period still names the rate it always named: gaps are drawn from a
+// set of consecutive integers centred on the period, so the mean gap is
+// exactly the period. Asserted to 1% over 200k launches -- at period 8 the
+// per-gap standard deviation is ~2.6 launches, so 25k gaps put a 1% band far
+// outside any plausible deviation of a correct schedule.
+func TestTheSampledRateStaysAtOneInPeriod(t *testing.T) {
+	const launches = 200_000
+	for _, period := range []uint32{2, 3, 4, 7, 8, 16, 64} {
+		got := float64(SampledCount(launches, period, DefaultSampleSeed))
+		want := float64(launches) / float64(period)
+		assert.InEpsilonf(t, want, got, 0.01,
+			"period %d sampled %.0f of %d launches, expected ~%.1f", period, got, launches, want)
+	}
+}
+
+// Period 1 samples every launch and period 0 is coerced to 1, exactly as the
+// fixed-stride sampler did. The gap band collapses to {1} at period 1, so
+// this is not a special case in the code, but it is the one behaviour a
+// caller can depend on by name.
+func TestPeriodOneAndZeroAreUnchanged(t *testing.T) {
+	assert.Equal(t, uint64(1), SampleGap(0, 1, DefaultSampleSeed))
+	assert.Equal(t, uint64(1), SampleGap(12345, 1, DefaultSampleSeed))
+	assert.Equal(t, uint64(100), SampledCount(100, 1, DefaultSampleSeed),
+		"period 1 must sample every launch")
+	assert.Equal(t, uint64(100), SampledCount(100, 0, DefaultSampleSeed),
+		"period 0 is coerced to 1, never a division by zero and never silent capture loss")
+}
+
+// Every gap lies inside the band the ABI promises, which is the invariant a
+// consumer can check from the sampled records' launch_seq values alone, with
+// no seed. It replaces `launch_seq % sample_period == 0` as the producer-side
+// sanity check.
+func TestEveryGapLiesInTheDeclaredBand(t *testing.T) {
+	for _, period := range []uint32{2, 3, 4, 8, 16, 64} {
+		lo := uint64(period - period/2)
+		hi := uint64(period + period/2)
+		sched := SampleSchedule(50_000, period, DefaultSampleSeed)
+		for i := 1; i < len(sched); i++ {
+			gap := sched[i] - sched[i-1]
+			assert.GreaterOrEqualf(t, gap, lo, "period %d gap %d below the band", period, gap)
+			assert.LessOrEqualf(t, gap, hi, "period %d gap %d above the band", period, gap)
+		}
+	}
+}
+
+// A different seed gives a different schedule, so PERFAGENT_GPU_SAMPLE_SEED
+// actually buys per-process variation rather than being decoration.
+func TestADifferentSeedGivesADifferentSchedule(t *testing.T) {
+	a := SampleSchedule(1000, 8, DefaultSampleSeed)
+	b := SampleSchedule(1000, 8, 0x1234567890ABCDEF)
+	assert.NotEqual(t, a, b)
+}

--- a/shim/core/sampler.h
+++ b/shim/core/sampler.h
@@ -1,15 +1,111 @@
-// Deterministic one-in-N launch sampling for CPU-stack capture.
+// Jittered-stride one-in-N launch sampling for CPU-stack capture.
 //
 // Why sampling at all: a batched launch probe cannot carry per-launch
 // stacks, and firing it unbatched costs an uprobe trap (~1-2us) per launch,
 // which is 0.4-0.8 s/s at the measured 393k launches/s ceiling. Spec §16
 // names sampling as the remedy.
 //
-// Why deterministic rather than randomized: reproducibility. The consumer
-// can verify the sampler from launch_seq alone, and the phase gate gets an
-// exact expected count. If bias against periodic launch patterns is ever
-// measured, randomize here — the ABI carries sample_period per record, so
-// the consumer needs no change.
+// # Why not `launch_seq % period == 0` (issue #50)
+//
+// That is what this sampler used to do, chosen for reproducibility, with the
+// note "if bias against periodic launch patterns is ever measured, randomize
+// here". It was measured. A fixed stride aliases against any workload whose
+// launch pattern is periodic with a period sharing a factor with `period`,
+// and the loss is total rather than partial: those launches NEVER get a
+// stack, however long the profile runs.
+//
+// gpu-cuda-45.pb.gz, 4000 launches at period 8 on an RTX 3090, workload
+// alternating two kernels:
+//
+//     perfagent_axpy    3,092,953 ns GPU     all 257 stacks
+//     perfagent_scale   2,894,901 ns GPU           0 stacks
+//
+// 48% of GPU time with no call path at all, while every honesty invariant in
+// spec §4 passed: 100% exact joins, full duration conservation. Alternating
+// or round-robin submission is ordinary (double buffering, ping-pong
+// buffers, forward/backward pairs, multi-stream pipelines), so this is not
+// an exotic workload.
+//
+// # What it does instead
+//
+// A renewal process: after sampling launch s, the next sample is at
+// s + gap, where gap is drawn uniformly from the 2k+1 consecutive integers
+// centred on `period` (k = period/2):
+//
+//     period 8  ->  gap in [4, 12]     mean exactly 8
+//     period 3  ->  gap in [2,  4]     mean exactly 3
+//     period 1  ->  gap == 1           every launch, as before
+//
+// The set is symmetric about `period`, so the mean gap is exactly `period`
+// and the long-run sampling rate is exactly 1/period -- the same rate the
+// fixed stride had, and the same rate `sample_period` names in the record.
+// Because the set always spans both parities (it holds at least two
+// consecutive integers for any period >= 2), the phase cannot lock: over a
+// c-cycle every residue mod c is reached.
+//
+// # Determinism is kept, and it is not incidental
+//
+// The gap is not read from a running PRNG state; it is a pure function of
+// (seed, period, the sample point). So the whole schedule 0, s1, s2, ... is
+// a deterministic chain replayable offline from the seed alone, the phase
+// gate still gets an EXACT expected count, and a consumer can still verify
+// the sampler -- see internal/gpuabi.SampleSchedule, which is the Go replica
+// of gap_at() below and is pinned to it by a shared vector in both test
+// suites. The seed is a fixed constant by default so two runs of the same
+// workload sample identically; PERFAGENT_GPU_SAMPLE_SEED (read by the CUPTI
+// adapter) buys per-process variation for anyone who wants to average
+// several runs.
+//
+// A consumer that does not have the seed still has a checkable invariant,
+// and a stronger one than `launch_seq % period == 0` was: consecutive
+// sampled records from one process must have launch_seq gaps inside
+// [period - period/2, period + period/2].
+//
+// # What determinism does and does not survive concurrency
+//
+// The chain of sample POINTS is thread-independent: next_ only ever takes the
+// values 0, s1, s2, ..., because each successor is derived from the value
+// being replaced, not from how many threads raced for it. So the sampled
+// COUNT over L launches is exactly the number of chain points below L no
+// matter how the launches were threaded -- which is what keeps the phase
+// gate an equality.
+//
+// What can shift is WHICH launch carries each stack. A thread whose ordinal
+// is well past a chain point claims that point, so under concurrent launches
+// the sampled launch_seq can be later than the chain point (never earlier).
+// A single-threaded launch stream -- the stub, the CUDA validation workload,
+// and most real submission loops -- sees no shift at all, and only there is
+// the gap-band invariant above exact rather than approximate. Sampling still
+// decides nothing but which launches carry a stack, so no accounting depends
+// on this.
+//
+// # Cost, measured rather than argued
+//
+// The non-sampling path -- 7 launches in 8 at the default period -- is one
+// relaxed fetch_add, one acquire load and a compare, against the fixed
+// stride's fetch_add and a 64-bit division. gap_at() runs only on the
+// launches actually sampled: a splitmix64 finalizer and a multiply-shift, no
+// division, no syscall, no lock, no allocation.
+//
+// That reads like it should be faster and it is not. Both are dominated by
+// the atomic increment, and the extra acquire load costs more than the
+// division saves. Single-threaded, -O2, period 8, 2e8 calls on this machine:
+//
+//     fixed stride    4.33 ns/launch
+//     jittered        4.87 ns/launch      +0.5 ns, +12%
+//
+// At the measured 393k launches/s ceiling that is 0.0002 s/s -- 0.02% of one
+// core, against an uprobe trap of 1-2us for each launch that IS sampled. The
+// figure is here so the next person does not have to re-derive it, and so the
+// claim is a number rather than an argument.
+//
+// # The ABI does not change
+//
+// sample_period still rides in every sampled record and still means "one
+// launch in N carries a stack". It is now the mean stride rather than an
+// exact stride; the rate it names is unchanged and it is still not a scale
+// factor (durations are never scaled -- sampling decides which launches
+// carry a stack, and every execution is measured and joined regardless).
 #ifndef PERFAGENT_SAMPLER_H
 #define PERFAGENT_SAMPLER_H
 
@@ -20,23 +116,97 @@ namespace perfagent {
 
 class Sampler {
 public:
-    explicit Sampler(uint32_t period) : period_(period ? period : 1) {}
+    // Fixed by default: reproducibility is why this sampler was deterministic
+    // in the first place, and the phase gate's exact sampled count depends on
+    // it. Any 64-bit value works; this one is the golden ratio constant.
+    static constexpr uint64_t kDefaultSeed = 0x9E3779B97F4A7C15ULL;
+
+    explicit Sampler(uint32_t period, uint64_t seed = kDefaultSeed)
+        : period_(period ? period : 1), seed_(seed) {}
 
     // Call once per launch. True means capture a stack for this one.
     bool should_sample() {
         const uint64_t n = observed_.fetch_add(1, std::memory_order_relaxed);
-        if (n % period_.load(std::memory_order_relaxed) != 0) return false;
-        sampled_.fetch_add(1, std::memory_order_relaxed);
-        return true;
+        uint64_t next = next_.load(std::memory_order_acquire);
+        // next_ starts at 0, so the very first launch is always sampled and a
+        // short-lived process is not silently stack-less.
+        //
+        // The loop is the multi-threaded case: launches arrive on whatever
+        // threads the application uses, and several may be at or past the
+        // sample point at once. Exactly one of them wins the CAS and takes
+        // the stack; the losers re-read next_ and check again, because a
+        // thread holding a much later ordinal must still be able to claim a
+        // sample point the winner did not advance past.
+        while (n >= next) {
+            const uint64_t gap = gap_at(next, period_.load(std::memory_order_relaxed), seed_);
+            if (next_.compare_exchange_weak(next, next + gap,
+                                            std::memory_order_acq_rel,
+                                            std::memory_order_acquire)) {
+                sampled_.fetch_add(1, std::memory_order_relaxed);
+                return true;
+            }
+            // compare_exchange_weak reloaded `next` on failure.
+        }
+        return false;
+    }
+
+    // The gap from the sample point at `seq` to the next one: uniform over
+    // the 2k+1 integers centred on `period`, k = period/2. Pure -- no state,
+    // no side effects -- which is what makes the schedule replayable and
+    // what lets two threads racing on the same sample point compute the same
+    // successor.
+    //
+    // Kept public and static because it IS the schedule: the Go replica in
+    // internal/gpuabi mirrors this function, and sampler_test.cc pins it to
+    // the same vector the Go test uses.
+    static uint64_t gap_at(uint64_t seq, uint32_t period, uint64_t seed) {
+        if (period <= 1) return 1;
+        const uint32_t k = period / 2;
+        const uint32_t span = 2u * k + 1u;   // odd, so the set is symmetric
+        const uint64_t r = mix(seed ^ (seq * 0x9E3779B97F4A7C15ULL));
+        // Lemire's multiply-shift in place of `% span`: a 32x32 multiply and
+        // a shift instead of a division. The residual non-uniformity is
+        // bounded by span/2^32 (~2e-9 at any sane period), which moves the
+        // mean gap by less than a part in a hundred million -- far below the
+        // sampling noise it sits inside.
+        const uint32_t off = (uint32_t)(((r >> 32) * (uint64_t)span) >> 32);
+        return (uint64_t)period - (uint64_t)k + (uint64_t)off;
     }
 
     uint32_t period() const { return period_.load(std::memory_order_relaxed); }
-    void set_period(uint32_t p) { period_.store(p ? p : 1, std::memory_order_relaxed); }
+
+    // Re-arms: the next launch is sampled and the chain restarts from there
+    // under the new period, rather than honouring a gap drawn under the old
+    // one (which at a large old period could hold off capture for thousands
+    // of launches). Nothing in the shipped shim changes the period mid-run;
+    // the schedule is replayable from (seed, period) precisely because of
+    // that, and a caller that does change it forfeits offline replay.
+    void set_period(uint32_t p) {
+        period_.store(p ? p : 1, std::memory_order_relaxed);
+        next_.store(observed_.load(std::memory_order_relaxed), std::memory_order_release);
+    }
+
+    uint64_t seed() const { return seed_; }
     uint64_t observed() const { return observed_.load(std::memory_order_relaxed); }
     uint64_t sampled() const { return sampled_.load(std::memory_order_relaxed); }
 
 private:
+    // splitmix64's finalizer: full avalanche in three xor-shifts and two
+    // multiplies, which is all this needs -- it is a hash of the sample
+    // point, not a generator with state to carry.
+    static uint64_t mix(uint64_t x) {
+        x ^= x >> 30;
+        x *= 0xBF58476D1CE4E5B9ULL;
+        x ^= x >> 27;
+        x *= 0x94D049BB133111EBULL;
+        x ^= x >> 31;
+        return x;
+    }
+
     std::atomic<uint32_t> period_;
+    const uint64_t seed_;
+    // The launch ordinal at which the next stack is taken. Starts at 0.
+    std::atomic<uint64_t> next_{0};
     std::atomic<uint64_t> observed_{0};
     std::atomic<uint64_t> sampled_{0};
 };

--- a/shim/core/sampler_test.cc
+++ b/shim/core/sampler_test.cc
@@ -12,6 +12,10 @@ using perfagent::Sampler;
 using perfagent::KernelNameTable;
 
 int main() {
+    // Unbuffered: these tests print the numbers a failure needs to be
+    // diagnosed, and assert() aborts without flushing stdout -- a buffered
+    // run loses exactly the line that explains the abort.
+    setvbuf(stdout, nullptr, _IONBF, 0);
     // One in N, deterministically, including the very first launch.
     {
         Sampler s(4);
@@ -42,6 +46,151 @@ int main() {
         s.set_period(5);
         assert(s.period() == 5);
         assert(s.observed() == 10);
+    }
+
+    // ---- issue #50: the sampler must not lock phase --------------------
+    //
+    // The regression test this fix exists for. A workload that alternates
+    // two kernels is an ordinary shape (double buffering, ping-pong buffers,
+    // forward/backward pairs, multi-stream pipelines), and the stub and the
+    // CUDA validation workload both have it. Under the old `seq % period`
+    // sampler at an even period every sampled index had the same parity, so
+    // one of the two kernels received every stack and the other received
+    // none -- for the whole run, no matter how long it was.
+    //
+    // gpu-cuda-45.pb.gz measured it on an RTX 3090: perfagent_axpy took all
+    // 257 stacks, perfagent_scale took 0 while holding 48% of GPU time.
+    {
+        Sampler s(8);
+        int stacks[2] = {0, 0};
+        for (int i = 0; i < 4000; i++) {
+            if (s.should_sample()) stacks[i % 2]++;
+        }
+        printf("  alternating 2-kernel at period 8: kernel_a=%d kernel_b=%d\n",
+               stacks[0], stacks[1]);
+        if (stacks[0] == 0 || stacks[1] == 0) {
+            printf("  FAIL: the sampler locked phase against a 2-cycle: "
+                   "one kernel of the pair received every stack and the other received none\n");
+        }
+        assert(stacks[0] > 0);
+        assert(stacks[1] > 0);
+    }
+    // The same statement generalized: over a 2-, 3- and 4-cycle, every phase
+    // must be reachable. A scheme that fixed only the 2-cycle (say, by
+    // alternating two strides) would pass the case above and still lose a
+    // kernel in a 3-stream pipeline.
+    {
+        for (int cycle = 2; cycle <= 4; cycle++) {
+            for (int period = 2; period <= 12; period++) {
+                Sampler s((uint32_t)period);
+                std::vector<int> phase((size_t)cycle, 0);
+                for (int i = 0; i < 20000; i++) {
+                    if (s.should_sample()) phase[(size_t)(i % cycle)]++;
+                }
+                for (int p = 0; p < cycle; p++) {
+                    if (phase[(size_t)p] == 0) {
+                        printf("  FAIL: period=%d locks phase against a %d-cycle: "
+                               "residue %d never sampled\n", period, cycle, p);
+                    }
+                    assert(phase[(size_t)p] > 0);
+                }
+            }
+        }
+    }
+    // The rate the ABI's sample_period claims. Gaps are drawn uniformly from
+    // a set of consecutive integers centred on `period`, so the mean gap is
+    // exactly `period` and the long-run rate is exactly 1/period. Over 200k
+    // launches the deterministic schedule must land within 2% of it -- a
+    // stated tolerance, not a hope: at period 8 the per-gap standard
+    // deviation is ~2.6 launches, so 25k gaps put the 2% band far outside
+    // any plausible deviation, and only a scheme whose mean gap is actually
+    // wrong can miss it.
+    {
+        const int kLaunches = 200000;
+        for (uint32_t period : {2u, 3u, 4u, 7u, 8u, 16u, 64u}) {
+            Sampler s(period);
+            for (int i = 0; i < kLaunches; i++) s.should_sample();
+            const double want = (double)kLaunches / (double)period;
+            const double got = (double)s.sampled();
+            const double err = (got - want) / want;
+            printf("  rate at period %2u: sampled=%llu expected=%.1f err=%+.3f%%\n",
+                   period, (unsigned long long)s.sampled(), want, err * 100.0);
+            assert(err < 0.02 && err > -0.02);
+        }
+    }
+    // Determinism: same period, same seed, same schedule. This is what keeps
+    // the phase gate's exact sampled count exact, and what lets a consumer
+    // replay the sampler offline. Two independently constructed samplers
+    // must agree launch for launch, not just in total.
+    {
+        Sampler a(8), b(8);
+        for (int i = 0; i < 5000; i++) assert(a.should_sample() == b.should_sample());
+        assert(a.sampled() == b.sampled());
+    }
+    // A different seed gives a different schedule -- otherwise the seed is
+    // decoration and per-process variation is not actually available.
+    {
+        Sampler a(8), b(8, 0x1234567890ABCDEFULL);
+        bool differed = false;
+        for (int i = 0; i < 5000; i++) {
+            if (a.should_sample() != b.should_sample()) differed = true;
+        }
+        assert(differed);
+    }
+    // Every gap lies in the band the schedule promises: [period - period/2,
+    // period + period/2]. This is the invariant a consumer can check from
+    // the sampled records' launch_seq values ALONE, with no seed -- it is
+    // what replaces `launch_seq % period == 0` as the producer-side check.
+    {
+        const uint32_t period = 8;
+        Sampler s(period);
+        long prev = -1;
+        for (long i = 0; i < 20000; i++) {
+            if (!s.should_sample()) continue;
+            if (prev >= 0) {
+                const long gap = i - prev;
+                assert(gap >= (long)(period - period / 2));
+                assert(gap <= (long)(period + period / 2));
+            }
+            prev = i;
+        }
+    }
+    // The shared pin between this sampler and its Go replica in
+    // internal/gpuabi/sampler.go. TestTheGoReplicaMatchesTheShimSampler
+    // asserts these exact numbers on the other side, so a change to the hash,
+    // the seed or the gap band breaks BOTH suites instead of silently letting
+    // the two implementations drift -- which is the failure mode that would
+    // make the consumer's verification of the sampler worthless.
+    {
+        static const uint64_t kGapsPeriod8[10] = {11, 4, 9, 6, 4, 8, 4, 8, 9, 5};
+        static const uint64_t kGapsPeriod3[10] = {4, 2, 3, 2, 2, 3, 2, 3, 3, 2};
+        for (uint64_t seq = 0; seq < 10; seq++) {
+            assert(Sampler::gap_at(seq, 8, Sampler::kDefaultSeed) == kGapsPeriod8[seq]);
+            assert(Sampler::gap_at(seq, 3, Sampler::kDefaultSeed) == kGapsPeriod3[seq]);
+        }
+        static const uint64_t kFirstPoints[10] = {0, 11, 19, 31, 38, 43, 51, 62, 70, 77};
+        uint64_t point = 0;
+        for (int i = 0; i < 10; i++) {
+            assert(point == kFirstPoints[i]);
+            point += Sampler::gap_at(point, 8, Sampler::kDefaultSeed);
+        }
+        // The two counts the phase gate and cmd/gpu-cuda-profile depend on.
+        for (int launches : {500, 4000}) {
+            Sampler s(8);
+            for (int i = 0; i < launches; i++) s.should_sample();
+            printf("  schedule pin: %d launches at period 8 -> %llu sampled\n",
+                   launches, (unsigned long long)s.sampled());
+        }
+        {
+            Sampler s(8);
+            for (int i = 0; i < 500; i++) s.should_sample();
+            assert(s.sampled() == 58);
+        }
+        {
+            Sampler s(8);
+            for (int i = 0; i < 4000; i++) s.should_sample();
+            assert(s.sampled() == 505);
+        }
     }
     // Interning: first sight yields a record, repeats do not.
     {
@@ -94,6 +243,32 @@ int main() {
         for (auto &th : threads) th.join();
         assert(s.observed() == 4000);
         assert(s.sampled() == true_returns.load());
+    }
+    // ...and the count it lands on is the SAME count a single-threaded run of
+    // the same length lands on. That is not obvious and it is what the phase
+    // gate's equality rests on: next_ walks the chain 0, s1, s2, ... whatever
+    // the interleaving, because each successor is derived from the value being
+    // replaced rather than from how many threads raced for it. Threading can
+    // move which launch carries a stack; it cannot move how many do.
+    {
+        Sampler serial(3);
+        for (int i = 0; i < 4000; i++) serial.should_sample();
+        for (int trial = 0; trial < 8; trial++) {
+            Sampler s(3);
+            std::vector<std::thread> threads;
+            for (int t = 0; t < 4; t++) {
+                threads.emplace_back([&] {
+                    for (int i = 0; i < 1000; i++) s.should_sample();
+                });
+            }
+            for (auto &th : threads) th.join();
+            if (s.sampled() != serial.sampled()) {
+                printf("  FAIL: 4 threads sampled %llu of 4000, one thread sampled %llu:"
+                       " the sampled count is not thread-independent\n",
+                       (unsigned long long)s.sampled(), (unsigned long long)serial.sampled());
+            }
+            assert(s.sampled() == serial.sampled());
+        }
     }
     printf("sampler_test OK\n");
     return 0;

--- a/shim/core/usdt_abi.h
+++ b/shim/core/usdt_abi.h
@@ -87,7 +87,13 @@ struct gpu_launch_sampled_v1 {
     uint64_t context_id;
     uint64_t time_ns;
     uint32_t tid;
-    uint32_t sample_period;   // the N in one-in-N, at capture time; never 0
+    // The N in one-in-N, at capture time; never 0. The MEAN stride, not an
+    // exact one: the sampler jitters each gap around N so it cannot lock
+    // phase against a periodic launch pattern (shim/core/sampler.h, issue
+    // #50). The rate it names -- one launch in N carries a stack -- is
+    // unchanged, and it is still not a scale factor: durations are never
+    // scaled by it.
+    uint32_t sample_period;
     uint64_t launch_seq;      // ordinal among ALL launches, sampled or not
 };
 

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -458,6 +458,21 @@ unsigned env_uint(const char *name, unsigned dflt) {
     return (unsigned)n;
 }
 
+// The sampler's seed. Defaulted to Sampler::kDefaultSeed rather than randomized
+// per process: a fixed seed is what keeps two runs of the same workload
+// sampling the same launches, which is why this sampler was deterministic in
+// the first place (shim/core/sampler.h). Set PERFAGENT_GPU_SAMPLE_SEED to any
+// non-zero value -- decimal or 0x-prefixed -- to vary the schedule per process,
+// e.g. to average several runs of the same workload.
+uint64_t env_u64(const char *name, uint64_t dflt) {
+    const char *v = getenv(name);
+    if (!v || !*v) return dflt;
+    char *end = nullptr;
+    const unsigned long long n = strtoull(v, &end, 0);
+    if (end == v || *end) return dflt;
+    return (uint64_t)n;
+}
+
 bool check(CUptiResult r, const char *what) {
     if (r == CUPTI_SUCCESS) return true;
     const char *msg = "?";
@@ -508,7 +523,9 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
     // Sampler under them is a use-after-free in somebody else's process.
     g_lb = new perfagent::Batch<gpu_launch_v1, 32>(gpu_launch_v1_emit, gpu_launch_v1_enabled);
     g_eb = new perfagent::Batch<gpu_exec_v1, 32>(gpu_exec_v1_emit, gpu_exec_v1_enabled);
-    g_sampler = new perfagent::Sampler(env_uint("PERFAGENT_GPU_SAMPLE_PERIOD", 8));
+    g_sampler = new perfagent::Sampler(env_uint("PERFAGENT_GPU_SAMPLE_PERIOD", 8),
+                                      env_u64("PERFAGENT_GPU_SAMPLE_SEED",
+                                              perfagent::Sampler::kDefaultSeed));
     g_names = new perfagent::KernelNameTable();
     g_drainer = new perfagent::Drainer();
 
@@ -537,9 +554,14 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
 
     atexit(at_exit_handler);
 
-    logf("perfagent-cupti: initialized pid=%d sample_period=%u drain_ms=%u "
-         "clock_offset_ns=%lld enroll=%s\n",
-         (int)getpid(), g_sampler->period(), drain_ms, (long long)g_clock.offset_ns(),
+    // The seed is logged because it IS the schedule: with it and the period,
+    // the exact set of sampled launch ordinals is replayable offline
+    // (internal/gpuabi.SampleSchedule). Without it a run using a non-default
+    // seed could not be audited after the fact.
+    logf("perfagent-cupti: initialized pid=%d sample_period=%u sample_seed=0x%016llx "
+         "drain_ms=%u clock_offset_ns=%lld enroll=%s\n",
+         (int)getpid(), g_sampler->period(),
+         (unsigned long long)g_sampler->seed(), drain_ms, (long long)g_clock.offset_ns(),
          perfagent::enroll_result_name(enrolled));
     return 1;
 }

--- a/shim/stub/stub.cc
+++ b/shim/stub/stub.cc
@@ -134,10 +134,15 @@ perfagent_stub_run(unsigned launches, unsigned period_us, unsigned sample_period
     lb.flush();
     eb.flush();
     drainer.stop();
-    fprintf(stderr, "stub: launches=%u observed=%llu sampled=%llu period=%u "
+    // seed= is part of the accounting, not decoration: the sampler's schedule
+    // is a deterministic chain from (seed, period), so this line is what makes
+    // the exact sampled= count above reproducible and auditable offline
+    // (internal/gpuabi.SampleSchedule replays it).
+    fprintf(stderr, "stub: launches=%u observed=%llu sampled=%llu period=%u seed=0x%016llx "
                     "launch_dropped=%llu exec_dropped=%llu enroll=%s\n",
             launches, (unsigned long long)sampler.observed(),
             (unsigned long long)sampler.sampled(), sampler.period(),
+            (unsigned long long)sampler.seed(),
             (unsigned long long)lb.dropped(), (unsigned long long)eb.dropped(),
             perfagent::enroll_result_name(enrolled));
 }


### PR DESCRIPTION
Closes #50.

`Sampler::should_sample()` sampled when `launch_seq % period == 0`. Deterministic and
reproducible — which is why it was chosen — but it aliases against any periodic launch
pattern, losing whole kernels permanently however long the profile runs.

The header comment anticipated exactly this: *"If bias against periodic launch patterns is
ever measured, randomize here — the ABI carries `sample_period` per record, so the consumer
needs no change."* It has now been measured.

On the RTX 3090 validation workload (alternating `perfagent_axpy` / `perfagent_scale`,
period 8), `perfagent_scale` held **2,894,901 ns — 48% of GPU time — and received zero CPU
stacks**, ever. Every sampled index is even; every even index in a 2-cycle is the same
kernel.

A sweep across (period, cycle) pairs found the old sampler locks phase in **30 of 33**. This
was never specific to that workload.

### Jittered stride, deterministic given a seed

After sampling launch `s`, the next is at `s + gap`, with `gap` drawn uniformly from the
`2k+1` integers centred on `period` (`k = period/2`) — `[4,12]` at period 8, `{1}` at period
1. The set is symmetric, so the mean gap is **exactly** `period` and the long-run rate
exactly `1/period`. The band always spans both parities, so no phase can lock.

The gap is a **pure function** of `(seed, period, sample point)` — splitmix64 over the sample
point, mapped into the band by multiply-shift — not a running PRNG state. The schedule is
therefore a deterministic chain, replayable offline, and every exact count stays exact. That
is why not Bernoulli: Bernoulli would have forced the gate's exact assertion into a tolerance
band, weakening a real check.

### No assertion was widened

`wantSampled` 63 → **58**, still an equality — the exact length of the default schedule over
500 launches, cross-checked three ways (stub stderr, consumer stats, pinned Go replica). Two
assertions **added**: more than one distinct kernel name among stack-carrying launches (this
fails under the old sampler while everything else passes), and the stub's stderr must name
the default seed. `expected_sampled` in `cmd/gpu-cuda-profile` stays exact via the replica.

Worth recording: **the rate check passed on the unfixed sampler.** A test that only asserts
the sampled rate would never have found this bug — which is why the regression test asserts
the *distribution across kernels*, and was written first.

### `sample_period`'s meaning changed — stated, not glossed

The wire ABI is byte-for-byte identical and no decode path is touched. But `sample_period` is
now the **mean** stride, not an exact one: `launch_seq % period == 0` no longer holds. That
mattered because the consumer could previously verify the sampler from `launch_seq` alone.
Replaced by two things: full replay via `internal/gpuabi.SampleSchedule`, pinned to the C++
side by a shared vector asserted in both suites; and a seedless invariant stronger than the
modulo — every gap must lie in `[period-period/2, period+period/2]`. Comments in
`usdt_abi.h` and `gpu.LaunchContext` updated.

**Durations are never scaled**, confirmed: `should_sample()` touches no timestamp, both
callers use it only to decide whether to fire the sampled probe, `gpu_launch_v1` and
`gpu_exec_v1` fire unconditionally, and `projection.go` still only labels.

### Cost, measured after a wrong claim

The header first said the new path was cheaper, since it drops a 64-bit division. Benchmarked,
it is **slower**: 4.33 → 4.87 ns/launch, +12%, which is 0.02% of one core at the measured
393k launches/s ceiling. The comment now carries the measurement rather than the argument.

Concurrency: the chain of sample *points* is thread-independent, so the count is exact under
any threading (asserted by an 8-trial 4-thread test against a serial run). What can shift is
*which* launch carries each stack. Documented; TSan clean.

### Prediction for the live run

4000 launches, period 8, default seed; even ordinal = `axpy`, odd = `scale`. Adapter
`sampled=` / `expected_sampled=` **505**; `axpy` **255**, `scale` **250**. The `gpu-cuda-45`
run yielded 257 stack-carrying launches from a nominal 500 (attrition outside this change),
so the robust prediction is the **split**: `scale` must be non-zero — it was exactly 0,
permanently — and the two should sit near 50.5/49.5. At the same yield, roughly 130 axpy /
127 scale. Anything near 100/0 means the fix did not take. GPU-time totals, joins and
duration conservation unchanged.
