### PR TITLE
chore: ignore the shim executables that have no extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,11 @@ pmu.txt
 
 ### Project binaries ###
 perf-agent
-# GPU shim stub executable (the .so/.a/.o forms are covered above)
+# GPU shim executables (the .so/.a/.o forms are covered above; these have no
+# extension for those rules to catch). Built by `make -C shim`.
 shim/perfagent-gpu-stub
+shim/perfagent-gpu-fpless
+shim/perfagent-gpu-dlopen-host
 # The frame-pointer-less producer the phase gate drives, same story
 shim/perfagent-gpu-fpless
 # The CUDA test workload the NVIDIA adapter is proven against: built by


### PR DESCRIPTION
`make -C shim` produces three extensionless executables. Only `perfagent-gpu-stub` was ignored; `perfagent-gpu-fpless` (added by #43) and `perfagent-gpu-dlopen-host` (added by #49) were not, so both show as untracked after any shim build.

The `.so`/`.a`/`.o` outputs are already covered by extension rules above — these three are exactly the ones those rules cannot catch.

Found while removing the #49 worktree: `git worktree remove` refused because of an untracked `shim/perfagent-gpu-dlopen-host`. Verified with `git check-ignore`, which matched nothing for it. After this change a full `make -C shim` leaves the tree clean.