### PR TITLE
test: stop recording a failure for the branch the || was meant to tolerate

### DIFF
--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -902,14 +902,24 @@ func TestPMUIOWorkloadHasIOWait(t *testing.T) {
 
 	outputStr := string(output)
 
-	// I/O workload should show some I/O wait or voluntary sleep
-	// (file operations cause both)
-	hasIOActivity := false
-	if assert.Contains(t, outputStr, "I/O Wait (D state):") ||
-		assert.Contains(t, outputStr, "Voluntary (sleep/mutex):") {
-		hasIOActivity = true
-	}
-	assert.True(t, hasIOActivity, "I/O workload should show I/O or voluntary sleep activity")
+	// An I/O workload should show I/O wait or voluntary sleep; file
+	// operations cause both.
+	//
+	// strings.Contains, not assert.Contains: assert.Contains records a
+	// failure on t as a side effect and returns a bool, so writing this as
+	// `if assert.Contains(...) || assert.Contains(...)` marked the test
+	// failed on the first branch before the second was ever considered -
+	// the || read as a tolerance but never tolerated anything, and a
+	// genuine miss recorded three failures for one condition.
+	//
+	// Note this is a weaker check than it appears: metrics/console.go
+	// prints both lines inside one `if totalSwitches > 0` block, so they
+	// appear together or not at all. What it really asserts is that some
+	// context switch was recorded. See issue #63.
+	hasIOActivity := strings.Contains(outputStr, "I/O Wait (D state):") ||
+		strings.Contains(outputStr, "Voluntary (sleep/mutex):")
+	assert.True(t, hasIOActivity,
+		"I/O workload should report I/O wait or voluntary sleep; output had neither line:\n%s", outputStr)
 }
 
 func TestPMUCPUWorkloadMostlyRunning(t *testing.T) {


### PR DESCRIPTION
Closes #55.

`assert.Contains` records a failure on `t` as a side effect **and** returns a bool. So:

```go
if assert.Contains(t, outputStr, "I/O Wait (D state):") ||
    assert.Contains(t, outputStr, "Voluntary (sleep/mutex):") {
```

marked the test failed on the first branch before the second was ever evaluated. The `||` read as "either is acceptable" and never tolerated anything — and on a genuine miss it recorded **three** failures for one condition (both asserts, then the `assert.True`).

Now `strings.Contains` for the branch tests and a single `assert.True` naming both acceptable forms, with the output included on failure.

### What settled the open question in #55

#55 noted the safe fix depended on whether `I/O Wait (D state):` is printed unconditionally, which it said needed a privileged run to establish. It does not — `metrics/console.go:88-99` answers it. All three context-switch lines sit inside one `if totalSwitches > 0` block, so they appear together or not at all.

### That makes the assertion weaker than it looks

Because both strings are emitted together, the `||` cannot distinguish them, and what the test actually verifies is that **some context switch of any kind was recorded** — not that any I/O was classified as I/O. A profiler that attributed every blocked read to preemption would pass it.

That is a separate defect from the `||` mechanics, so it is filed as **#63** rather than folded in here, with a comment at the call site pointing to it. This PR is the mechanical fix only, and should not be read as having addressed it.