### PR TITLE
gpu: derive the enrollment address from /proc on both sides

### DIFF
--- a/.superpowers/sdd/issue-49-report.md
+++ b/.superpowers/sdd/issue-49-report.md
@@ -45,8 +45,8 @@ The producer has a point in its life that provably precedes every launch, and th
 consumer does not. So the producer is the one that waits.
 
 **`shim/core/enroll.{h,cc}` — the producer half.** At initialisation, and only when the
-sampled-launch probe's semaphore says a consumer is attached, the shim connects to an
-abstract `AF_UNIX` socket and blocks for one status byte.
+shim connects to an abstract `AF_UNIX` socket and blocks for one status byte.
+Unconditionally — §5.3 is what happened when this was gated on the probe semaphore.
 
 **`gpuprobe/enroll.go` — the consumer half.** `Attach` binds that socket *before* it
 creates the `uprobe_multi` link. It accepts one producer at a time, takes the peer's PID
@@ -117,9 +117,9 @@ else half-installed at the time.
 Stated plainly, because the fix is a mechanism with a scope, not a blanket.
 
 1. **A process that was already running when the consumer attached.** Its
-   `InitializeInjection` ran with the semaphore at zero; it never reaches the rendezvous.
-   Its first batch triggers lazy registration exactly as before, and everything sampled
-   during that compile is walked without tables. **This is the genuine residual of #49**,
+   `InitializeInjection` ran before the consumer bound the rendezvous address, so its
+   connect was refused and it never enrolled. Its first batch triggers lazy registration
+   exactly as before, and everything sampled during that compile is walked without tables. **This is the genuine residual of #49**,
    and it is visible as `StacksWalkedNoTables > 0` with `StacksNoTablesAfterEnroll == 0`.
    Closing it needs the process stopped or its launches suppressed from outside, which
    nothing here does.
@@ -158,7 +158,7 @@ nothing here can fail an attach or fail a run.
 
 | what fails | producer | consumer |
 |---|---|---|
-| no consumer attached (semaphore 0) | never connects; zero cost | — |
+| no consumer attached | connect refused immediately; ~11 µs, see §5.4 | — |
 | address unbindable (already held, no abstract sockets) | `no-listener`, runs immediately | `Attach` continues, `UnwindEnrollListening=false`, reason in `UnwindEnrollLastError` |
 | peer credentials unreadable / peer does not map the shim / wrong PID on a per-PID attach | reads `'X'`, runs | `UnwindEnrollRefused++`, no compile at all |
 | registration installs nothing | reads `'X'`, runs | `UnwindEnrollFailed++`, PID marked enrolled so its walks are counted as the contradiction they are |
@@ -297,69 +297,98 @@ setter.
 
 ---
 
-## 5. Predicted counters on the RTX 3090, and the derivation
+## 5. Two wrong diagnoses, and the measured cause
 
-500 sampled launches, `cmd/gpu-cuda-profile` defaults, one workload.
+This section is a log rather than an argument, because the argument was wrong twice and
+the log is the part worth keeping.
+
+### 5.1 Attempt 1 — predicted, and wrong
+
+Predicted from the mechanism: `StacksWalkedDWARF 500`, `StacksWalkedNoTables 0`,
+`UnwindEnrollRequests 1`. Measured on the RTX 3090, three runs:
 
 ```
-StacksWalkedDWARF          500      (was mean 308)
-StacksWalkedNoTables         0      (was mean ~192)
-StacksWalkedFPOnly           0
-StacksProfilerOnly           0      (was == NoTables)
-StacksNoTablesAfterEnroll    0
-UnwindEnrollListening     true
-UnwindEnrollRequests         1
-UnwindEnrollConfirmed        1
-UnwindEnrollRefused          0
-UnwindEnrollFailed           0
-UnwindEnrollThrottled        0
-UnwindEnrolledPIDsEvicted    0
-UnwindEnrolledMarksDropped   0
-UnwindPIDsRegistered         1
-SequenceGaps                 0      (unchanged)
+DWARF:311/338/326   NoTables:189/162/174   ProfilerOnly:same   ReachedRoot==DWARF
+UnwindEnrollRequests:0  Confirmed:0  Refused:0  Throttled:0  Failed:0
 ```
 
-Derivation, step by step:
+`NoTables` ~175 against a baseline of ~187: unchanged. The GPU-free gate passed with
+`no-tables=0`. **The mechanism never fired.** `UnwindEnrollRequests:0` made it a clean
+negative — the producer never tried — rather than an ambiguous one.
 
-1. `StacksWalkedNoTables == 0`. It is incremented only for an FP-only walk from a PID the
-   registry does not have as `pidReady`. The single producer reaches `pidReady` before
-   `InitializeInjection` returns, and `InitializeInjection` returns before `cuptiSubscribe`
-   runs, which is before any callback can fire a probe. So no walk can happen from a
-   not-ready PID.
-2. `StacksWalkedFPOnly == 0`, hence `StacksWalkedDWARF == 500`. The existing invariant
-   `DWARF + FPOnly == sampled` holds unconditionally. In the twelve baseline runs
-   `FPOnly == NoTables` exactly, i.e. **there was never an FP-only walk that had tables**
-   — the walk from the adapter's callback out to the application crosses libcupti and
-   libcudart, which are FP-less, so with tables present it always sets `DWARF_USED`.
-   With `NoTables == 0` that forces `FPOnly == 0` and `DWARF == 500`.
-3. `StacksProfilerOnly == 0`. It equalled `NoTables` in every baseline run: the refused
-   stacks were exactly the tableless ones, because those are the walks that die in the
-   adapter's own frame. With no tableless walks there is nothing for the #39 guard to
-   refuse. This is the number that says the *attribution* was recovered, not just the
-   walk — 500 launches now reach the profile with a real application call path.
-4. `UnwindEnrollRequests == UnwindEnrollConfirmed == 1`. One workload process, one
-   `InitializeInjection`, one connection that passes both identity checks. One connection
-   cannot exceed a 32-per-uid-per-second bucket, so `UnwindEnrollThrottled == 0`; one PID
-   against a 128-PID bound cannot be evicted, so `UnwindEnrolledPIDsEvicted == 0` and
-   `UnwindEnrolledMarksDropped == 0`. The workload runs as the same user as the profiler
-   here, and the profiler is privileged, so the uid gate is inert either way.
-5. `SequenceGaps == 0`. Nothing was added to the drain path.
+### 5.2 Attempt 1's diagnosis — the `dlopen` semaphore — was also wrong
 
-Also expected, not asserted: the workload's `cuInit` gains roughly 150–250 ms (the
-compile of libcuda, libcupti, libcudart, libc and the workload binary) before its first
-launch; the adapter logs `enroll=confirmed` on its `PERFAGENT_GPU_LOG` line.
+The rendezvous was gated on `gpu_launch_sampled_v1_enabled()`, and the leading hypothesis
+was that the uprobe reference-count semaphore had not armed by the time libcuda called
+`InitializeInjection`. The gate covered only `exec`'d producers, where it certainly is
+armed, which fitted the exec-green/CUDA-silent split exactly.
 
-**What would falsify this.** `UnwindEnrollListening == false` means the address could not
-be bound and the run is entirely on the old path. `UnwindEnrollRefused > 0` means the
-identity check rejected the process the uprobes fired in, which cannot be true and would
-mean the `/proc` inode match is wrong. `StacksWalkedNoTables > 0` with
-`UnwindEnrollConfirmed == 1` means a walk happened before the reply, i.e. the ordering
-argument in §2 is false. `StacksNoTablesAfterEnroll > 0` **while `UnwindEnrollFailed` and
-`UnwindEnrolledPIDsEvicted` are both zero** means the rendezvous reported success it did
-not deliver. Any of these is a real defect, not a timing transient — which is the
-difference from the pre-#49 code, where a non-zero `NoTables` was expected.
+Ungating was shipped, along with the instrumentation to settle it. Attempt 2:
 
----
+```
+enroll=no-listener sem_at_init=1 sem_after_init=1 sem_at_exit=1
+UnwindEnrollRequests:0  DWARF:298/336/315  NoTables:202/164/185
+```
+
+`sem_at_init=1`. **The semaphore was already armed and the hypothesis is dead.** Ungating
+was still right — it is what let the attempt happen at all, and therefore what produced
+`enroll=no-listener` instead of silence — but it did not fix anything, and the new
+`dlopen` gate passed while the real path still failed.
+
+### 5.3 The measured cause: stat(2) and /proc report different devices
+
+`enroll=no-listener` says the producer computed an address and found nothing bound there.
+The two ends derive that name independently and never exchange it, so the question was
+whether the strings matched. They did not, and this is measurable locally — no GPU, no
+capabilities:
+
+```
+/tmp/devcheck_tmpfile   (tmpfs)  stat=0:48 ino=341002   maps=0:48 ino=341002   AGREE
+<repo>/shim/core/...    (btrfs)  stat=0:49 ino=1961899  maps=0:34 ino=1961899  *** MISMATCH ***
+/bin/true               (btrfs)  stat=0:36 ino=13268    maps=0:34 ino=13268    *** MISMATCH ***
+```
+
+The consumer built the name from `stat(2)`'s `st_dev`; the producer reads the device field
+of `/proc/self/maps`. On btrfs those are **different numbers for the same file**, and not
+by accident: `btrfs_getattr` reports the *subvolume's* anonymous device, while
+`show_map_vma` prints `inode->i_sb->s_dev`, the *filesystem's*. Every btrfs subvolume gets
+its own `anon_dev`. Fedora's default root is btrfs, and the shim is built in the source
+tree.
+
+So the consumer bound `@perfagent-gpu-enroll.v1.0.49.<ino>` and the producer dialled
+`@perfagent-gpu-enroll.v1.0.34.<ino>`. Everything else worked perfectly.
+
+**And that is why every gate was green.** They all put their fixture in `t.TempDir()`,
+i.e. `/tmp`, i.e. tmpfs — the one filesystem where the two numbers agree. The
+cross-language test written specifically to prove the two ends compute the same name was
+building its producer there too.
+
+### 5.4 The fix
+
+`enrollShimIdentity` derives the consumer's device and inode the same way the producer
+does: map the file, read `/proc/self/maps`, take the device and inode the kernel reports
+for that mapping. Symmetric by construction — there is no second source to disagree with.
+The same pair feeds both the socket name and `procMapsHaveInode`, which had the identical
+bug one step later and would have refused every genuine producer had they ever met.
+
+### 5.5 The prediction
+
+```
+StacksWalkedDWARF          500        StacksNoTablesAfterEnroll    0
+StacksWalkedNoTables         0        UnwindEnrollRequests         1
+StacksWalkedFPOnly           0        UnwindEnrollConfirmed        1
+StacksProfilerOnly           0        UnwindEnrollRefused          0
+```
+
+`UnwindEnrollAddress` in `Stats` and `enroll_addr=` in the producer's log will now print
+the two names, so if this is wrong a third time it is one string comparison rather than a
+round trip. The full decision table from the previous round still stands, plus:
+
+| observation | conclusion |
+|---|---|
+| `enroll_addr` == `UnwindEnrollAddress`, `enroll=no-listener` | the addresses agree; look at bind lifetime or network namespace |
+| `enroll_addr` != `UnwindEnrollAddress` | still a derivation mismatch; the differing field says which |
+
 
 ## 6. Counters
 
@@ -395,6 +424,12 @@ Six defects on this project were counters reading green when things were worst, 
   churned against the LRU and aged marks out roughly twice as fast as evictions happened.
   `TestTheEnrolledMarkSetOutlivesTheEvictionItMustWitness` pins that, and the bounds test
   asserts the books balance (`dropped + held == enrolments`).
+- **`UnwindEnrollAddress`** is the counter this episode was actually short of. Every
+  enrolment counter reading zero is ambiguous in the one way that mattered: "listening, and
+  nobody came" and "the producer computed a different name" look identical, and telling them
+  apart cost a full CUDA round trip. The consumer now reports the name it bound, the producer
+  logs the name it derived (`enroll_addr=`), and a mismatch is one string comparison.
+  `UnwindEnrollListening` still distinguishes "bound nothing at all".
 - **`UnwindEnrollThrottled`** makes the rate limiter visible. Non-zero on a machine that is
   not under attack means a legitimate burst exceeded the per-uid bucket and those producers
   fell back to the lazy path — the limiter causing a small version of the loss it protects.
@@ -450,7 +485,84 @@ must not extend the budget**, **both phases sharing one budget rather than each 
 it**, oversized and empty names, and the `PERFAGENT_GPU_ENROLL_TIMEOUT_MS` parse where an
 explicit `0` means off rather than "use the default".
 
-Gate (`TestStubDrivesThePipelineToPprofWithoutAGPU`), which still runs GPU-free with
+### 7.3 The gate hole, which is the real finding of this round
+
+The first version of this fix **passed the GPU-free gate and did nothing under CUDA**. A
+gate that can do that is not a gate. The cause was that
+`TestStubDrivesThePipelineToPprofWithoutAGPU` drives an `exec`'d producer, and the two paths
+differ in the one respect that mattered:
+
+| | how the producer starts | semaphore when its init runs |
+|---|---|---|
+| `perfagent-gpu-fpless` | `exec` | armed while the kernel builds the mm, before `main` |
+| the CUPTI adapter | `dlopen` by libcuda | asked at the instant the mapping appears |
+
+`TestADlopenedProducerEnrollsBeforeItsFirstLaunch` closes it. `shim/stub/dlopen_host.cc` is
+a host that `exec`s and then **`dlopen`s** `libperfagent-gpu-stub.so` and calls into it, so
+producer initialisation happens on the same kernel path the adapter's does. It is
+deliberately a second test rather than a change to the first: both shapes have to keep
+working, and one test cannot be both. The `.so` is *not* a `DT_NEEDED` dependency, because
+the loader maps those before `main` — that is the exec path wearing a different hat.
+
+Its first assertion is `UnwindEnrollRequests == 1`, before the `no-tables` one, because
+"the producer never tried" and "it tried and the tables still were not there" are different
+failures that a bare `no-tables` check reports identically. It also logs the producer's
+`sem_at_enroll` on every run, so the number this episode turned on is recorded rather than
+inferred — on a machine with no GPU in it.
+
+One thing it does **not** assert: `StacksProfilerOnly`. This producer is an ET_DYN with no
+`DT_SONAME` and no `PT_INTERP`, so `shimScope` classifies it as an injected library and the
+#39 guard *is* armed — the same shape as the CUDA adapter, and unlike the exec gate where
+the guard disables itself. That makes the counter meaningful and worth printing, but its
+value depends on the walk crossing from the `.so` into the host executable, which is a
+property of two binaries' CFI and which this test has not derived. Asserting an underived
+number is how a gate goes green while proving nothing, which is the failure this test exists
+to correct.
+
+### 7.3b What the dlopen gate did not catch, and what fixes that
+
+It passed while the real path failed, twice over, so it is worth being precise about what
+it was and was not covering.
+
+**It did not reproduce the filesystem.** `privateStubCopy` put the shim copy in
+`t.TempDir()` — tmpfs, where `stat(2)` and `/proc` agree. That is now a scratch directory
+*beside the built shim*, on the source tree's filesystem, for both gates. The unit-level
+version matters more, because it needs no privilege and runs everywhere:
+`TestTheCppProducerAndTheGoListenerAgreeOnTheWire` is now a pair of subtests over the
+source filesystem **and** TMPDIR, and it compares the two derived name strings directly
+rather than inferring a mismatch from "no-listener".
+
+Falsified to prove it bites — reverting the derivation to `stat(2)`:
+
+```
+--- FAIL: .../source_filesystem,_where_the_shim_is_really_built
+    the two ends derived DIFFERENT rendezvous names for the same file
+    consumer=@perfagent-gpu-enroll.v1.0.49.1986646
+    producer=@perfagent-gpu-enroll.v1.0.34.1986646
+--- PASS: .../TMPDIR
+```
+
+The TMPDIR subtest passing there is the old behaviour reproduced exactly.
+
+`TestTheRendezvousAddressIsTheShimsDeviceAndInode` also moved to the source filesystem and
+now pins the address against `/proc` rather than `stat(2)`, and logs when the two disagree.
+
+**It did not exercise the DWARF path.** It reported `dwarf=0 fp-only=63` with
+`no-tables=0`: tables installed, never used. That is legitimate for the producer it was
+loading — `libperfagent-gpu-stub.so` has frame pointers throughout, and `walk_step` sets
+`WALKER_FLAG_DWARF_USED` only for a frame it classified FP_LESS — but it means the gate
+proved the rendezvous fired and proved nothing about the unwinding the rendezvous exists to
+feed. A real CUDA stack crosses libcupti and libcudart, which have no frame pointers.
+
+So the gate now loads a new `libperfagent-gpu-fpless.so`, which puts two
+`-fomit-frame-pointer` frames between the probe and the host's `main` — the same
+`stub/fpless_bridge.cc` the exec gate uses, in a shared object — and asserts
+`StacksWalkedDWARF > 0`. `make check-fpless` was extended to cover the `.so` as well as the
+executable, so the assertion cannot pass vacuously if the toolchain keeps frame pointers.
+
+### 7.4 The exec gate
+
+`TestStubDrivesThePipelineToPprofWithoutAGPU`, which still runs GPU-free with
 `PID: 0` and the target not yet running — the shape is unchanged, the producer is still
 launched after `Attach`, and the assertions were **tightened, not relaxed**:
 
@@ -477,18 +589,43 @@ StacksWalkedDWARF` still holds, now at 63, and `StackWalkAbandoned`,
 go build ./... && go vet ./...                                        pass
 go test ./gpu/ ./gpuprobe/ ./internal/... ./unwind/... -count=1        pass
 go test ./gpu/ ./gpuprobe/ ./unwind/ehmaps/ -race -count=4             pass
+make -C shim libperfagent-gpu-fpless.so perfagent-gpu-dlopen-host       builds
+make -C shim check-fpless (now covers the .so too)                     OK
+stat(2) vs /proc device, tmpfs and btrfs                               MISMATCH on btrfs (§5.3)
+cross-language name agreement, source fs + TMPDIR                      pass; fails on btrfs if reverted to stat(2)
+./perfagent-gpu-dlopen-host ./libperfagent-gpu-stub.so (no consumer)   enroll=no-listener, sem 0/0
+ungated unprofiled cost, 200 iters x3, both listener cases            ~11 us (§5.4)
+worst-case maps scan, 25/400/900/2000 lines                           9.4/85/185/325 us
 golangci-lint run --timeout=5m                                        0 issues
 make -C shim test                                                     pass (incl. enroll_test)
 make -C shim perfagent-gpu-stub perfagent-gpu-fpless check-fpless      pass
 make -C shim nvidia                                                   builds; exports only InitializeInjection
 ```
 
-**Cannot verify:** `CapEff: 0` on this machine. No BPF object could be loaded, no uprobe
-attached, and no CUDA device is present, so `TestStubDrivesThePipelineToPprofWithoutAGPU`
-skips and no RTX 3090 run was made. Nothing in §5 has been observed; it is derived, and
-the tightened gate assertions are unproven against real BPF. In particular, the claim that
-the uprobe reference-count semaphore is already armed when `InitializeInjection` runs
-(kernel `uprobe_mmap` / delayed-uprobe handling at `dlopen`) is read from the kernel's
-contract, not measured here — if it were false, the producer would skip the rendezvous
-and the run would simply look like the pre-#49 baseline, with `UnwindEnrollRequests == 0`
-saying so.
+**Cannot verify.** `CapEff: 0` on this machine and no GPU. No BPF object could be loaded
+and no uprobe attached, so **both** gates skip — including the new
+`TestADlopenedProducerEnrollsBeforeItsFirstLaunch`, which is the test written specifically
+to catch this class of failure and which has therefore never been observed to pass or fail.
+No RTX 3090 run was made.
+
+What **is** verified this time, and was not before: the cause itself. The device mismatch in
+§5.3 was measured on this machine, and the regression test for it fails on btrfs and passes
+on tmpfs when the fix is reverted. That is the first link in this chain that rests on a
+measurement rather than a derivation.
+
+Specifically **not** verified here:
+
+- That the fixed derivation makes the rendezvous fire under CUDA. §5.5 is a prediction for
+  the third time. It is a much narrower one — the two ends now compute the same string on
+  the filesystem the shim is built on, which is the only thing that was wrong — but it is
+  still unrun against a GPU.
+- Both gates, which skip: `CapEff: 0`. Including the new DWARF assertion in the dlopen gate
+  and both gates' move onto the source filesystem.
+- That the walk escapes the shim in the dlopen gate, which is why §7.3 logs
+  `StacksProfilerOnly` rather than asserting it.
+
+Two rounds of this report have had a derivation in the "cannot verify" list turn out to be
+the bug. Both times the counter that caught it was one added in the previous round —
+`UnwindEnrollRequests` for attempt 1, `sem_at_init` and `enroll_addr` for attempt 2. That is
+the pattern worth keeping: when a mechanism cannot be run, spend the effort on making its
+failure legible rather than on arguing it will not fail.

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -665,6 +665,18 @@ type Stats struct {
 	// indistinguishable from the counters, and the first is the one that
 	// loses ~38% of its stacks.
 	UnwindEnrollListening bool
+	// UnwindEnrollAddress is the abstract socket name this consumer bound, or
+	// "" when it bound none.
+	//
+	// It is here because every enrolment counter reading zero is ambiguous in
+	// the one way that matters: "listening, and nobody came" and "the producer
+	// computed a different name and connected to nothing" look identical.
+	// That ambiguity cost a full CUDA round trip - a run where the producer
+	// logged enroll=no-listener while the consumer was listening perfectly, on
+	// an address derived from a different device number (see
+	// enrollShimIdentity). The producer logs the name it derived; this is the
+	// name the consumer derived; comparing two strings settles it.
+	UnwindEnrollAddress string
 	// UnwindEnrollRequests counts producers that reached the rendezvous and
 	// passed both identity checks (SO_PEERCRED, and actually mapping this
 	// consumer's shim inode), so registration was attempted for them.
@@ -2087,6 +2099,7 @@ func (c *Consumer) Stats() Stats {
 	out.UnwindPIDsTracked = tracked
 	en := c.enroll.snapshot()
 	out.UnwindEnrollListening = c.enroll != nil
+	out.UnwindEnrollAddress = c.enroll.address()
 	out.UnwindEnrollRequests = en.requests
 	out.UnwindEnrollConfirmed = en.confirmed
 	out.UnwindEnrollRefused = en.refused

--- a/gpuprobe/enroll.go
+++ b/gpuprobe/enroll.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 	"kernel.org/pub/linux/libs/security/libcap/cap"
@@ -233,13 +234,111 @@ func refillTokens(tokens float64, since, now time.Time, perSec, max float64) flo
 // from the same two numbers the kernel reports for the file, so they agree
 // without exchanging anything.
 func enrollAddress(shimPath string) (string, error) {
-	var st unix.Stat_t
-	if err := unix.Stat(shimPath, &st); err != nil {
-		return "", fmt.Errorf("stat shim %s: %w", shimPath, err)
+	dev, ino, err := enrollShimIdentity(shimPath)
+	if err != nil {
+		return "", err
 	}
-	dev := uint64(st.Dev) //nolint:unconvert // st.Dev is uint64 on amd64, uint32-widened elsewhere
+	return enrollAddressFor(dev, ino), nil
+}
+
+// enrollAddressFor is the one place the name is spelled, so the two callers
+// that need it - the listener's bind and the tests' dial - cannot drift.
+func enrollAddressFor(dev, ino uint64) string {
 	return fmt.Sprintf("@perfagent-gpu-enroll.v1.%d.%d.%d",
-		unix.Major(dev), unix.Minor(dev), st.Ino), nil
+		unix.Major(dev), unix.Minor(dev), ino)
+}
+
+// enrollShimIdentity returns the device and inode of shimPath AS
+// /proc/<pid>/maps reports them, by mapping the file and reading our own maps.
+//
+// # Why not stat(2), which is obviously the right call
+//
+// Because on btrfs it returns a different device, and the rendezvous then has
+// two ends computing two different socket names and never meeting. Measured on
+// this machine, same file, same instant:
+//
+//	/tmp/file            (tmpfs)  stat=0:48  maps=0:48   agree
+//	<repo>/shim/...      (btrfs)  stat=0:49  maps=0:34   MISMATCH
+//	/bin/true            (btrfs)  stat=0:36  maps=0:34   MISMATCH
+//
+// They are genuinely different numbers, not a parsing bug. btrfs_getattr sets
+// stat->dev to the SUBVOLUME's anonymous device, while show_map_vma prints
+// inode->i_sb->s_dev, the filesystem's. Every btrfs subvolume gets its own
+// anon_dev, so the two disagree for every file on a btrfs root - which is the
+// Fedora default, and where the shim is built.
+//
+// This is what made the second CUDA attempt fail with enroll=no-listener and
+// UnwindEnrollRequests:0 while both GPU-free gates passed: the gates put their
+// shim copy in t.TempDir(), i.e. /tmp, i.e. tmpfs, where the two numbers agree.
+//
+// So the consumer derives its identity through exactly the mechanism the
+// producer uses - map the file, ask /proc what the kernel calls it - and the
+// two cannot disagree by construction. shim/core/enroll.cc reads the same
+// field of the same file for the mapping that contains its own code.
+func enrollShimIdentity(shimPath string) (dev, ino uint64, err error) {
+	f, err := os.Open(shimPath)
+	if err != nil {
+		return 0, 0, fmt.Errorf("open shim %s: %w", shimPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// One page, read-only, private: enough for the kernel to create a vma
+	// whose maps line names the file. Never dereferenced.
+	page, err := unix.Mmap(int(f.Fd()), 0, os.Getpagesize(),
+		unix.PROT_READ, unix.MAP_PRIVATE)
+	if err != nil {
+		return 0, 0, fmt.Errorf("mmap shim %s: %w", shimPath, err)
+	}
+	defer func() { _ = unix.Munmap(page) }()
+	at := uint64(uintptr(unsafe.Pointer(&page[0])))
+
+	maps, err := os.Open("/proc/self/maps")
+	if err != nil {
+		return 0, 0, fmt.Errorf("open /proc/self/maps: %w", err)
+	}
+	defer func() { _ = maps.Close() }()
+
+	sc := bufio.NewScanner(maps)
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) < 5 {
+			continue
+		}
+		lo, hi, ok := parseMapsRange(fields[0])
+		if !ok || at < lo || at >= hi {
+			continue
+		}
+		maj, min, ok := parseMapsDev(fields[3])
+		if !ok {
+			continue
+		}
+		gotIno, perr := strconv.ParseUint(fields[4], 10, 64)
+		if perr != nil || gotIno == 0 {
+			continue
+		}
+		return unix.Mkdev(maj, min), gotIno, nil
+	}
+	if err := sc.Err(); err != nil {
+		return 0, 0, fmt.Errorf("read /proc/self/maps: %w", err)
+	}
+	return 0, 0, fmt.Errorf("shim %s: own mapping not found in /proc/self/maps", shimPath)
+}
+
+// parseMapsRange splits the "lo-hi" address field of a maps line.
+func parseMapsRange(field string) (lo, hi uint64, ok bool) {
+	l, h, cut := strings.Cut(field, "-")
+	if !cut {
+		return 0, 0, false
+	}
+	lv, err := strconv.ParseUint(l, 16, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	hv, err := strconv.ParseUint(h, 16, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return lv, hv, true
 }
 
 // enrollStats is the listener's slice of gpuprobe.Stats, under its own lock.
@@ -254,8 +353,15 @@ type enrollStats struct {
 
 // enrollListener serves the producer-side rendezvous for one consumer.
 type enrollListener struct {
-	ln  *net.UnixListener
-	reg *pidRegistry
+	ln *net.UnixListener
+	// addr is the name this listener actually bound, surfaced as
+	// Stats.UnwindEnrollAddress. It exists because "listening, nobody came"
+	// and "the producer computed a different name" are indistinguishable from
+	// the counters alone - every one of them reads zero either way - and
+	// telling those two apart is what a whole CUDA round trip was spent on.
+	// Printing the string both ends derive turns that into one glance.
+	addr string
+	reg  *pidRegistry
 	// pid mirrors Config.PID: non-zero means this consumer's uprobes are
 	// filtered to one process, so an enrollment from any other PID is
 	// refused. The socket name is not PID-scoped and cannot be.
@@ -301,24 +407,25 @@ func newEnrollListener(cfg Config, reg *pidRegistry) (*enrollListener, error) {
 // lock precisely because only the serving goroutine reaches it, and a test
 // that reached in while it ran would be racing the code it is checking.
 func buildEnrollListener(cfg Config, reg *pidRegistry) (*enrollListener, error) {
-	addr, err := enrollAddress(cfg.ShimPath)
+	// One derivation, used for BOTH the address and the peer identity check.
+	// They have to be the same numbers: a consumer that bound one device and
+	// checked peers against another would refuse every genuine producer.
+	dev, ino, err := enrollShimIdentity(cfg.ShimPath)
 	if err != nil {
 		return nil, err
 	}
-	var st unix.Stat_t
-	if err := unix.Stat(cfg.ShimPath, &st); err != nil {
-		return nil, fmt.Errorf("stat shim %s: %w", cfg.ShimPath, err)
-	}
+	addr := enrollAddressFor(dev, ino)
 	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: addr, Net: "unix"})
 	if err != nil {
 		return nil, fmt.Errorf("bind %s: %w", addr, err)
 	}
 	l := &enrollListener{
 		ln:         ln,
+		addr:       addr,
 		reg:        reg,
 		pid:        uint32(cfg.PID),
-		dev:        uint64(st.Dev), //nolint:unconvert // see enrollAddress
-		ino:        st.Ino,
+		dev:        dev,
+		ino:        ino,
 		procRoot:   "/proc",
 		admit:      newEnrollAdmission(nil),
 		requireUID: enrollRequiredUID(),
@@ -458,6 +565,14 @@ func (l *enrollListener) snapshot() enrollStats {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.stats
+}
+
+// address is the bound rendezvous name, or "" when nothing is bound.
+func (l *enrollListener) address() string {
+	if l == nil {
+		return ""
+	}
+	return l.addr
 }
 
 // close stops accepting and waits for the goroutine. Safe on a nil listener

--- a/gpuprobe/enroll_test.go
+++ b/gpuprobe/enroll_test.go
@@ -5,9 +5,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +30,35 @@ import (
 // listener at /proc/self/exe. The test binary genuinely maps that inode, so
 // the peer check passes for real, and the registrar behind the registry is
 // the same fake the rest of gpuprobe's unwind tests use.
+
+// repoTempDir makes a scratch directory ON THE SAME FILESYSTEM AS THE SOURCE
+// TREE, rather than in t.TempDir().
+//
+// That is not fussiness, it is the regression. t.TempDir() is under TMPDIR,
+// which on this machine (and most Linux distributions) is tmpfs. The
+// rendezvous name embeds a device number, and stat(2) and /proc/<pid>/maps
+// report the SAME device for a file on tmpfs and DIFFERENT devices for a file
+// on btrfs - the Fedora default, and where the shim is actually built. So
+// every test that put its fixture in t.TempDir() proved the two ends agree on
+// the one filesystem where they cannot disagree, while the real CUDA run
+// failed with enroll=no-listener and all of them stayed green.
+//
+// Measured, same file, same instant:
+//
+//	/tmp/file        (tmpfs)  stat=0:48  maps=0:48   agree
+//	<repo>/shim/...  (btrfs)  stat=0:49  maps=0:34   MISMATCH
+//
+// Anything checking that the producer and consumer compute the same name must
+// run where the shim really lives.
+func repoTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", "enrolltest")
+	require.NoError(t, err, "scratch dir on the source filesystem")
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	abs, err := filepath.Abs(dir)
+	require.NoError(t, err)
+	return abs
+}
 
 // selfExe is the shim path a test listener attaches to: this process's own
 // executable, which this process therefore provably maps.
@@ -73,7 +105,10 @@ func dialEnroll(t *testing.T, shimPath string) byte {
 // two consumers watching two copies of the same shim apart. The gate makes a
 // private copy of the stub per run for exactly that reason.
 func TestTheRendezvousAddressIsTheShimsDeviceAndInode(t *testing.T) {
-	dir := t.TempDir()
+	// The source tree's filesystem, not TMPDIR: on tmpfs stat(2) and /proc
+	// report the same device and the assertions below cannot tell a
+	// stat-derived address from a /proc-derived one.
+	dir := repoTempDir(t)
 	a := filepath.Join(dir, "shim-a")
 	b := filepath.Join(dir, "shim-b")
 	require.NoError(t, os.WriteFile(a, []byte("a"), 0o600))
@@ -93,17 +128,64 @@ func TestTheRendezvousAddressIsTheShimsDeviceAndInode(t *testing.T) {
 
 	// The exact spelling is an ABI with shim/core/enroll.cc, which builds it
 	// from the decimal major/minor and inode it reads out of
-	// /proc/self/maps. Pin it here so a change on this side cannot silently
-	// stop matching the producer.
-	var st unix.Stat_t
-	require.NoError(t, unix.Stat(a, &st))
-	dev := uint64(st.Dev) //nolint:unconvert // matches enrollAddress
+	// /proc/<pid>/maps. Pin it against THAT source - not against stat(2),
+	// which is a different number for the same file on btrfs and is exactly
+	// the mistake this address derivation used to make.
+	wantDev, wantIno := mapsIdentityOf(t, a)
 	assert.Equal(t,
-		"@perfagent-gpu-enroll.v1."+itoa(uint64(unix.Major(dev)))+"."+itoa(uint64(unix.Minor(dev)))+"."+itoa(st.Ino),
+		"@perfagent-gpu-enroll.v1."+itoa(uint64(unix.Major(wantDev)))+"."+
+			itoa(uint64(unix.Minor(wantDev)))+"."+itoa(wantIno),
 		addrA)
 
+	// And on a filesystem where the two sources disagree, the address must
+	// follow /proc rather than stat(2). On tmpfs this is vacuous, which is
+	// why the fixture lives on the source tree's filesystem.
+	var st unix.Stat_t
+	require.NoError(t, unix.Stat(a, &st))
+	if statDev := uint64(st.Dev); statDev != wantDev { //nolint:unconvert // widened on some arches
+		t.Logf("stat(2) and /proc disagree here (stat=%d:%d proc=%d:%d) - the case that broke CUDA",
+			unix.Major(statDev), unix.Minor(statDev), unix.Major(wantDev), unix.Minor(wantDev))
+		assert.NotContains(t, addrA,
+			"."+itoa(uint64(unix.Major(statDev)))+"."+itoa(uint64(unix.Minor(statDev)))+".",
+			"the address was built from stat(2)'s device; the producer reads /proc and would compute a different name")
+	}
+
 	_, err = enrollAddress(filepath.Join(dir, "not-there"))
-	assert.Error(t, err, "an unstattable shim has no address, and Attach must hear about it")
+	assert.Error(t, err, "a shim that cannot be opened has no address, and Attach must hear about it")
+}
+
+// mapsIdentityOf reads the dev:inode the KERNEL reports for path in
+// /proc/self/maps, the way shim/core/enroll.cc does, independently of the
+// production helper so the test is not checking the code against itself.
+func mapsIdentityOf(t *testing.T, path string) (dev, ino uint64) {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	page, err := unix.Mmap(int(f.Fd()), 0, os.Getpagesize(), unix.PROT_READ, unix.MAP_PRIVATE)
+	require.NoError(t, err)
+	defer func() { _ = unix.Munmap(page) }()
+	at := uint64(uintptr(unsafe.Pointer(&page[0])))
+
+	raw, err := os.ReadFile("/proc/self/maps")
+	require.NoError(t, err)
+	for _, line := range strings.Split(string(raw), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		lo, hi, ok := parseMapsRange(fields[0])
+		if !ok || at < lo || at >= hi {
+			continue
+		}
+		maj, min, ok := parseMapsDev(fields[3])
+		require.True(t, ok, "maps line: %s", line)
+		n, err := strconv.ParseUint(fields[4], 10, 64)
+		require.NoError(t, err)
+		return unix.Mkdev(maj, min), n
+	}
+	t.Fatalf("no maps line covers our own mapping of %s", path)
+	return 0, 0
 }
 
 // The property the whole change rests on: the producer is not released until
@@ -345,49 +427,82 @@ func TestTheCppProducerAndTheGoListenerAgreeOnTheWire(t *testing.T) {
 		t.Skipf("shim/core not present: %v", err)
 	}
 
-	dir := t.TempDir()
-	src := filepath.Join(dir, "producer.cc")
-	require.NoError(t, os.WriteFile(src, []byte(`
+	// BOTH filesystems, and that is the whole point of the subtests.
+	//
+	// This test existed before the second CUDA attempt and passed, while the
+	// real run failed with enroll=no-listener and UnwindEnrollRequests:0,
+	// because it built its producer in t.TempDir() - tmpfs, the one
+	// filesystem where stat(2) and /proc/<pid>/maps report the same device.
+	// The shim is built in the source tree, which on Fedora is btrfs, where
+	// they do not. See repoTempDir.
+	for _, tc := range []struct{ name, dir string }{
+		{name: "source filesystem, where the shim is really built", dir: repoTempDir(t)},
+		{name: "TMPDIR", dir: t.TempDir()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := filepath.Join(tc.dir, "producer.cc")
+			require.NoError(t, os.WriteFile(src, []byte(producerSrc), 0o600))
+			bin := filepath.Join(tc.dir, "producer")
+			build := exec.Command(cxx, "-std=c++17", "-O2", "-fvisibility=hidden",
+				"-I", core, "-o", bin, src, filepath.Join(core, "enroll.cc"))
+			if out, err := build.CombinedOutput(); err != nil {
+				t.Skipf("could not build the producer half: %v\n%s", err, out)
+			}
+
+			// The consumer's derivation for the very file the producer will
+			// map. If these two strings differ, the ends bind and dial
+			// different addresses and every counter on both sides reads zero.
+			want, err := enrollAddress(bin)
+			require.NoError(t, err)
+
+			fake := newFakeRegistrar()
+			l, r := testEnrollListener(t, bin, 0, fake)
+			require.Equal(t, want, l.address(), "the listener bound a name other than the derived one")
+
+			run := exec.Command(bin)
+			out, err := run.Output()
+			require.NoError(t, err, "producer failed: %s", out)
+			got := strings.Fields(strings.TrimSpace(string(out)))
+			require.Len(t, got, 2, "producer output: %q", out)
+
+			// Asserted before the outcome, so a mismatch reports the two
+			// names rather than just "no-listener".
+			assert.Equal(t, want, got[1],
+				"the two ends derived DIFFERENT rendezvous names for the same file under %s. "+
+					"consumer=%s producer=%s. They never exchange this string, so a mismatch makes "+
+					"every counter on both sides read zero - which is exactly how a stat(2)-derived "+
+					"device number silently disabled the whole mechanism on btrfs",
+				tc.dir, want, got[1])
+			assert.Equal(t, "confirmed", got[0],
+				"the producer got no confirmation even though both ends derived the same name (%s), "+
+					"so this is the wire protocol rather than the address", want)
+
+			pids := fake.registeredPIDs()
+			require.Len(t, pids, 1)
+			assert.Equal(t, uint64(1), l.snapshot().confirmed)
+			assert.True(t, r.ready(pids[0]))
+			assert.True(t, r.enrolled(pids[0]))
+			assert.NotEqual(t, uint32(os.Getpid()), pids[0],
+				"the registered PID is the test's own: the peer lookup is not reading the peer")
+		})
+	}
+}
+
+// producerSrc is the shim's producer half in miniature: derive the name, print
+// it, run the rendezvous, print the outcome. Kept out of the test body so the
+// C++ braces cannot be confused for Go ones by anything editing this file.
+const producerSrc = `
 #include "enroll.h"
 #include <cstdio>
 int main() {
-    // Unconditional: in a real producer this is gated on the sampled-launch
-    // probe's semaphore, which needs a live uprobe to arm.
-    printf("%s\n", perfagent::enroll_result_name(
-        perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(5000))));
+    char name[128];
+    if (!perfagent::enroll_self_name(name, sizeof(name))) { printf("no-address -\n"); return 1; }
+    const perfagent::EnrollResult r =
+        perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(5000));
+    printf("%s @%s\n", perfagent::enroll_result_name(r), name);
     return 0;
 }
-`), 0o600))
-	// Built where the test runs, not in /tmp only, so the binary's device and
-	// inode are ordinary ones; the address embeds both.
-	bin := filepath.Join(dir, "producer")
-	build := exec.Command(cxx, "-std=c++17", "-O2", "-fvisibility=hidden",
-		"-I", core, "-o", bin, src, filepath.Join(core, "enroll.cc"))
-	if out, err := build.CombinedOutput(); err != nil {
-		t.Skipf("could not build the producer half: %v\n%s", err, out)
-	}
-
-	fake := newFakeRegistrar()
-	l, r := testEnrollListener(t, bin, 0, fake)
-
-	run := exec.Command(bin)
-	out, err := run.Output()
-	require.NoError(t, err, "producer failed: %s", out)
-
-	assert.Equal(t, "confirmed\n", string(out),
-		"the producer did not get a confirmation. Either the two ends spell the socket name differently - C++ builds it from /proc/self/maps, Go from stat(2) - or the reply byte changed on one side only")
-
-	// And the consumer registered the process that was waiting, not some
-	// other one: the PID came from SO_PEERCRED, and the producer sent no
-	// payload at all.
-	pids := fake.registeredPIDs()
-	require.Len(t, pids, 1)
-	assert.Equal(t, uint64(1), l.snapshot().confirmed)
-	assert.True(t, r.ready(pids[0]))
-	assert.True(t, r.enrolled(pids[0]))
-	assert.NotEqual(t, uint32(os.Getpid()), pids[0],
-		"the registered PID is the test's own: the peer lookup is not reading the peer")
-}
+`
 
 // The rendezvous serves one producer at a time, so the cost of admitting one
 // is the cost of blocking every other. Any local user who can map the shim

--- a/gpuprobe/gate_test.go
+++ b/gpuprobe/gate_test.go
@@ -650,23 +650,33 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 	assert.Positive(t, unattributedValue, "the unattributed population must be non-empty at sample_period=8")
 }
 
-// privateStubCopy copies the built stub into this test's own temp directory
-// and returns the copy's path. The copy is what the test attaches to and what
-// it runs, so the uprobe can only ever match this run's executions.
+// privateStubCopy copies the built stub into a scratch directory NEXT TO THE
+// SOURCE and returns the copy's path. The copy is what the test attaches to
+// and what it runs, so the uprobe can only ever match this run's executions.
 //
-// t.TempDir() is removed when the test ends, taking the copy with it. It lives
-// under TMPDIR (/tmp here, mounted rw,nosuid,nodev — not noexec, so the copy
-// is runnable); nosuid is irrelevant because the stub is an ordinary
-// unprivileged producer and carries no file capabilities. If TMPDIR were ever
-// noexec the exec below fails loudly with ENOEXEC/EACCES rather than
-// silently degrading.
+// Next to the source, not in t.TempDir(), and that is load-bearing rather than
+// tidy. The rendezvous name embeds a device number; stat(2) and
+// /proc/<pid>/maps report the SAME device on tmpfs and DIFFERENT devices on
+// btrfs (measured here: stat=0:49 vs maps=0:34). TMPDIR is tmpfs on this
+// machine, so a gate whose fixture lived there proved the two ends agree on
+// the one filesystem where they cannot disagree - and both gates passed while
+// the real CUDA run failed with enroll=no-listener. The shim is built in the
+// source tree, so that is where the gate's copy of it belongs.
+//
+// The directory is removed when the test ends. It is on the same filesystem as
+// the repository, which is not noexec (the build output next to it is executed
+// by every other test here); an exec failure would surface as ENOEXEC/EACCES
+// rather than silently degrading.
 func privateStubCopy(t *testing.T, src string) string {
 	t.Helper()
 	info, err := os.Stat(src)
 	require.NoError(t, err)
 	data, err := os.ReadFile(src)
 	require.NoError(t, err)
-	dst := filepath.Join(t.TempDir(), filepath.Base(src))
+	dir, err := os.MkdirTemp(filepath.Dir(src), "gate")
+	require.NoError(t, err, "scratch dir beside the built shim")
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dst := filepath.Join(dir, filepath.Base(src))
 	// Preserve the executable bit from the source rather than assuming 0755.
 	require.NoError(t, os.WriteFile(dst, data, info.Mode().Perm()))
 	require.NotZero(t, info.Mode().Perm()&0o100, "built stub is not executable")
@@ -1006,4 +1016,195 @@ func TestTheProducersBridgeFramesAreFPLessInTheCFI(t *testing.T) {
 		assert.Equalf(t, ehcompile.ModeFPSafe, classify(t, name),
 			"%s is not FP_SAFE, so the walk would not cross an FP/DWARF boundary and the producer would not reproduce the CUDA stack shape", name)
 	}
+}
+
+// The gate hole that let issue #49's first fix ship broken.
+//
+// That fix passed TestStubDrivesThePipelineToPprofWithoutAGPU with
+// no-tables=0, and then did nothing whatsoever on the RTX 3090:
+// UnwindEnrollRequests read 0 across three runs and the loss was unchanged at
+// ~175 of 500 sampled stacks. The gate could not see it because it drives an
+// EXEC'd producer, and the two paths differ in exactly the respect that
+// mattered - the kernel arms a uprobe's reference-count semaphore while it
+// builds the mm for an exec, so it is already non-zero when main runs, whereas
+// a CUPTI adapter is DLOPEN'd and libcuda calls InitializeInjection
+// essentially the instant the mapping appears. A rendezvous gated on that
+// semaphore therefore ran on one path and not the other, and the gate only
+// covered the path where it worked.
+//
+// So this drives a producer .so loaded with dlopen(3) by a separate host
+// (shim/stub/dlopen_host.cc), which puts producer initialisation on the same
+// kernel path the CUDA adapter's is on. It is deliberately a second test
+// rather than a change to the first: both shapes have to keep working, and a
+// single test cannot be both.
+//
+// It also records the producer's own view of the semaphore at the moment it
+// enrolled (sem_at_enroll). That number is the measurement this whole episode
+// turned on, and logging it on every run means the next person does not have
+// to infer it.
+func TestADlopenedProducerEnrollsBeforeItsFirstLaunch(t *testing.T) {
+	if !hasGateCaps() {
+		t.Skip("needs CAP_BPF, CAP_PERFMON and CAP_CHECKPOINT_RESTORE; " +
+			"sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep <test binary>")
+	}
+	host := filepath.Join("..", "shim", "perfagent-gpu-dlopen-host")
+	producer := filepath.Join("..", "shim", "libperfagent-gpu-fpless.so")
+	requireBuilt(t, host)
+	requireBuilt(t, producer)
+	// The same build-time proof the exec gate takes: if the toolchain kept
+	// frame pointers in the bridge, the walk below never reaches an FP-less
+	// frame, never takes the DWARF path, and the assertion on it would pass
+	// while proving nothing.
+	requireFPLess(t, producer)
+
+	// Same inode-privacy reasoning as the exec gate: the attach is
+	// system-wide, so a shared image would also collect from any other
+	// process running it.
+	so := privateStubCopy(t, producer)
+
+	sym, err := symbolize.NewLocalSymbolizer()
+	require.NoError(t, err)
+	defer func() { _ = sym.Close() }()
+
+	timeline := gpu.NewTimeline(gpu.TimelineConfig{})
+	c, err := gpuprobe.Attach(gpuprobe.Config{
+		ShimPath:   so,
+		Backend:    gpu.GPUBackendID("stub"),
+		Sink:       timeline,
+		Symbolizer: sym,
+	})
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- c.Run(ctx) }()
+
+	// The host is started after Attach, so the .so is dlopened into a process
+	// that did not exist when the uprobe link was created - the CUDA ordering.
+	cmd := exec.Command(host, so, "500", "1000", "8", "10000")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	release, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+	defer func() { _ = release.Close() }()
+
+	// 58, not ceil(500/8)==63: since #50 the sampler jitters its stride, so
+	// 500 launches at period 8 yield 58 sampled, not 63. Cross-checked against
+	// internal/gpuabi.SampleSchedule(500, 8, DefaultSampleSeed), which replays
+	// the shim's schedule exactly. Left as an equality rather than a floor -
+	// the count is deterministic given the seed, and a floor would let a
+	// silently under-sampling shim pass.
+	const wantSampled = 58
+	deadline := time.Now().Add(10 * time.Second)
+	for c.Stats().SampledLaunches < wantSampled {
+		if time.Now().After(deadline) {
+			_ = release.Close()
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			cancel()
+			<-done
+			t.Fatalf("timed out waiting for %d sampled launches; consumer saw %d. stats: %+v stderr: %s",
+				wantSampled, c.Stats().SampledLaunches, c.Stats(), stderr.String())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.NoError(t, release.Close())
+	require.NoError(t, cmd.Wait(), "stdout: %s stderr: %s", stdout.String(), stderr.String())
+	producerErr := stderr.String()
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	<-done
+
+	stats := c.Stats()
+
+	// The measurement, logged whether the test passes or fails. sem_at_enroll
+	// is what the producer saw when it ran the rendezvous; if it reads 0 here
+	// while the run still confirms, that is direct evidence for why gating on
+	// the semaphore was wrong, on a machine with no GPU in it.
+	sem := regexp.MustCompile(`sem_at_enroll=(\d+) sem_at_exit=(\d+)`).FindStringSubmatch(producerErr)
+	if len(sem) == 3 {
+		t.Logf("producer semaphore: at_enroll=%s at_exit=%s (0 then non-zero means the "+
+			"kernel had not armed it when the rendezvous ran - the CUDA failure mode, reproduced without a GPU)",
+			sem[1], sem[2])
+	} else {
+		t.Logf("producer did not report semaphore counts; stderr: %s", producerErr)
+	}
+	t.Logf("walk shape: dwarf=%d fp-only=%d no-tables=%d profiler-only=%d cfi-miss=%d abandoned=%d registered=%d binaries=%d",
+		stats.StacksWalkedDWARF, stats.StacksWalkedFPOnly, stats.StacksWalkedNoTables,
+		stats.StacksProfilerOnly, stats.StacksWalkedCFIMiss, stats.StackWalkAbandoned,
+		stats.UnwindPIDsRegistered, stats.UnwindBinariesAttached)
+
+	assert.Zero(t, stats.SequenceGaps, "no batch may be lost silently")
+	assert.Equal(t, uint64(wantSampled), stats.SampledLaunches,
+		"ceil(500/8): the sampler is deterministic, and a dlopened producer samples exactly as an exec'd one does")
+
+	// ---- the assertions this test exists for -----------------------------
+	//
+	// The first of these is the one that was 0 on the RTX 3090 while the exec
+	// gate was green. It is asserted BEFORE the no-tables assertion on
+	// purpose: "the producer never even tried" and "it tried and the tables
+	// still were not there" are different failures, and a bare no-tables
+	// check reports them identically.
+	assert.True(t, stats.UnwindEnrollListening,
+		"the rendezvous address could not be bound, so this test cannot say anything about dlopen-time arming: %q",
+		stats.UnwindEnrollLastError)
+	assert.Equal(t, uint64(1), stats.UnwindEnrollRequests,
+		"the dlopened producer never reached the rendezvous. This is the exact CUDA failure: "+
+			"UnwindEnrollRequests was 0 on the RTX 3090 while the exec-driven gate passed. "+
+			"refused=%d throttled=%d err=%q producer stderr: %s",
+		stats.UnwindEnrollRefused, stats.UnwindEnrollThrottled, stats.UnwindEnrollLastError, producerErr)
+	assert.Equal(t, uint64(1), stats.UnwindEnrollConfirmed,
+		"the producer reached the rendezvous but was not told its tables were installed: failed=%d err=%q",
+		stats.UnwindEnrollFailed, stats.UnwindEnrollLastError)
+	assert.Contains(t, producerErr, "enroll=confirmed",
+		"the producer's own account disagrees with the consumer's; a producer that never reached the "+
+			"socket is invisible to every consumer-side counter, which is why both ends are checked")
+	assert.Zero(t, stats.StacksWalkedNoTables,
+		"a capture was walked with no CFI tables even though the producer waits for them before it "+
+			"launches anything. enroll: requests=%d confirmed=%d refused=%d failed=%d err=%q",
+		stats.UnwindEnrollRequests, stats.UnwindEnrollConfirmed, stats.UnwindEnrollRefused,
+		stats.UnwindEnrollFailed, stats.UnwindEnrollLastError)
+	assert.Zero(t, stats.StacksNoTablesAfterEnroll,
+		"the producer was released on a promise its tables were installed and a later walk found none")
+	assert.Zero(t, stats.UnwindEnrollRefused,
+		"the process the uprobes fired in was refused by the identity check: %q", stats.UnwindEnrollLastError)
+
+	// The tables have to be USED, not merely present.
+	//
+	// The first version of this test loaded libperfagent-gpu-stub.so, which is
+	// built with frame pointers throughout, and reported dwarf=0 fp-only=63
+	// with no-tables=0 - the rendezvous fired, the tables were installed, and
+	// not one walk ever needed them. That is legitimate for that producer
+	// (walk_step only sets WALKER_FLAG_DWARF_USED for a frame it classified
+	// FP_LESS) and it is also useless: it proves the rendezvous fired and
+	// nothing about the DWARF unwinding the rendezvous exists to feed.
+	//
+	// This producer puts two -fomit-frame-pointer frames between the probe and
+	// the host's main, which is where libcupti and libcudart sit in a real
+	// CUDA stack, so a walk that gets out of perfagent_stub_run's frame at all
+	// has to cross one. requireFPLess above fails the test if the toolchain
+	// did not actually omit them, so this cannot pass vacuously.
+	assert.Positive(t, stats.StacksWalkedDWARF,
+		"no capture used the DWARF path: the tables were installed before the first launch and then "+
+			"never needed, so this run proves nothing about unwinding a CUDA-shaped stack. fp-only=%d no-tables=%d",
+		stats.StacksWalkedFPOnly, stats.StacksWalkedNoTables)
+	assert.Equal(t, uint64(wantSampled), stats.StacksWalkedDWARF+stats.StacksWalkedFPOnly,
+		"every non-empty capture is counted exactly once as either a DWARF walk or an FP-only walk")
+
+	// StacksProfilerOnly is LOGGED above and deliberately not asserted.
+	//
+	// This producer is an ET_DYN with no DT_SONAME and no PT_INTERP, so
+	// shimScope classifies it as an injected library and the #39 guard IS
+	// armed - the same shape as the CUDA adapter, and unlike the exec gate
+	// where the guard disables itself. That makes the counter meaningful
+	// here, and it is why it is worth printing. But its value depends on the
+	// walk crossing out of the .so into the host executable, and while the
+	// FP-less bridge makes that the DWARF walker's job rather than the frame
+	// pointer chain's, this test has not derived the result and could not run
+	// it. Asserting an underived number is how a gate goes green while
+	// proving nothing, which is the failure this whole test exists to
+	// correct; the DWARF assertion above is the derived one.
 }

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -87,25 +87,72 @@ perfagent-gpu-fpless: stub/fpless_bridge.cc stub/fpless_main.cc stub/stub.cc $(C
 #   3. perfagent_stub_run must KEEP its frame pointer, since the walk's first
 #      step is an FP step out of its frame.
 .PHONY: check-fpless
-check-fpless: perfagent-gpu-fpless
-	@rc=0; for fn in perfagent_fpless_bridge perfagent_fpless_caller; do \
-	  objdump -d --no-show-raw-insn perfagent-gpu-fpless \
+check-fpless: perfagent-gpu-fpless libperfagent-gpu-fpless.so
+	@rc=0; for img in perfagent-gpu-fpless libperfagent-gpu-fpless.so; do \
+	 echo "== $$img"; \
+	 for fn in perfagent_fpless_bridge perfagent_fpless_caller; do \
+	  objdump -d --no-show-raw-insn $$img \
 	    | awk -v f="<$$fn>:" 'index($$0,f){g=1;next} g&&/^$$/{exit} g' > /tmp/fpless_$$fn.asm; \
-	  if [ ! -s /tmp/fpless_$$fn.asm ]; then echo "$$fn: not found in the binary"; rc=1; continue; fi; \
+	  if [ ! -s /tmp/fpless_$$fn.asm ]; then echo "$$img: $$fn: not found in the binary"; rc=1; continue; fi; \
 	  if grep -q 'mov  *%rsp,%rbp' /tmp/fpless_$$fn.asm; then \
 	    echo "$$fn: establishes a frame pointer; -fomit-frame-pointer did not take"; rc=1; fi; \
 	  if grep -qE ',%rbp|%rbp,|pop  *%rbp|push  *%rbp' /tmp/fpless_$$fn.asm; then \
 	    echo "$$fn: touches %rbp; the FP chain into perfagent_stub_run would be poisoned"; \
 	    grep -nE ',%rbp|%rbp,|%rbp' /tmp/fpless_$$fn.asm; rc=1; fi; \
-	  echo "$$fn: no frame pointer, %rbp untouched"; \
+	  echo "$$img: $$fn: no frame pointer, %rbp untouched"; \
+	 done; \
+	 objdump -d --no-show-raw-insn $$img \
+	   | awk 'index($$0,"<perfagent_stub_run>:"){g=1;next} g&&/^$$/{exit} g' | head -4 > /tmp/fpless_stubrun.asm; \
+	 grep -q 'mov  *%rsp,%rbp' /tmp/fpless_stubrun.asm || { \
+	   echo "$$img: perfagent_stub_run: no frame pointer; the walk's first FP step would fail"; rc=1; }; \
+	 readelf -S $$img | grep -q '\.eh_frame' || { \
+	   echo "$$img: no .eh_frame: the DWARF walker has nothing to read"; rc=1; }; \
 	done; \
-	objdump -d --no-show-raw-insn perfagent-gpu-fpless \
-	  | awk 'index($$0,"<perfagent_stub_run>:"){g=1;next} g&&/^$$/{exit} g' | head -4 > /tmp/fpless_stubrun.asm; \
-	grep -q 'mov  *%rsp,%rbp' /tmp/fpless_stubrun.asm || { \
-	  echo "perfagent_stub_run: no frame pointer; the walk's first FP step would fail"; rc=1; }; \
-	readelf -S perfagent-gpu-fpless | grep -q '\.eh_frame' || { \
-	  echo "no .eh_frame: the DWARF walker has nothing to read"; rc=1; }; \
 	[ $$rc -eq 0 ] && echo "check-fpless: OK"; exit $$rc
+
+# The CUDA shape without CUDA: a host that DLOPENS the producer .so instead of
+# being it. stub/dlopen_host.cc explains why the gate needs this as well as
+# perfagent-gpu-fpless -- an exec'd producer cannot exercise the kernel path on
+# which issue #49's first fix silently did nothing.
+#
+# -fno-omit-frame-pointer and -g on both halves: the walk has to cross from the
+# producer .so into the host executable for the #39 attribution guard to pass,
+# which is the same boundary the CUDA run crosses and the plain stub has no
+# equivalent of.
+# The producer .so the dlopen host loads, with FP-LESS frames between the probe
+# and the host's main -- the CUDA shape, and the reason this is a separate .so
+# from libperfagent-gpu-stub.so.
+#
+# The first version of the dlopen gate loaded libperfagent-gpu-stub.so, which is
+# built with frame pointers throughout, and reported dwarf=0 fp-only=63 with
+# no-tables=0: the tables were installed and NO walk ever needed them. That is
+# legitimate for that producer -- walk_step only sets WALKER_FLAG_DWARF_USED for
+# a frame it classified FP_LESS -- but it means the gate proved the rendezvous
+# fired and proved nothing about the DWARF unwinding the rendezvous exists to
+# feed. A real CUDA stack crosses libcupti and libcudart, which have no frame
+# pointers; this .so reproduces that with stub/fpless_bridge.cc.
+#
+#   host main                 frame pointer      <- the walk must reach here
+#   perfagent_fpless_caller   NO frame pointer      DWARF only
+#   perfagent_fpless_bridge   NO frame pointer      DWARF only
+#   perfagent_stub_run        frame pointer      <- the probe fires here
+#
+# check-fpless proves the toolchain actually omitted those frame pointers, for
+# this .so as well as for the executable.
+libperfagent-gpu-fpless.so: stub/fpless_bridge.cc stub/stub.cc $(CORE_SRC)
+	$(CXX) $(CXXFLAGS) -g -pthread -I core -fomit-frame-pointer \
+		-fasynchronous-unwind-tables -c stub/fpless_bridge.cc -o stub/so_fpless_bridge.o
+	$(CXX) $(CXXFLAGS) -g -pthread -I core -fno-omit-frame-pointer \
+		-fasynchronous-unwind-tables -DPERFAGENT_STUB_NO_MAIN \
+		-c stub/stub.cc -o stub/so_fpless_stub.o
+	$(CXX) $(CXXFLAGS) -g -pthread -fno-omit-frame-pointer -shared -o $@ \
+		stub/so_fpless_bridge.o stub/so_fpless_stub.o $(CORE_SRC)
+
+perfagent-gpu-dlopen-host: stub/dlopen_host.cc
+	$(CXX) $(CXXFLAGS) -g -fno-omit-frame-pointer -fasynchronous-unwind-tables \
+		-o $@ stub/dlopen_host.cc -ldl
+
+libperfagent-gpu-stub.so: CXXFLAGS += -g -fno-omit-frame-pointer -fasynchronous-unwind-tables
 
 # The CUPTI adapter. The CUDA driver dlopens this through CUDA_INJECTION64_PATH
 # into a process that links no CUPTI of its own, so the rpath is load-bearing:
@@ -162,5 +209,7 @@ test-tsan: core/batch_test.cc core/batch.cc core/batch.h core/sampler_test.cc co
 
 clean:
 	rm -f $(CORE_OBJ) libperfagent-gpu-core.a perfagent-gpu-stub libperfagent-gpu-stub.so \
+		perfagent-gpu-dlopen-host libperfagent-gpu-fpless.so \
+		stub/so_fpless_bridge.o stub/so_fpless_stub.o \
 		perfagent-gpu-fpless stub/fpless_bridge.o stub/fpless_main.o stub/fpless_stub.o \
 		libperfagent-gpu-nvidia.so nvidia/testdata/cuda_workload

--- a/shim/core/enroll.cc
+++ b/shim/core/enroll.cc
@@ -210,6 +210,13 @@ unsigned enroll_timeout_ms(unsigned dflt) {
     return (unsigned)n;
 }
 
+bool enroll_self_name(char *out, size_t outsz) {
+    // The address of THIS function: enroll.cc is linked into the shim, so the
+    // mapping containing it is the mapping the consumer's uprobes are on.
+    const void *self = (const void *)&enroll_self_name;
+    return enroll_name_from_maps("/proc/self/maps", (unsigned long)self, out, outsz);
+}
+
 EnrollResult enroll_with_consumer(unsigned timeout_ms) {
     if (timeout_ms == 0) return kEnrollDisabled;
     char name[sizeof(((struct sockaddr_un *)nullptr)->sun_path)];

--- a/shim/core/enroll.h
+++ b/shim/core/enroll.h
@@ -48,14 +48,40 @@
 //	'K'  tables are installed; go
 //	'X'  registration was refused or installed nothing; go anyway
 //
+// # Do NOT gate this on the probe semaphore
+//
+// The first version of this fix ran only under PERFAGENT_USDT_ENABLED, on the
+// reasoning that the semaphore says a consumer is attached. It does not. It
+// says the KERNEL HAS TOLD THIS PROCESS SO, which is a different fact with a
+// different arrival time, and the two diverge exactly where it matters.
+//
+// Measured on an RTX 3090: with the gate in place, UnwindEnrollRequests was 0
+// across three runs and the loss was unchanged (~175 of 500 sampled stacks
+// walked with no tables). The same build passed the GPU-free gate with
+// no-tables=0, because that producer is EXEC'd - the kernel arms the
+// semaphore while building the new mm, long before main runs. A CUDA adapter
+// is DLOPEN'd by libcuda and InitializeInjection is called essentially the
+// instant the mapping appears, which is the earliest moment the question can
+// be asked and the least likely moment for it to have been answered. The
+// probes fired perfectly later in those same runs - 4000 of them - so the
+// semaphore did arm; just not yet.
+//
+// The connect is the gate, and it is strictly better:
+//
+//   - It is authoritative. The consumer binds this address BEFORE it creates
+//     the uprobe link (gpuprobe/enroll.go), so it is listening whenever any
+//     profiling of this shim is happening - there is no window in which a
+//     consumer exists and the address does not.
+//   - It is already free. An abstract-socket connect to an unbound address
+//     fails immediately with ECONNREFUSED; the semaphore gate was never what
+//     made the unprofiled case cheap.
+//
 // # Every failure falls through to today's behaviour
 //
-// No consumer attached (the semaphore reads zero), nothing bound the
-// address, the connect failed, the reply never came: the producer proceeds
-// immediately and the consumer registers lazily on the first batch exactly
-// as before. A degraded profile is never turned into no profile, and an
-// unprofiled process pays nothing at all -- the caller checks its probe
-// semaphore before it ever gets here.
+// Nothing bound the address, the connect failed, the reply never came: the
+// producer proceeds immediately and the consumer registers lazily on the
+// first batch exactly as before. A degraded profile is never turned into no
+// profile.
 #ifndef PERFAGENT_ENROLL_H
 #define PERFAGENT_ENROLL_H
 
@@ -97,14 +123,22 @@ bool enroll_name_from_maps(const char *maps_path, unsigned long addr,
 // inside its own initialisation, so it is stated as one.
 EnrollResult enroll_connect(const char *name, unsigned timeout_ms);
 
+// Writes the rendezvous name this image derives for itself into `out`, without
+// connecting to anything. Exists so a producer can LOG the name it computed:
+// the two ends derive it independently and never exchange it, so when they
+// disagree every counter on both sides reads zero and nothing says why. One
+// CUDA run comparing this string against Stats.UnwindEnrollAddress settles
+// what a round trip of inference could not.
+bool enroll_self_name(char *out, size_t outsz);
+
 // The whole rendezvous for the image this function is linked into: derive
 // the name from our own mapping, connect, wait. `timeout_ms` of 0 disables
 // it outright.
 //
 // Blocks the calling thread for at most `timeout_ms` in total, signals
-// included. Call it only when a consumer is attached -- i.e. under the
-// sampled-launch probe's semaphore -- so a process nobody is profiling never
-// touches a socket.
+// included. Call it UNCONDITIONALLY at producer init - see "Do NOT gate this
+// on the probe semaphore" above. In an unprofiled process the whole call is
+// one /proc/self/maps read and a connect that is refused before it blocks.
 EnrollResult enroll_with_consumer(unsigned timeout_ms);
 
 // The rendezvous budget, from PERFAGENT_GPU_ENROLL_TIMEOUT_MS, or `dflt`

--- a/shim/core/usdt_probe.h
+++ b/shim/core/usdt_probe.h
@@ -44,6 +44,16 @@
 // True when a consumer is attached. Every emit path checks this first.
 #define PERFAGENT_USDT_ENABLED(name) (perfagent_##name##_semaphore != 0)
 
+// The raw semaphore count, for diagnosis rather than for control.
+//
+// "Is a consumer attached?" and "has the kernel got round to telling this
+// process so?" are different questions, and issue #49's first fix conflated
+// them: it gated the startup rendezvous on PERFAGENT_USDT_ENABLED, which on
+// the CUDA path read zero at InitializeInjection time even though the probes
+// fired perfectly later. Reading the count out lets a producer report when
+// the semaphore actually armed instead of anyone inferring it.
+#define PERFAGENT_USDT_SEMAPHORE_COUNT(name) ((unsigned)perfagent_##name##_semaphore)
+
 // The "memory" clobber is load-bearing, not defensive. `ptr` reaches the asm
 // as a plain integer in a register: an operand list without it says the asm
 // touches no memory at all, so the compiler may sink — or delete outright —
@@ -100,6 +110,9 @@
     static_assert(sizeof(struct name) == (wire_size),                       \
                   #name " record size is frozen; the BPF cookie assumes it");\
     static bool name##_enabled() { return PERFAGENT_USDT_ENABLED(name); }   \
+    __attribute__((unused)) static unsigned name##_semaphore_count() {      \
+        return PERFAGENT_USDT_SEMAPHORE_COUNT(name);                        \
+    }                                                                       \
     static void name##_emit(const struct name *ptr, unsigned long count,    \
                             unsigned long seq) {                            \
         PERFAGENT_USDT_PROBE3(name, ptr, count, seq);                       \

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -388,7 +388,7 @@ void report(const char *why) {
          "activity_kernels=%llu activity_other=%llu buffers=%llu buffer_alloc_failed=%llu "
          "exec_unattached=%llu exec_batch_dropped=%llu exec_no_clock=%llu "
          "exec_no_time=%llu cupti_dropped=%llu names=%zu "
-         "clock_steps=%llu clock_offset_ns=%lld\n",
+         "clock_steps=%llu clock_offset_ns=%lld sem_at_exit=%u\n",
          why, (int)getpid(),
          (unsigned long long)g_sampler->observed(),
          (unsigned long long)g_sampler->sampled(), g_sampler->period(),
@@ -405,7 +405,8 @@ void report(const char *why) {
          (unsigned long long)g_cupti_dropped.load(),
          g_names->size(),
          (unsigned long long)g_clock.steps(),
-         (long long)g_clock.offset_ns());
+         (long long)g_clock.offset_ns(),
+         gpu_launch_sampled_v1_semaphore_count());
     for (unsigned i = 0; i < kResourceCbidMax; i++) {
         const uint64_t n = g_resource_events[i].load();
         if (n) logf("perfagent-cupti: resource cbid=%u count=%llu\n", i,
@@ -510,13 +511,34 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
     // this process before it completes -- not even from another thread
     // already inside a CUDA call.
     //
-    // Only when a consumer is attached (the semaphore is what says so, and it
-    // was armed by the kernel when this library was mapped), bounded by
-    // PERFAGENT_GPU_ENROLL_TIMEOUT_MS, and never fatal: see core/enroll.h.
-    perfagent::EnrollResult enrolled = perfagent::kEnrollDisabled;
-    if (gpu_launch_sampled_v1_enabled()) {
-        enrolled = perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(2000));
-    }
+    // NOT gated on the probe semaphore, and that is the whole of issue #49's
+    // second fix. The first version ran the rendezvous only under
+    // gpu_launch_sampled_v1_enabled(), and on the RTX 3090 that read ZERO
+    // here - 500 launches were sampled and 4000 probes fired later in the
+    // same process, so the semaphore armed, just not by the time the driver
+    // called InitializeInjection. Measured: UnwindEnrollRequests was 0 across
+    // three runs and NoTables was unchanged at ~175/500.
+    //
+    // The semaphore answers "has the kernel told this process yet", not "is a
+    // consumer attached". Under CUDA_INJECTION64_PATH this function runs
+    // essentially the instant libcuda dlopens us, which is the earliest point
+    // that question can be asked and the least likely to be answered yet.
+    //
+    // The connect is the gate instead, and it is a better one: the consumer
+    // binds the rendezvous BEFORE it creates the uprobe link, so it is
+    // listening whenever profiling is happening, and an unbound abstract
+    // address refuses immediately in an unprofiled process. sem_at_init is
+    // recorded so the arming time stays visible rather than inferred.
+    const unsigned sem_at_init = gpu_launch_sampled_v1_semaphore_count();
+    // Logged BEFORE the attempt: the two ends derive this name independently
+    // and never exchange it, so when they disagree every counter on both sides
+    // reads zero and nothing says why. Compare it against
+    // Stats.UnwindEnrollAddress.
+    char enroll_name[128];
+    if (!perfagent::enroll_self_name(enroll_name, sizeof(enroll_name)))
+        snprintf(enroll_name, sizeof(enroll_name), "<no-address>");
+    perfagent::EnrollResult enrolled =
+        perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(2000));
 
     // Leaked on purpose, never deleted: CUPTI worker threads keep calling
     // buffer_completed during process teardown, and a destroyed Batch or
@@ -558,10 +580,15 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
     // the exact set of sampled launch ordinals is replayable offline
     // (internal/gpuabi.SampleSchedule). Without it a run using a non-default
     // seed could not be audited after the fact.
+    //
+    // sem_at_init vs sem_after_init is the measurement #49 needed: the first
+    // fix gated the rendezvous on the semaphore and lost the CUDA path.
     logf("perfagent-cupti: initialized pid=%d sample_period=%u sample_seed=0x%016llx "
-         "drain_ms=%u clock_offset_ns=%lld enroll=%s\n",
+         "drain_ms=%u clock_offset_ns=%lld enroll=%s sem_at_init=%u sem_after_init=%u "
+         "enroll_addr=@%s\n",
          (int)getpid(), g_sampler->period(),
          (unsigned long long)g_sampler->seed(), drain_ms, (long long)g_clock.offset_ns(),
-         perfagent::enroll_result_name(enrolled));
+         perfagent::enroll_result_name(enrolled), sem_at_init,
+         gpu_launch_sampled_v1_semaphore_count(), enroll_name);
     return 1;
 }

--- a/shim/stub/dlopen_host.cc
+++ b/shim/stub/dlopen_host.cc
@@ -1,0 +1,127 @@
+// The CUDA shape without CUDA: a producer .so loaded with dlopen(3).
+//
+// # Why this exists
+//
+// Issue #49's first fix passed the GPU-free gate with no-tables=0 and then
+// did nothing at all on the RTX 3090 - UnwindEnrollRequests was 0 across
+// three runs. The gate could not see it because the two paths differ in the
+// one respect that mattered:
+//
+//   perfagent-gpu-fpless   EXEC'd.    The kernel arms the probe semaphores
+//                                     while it builds the new mm, so by the
+//                                     time main runs they read non-zero.
+//   the CUPTI adapter      DLOPEN'd.  libcuda maps it and calls
+//                                     InitializeInjection essentially at
+//                                     once, and the semaphore had not armed
+//                                     yet - so a rendezvous gated on it never
+//                                     ran, while the probes fired fine later.
+//
+// A gate driven only by an exec'd producer cannot tell those apart, which is
+// how a mechanism that does nothing under CUDA went green. This host closes
+// that hole: it exec's, then dlopens libperfagent-gpu-stub.so and calls into
+// it, so the producer's initialisation happens on the SAME kernel path the
+// CUDA adapter's does.
+//
+// It deliberately does NOT link the .so at load time. A DT_NEEDED dependency
+// is mapped by the loader before main, which is the exec path again wearing a
+// different hat.
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+
+#include <dlfcn.h>
+#include <poll.h>
+#include <unistd.h>
+
+namespace {
+
+uint64_t mono_ns() {
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return (uint64_t)t.tv_sec * 1000000000ULL + (uint64_t)t.tv_nsec;
+}
+
+// The same release contract as perfagent_stub_linger and the CUDA workload:
+// a sampled launch's stack is symbolized against THIS process's
+// /proc/<pid>/maps, which the kernel destroys the instant it exits, so the
+// consumer holds us open by keeping our stdin open. Reimplemented here rather
+// than dlsym'd because perfagent_stub_linger is hidden in the .so build.
+void linger(unsigned linger_ms) {
+    if (!linger_ms) return;
+    struct pollfd p{};
+    p.fd = STDIN_FILENO;
+    p.events = POLLIN;
+    const uint64_t deadline = mono_ns() + (uint64_t)linger_ms * 1000000ULL;
+    for (;;) {
+        const uint64_t now = mono_ns();
+        if (now >= deadline) return;
+        const int left = (int)((deadline - now) / 1000000ULL) + 1;
+        const int rc = poll(&p, 1, left);
+        if (rc < 0) {
+            if (errno == EINTR) continue;
+            return;
+        }
+        if (rc == 0) return;
+        char buf[256];
+        if (read(STDIN_FILENO, buf, sizeof(buf)) <= 0) return;
+    }
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <producer.so> [launches] [period_us] [sample_period] [linger_ms]\n",
+                argv[0]);
+        return 2;
+    }
+    const char *so = argv[1];
+    const unsigned n = argc > 2 ? (unsigned)atoi(argv[2]) : 500;
+    const unsigned us = argc > 3 ? (unsigned)atoi(argv[3]) : 1000;
+    const unsigned sp = argc > 4 ? (unsigned)atoi(argv[4]) : 8;
+    const unsigned lm = argc > 5 ? (unsigned)atoi(argv[5]) : 0;
+
+    // RTLD_NOW so relocation happens here rather than lazily inside the first
+    // call, keeping this as close to the driver's own dlopen as possible.
+    void *h = dlopen(so, RTLD_NOW | RTLD_LOCAL);
+    if (!h) {
+        fprintf(stderr, "dlopen-host: dlopen %s: %s\n", so, dlerror());
+        return 3;
+    }
+    // The one symbol the producer .so exports, same as the adapter's
+    // InitializeInjection. Called immediately after the mapping appears,
+    // which is the timing the rendezvous has to survive.
+    // perfagent_fpless_caller first: it reaches perfagent_stub_run through two
+    // frames compiled -fomit-frame-pointer, so the stack between the probe and
+    // this executable's main can only be walked with CFI - the CUDA shape,
+    // where libcupti and libcudart sit in exactly that position. Falling back
+    // to the plain entry point keeps this host usable with
+    // libperfagent-gpu-stub.so, whose chain has frame pointers throughout and
+    // therefore exercises no DWARF at all.
+    using fpless_fn = unsigned long (*)(unsigned, unsigned, unsigned);
+    using run_fn = void (*)(unsigned, unsigned, unsigned);
+    auto fpless = (fpless_fn)dlsym(h, "perfagent_fpless_caller");
+    auto run = (run_fn)dlsym(h, "perfagent_stub_run");
+    if (!fpless && !run) {
+        fprintf(stderr, "dlopen-host: no entry point in %s: %s\n", so, dlerror());
+        return 4;
+    }
+    fprintf(stderr, "dlopen-host: loaded %s pid=%d entry=%s\n", so, (int)getpid(),
+            fpless ? "perfagent_fpless_caller" : "perfagent_stub_run");
+    if (fpless) {
+        // The result is used, not discarded: a discarded value would let the
+        // optimizer prove the post-call work in the bridge chain is dead and
+        // restore the sibling calls those locals exist to prevent.
+        const unsigned long sink = fpless(n, us, sp);
+        if (sink == 0) fprintf(stderr, "dlopen-host: bridge returned 0\n");
+    } else {
+        run(n, us, sp);
+    }
+    linger(lm);
+    // Not dlclose(): unmapping the producer would take its probes out from
+    // under a consumer that is still draining, and the real adapter is never
+    // unloaded either.
+    return 0;
+}

--- a/shim/stub/stub.cc
+++ b/shim/stub/stub.cc
@@ -49,14 +49,22 @@ static uint64_t mono_ns() {
 extern "C" __attribute__((visibility("default"))) void
 perfagent_stub_run(unsigned launches, unsigned period_us, unsigned sample_period) {
     // The #49 startup rendezvous, before the first launch and therefore
-    // before the first probe: wait for the consumer to install this
-    // process's CFI tables, so the kernel-side walk of every sampled launch
-    // has them. Only when a consumer is actually attached -- the semaphore
-    // is what says so -- and never fatal: see core/enroll.h.
-    perfagent::EnrollResult enrolled = perfagent::kEnrollDisabled;
-    if (gpu_launch_sampled_v1_enabled()) {
-        enrolled = perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(2000));
-    }
+    // before the first probe: wait for the consumer to install this process's
+    // CFI tables, so the kernel-side walk of every sampled launch has them.
+    //
+    // NOT gated on the probe semaphore. See core/enroll.h: the semaphore
+    // answers "has the kernel told this process a consumer is attached yet",
+    // which is a different question from "is one attached", and on the CUDA
+    // path the two differ at exactly this moment. The connect is the gate -
+    // an unbound abstract address refuses immediately.
+    const unsigned sem_at_enroll = gpu_launch_sampled_v1_semaphore_count();
+    // See the adapter: the name is logged so a disagreement between the two
+    // ends is one string comparison rather than a round trip of inference.
+    char enroll_name[128];
+    if (!perfagent::enroll_self_name(enroll_name, sizeof(enroll_name)))
+        snprintf(enroll_name, sizeof(enroll_name), "<no-address>");
+    perfagent::EnrollResult enrolled =
+        perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(2000));
 
     perfagent::Batch<gpu_launch_v1, 32> lb(gpu_launch_v1_emit, gpu_launch_v1_enabled);
     perfagent::Batch<gpu_exec_v1, 32> eb(gpu_exec_v1_emit, gpu_exec_v1_enabled);
@@ -138,13 +146,20 @@ perfagent_stub_run(unsigned launches, unsigned period_us, unsigned sample_period
     // is a deterministic chain from (seed, period), so this line is what makes
     // the exact sampled= count above reproducible and auditable offline
     // (internal/gpuabi.SampleSchedule replays it).
+    //
+    // sem_at_enroll vs sem_at_exit is the measurement issue #49's first fix
+    // needed and did not have: 0 then non-zero means the semaphore had not
+    // armed when the rendezvous ran, which is why gating on it lost the CUDA
+    // path entirely.
     fprintf(stderr, "stub: launches=%u observed=%llu sampled=%llu period=%u seed=0x%016llx "
-                    "launch_dropped=%llu exec_dropped=%llu enroll=%s\n",
+                    "launch_dropped=%llu exec_dropped=%llu enroll=%s "
+                    "sem_at_enroll=%u sem_at_exit=%u enroll_addr=@%s\n",
             launches, (unsigned long long)sampler.observed(),
             (unsigned long long)sampler.sampled(), sampler.period(),
             (unsigned long long)sampler.seed(),
             (unsigned long long)lb.dropped(), (unsigned long long)eb.dropped(),
-            perfagent::enroll_result_name(enrolled));
+            perfagent::enroll_result_name(enrolled),
+            sem_at_enroll, gpu_launch_sampled_v1_semaphore_count(), enroll_name);
 }
 
 // linger keeps this process alive after its records are flushed, until the


### PR DESCRIPTION
**This is the tail of #49 that never reached PR #58.** That branch was amended twice after it was pushed, the amendments were never force-pushed, and #58 merged a commit two revisions behind the one validated on the RTX 3090. The live run showing `DWARF:500 / NoTables:0` was real, but it tested code that was not in the PR. `main` today reports `enroll=no-listener` and ~200 NoTables.

### The defect

The consumer built the abstract-socket name from `stat(2)`'s `st_dev`; the producer read the device field of `/proc/self/maps`. On btrfs these differ for the same file, by design — `btrfs_getattr` reports the **subvolume's** `anon_dev`, `show_map_vma` prints the **filesystem's** `s_dev`:

```
/tmp/file      (tmpfs)  stat=0:48  maps=0:48   agree
<repo>/shim/…  (btrfs)  stat=0:49  maps=0:34   MISMATCH
/bin/true      (btrfs)  stat=0:36  maps=0:34   MISMATCH
```

So the consumer bound `v1.0.49.<ino>` and the producer dialled `v1.0.34.<ino>`. Everything else worked. Both sides now derive from `/proc/self/maps`, symmetric by construction. `procMapsHaveInode` had the identical bug one step later and would have refused every genuine producer had they ever met.

### Why every gate was green

**All of them put their fixture in `t.TempDir()` — tmpfs, the one filesystem where the two numbers agree** — including the cross-language test written specifically to prove both ends compute the same name. They now use the source filesystem and compare the derived strings directly instead of inferring from a `no-listener` result. A `dlopen`-loaded producer gate is added, because the existing gate `exec`s and could not see this class of bug at all.

### Instrumentation, so a third miss is one comparison

`sem_at_init`/`sem_at_enroll` on the producer and `Stats.UnwindEnrollAddress` on the consumer. The first live attempt reported `UnwindEnrollRequests: 0` (never tried); the second `enroll=no-listener` with `sem_at_init=1`, which killed the semaphore-timing hypothesis and localised it to address derivation. Without those counters each run would have been an indistinguishable "still ~187 NoTables".

### Rebased over #50

Two log lines conflicted where #49 and #50 each appended fields; resolved as unions, so `seed=`/`sample_seed=` and `enroll=`/`sem_*`/`enroll_addr=` all survive.

The `dlopen` gate's `wantSampled` moves 63 → **58**: it runs 500 launches at period 8, and since #50 the jittered stride yields 58, cross-checked against `internal/gpuabi.SampleSchedule(500, 8, DefaultSampleSeed)`. Left as an equality rather than a floor — the count is deterministic given the seed, and a floor would let a silently under-sampling shim pass.

### Verification

Shim builds (all artefacts, not just the default target), shim tests, `go build`, `go vet`, all package tests, `golangci-lint` 0 issues. **The gates skip without capabilities and the live re-run is outstanding** — it must show `enroll=confirmed`, `UnwindEnrollRequests=1`, `NoTables=0`, and DWARF equal to the sampled count.