### PR TITLE
test: assert PMU context-switch values, not the presence of their labels

### DIFF
--- a/.superpowers/sdd/issue-63-report.md
+++ b/.superpowers/sdd/issue-63-report.md
@@ -1,0 +1,253 @@
+# Issue #63 — `TestPMUIOWorkload` asserted only that some context switch happened
+
+Branch: `fix/pmu-io-value-assertions`. Scope: `test/` only — `metrics/console.go`, the
+collector and the BPF programs are untouched.
+
+## The defect, restated
+
+`TestPMUIOWorkloadHasIOWait` asked:
+
+```go
+hasIOActivity := strings.Contains(outputStr, "I/O Wait (D state):") ||
+    strings.Contains(outputStr, "Voluntary (sleep/mutex):")
+```
+
+`metrics/console.go:88-99` prints all three reason lines inside one `if totalSwitches > 0`
+guard, so both strings appear together or not at all. The `||` therefore could not
+distinguish the two branches, and the effective assertion was **"at least one context
+switch of any kind was recorded"**. A collector that filed every blocked `read` under
+*Preempted* and classified zero I/O wait passed a test named for I/O accounting.
+
+`TestPMUCPUWorkloadMostlyRunning` asserted `Contains(out, "Preempted (running):")` — the
+same line, from the same guard. Same defect, mirrored: a collector that filed every switch
+as *Voluntary* passed a test named for a workload that never voluntarily yields.
+
+## What was built
+
+### 1. `test/pmu_output.go` (new) — a strict parser for the block
+
+`parseContextSwitchReasons(out string) (contextSwitchCounts, error)` reads the counts off
+the lines that already carry them:
+
+```
+Context Switch Reasons:
+  Preempted (running):     19.3%  (812 times)
+  Voluntary (sleep/mutex): 45.3%  (1904 times)
+  I/O Wait (D state):      35.3%  (1483 times)
+```
+
+- Handles both emitters: `printSinglePIDMetrics` (`Context Switch Reasons:`) and
+  `printAggregateMetrics` (`Context Switch Reasons (aggregate):`, `console.go:160-168`).
+- Sums across every block in the output, so `--per-pid` system-wide reports (one block per
+  process) aggregate correctly. `Blocks` records how many were summed.
+- Requires the three labels, in `console.go`'s order, with the percentage **and** the count
+  present. The percentage is parsed but not aggregated — parsing it is what makes a change
+  to that half of the line a loud failure rather than a silent one. Summed percentages
+  would be meaningless, so `Percent()` recomputes shares from the totals for diagnostics.
+- `contextSwitchCounts.Blocking() = Voluntary + IOWait`, per the issue: which bucket a file
+  operation lands in depends on the filesystem and page-cache state, so requiring `IOWait`
+  alone would make the test a property of the runner's storage stack rather than of the
+  collector.
+
+### 2. `test/pmu_output.go` — `collectPMUContextSwitches`, the collect-until wrapper
+
+One `perf-agent --pmu --pid N --duration 5s` run per attempt, looping until the report is
+**judgeable**, bounded by `collectBudgetFor(5s)` = 15s (4 attempts max, per
+`collect_until.go`'s own `maxAttempts = budget/window + 1`).
+
+The loop condition is `counts.Total() >= ctxSwitchJudgeableFloor` (20) — a *data
+sufficiency* precondition, deliberately **not** the property either caller asserts:
+
+- It is satisfied by a report in which all 20+ switches were filed under the *wrong*
+  reason. That is exactly the regression the assertions must still be able to report, so
+  the loop cannot retry a genuine failure into a pass.
+- Neither `Blocking() > 0` nor `Preempted > 0` is implied by it; the loop exits on the
+  first attempt that has data, and then the assertion decides.
+
+Floor of 20 mirrors `degenerateSampleFloor` in `collect_until.go`: a verdict on *how*
+switches were classified is meaningless when there were two of them. Both Go workloads
+produce switches in the hundreds-to-thousands per 5s window (the Go runtime's sysmon thread
+alone parks ~100×/s), so 20 is a "did the collection see the target at all" bar, not a
+performance expectation.
+
+Three outcomes are kept distinct:
+
+| condition | handling |
+|---|---|
+| agent exited non-zero | `t.Fatalf` immediately, with the output |
+| block present but unparseable (`errContextSwitchFormat`) | `t.Fatalf` immediately, quoting the parse error and the full output, pointing at `test/pmu_output.go` — **no fallback** |
+| no block at all (`errNoContextSwitchBlock`), or fewer than 20 switches | unsatisfied attempt → retried; fatal at the deadline with the last output attached |
+
+### 3. The two rewritten tests
+
+`TestPMUIOWorkloadHasIOWait` (name kept — it is referenced in `issue-42-report.md`):
+
+```go
+counts, output := collectPMUContextSwitches(t, agentPath, workload, wl.Name,
+    "--pmu", "--pid", pid)
+assert.Positive(t, counts.Blocking(), ...)
+```
+
+`TestPMUCPUWorkloadMostlyRunning`:
+
+```go
+assert.Positive(t, counts.Preempted, ...)
+assert.Less(t, counts.Percent(counts.IOWait), 50.0, ...)
+```
+
+## What each new assertion catches that the old one did not
+
+| assertion | catches |
+|---|---|
+| `counts.Blocking() > 0` (I/O test) | every switch of an I/O-bound workload filed as *Preempted* — D-state and S-state classification both lost. The old `\|\|` passed on this output; `TestParseContextSwitchReasonsSeesTheRegression` pins that the parser reports `Blocking() == 0` for it while both labels are still printed. |
+| `counts.Preempted > 0` (CPU test) | every switch of a spinning workload filed as *Voluntary* or *I/O Wait* — the mirror loss. Pinned by `TestParseContextSwitchReasonsSeesZeroPreempted`. |
+| `IOWait share < 50%` (CPU test) | a collector that files the majority of a compute-only workload's switches as uninterruptible I/O wait, i.e. D-state over-attribution rather than under-attribution. Nothing in the suite tested that direction. |
+| `Total() >= 20` reached within the budget | a run that records essentially nothing now fails with a diagnostic naming the condition and the last output, instead of silently satisfying a substring check. |
+| the parse succeeding at all | any drift in `console.go`'s line format. Previously a renamed label would have turned the `\|\|` false and produced "output had neither line" plus a raw dump; now the failure says *which* line, at *which* line number, what shape was expected and what was read. |
+
+Nothing was weakened. Every old check is implied by the new preconditions: `Total() >= 20`
+implies `totalSwitches > 0`, which implies `console.go` printed all three labels, which is
+all the old `Contains` calls verified.
+
+The one behavioural change worth flagging explicitly: a run that records between 1 and 19
+context switches used to **pass** the I/O test and now **fails** it at the deadline. That
+is a deliberate tightening, not an accident — a distribution over fewer than 20 switches
+cannot support the claim either test makes — and such a run is far outside anything the Go
+workloads produce (the io_bound workload does ~10 write/fsync/read cycles per second per
+thread across 2 threads; the cpu_bound workload's runtime threads alone clear the floor).
+
+## Verdict on `TestPMUCPUWorkloadMostlyRunning`
+
+**It had the same defect and is fixed.** `assert.Contains(outputStr, "Preempted (running):")`
+tests the presence of a line printed under the shared `totalSwitches > 0` guard, so it is
+the same "some context switch happened" assertion wearing the opposite name.
+
+Two judgement calls in the fix:
+
+1. **The workload is now deliberately oversubscribed**: `2 × runtime.NumCPU()` spinning
+   goroutines *with `GOMAXPROCS` raised to match*, via `cmd.Env`. Raising the goroutine
+   count alone would not have worked — Go would still run only `GOMAXPROCS` OS threads and
+   multiplex the goroutines in user space, producing no extra *kernel* preemption. Without
+   oversubscription, `Preempted > 0` is a coin flip on the machine: on an idle many-core
+   box, 4 spinning threads can each own a CPU and never be preempted in a 5s window (CFS
+   does not preempt a task that is alone on its runqueue), which would have made the fix
+   flaky exactly where the constraint says not to be. With every CPU carrying ≥2 runnable
+   threads, preemption is a property of the run, not of the runner.
+   (`exec.Cmd` dedups `Env` keeping the last occurrence, so appending `GOMAXPROCS=` after
+   `os.Environ()` overrides an inherited value.)
+
+2. **Preemption being the *majority* is deliberately not asserted**, despite the test's
+   name. The Go runtime's sysmon thread parks and wakes ~100×/s and every park is a
+   voluntary switch, so the majority reason for a spinning Go program is a property of the
+   runtime's bookkeeping threads, not of the workload. Asserting a majority would be
+   asserting a Go-runtime implementation detail; `Preempted > 0` plus "I/O wait is not the
+   dominant reason" are the two claims the workload actually licenses. Both are recorded in
+   the test's doc comment.
+
+## Parser failure behaviour (real output, captured on this machine)
+
+Fixtures rendered by driving the real `metrics.ConsoleExporter`, then mutated:
+
+```
+[count renamed]  -> could not parse the counts from this output: line 15 should be the
+   "Preempted (running)" line of a "Context Switch Reasons:" block, formatted like
+   "  Preempted (running):      37.2%  (1483 times)", but reads
+   "  Preempted (running):     19.3%  (812 switches)"
+
+[label reworded] -> could not parse the counts from this output: line 17 of the
+   "Context Switch Reasons:" block is labelled "IO Wait (D-state)", expected
+   "I/O Wait (D state)" (console.go prints the three reasons in a fixed order)
+
+[truncated]      -> could not parse the counts from this output: line 16 should be the
+   "Voluntary (sleep/mutex)" line of a "Context Switch Reasons:" block, formatted like
+   "  Voluntary (sleep/mutex):      37.2%  (1483 times)", but reads "(truncated)"
+
+[no block]       -> the output contains no "Context Switch Reasons" block
+```
+
+The first three wrap `errContextSwitchFormat` → the test dies immediately with the full
+output and a pointer to the parser. The fourth is `errNoContextSwitchBlock` → retried, then
+fatal at the deadline. The two are never conflated, and there is no path on which a parse
+failure degrades into a substring check.
+
+Successful parse renders as:
+
+```
+context switches: total=4199 preempted=812 (19.3%) voluntary=1904 (45.3%) io_wait=1483 (35.3%) [1 block(s)]
+```
+
+quoted by every collect-until attempt log and by every assertion failure message.
+
+## `test/pmu_output_test.go` (new, unprivileged)
+
+The happy-path fixtures are **not** hand-written strings: they are produced by driving
+`metrics.ConsoleExporter` over a constructed `MetricsSnapshot`, which makes this a contract
+test between the parser and the emitter. If `console.go`'s format drifts, it fails here, on
+an unprivileged machine, rather than as an unexplained integration failure on a runner.
+
+Coverage: single-PID block; `(aggregate)` variant; `--per-pid` multi-block summing;
+all-preempted output (the regression the old test missed); zero-preempted output (the
+mirror); block omitted for zero switches; `No PMU metrics collected`; the string
+diagnostic and its divide-by-zero guard; and seven format mutations (count field renamed,
+count dropped, percentage dropped, label reworded, reasons reordered, report truncated
+after the header, block truncated mid-way) each required to wrap `errContextSwitchFormat`.
+
+Each mutation is guarded by an `m.out == good` check, so a mutation that no longer applies
+(because the format moved) fails rather than passing vacuously.
+
+## Control-flow walk (by hand)
+
+`collectPMUContextSwitches`:
+
+- `collectUntil` computes `maxAttempts = 15s/5s + 1 = 4`; the `for n := 1; n <= maxAttempts`
+  loop is bounded independently of the clock, so an attempt that returns instantly cannot
+  spin. **Terminates.**
+- Every attempt runs one `--duration 5s` agent invocation, so an attempt cannot return
+  faster than the window except on a hard failure, which is `t.Fatalf` (immediate exit via
+  `runtime.Goexit`; the closure runs synchronously on the test goroutine).
+- `requireWorkloadAlive` fires first on every attempt, so a workload that outlived its
+  duration is reported as such rather than blamed on the profiler. `workloadRuntime` is
+  150s against a worst case of budget + one window = 20s.
+- Exit paths: satisfied → return counts; deadline or shared-retry starvation → `t.Fatalf`
+  with the report and the last output. There is no path that returns "ok" without a parsed
+  block, and none that returns zeroed counts as a success.
+- **Cannot pass vacuously**: the only success return carries counts from a successfully
+  parsed report with `Total() >= 20`, and the assertions afterwards read fields of those
+  counts. An empty/absent block never reaches the assertion; a mis-classified block does,
+  and fails.
+
+## Verification
+
+Run on this machine:
+
+```
+go build ./... && go vet ./...                    # clean
+cd test && go vet -tags integration ./...          # clean
+        && go test -c -tags integration -o /dev/null ./...   # compiles
+~/go/bin/golangci-lint run --timeout=5m            # root module: 0 issues
+go test -run 'TestParseContextSwitchReasons|TestContextSwitchCountsString' -v ./...
+```
+
+All parser tests pass (9 top-level, 7 subtests). The harness tests in
+`collect_until_test.go` still pass. `golangci-lint` inside `test/` reports 25 findings, all
+of them pre-existing `errcheck`/`staticcheck` hits at `integration_test.go` lines 93–1617,
+none inside the rewritten region (lines 873–980) and none in the new files.
+
+## Cannot verify
+
+**Nothing in the integration suite was executed.** This session has `CapEff: 0` and is not
+root, so `requireBPFRunnable` would skip every PMU test and no BPF program could be loaded.
+Specifically **not** verified by execution:
+
+- that `TestPMUIOWorkloadHasIOWait` and `TestPMUCPUWorkloadMostlyRunning` pass against a
+  real agent run — including whether the real `perf-agent --pmu` output parses (only
+  `metrics.ConsoleExporter`'s output, rendered in-process, was parsed; that is the same
+  code path, but not the same process, and any wrapper text the CLI adds around it was not
+  observed);
+- the empirical context-switch counts either workload produces in a 5s window, and so the
+  real headroom above the floor of 20;
+- that the `GOMAXPROCS` oversubscription does in fact drive `Preempted > 0` on a real
+  runner — the argument for it is mechanical (≥2 runnable threads per CPU forces CFS
+  preemption) but unmeasured here;
+- the wall-clock cost of the added retries (worst case +15s per test, bounded by the
+  package-wide `suiteRetryBudget`, which these two loops now also draw on).

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -870,6 +870,23 @@ func TestPMUTaskStateClassification(t *testing.T) {
 	assert.Contains(t, outputStr, "times)")
 }
 
+// TestPMUIOWorkloadHasIOWait asserts that an I/O-bound workload's
+// context switches were CLASSIFIED as blocking — not merely that some
+// context switch happened.
+//
+// The previous version asked whether the output contained
+// "I/O Wait (D state):" or "Voluntary (sleep/mutex):". metrics/console.go
+// prints all three reason lines inside one `if totalSwitches > 0` guard,
+// so those two strings appear together or not at all: the `||` could not
+// distinguish them, and the real assertion was "at least one context
+// switch of any kind was recorded". A collector that filed every blocked
+// read under "Preempted" and classified zero I/O wait passed it — which
+// is the regression a test with this name exists to catch (issue #63).
+//
+// Now the counts are read off those lines and the assertion is on the
+// values. The sum of voluntary + I/O wait is used rather than I/O wait
+// alone: see contextSwitchCounts.Blocking for why the split between them
+// is a property of the filesystem, not of the collector.
 func TestPMUIOWorkloadHasIOWait(t *testing.T) {
 	requireBPFRunnable(t, getAgentPath(t))
 
@@ -888,48 +905,52 @@ func TestPMUIOWorkloadHasIOWait(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	// Run perf-agent with PMU
-	agent := exec.Command(agentPath,
-		"--pmu",
-		"--pid", fmt.Sprintf("%d", workload.Process.Pid),
-		"--duration", "5s",
-	)
+	counts, output := collectPMUContextSwitches(t, agentPath, workload, wl.Name,
+		"--pmu", "--pid", fmt.Sprintf("%d", workload.Process.Pid))
+	t.Logf("%s", counts)
 
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
-	}
-
-	outputStr := string(output)
-
-	// An I/O workload should show I/O wait or voluntary sleep; file
-	// operations cause both.
-	//
-	// strings.Contains, not assert.Contains: assert.Contains records a
-	// failure on t as a side effect and returns a bool, so writing this as
-	// `if assert.Contains(...) || assert.Contains(...)` marked the test
-	// failed on the first branch before the second was ever considered -
-	// the || read as a tolerance but never tolerated anything, and a
-	// genuine miss recorded three failures for one condition.
-	//
-	// Note this is a weaker check than it appears: metrics/console.go
-	// prints both lines inside one `if totalSwitches > 0` block, so they
-	// appear together or not at all. What it really asserts is that some
-	// context switch was recorded. See issue #63.
-	hasIOActivity := strings.Contains(outputStr, "I/O Wait (D state):") ||
-		strings.Contains(outputStr, "Voluntary (sleep/mutex):")
-	assert.True(t, hasIOActivity,
-		"I/O workload should report I/O wait or voluntary sleep; output had neither line:\n%s", outputStr)
+	assert.Positive(t, counts.Blocking(),
+		"an I/O-bound workload must record context switches classified as blocking "+
+			"(voluntary sleep, or D-state I/O wait), but all %d of its switches were filed "+
+			"as preemption — task-state classification is broken.\n%s\nOutput:\n%s",
+		counts.Total(), counts, output)
 }
 
+// TestPMUCPUWorkloadMostlyRunning is the mirror of the test above, and
+// had the same defect: it asserted `Contains(out, "Preempted (running):")`,
+// a line console.go prints whenever ANY switch was recorded, so a
+// collector that filed every switch as voluntary sleep passed a test
+// named for a workload that never voluntarily yields.
+//
+// It now asserts on the counts: at least one switch classified as
+// preemption, and I/O wait not the dominant reason for a workload that
+// touches no files after start-up.
+//
+// The workload is deliberately oversubscribed — see below — so that
+// "was preempted at least once in 5 seconds" is true by construction of
+// the run rather than by luck of the runner's core count.
+//
+// What is deliberately NOT asserted is that preemption is the MAJORITY.
+// The Go runtime's sysmon thread parks and wakes on the order of 100
+// times a second and each park is a voluntary switch, so the majority
+// reason for a spinning Go program is a property of the runtime's
+// bookkeeping threads, not of the workload.
 func TestPMUCPUWorkloadMostlyRunning(t *testing.T) {
 	requireBPFRunnable(t, getAgentPath(t))
 
 	agentPath := getAgentPath(t)
-	wl := workloads[0] // Go CPU workload
 
-	// Start CPU-bound workload
-	workload := exec.Command(wl.Binary, wl.Args...)
+	// Oversubscribe: 2x NumCPU spinning goroutines AND GOMAXPROCS raised
+	// to match, so they become that many runnable OS threads rather than
+	// NumCPU threads multiplexing them in user space. Goroutines alone
+	// would not do it — Go would still run only GOMAXPROCS threads, and
+	// on an idle many-core machine each could sit on its own CPU and
+	// never be preempted for the whole window, which is exactly how
+	// "assert Preempted > 0" would otherwise become flaky.
+	threads := 2 * runtime.NumCPU()
+	workload := exec.Command("./workloads/go/cpu_bound",
+		workloadRuntimeFlag, fmt.Sprintf("-threads=%d", threads))
+	workload.Env = append(os.Environ(), fmt.Sprintf("GOMAXPROCS=%d", threads))
 	require.NoError(t, workload.Start())
 	defer func() {
 		if workload.Process != nil {
@@ -940,24 +961,21 @@ func TestPMUCPUWorkloadMostlyRunning(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	// Run perf-agent with PMU
-	agent := exec.Command(agentPath,
-		"--pmu",
-		"--pid", fmt.Sprintf("%d", workload.Process.Pid),
-		"--duration", "5s",
-	)
+	counts, output := collectPMUContextSwitches(t, agentPath, workload, "go/cpu_bound",
+		"--pmu", "--pid", fmt.Sprintf("%d", workload.Process.Pid))
+	t.Logf("%s (%d spinning threads on %d CPUs)", counts, threads, runtime.NumCPU())
 
-	output, err := agent.CombinedOutput()
-	if err != nil {
-		t.Fatalf("perf-agent failed: %v\nOutput: %s", err, string(output))
-	}
+	assert.Positive(t, counts.Preempted,
+		"a CPU-bound workload oversubscribing every CPU (%d threads on %d CPUs) must record "+
+			"switches classified as preemption, but none of its %d switches were — "+
+			"task-state classification is broken.\n%s\nOutput:\n%s",
+		threads, runtime.NumCPU(), counts.Total(), counts, output)
 
-	outputStr := string(output)
-	t.Logf("Output:\n%s", outputStr)
-
-	// CPU-bound workload should show preempted switches
-	// (it gets preempted because it never voluntarily yields)
-	assert.Contains(t, outputStr, "Preempted (running):")
+	assert.Less(t, counts.Percent(counts.IOWait), 50.0,
+		"a CPU-bound workload that touches no files after start-up should not spend most of "+
+			"its context switches in uninterruptible I/O wait; %d of %d switches were classified "+
+			"as D state.\n%s\nOutput:\n%s",
+		counts.IOWait, counts.Total(), counts, output)
 }
 
 func TestSystemWidePMUWithNewMetrics(t *testing.T) {

--- a/test/pmu_output.go
+++ b/test/pmu_output.go
@@ -1,0 +1,307 @@
+package test
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------
+// Parsing the PMU "Context Switch Reasons" block (issue #63)
+// ---------------------------------------------------------------------
+//
+// The PMU integration tests used to assert on the PRESENCE of the
+// context-switch labels:
+//
+//	strings.Contains(out, "I/O Wait (D state):") ||
+//	strings.Contains(out, "Voluntary (sleep/mutex):")
+//
+// metrics/console.go prints all three of those lines inside a single
+// `if totalSwitches > 0` guard, so they appear together or not at all:
+// the `||` could not distinguish them, and what the assertion actually
+// verified was "at least one context switch of any kind was recorded".
+// A collector that attributed every blocked read to preemption and
+// classified zero I/O wait passed it — the exact regression the test
+// exists to catch.
+//
+// The counts are right there on the same lines:
+//
+//	  I/O Wait (D state):      37.2%  (1483 times)
+//
+// so this parser lifts them out and lets the tests assert on the
+// VALUES. Presence of the label becomes a precondition, not a verdict.
+//
+// The parser is deliberately strict and loud. If metrics/console.go
+// changes the line shape, every caller must fail with "could not parse
+// the counts from this output" and the output attached — never fall
+// back to a substring check that would pass by accident. That silent
+// fallback is what this whole file exists to remove, so it must not be
+// reintroduced in the parser's own error path.
+
+var (
+	// errNoContextSwitchBlock reports that the output carries no
+	// "Context Switch Reasons" section at all.
+	//
+	// This is NOT a format failure: metrics/console.go omits the whole
+	// block when the collection recorded zero context switches for the
+	// target, and it prints "No PMU metrics collected" when no process
+	// was seen. Both are data-sufficiency misses — the collection
+	// caught nothing to classify — so callers retry them under a
+	// deadline rather than failing immediately.
+	errNoContextSwitchBlock = errors.New(`the output contains no "Context Switch Reasons" block`)
+
+	// errContextSwitchFormat reports that a block WAS found but did not
+	// have the shape metrics/console.go emits. Callers must treat this
+	// as fatal: the counts this suite asserts on are unreadable, and
+	// no weaker check may stand in for them.
+	errContextSwitchFormat = errors.New("could not parse the counts from this output")
+)
+
+var (
+	// Matches both variants printSinglePIDMetrics and
+	// printAggregateMetrics emit ("Context Switch Reasons:" and
+	// "Context Switch Reasons (aggregate):"). Neither is indented.
+	ctxSwitchHeaderRe = regexp.MustCompile(`^Context Switch Reasons(?: \(aggregate\))?:$`)
+
+	// Matches one classification line, e.g.
+	//   "  I/O Wait (D state):      37.2%  (1483 times)"
+	// Capturing the label, the percentage and the count means a change
+	// to ANY part of the line shape — including the percentage this
+	// parser does not aggregate — surfaces as a format error rather
+	// than as a silently missing count.
+	ctxSwitchLineRe = regexp.MustCompile(`^\s+(\S.*\S):\s+(\d+(?:\.\d+)?)%\s+\((\d+) times\)$`)
+)
+
+// ctxSwitchLabels are the three lines metrics/console.go prints under
+// the header, in the order it prints them. The order is part of the
+// contract this parser checks: a reordering is a format change.
+var ctxSwitchLabels = [3]string{
+	"Preempted (running)",
+	"Voluntary (sleep/mutex)",
+	"I/O Wait (D state)",
+}
+
+// ctxSwitchJudgeableFloor is the number of classified context switches
+// below which the classification distribution is too thin to judge.
+//
+// Same role as degenerateSampleFloor in collect_until.go, and the same
+// reasoning: a verdict on how switches were classified means nothing
+// when there were two of them. A 5s window on either of the Go test
+// workloads records switches in the hundreds or thousands — the Go
+// runtime's sysmon thread alone parks and wakes on the order of 100
+// times a second — so this floor is a "did the collection see the
+// target at all" bar, not a performance expectation.
+//
+// It is a PRECONDITION for the collect-until loops, never the property
+// under test: "at least 20 switches were classified somehow" is
+// satisfied by a collector that files all 20 under the wrong reason,
+// which is precisely the failure the assertions must still be able to
+// report. See the loop-condition invariants in collect_until.go.
+const ctxSwitchJudgeableFloor = 20
+
+// contextSwitchCounts holds the counts parsed out of every "Context
+// Switch Reasons" block in one PMU report.
+//
+// Counts are summed across blocks: --per-pid system-wide output prints
+// one block per process, and "did this run classify any I/O wait" is a
+// question about the run, not about a particular block. Percentages are
+// deliberately NOT carried over — averaging or summing per-block
+// percentages is meaningless, and Percent() recomputes them from the
+// totals when a diagnostic needs them.
+type contextSwitchCounts struct {
+	Preempted uint64
+	Voluntary uint64
+	IOWait    uint64
+
+	// Blocks is how many "Context Switch Reasons" blocks were summed.
+	Blocks int
+}
+
+// Total is every classified switch.
+func (c contextSwitchCounts) Total() uint64 { return c.Preempted + c.Voluntary + c.IOWait }
+
+// Blocking is the switches where the task gave up the CPU because it
+// could not proceed: a voluntary sleep (S) or an uninterruptible I/O
+// wait (D).
+//
+// The tests assert on the SUM rather than on IOWait alone because which
+// of the two a file operation lands in depends on the filesystem and
+// the page-cache state: a write that hits page cache parks the task in
+// S, the fsync behind it blocks in D, and a re-read served from cache
+// blocks in neither. Requiring IOWait specifically would make the test
+// a property of the runner's storage stack. Requiring the sum keeps it
+// a property of the collector: an I/O-bound workload must show that it
+// blocked, somewhere.
+func (c contextSwitchCounts) Blocking() uint64 { return c.Voluntary + c.IOWait }
+
+// Percent renders n as a share of Total, matching console.go's own
+// one-decimal formatting. Returns 0 for an empty total.
+func (c contextSwitchCounts) Percent(n uint64) float64 {
+	total := c.Total()
+	if total == 0 {
+		return 0
+	}
+	return float64(n) / float64(total) * 100
+}
+
+// String is the one-line diagnostic quoted by the collect-until loops
+// and by the assertion failures.
+func (c contextSwitchCounts) String() string {
+	return fmt.Sprintf(
+		"context switches: total=%d preempted=%d (%.1f%%) voluntary=%d (%.1f%%) io_wait=%d (%.1f%%) [%d block(s)]",
+		c.Total(),
+		c.Preempted, c.Percent(c.Preempted),
+		c.Voluntary, c.Percent(c.Voluntary),
+		c.IOWait, c.Percent(c.IOWait),
+		c.Blocks)
+}
+
+// parseContextSwitchReasons extracts the context-switch counts from a
+// perf-agent --pmu report.
+//
+// Every block in the output is parsed and the counts summed. The three
+// classification lines must follow the header in console.go's order
+// with console.go's exact labels; anything else is a format error
+// wrapping errContextSwitchFormat. An output with no block at all
+// returns errNoContextSwitchBlock, which is a different condition
+// entirely — see the sentinel's doc comment.
+func parseContextSwitchReasons(out string) (contextSwitchCounts, error) {
+	var c contextSwitchCounts
+	dst := [3]*uint64{&c.Preempted, &c.Voluntary, &c.IOWait}
+
+	lines := strings.Split(out, "\n")
+	for i := 0; i < len(lines); i++ {
+		if !ctxSwitchHeaderRe.MatchString(strings.TrimRight(lines[i], "\r")) {
+			continue
+		}
+		header := i
+		for k, label := range ctxSwitchLabels {
+			i++
+			if i >= len(lines) {
+				return c, fmt.Errorf(
+					"%w: the %q block at line %d ends after %d of its %d classification lines "+
+						"(expected %q); the report is truncated or console.go's format changed",
+					errContextSwitchFormat, lines[header], header+1, k, len(ctxSwitchLabels), label)
+			}
+			line := strings.TrimRight(lines[i], "\r")
+			m := ctxSwitchLineRe.FindStringSubmatch(line)
+			if m == nil {
+				return c, fmt.Errorf(
+					"%w: line %d should be the %q line of a %q block, formatted like "+
+						`"  %s:      37.2%%  (1483 times)", but reads %q`,
+					errContextSwitchFormat, i+1, label, lines[header], label, line)
+			}
+			if m[1] != label {
+				return c, fmt.Errorf(
+					"%w: line %d of the %q block is labelled %q, expected %q "+
+						"(console.go prints the three reasons in a fixed order)",
+					errContextSwitchFormat, i+1, lines[header], m[1], label)
+			}
+			// The percentage is not aggregated, but it must still be a
+			// number: parsing it is how a change to that half of the
+			// line becomes a loud failure instead of a silent one.
+			if _, err := strconv.ParseFloat(m[2], 64); err != nil {
+				return c, fmt.Errorf("%w: line %d of the %q block has an unreadable percentage %q: %w",
+					errContextSwitchFormat, i+1, lines[header], m[2], err)
+			}
+			n, err := strconv.ParseUint(m[3], 10, 64)
+			if err != nil {
+				return c, fmt.Errorf("%w: line %d of the %q block has an unreadable count %q: %w",
+					errContextSwitchFormat, i+1, lines[header], m[3], err)
+			}
+			*dst[k] += n
+		}
+		c.Blocks++
+	}
+
+	if c.Blocks == 0 {
+		return c, errNoContextSwitchBlock
+	}
+	return c, nil
+}
+
+// pmuContextSwitchWindow is how long a single --pmu collection runs for
+// in the context-switch tests. Unchanged from the fixed 5s window these
+// tests used before; what changed is that a window catching too little
+// is now retried rather than asserted on.
+const pmuContextSwitchWindow = 5 * time.Second
+
+// collectPMUContextSwitches runs `perf-agent --pmu ...` against a live
+// workload until the report carries enough classified context switches
+// to judge how they were classified, and returns the parsed counts
+// together with the output they came from.
+//
+// The loop condition is `Total() >= ctxSwitchJudgeableFloor` — a
+// DATA-SUFFICIENCY precondition, not the property any caller asserts.
+// Both callers go on to make a claim about the SHAPE of the
+// distribution (an I/O workload must show blocking switches; a
+// CPU-bound one must show preemption), and a run in which every switch
+// landed in the wrong bucket satisfies this condition on the first
+// attempt and then fails the caller's assertion. That is the invariant
+// collect_until.go's header sets out, and getting it backwards here
+// would retry a real regression into a pass.
+//
+// The three outcomes are kept distinct on purpose:
+//
+//   - the agent itself failed            -> fatal, immediately
+//   - console.go's format is unreadable  -> fatal, immediately, quoting
+//     the output (never a fallback to a weaker check)
+//   - no block / too few switches        -> retried, and fatal at the
+//     deadline with the last output attached
+func collectPMUContextSwitches(
+	t *testing.T,
+	agentPath string,
+	workload *exec.Cmd,
+	name string,
+	agentArgs ...string,
+) (contextSwitchCounts, string) {
+	t.Helper()
+
+	args := append(append([]string{}, agentArgs...), "--duration", pmuContextSwitchWindow.String())
+	var (
+		counts contextSwitchCounts
+		last   string
+	)
+
+	ok, report := collectUntil(t,
+		fmt.Sprintf("a PMU report classifying at least %d context switches", ctxSwitchJudgeableFloor),
+		pmuContextSwitchWindow, collectBudgetFor(pmuContextSwitchWindow),
+		func(int) (bool, string) {
+			requireWorkloadAlive(t, workload, name)
+
+			out, err := exec.Command(agentPath, args...).CombinedOutput()
+			last = string(out)
+			if err != nil {
+				t.Fatalf("perf-agent %v failed: %v\nOutput: %s", args, err, last)
+			}
+
+			c, perr := parseContextSwitchReasons(last)
+			if perr != nil {
+				if errors.Is(perr, errNoContextSwitchBlock) {
+					// console.go omits the block when it classified
+					// nothing at all: the window caught the target
+					// doing nothing, or the target was never seen.
+					counts = contextSwitchCounts{}
+					return false, perr.Error()
+				}
+				t.Fatalf("%v\n\nThis test asserts on the counts inside metrics/console.go's "+
+					"\"Context Switch Reasons\" lines. The format no longer matches, so the "+
+					"counts cannot be read — update the parser in test/pmu_output.go. There is "+
+					"deliberately no weaker fallback: substring checks on these labels are what "+
+					"issue #63 removed.\nFull output:\n%s", perr, last)
+			}
+
+			counts = c
+			return c.Total() >= ctxSwitchJudgeableFloor, c.String()
+		})
+	if !ok {
+		t.Fatalf("%s\nLast output:\n%s", report, last)
+	}
+
+	return counts, last
+}

--- a/test/pmu_output_test.go
+++ b/test/pmu_output_test.go
@@ -1,0 +1,292 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dpsoft/perf-agent/metrics"
+)
+
+// These tests cover the "Context Switch Reasons" parser (issue #63).
+// They load no BPF and spawn no workload, so they run without root or
+// capabilities.
+//
+// The fixtures for the happy paths are not hand-written strings: they
+// are produced by driving metrics.ConsoleExporter — the very code whose
+// output the integration tests parse. That makes this a contract test
+// between the two. If console.go's format drifts, these fail here, on
+// an unprivileged machine, instead of surfacing as an unexplained
+// integration failure on a runner.
+
+// renderPMUReport runs the real console exporter over a snapshot and
+// returns exactly what perf-agent --pmu would print.
+func renderPMUReport(t *testing.T, systemWide, perPID bool, procs ...*metrics.ProcessMetrics) string {
+	t.Helper()
+	snap := metrics.NewMetricsSnapshot(systemWide)
+	for _, p := range procs {
+		snap.Processes[p.PID] = p
+	}
+	var buf bytes.Buffer
+	exp := metrics.NewConsoleExporter(perPID)
+	exp.Writer = &buf
+	if err := exp.Export(context.Background(), snap); err != nil {
+		t.Fatalf("console exporter failed: %v", err)
+	}
+	return buf.String()
+}
+
+func procWithSwitches(pid uint32, preempted, voluntary, ioWait uint64) *metrics.ProcessMetrics {
+	return &metrics.ProcessMetrics{
+		PID:         pid,
+		SampleCount: 1000,
+		ContextSwitches: metrics.ContextSwitchStats{
+			PreemptedCount: preempted,
+			VoluntaryCount: voluntary,
+			IOWaitCount:    ioWait,
+		},
+	}
+}
+
+func TestParseContextSwitchReasonsSinglePID(t *testing.T) {
+	out := renderPMUReport(t, false, false, procWithSwitches(4242, 812, 1904, 1483))
+	if !strings.Contains(out, "I/O Wait (D state):") {
+		t.Fatalf("fixture does not look like a PMU report:\n%s", out)
+	}
+
+	c, err := parseContextSwitchReasons(out)
+	if err != nil {
+		t.Fatalf("parse failed on real console output: %v\n%s", err, out)
+	}
+	if c.Blocks != 1 {
+		t.Errorf("Blocks = %d, want 1", c.Blocks)
+	}
+	if c.Preempted != 812 || c.Voluntary != 1904 || c.IOWait != 1483 {
+		t.Errorf("got %+v, want preempted=812 voluntary=1904 io_wait=1483", c)
+	}
+	if got, want := c.Total(), uint64(812+1904+1483); got != want {
+		t.Errorf("Total() = %d, want %d", got, want)
+	}
+	if got, want := c.Blocking(), uint64(1904+1483); got != want {
+		t.Errorf("Blocking() = %d, want %d", got, want)
+	}
+}
+
+func TestParseContextSwitchReasonsAggregate(t *testing.T) {
+	// System-wide without --per-pid: one "(aggregate)" block summing
+	// every process.
+	out := renderPMUReport(t, true, false,
+		procWithSwitches(1, 10, 20, 30),
+		procWithSwitches(2, 1, 2, 3),
+	)
+	if !strings.Contains(out, "Context Switch Reasons (aggregate):") {
+		t.Fatalf("fixture is not the aggregate variant:\n%s", out)
+	}
+
+	c, err := parseContextSwitchReasons(out)
+	if err != nil {
+		t.Fatalf("parse failed on aggregate output: %v\n%s", err, out)
+	}
+	if c.Blocks != 1 {
+		t.Errorf("Blocks = %d, want 1 (the aggregate prints a single block)", c.Blocks)
+	}
+	if c.Preempted != 11 || c.Voluntary != 22 || c.IOWait != 33 {
+		t.Errorf("got %+v, want preempted=11 voluntary=22 io_wait=33", c)
+	}
+}
+
+func TestParseContextSwitchReasonsSumsPerPIDBlocks(t *testing.T) {
+	// System-wide --per-pid prints one block per process; the counts
+	// are summed so "did this run classify any blocking" stays a
+	// question about the run.
+	out := renderPMUReport(t, true, true,
+		procWithSwitches(1, 10, 20, 30),
+		procWithSwitches(2, 1, 2, 3),
+	)
+
+	c, err := parseContextSwitchReasons(out)
+	if err != nil {
+		t.Fatalf("parse failed on per-pid output: %v\n%s", err, out)
+	}
+	if c.Blocks != 2 {
+		t.Errorf("Blocks = %d, want 2", c.Blocks)
+	}
+	if c.Preempted != 11 || c.Voluntary != 22 || c.IOWait != 33 {
+		t.Errorf("got %+v, want preempted=11 voluntary=22 io_wait=33", c)
+	}
+}
+
+// TestParseContextSwitchReasonsSeesTheRegression is the point of the
+// whole exercise: output in which every switch was filed as
+// "Preempted" — a collector that lost D-state classification entirely —
+// parses fine and reports Blocking() == 0. The old substring assertion
+// passed on this output.
+func TestParseContextSwitchReasonsSeesTheRegression(t *testing.T) {
+	out := renderPMUReport(t, false, false, procWithSwitches(7, 5000, 0, 0))
+
+	if !strings.Contains(out, "I/O Wait (D state):") || !strings.Contains(out, "Voluntary (sleep/mutex):") {
+		t.Fatalf("both labels should still be printed - that is the defect:\n%s", out)
+	}
+
+	c, err := parseContextSwitchReasons(out)
+	if err != nil {
+		t.Fatalf("parse failed: %v\n%s", err, out)
+	}
+	if c.Blocking() != 0 {
+		t.Errorf("Blocking() = %d, want 0 for an all-preempted report", c.Blocking())
+	}
+	if c.Total() != 5000 {
+		t.Errorf("Total() = %d, want 5000", c.Total())
+	}
+}
+
+// The mirror case, for TestPMUCPUWorkloadMostlyRunning: everything
+// filed as voluntary, nothing preempted.
+func TestParseContextSwitchReasonsSeesZeroPreempted(t *testing.T) {
+	out := renderPMUReport(t, false, false, procWithSwitches(7, 0, 3000, 12))
+
+	c, err := parseContextSwitchReasons(out)
+	if err != nil {
+		t.Fatalf("parse failed: %v\n%s", err, out)
+	}
+	if c.Preempted != 0 {
+		t.Errorf("Preempted = %d, want 0", c.Preempted)
+	}
+	if c.Total() != 3012 {
+		t.Errorf("Total() = %d, want 3012", c.Total())
+	}
+}
+
+func TestParseContextSwitchReasonsNoBlock(t *testing.T) {
+	// console.go omits the whole block when nothing was classified.
+	out := renderPMUReport(t, false, false, procWithSwitches(7, 0, 0, 0))
+	if strings.Contains(out, "Context Switch Reasons") {
+		t.Fatalf("expected console.go to omit the block for zero switches:\n%s", out)
+	}
+
+	c, err := parseContextSwitchReasons(out)
+	if !errors.Is(err, errNoContextSwitchBlock) {
+		t.Fatalf("err = %v, want errNoContextSwitchBlock", err)
+	}
+	if errors.Is(err, errContextSwitchFormat) {
+		t.Error("a missing block must NOT be reported as a format error: the two are retried differently")
+	}
+	if c.Total() != 0 {
+		t.Errorf("Total() = %d, want 0", c.Total())
+	}
+}
+
+func TestParseContextSwitchReasonsNoMetricsAtAll(t *testing.T) {
+	out := renderPMUReport(t, false, false)
+	if !strings.Contains(out, "No PMU metrics collected") {
+		t.Fatalf("expected the empty-snapshot message:\n%s", out)
+	}
+	if _, err := parseContextSwitchReasons(out); !errors.Is(err, errNoContextSwitchBlock) {
+		t.Fatalf("err = %v, want errNoContextSwitchBlock", err)
+	}
+}
+
+// Every mutation below is a plausible edit to metrics/console.go's
+// format. Each must produce a format error naming the line, never a
+// silent zero and never a bare "no block".
+func TestParseContextSwitchReasonsFormatChangesFailLoudly(t *testing.T) {
+	const (
+		preempted = uint64(812)
+		voluntary = uint64(1904)
+		ioWait    = uint64(1483)
+		total     = preempted + voluntary + ioWait
+	)
+	good := renderPMUReport(t, false, false, procWithSwitches(9, preempted, voluntary, ioWait))
+
+	preemptedLine := ctxLine(0, preempted, total)
+	voluntaryLine := ctxLine(1, voluntary, total)
+	ioWaitLine := ctxLine(2, ioWait, total)
+
+	mutations := []struct {
+		name string
+		out  string
+	}{
+		{
+			name: "count field renamed",
+			out:  strings.ReplaceAll(good, " times)", " switches)"),
+		},
+		{
+			name: "count dropped",
+			out:  strings.Replace(good, ioWaitLine, "  I/O Wait (D state):      35.3%", 1),
+		},
+		{
+			name: "percentage dropped",
+			out:  strings.Replace(good, ioWaitLine, "  I/O Wait (D state):      (1483 times)", 1),
+		},
+		{
+			name: "label reworded",
+			out:  strings.Replace(good, "I/O Wait (D state):", "IO Wait (D-state):", 1),
+		},
+		{
+			name: "reasons reordered",
+			out: strings.Replace(good,
+				preemptedLine+"\n"+voluntaryLine,
+				voluntaryLine+"\n"+preemptedLine, 1),
+		},
+		{
+			name: "report truncated after the header",
+			out:  good[:strings.Index(good, "Context Switch Reasons:")+len("Context Switch Reasons:\n")],
+		},
+		{
+			name: "block truncated mid-way",
+			out:  good[:strings.Index(good, voluntaryLine)] + "(output truncated)\n",
+		},
+	}
+
+	for _, m := range mutations {
+		t.Run(m.name, func(t *testing.T) {
+			if m.out == good {
+				t.Fatalf("mutation %q did not change the fixture; the format it targets moved:\n%s", m.name, good)
+			}
+			c, err := parseContextSwitchReasons(m.out)
+			if err == nil {
+				t.Fatalf("parse SUCCEEDED on mutated output (%+v) - a format change must fail loudly:\n%s", c, m.out)
+			}
+			if !errors.Is(err, errContextSwitchFormat) {
+				t.Fatalf("err = %v, want it to wrap errContextSwitchFormat (got a retryable "+
+					"no-block error instead, which would be waited on rather than reported)", err)
+			}
+			if !strings.Contains(err.Error(), "could not parse the counts from this output") {
+				t.Errorf("error text does not name the failure: %v", err)
+			}
+		})
+	}
+}
+
+// ctxLineFormats mirror the three Fprintf formats in
+// metrics/console.go, so the mutation fixtures above can target a real
+// line without hard-coding a percentage. If console.go's spacing
+// changes these no longer match, the Replace becomes a no-op, and the
+// `m.out == good` guard in the test above turns that into a failure
+// rather than a vacuous pass.
+var ctxLineFormats = [3]string{
+	"  Preempted (running):     %.1f%%  (%d times)",
+	"  Voluntary (sleep/mutex): %.1f%%  (%d times)",
+	"  I/O Wait (D state):      %.1f%%  (%d times)",
+}
+
+func ctxLine(k int, n, total uint64) string {
+	return fmt.Sprintf(ctxLineFormats[k], float64(n)/float64(total)*100, n)
+}
+
+func TestContextSwitchCountsString(t *testing.T) {
+	c := contextSwitchCounts{Preempted: 1, Voluntary: 2, IOWait: 1, Blocks: 1}
+	s := c.String()
+	for _, want := range []string{"total=4", "preempted=1", "voluntary=2", "io_wait=1", "25.0%", "50.0%"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("String() = %q, missing %q", s, want)
+		}
+	}
+	// An empty total must not divide by zero.
+	if got := (contextSwitchCounts{}).Percent(0); got != 0 {
+		t.Errorf("Percent on empty counts = %v, want 0", got)
+	}
+}


### PR DESCRIPTION
Closes #63.

`metrics/console.go:88-99` prints all three context-switch lines inside one `if totalSwitches > 0` guard, so they appear together or not at all. Both PMU tests keyed on `Contains(output, "<label>:")`, which meant each verified only that **at least one context switch of any kind was recorded** — close to unfalsifiable for a 5-second workload.

A profiler that reported every blocked read as `Preempted` and zero I/O wait passed `TestPMUIOWorkload`. The test is named for I/O and reads as though it checks I/O accounting; it checked no count, no percentage, and no classification.

`TestPMUCPUWorkloadMostlyRunning` had the identical defect — same shared guard, opposite claim. The issue flagged it as a suspect; it is one, and it is fixed here too.

### What replaces it

`test/pmu_output.go`: a strict parser for the block, plus `collectPMUContextSwitches`, a collect-until wrapper around one `--pmu --duration 5s` run per attempt.

- `TestPMUIOWorkloadHasIOWait` asserts `Voluntary + IOWait > 0` — a **sum**, deliberately, since which one a file operation lands in depends on filesystem and page-cache state. That variability is presumably why the original `||` was written.
- `TestPMUCPUWorkloadMostlyRunning` asserts `Preempted > 0` and `IOWait share < 50%`.

Both emitters are handled (per-PID and `(aggregate)`), summing across blocks so `--per-pid` output aggregates. The percentage is parsed but not aggregated — parsing it is what makes drift in that half of the line loud.

### The precondition is sufficiency, not the property

Following the harness rule from #42: the loop condition is `Total() >= 20`, which is satisfied by a report that files all 20 switches under the **wrong** reason. So a real regression exits the loop on attempt 1 and fails the assertion, rather than being retried into a pass. Neither asserted property is implied by the precondition.

Three outcomes stay distinct: agent failure is fatal; a block present but unparseable is fatal immediately, quoting line number, expected shape, actual text and full output, with no fallback to a weaker check; a block absent or too few switches is retried and fatal at the deadline.

### Tests that need no privilege

`test/pmu_output_test.go` builds its happy-path fixtures by driving the real `metrics.ConsoleExporter`, so it is a contract test between parser and emitter rather than a copy of the format that can drift from it. It covers the all-preempted regression (which the old test passed), the zero-preempted mirror, block omission, `No PMU metrics collected`, and seven format mutations each required to wrap `errContextSwitchFormat`.

### Two judgement calls

The CPU workload is now oversubscribed at `2 × NumCPU` goroutines **with `GOMAXPROCS` raised to match** — goroutines alone would not add kernel preemption. On an idle many-core box four spinning threads can each own a CPU and never be preempted within 5 s, which would have made `Preempted > 0` flaky.

Preemption being the *majority* reason is deliberately **not** asserted: Go's sysmon parks threads ~100×/s, so the majority reason is a runtime bookkeeping detail rather than a property of the workload.

### One deliberate tightening

A run recording 1–19 context switches used to pass the I/O test and now fails at the deadline. Everything the old checks caught is implied by the new precondition.

**Not verified:** `CapEff: 0` here, so nothing in the integration suite ran — no BPF, no real agent output parsed, and the `GOMAXPROCS` preemption argument is mechanical but unmeasured. CI does run this suite, so it will be exercised there.