### PR TITLE
gpu: refuse a heuristic join that would cross processes

### DIFF
--- a/.superpowers/sdd/issue-52-report.md
+++ b/.superpowers/sdd/issue-52-report.md
@@ -1,0 +1,315 @@
+# Issue #52 — the heuristic GPU join path was process-blind, guarded only by shim contract
+
+Branch `fix/heuristic-process-guard`, worktree `.worktrees/heuristic-guard`, cut from
+`origin/main` (`a044264b`). One commit. Not pushed, no PR.
+
+---
+
+## 1. The finding that decided the design
+
+The issue says:
+
+> It also cannot be fixed the way #36 fixed the exact path: the heuristic runs
+> precisely when there is no correlation, and after #36 the correlation is the only
+> place an execution's process identity lives. There is no pid to group by. Closing it
+> needs a pid field on `GPUKernelExec` itself — which no current producer would write.
+
+**That premise is wrong, and the tree already contained the proof.**
+
+`CorrelationID` is `{Backend, PID, Value}`, and `Present()` is:
+
+```go
+func (c CorrelationID) Present() bool { return c.Value != "" }
+```
+
+`PID` and `Value` are independent. A record can name its process and carry no vendor
+correlation. That is not a hypothetical shape — `gpu/crossprocess_test.go`'s
+`TestCorrelationCarryingOnlyAProcessIsNotPresent` (added by #36) constructs exactly it,
+`CorrelationID{Backend: BackendLinuxDRM, PID: 4242}`, and asserts it takes the
+heuristic path. And `gpu/projection.go`'s `labelPID` already *reads* it, falling back
+to `view.Exec.Correlation.PID` for an execution with no launch.
+
+So the pid option 2 wanted on `GPUKernelExec` was already there, on the correlation,
+where #36 put it. Option 2's semantics were available at option 1's cost, and that is
+what I built.
+
+## 2. Option chosen
+
+**Option 2, realised without the event-type change #36 avoided.** The heuristic join is
+process-qualified end to end:
+
+- `candidateGroupKey` gains a `pid`, so a launch is only a candidate for an execution
+  in the same process.
+- `Timeline.Snapshot` refuses the heuristic outright when `exec.Correlation.PID == 0`.
+  An execution that names neither a correlation nor a process cannot be shown to share
+  one with any launch, so it is not joined at all.
+- The launch's side of the pid is `launchProcessID(l)` — `LaunchContext.PID`, falling
+  back to `Correlation.PID`. Two fields exist and producers populate them
+  independently; `gpuprobe` sets both from the batch header.
+
+A refused execution is **not dropped**. It degrades to unattributed: its measured GPU
+time stays in the profile under `FrameLaunchUnsampled`, carrying no CPU stack, no
+`pod_uid` and no `container_id`, and lands in `UnmatchedExecutionCount` like any other
+miss. Two new counters say why.
+
+A heuristic join that *does* happen is still labelled and counted as a guess —
+`gpu_join="heuristic"`, `HeuristicExecutionJoinCount`, `Ambiguous` — unchanged. The
+guard narrows *which* guesses are permitted; it never promotes one.
+
+### What I rejected, and why
+
+**Option 1 as written (reject or count-and-drop at the consumer boundary).** Rejected
+in its dropping form. The parent asked directly whether count-and-drop is honest
+enough; it is not. An execution is a *measurement* — a real kernel that really ran for
+a real duration. Dropping it removes GPU time from the profile, which is a worse lie
+than removing its stack: the profile would under-report total GPU time with nothing in
+the output to say so. Count-and-degrade-to-unattributed is the honest form, and that is
+what the timeline now does by construction. The degradation lives in `Timeline`, not in
+`gpuprobe`, because `gpuprobe` has no way to express "emit this but do not guess at
+it" — the join decision is the timeline's, so the guard belongs there. Option 1 also
+only ever covers one producer; a guard in `Timeline` covers every producer, including
+the ones that do not exist yet, which is the entire premise of the issue.
+
+**Option 1's counting half I did keep**, in a narrower form — see §4.
+
+**Option 3 (restrict candidates when `Config.PID != 0`).** Rejected as redundant and as
+the wrong shape. Redundant: with the pid in the group key, single-process mode is
+already the case where every candidate is in the exec's own process, so option 3's
+safety falls out for free — and it falls out for *system-wide* profiling too, which
+option 3 explicitly could not do. Wrong shape: `gpu/` has no access to the agent's mode
+and `projection.go` documents a deliberate decision not to grow one ("This package has
+no access to the agent's mode and should not grow one for this"). Plumbing `Config.PID`
+into `TimelineConfig` to buy a subset of what the group key already buys is cost with
+no return.
+
+**Changing `gpuprobe.correlationOf` to preserve the pid on a zero wire correlation.**
+Tempting — it would let a contract-violating `gpuprobe` exec still join correctly
+within its own process instead of degrading. Rejected: `correlationOf` is shared with
+the launch, PC-sample and sampled-stack paths, `Timeline.pending` is keyed on the whole
+`CorrelationID`, and the function's doc comment justifies returning the whole zero
+value so that the `== gpu.CorrelationID{}` reading and the `Present()` reading agree.
+Changing it would alter pending-sample bucketing on the path #68 just stabilised, to
+improve a case that must never occur. The safe direction is the one it already takes:
+pid 0 → refused → unattributed.
+
+**Did not touch the exact-join path.** `TestExactJoinsNeverEnterTheHeuristicCounters`
+pins that an execution carrying a correlation never enters either new counter, whatever
+the process layout — including #36's honest cross-process miss, which must stay
+credited to the exact path and not to this guard.
+
+## 3. Pre-change behaviour, measured
+
+`CapEff: 0`, so no live run. The heuristic is pure Go; I ran the motivating case against
+`origin/main` directly (stash, drop in a throwaway test, run, restore):
+
+```
+RESULT: pid 5353's execution joined pid 4242's launch; join="heuristic" heuristic=true
+RESULT labels: gpu_join="heuristic" gpu_pid="4242" pod_uid="pod-a" container_id="c-pod-a"
+RESULT frames: [a_work [gpu:launch] [gpu:kernel:hot_kernel]]
+RESULT counters: heuristic=1 unmatched=0
+```
+
+One launch, from pid 4242 in pod-a. One correlation-less execution, from pid 5353. The
+old code handed pid 5353's GPU time pid 4242's call stack and pod-a's `pod_uid` and
+`container_id`. Note `gpu_pid="4242"`: `labelPID` prefers the launch's pid over the
+execution's own, so the sample named the **wrong process as producer** even though the
+execution's own correlation said 5353. The issue describes the stack and tags; the
+producer label went with them.
+
+After the change the same input yields no launch, `gpu_join="unmatched"`, no `pod_uid`,
+no `container_id`, `gpu_pid="5353"`, and the GPU time intact.
+
+The tree's own suite contained two live cross-process heuristic joins asserted as
+correct, which is how thin "unreachable by convention" was:
+
+- `TestTimelineHeuristicRespectsJoinWindow` — candidate "far" at PID 1, candidate
+  "near" at PID 2, pid-less exec. It joined PID 2's launch.
+- `TestProjectionEmitsGpuJoinHeuristicAndAmbiguous` — "older" at PID 1 tagged
+  `pod_uid: guessed-pod`, "newer" at PID 2, pid-less exec. It joined PID 2's and was
+  flagged ambiguous *against a different process's launch*.
+
+Both are now single-process, so they test the window and the ambiguity rule rather than
+smuggling a cross-process join through them.
+
+## 4. The counter story
+
+Eight defects on this project were counters reading green when things were worst, so
+the rule for this change was: nothing about the guard may be invisible, and a guarded
+path that starts firing must announce itself.
+
+Three counters, at two independent boundaries.
+
+**`gpu.JoinStats.CorrelationlessExecutionCount`** — every execution that entered the
+heuristic path, joined or not. This is the "attempts to reach the now-guarded path"
+counter the constraint asks for. It is zero on every backend shipping today (spec §6
+makes a correlation mandatory) and a non-zero reading is a producer contract violation,
+whoever the producer is. It deliberately overlaps `HeuristicExecutionJoinCount` and
+`UnmatchedExecutionCount` and is *not* part of the three-outcome sum `joinAnomalies`
+checks — documented on the field.
+
+**`gpu.JoinStats.CrossProcessHeuristicBlockedCount`** — the load-bearing one. It counts
+refusals *where a candidate actually qualified*: on a refusal, the pre-#52 grouping is
+rebuilt (process dropped) and searched under the same window, and only a hit counts.
+Every increment is one cross-container attribution that did not happen. Deliberately
+not "every correlation-less miss" — that would read high for reasons unrelated to
+processes, and "N cross-container attributions prevented" would stop meaning that.
+`TestCorrelationlessExecutionIsCountedWithNoCandidateToRefuse` pins the separation, and
+the two "rejects" tests assert it stays zero when causality or the queue/name filter is
+what rejected the candidate, so the guard cannot take credit for other filters' work.
+
+Keeping the old rule *executable* rather than deleting it is the mechanism that stops
+the guarded path going dark. A refusal that produced no join and no counter is
+indistinguishable from a workload that never had a candidate.
+
+**`gpuprobe.Stats.ZeroCorrelationExecs`** — option 1's counting half, at the producer
+boundary. The issue notes a contract-violating exec is "counted only in
+`ZeroCorrelation`", but in practice that is invisible: `ZeroCorrelation` aggregates
+every record kind, and a zero correlation is the documented *normal* case for PC
+samples in continuous collection (spec §6.3 finding 3), so the aggregate is large on a
+healthy run and a handful of bad executions vanishes inside it. The narrow counter can
+be asserted zero where the aggregate cannot, and `gate_test.go` now does. Counted at
+the `kindExec` site, not inside `correlationOf`, which is shared and cannot tell the
+kinds apart.
+
+**Surfaced, not just recorded.** #51's complaint is that these counters are never
+printed. Both new `JoinStats` fields get a `JoinHealth` anomaly line — the one thing
+both drivers do print — and `TestJoinHealthSurfacesTheHeuristicProcessGuard` asserts
+the lines appear when the counters move and that a healthy snapshot stays one line.
+`gpuprobe.Stats` is already printed whole via `%+v`.
+
+I also corrected the existing heuristic anomaly line, which said "the CPU stack may be
+another launch's". It now says "another launch's **from the same process**", which is
+what is true after this change.
+
+## 5. Unreachable versus merely unlikely
+
+**Now unreachable by construction:** a heuristic join between an execution and a launch
+that the timeline cannot prove share a process. Not "no producer does this" — the
+lookup key makes the other process's launches unreachable, and the zero-pid case never
+reaches a lookup at all. The pre-#52 grouping still exists, but only as an argument to
+a counter; nothing found through it is ever attached to an `ExecutionView`.
+
+**Still reachable, and intended:** a heuristic join *within* one process. It remains a
+guess — same kernel name, same queue, most recent preceding launch inside the window —
+and is still labelled `gpu_join="heuristic"` and counted. Ambiguity is now
+same-process-only, which is a narrower and more meaningful signal than before.
+
+**Merely unlikely, not closed:**
+
+- A producer that leaves `Correlation.PID` zero on **both** the launch and the
+  execution puts them both in process-group 0 — except that Snapshot refuses a zero-pid
+  execution before any lookup, so they cannot join either. This is the one behaviour
+  change that could cost a hypothetical future producer a join it used to get. It is
+  deliberate: such a producer is claiming no process identity anywhere, which in
+  system-wide mode is precisely the condition under which the guess crosses containers.
+  Its remedy is one field, and `CrossProcessHeuristicBlockedCount` plus the JoinHealth
+  line name that field explicitly.
+- An execution whose process is known but whose own process's launch is missing, while
+  another process holds a plausible one, is refused and counted — but the *converse*
+  is not detectable: if a correlation-less execution's true producer were misreported
+  by the backend, the guard would happily join it inside the wrong process. Nothing
+  downstream of a producer can catch a producer lying about its own pid.
+- `matched[match.launch.Correlation]` still keys `MatchedLaunchCount` on the launch's
+  correlation, so heuristic matches against launches with a zero correlation collapse
+  into one bucket. Pre-existing, unrelated to #52, untouched.
+- **`launchProcessID` prefers `Launch.PID` over `Correlation.PID`, and the two could
+  disagree.** A producer that populated them inconsistently — say `LaunchContext.PID`
+  from the batch header but `Correlation.PID` from somewhere else — would file its
+  launch under one pid and its execution (which has only `Correlation.PID`) under the
+  other. The same-process join then becomes a *counted cross-process refusal*: correct
+  data, refused, and `CrossProcessHeuristicBlockedCount` reading as though a
+  container boundary had been defended when nothing of the sort happened. Theoretical
+  today — `gpuprobe` sets both from the batch header, so they cannot diverge — but it
+  is a real way for this guard to be wrong in the *safe* direction while making its own
+  counter lie, and it is named on `launchProcessID`'s doc comment as well as here. A
+  future producer must treat the two fields as one fact.
+- **For `gpuprobe` the heuristic rung is now closed in both directions**, and anyone
+  reading `HeuristicExecutionJoinCount` should know why it reads zero. The exec side
+  can never reach the rung (spec §6 guarantees a correlation, and `gate_test.go` now
+  asserts `ZeroCorrelationExecs == 0`); if it ever did, `correlationOf`'s whole-zero
+  return means the guard refuses it anyway. So that counter can only move for a backend
+  that does not exist yet. It reads zero because the path is shut, **not** because the
+  guessing is going well — a distinction that matters if it is ever mistaken for live
+  coverage of the heuristic. `CorrelationlessExecutionCount` is the counter to watch:
+  it is what fires first if the path ever reopens.
+
+## 6. Cannot verify
+
+- **No hardware, no live run.** `CapEff: 0` on this box; the eBPF and probe paths were
+  not exercised. Everything here is unit-level Go against `gpu/` and `gpuprobe/`'s
+  wire-format decoder.
+- **No end-to-end proof that a real correlation-less backend behaves as designed**,
+  because there is no such backend: `BackendLinuxDRM` has no implementation and the
+  ROCm adapter is unwritten. `heurExecIn`/`noCorrelation` model what one would emit;
+  whether a real ROCm adapter populates `Correlation.PID` is a decision that has not
+  been made yet. If it does not, it gets refusals and a counter telling it exactly what
+  to set — which is the outcome I designed for, but I cannot demonstrate it against a
+  producer that does not exist.
+- **`CrossProcessHeuristicBlockedCount`'s "would have matched" claim is verified by
+  construction, not by A/B run.** It re-runs `findLaunchHeuristic` against the pre-#52
+  grouping through the same shared `groupLaunchesByTime` helper, so the two indexes
+  cannot drift in their sort or bucketing rule — but it is the same *code*, not the
+  same *binary*, as pre-change `main`. The §3 measurement against `origin/main` is the
+  independent check on the one case that mattered.
+- **Cost under a pathological all-refusal workload is reasoned, not measured.** The
+  second index is built lazily, at most once per `Snapshot`, so the added cost is one
+  `O(capacity)` group-and-sort on a snapshot that has at least one refusal, and nothing
+  at all otherwise. `BenchmarkTimelineSnapshotAllMisses` exists and still runs, but I
+  did not take before/after numbers — no correlation-less production workload exists to
+  make them mean anything.
+
+## 7. Verification run
+
+```
+go build ./... && go vet ./...                                  clean
+go test ./gpu/ ./gpuprobe/ ./internal/... -count=1              ok (11 packages)
+go test ./gpu/ ./gpuprobe/ -race -count=4                       ok
+~/go/bin/golangci-lint run --timeout=5m                         0 issues
+gofmt -l gpu gpuprobe                                           clean
+```
+
+Seven existing tests failed on the first build of the guard, all of them
+correlation-less executions being joined to a launch from a named process. Each was
+updated to name the execution's process — which is what a real correlation-less backend
+must do — and none had its assertion weakened. Two of them (§3) were cross-process
+joins the suite had been asserting as correct.
+
+I also re-checked that the two tests whose *purpose* the guard could have quietly
+voided still do their job:
+`TestTimelineHeuristicScalesWithSingleQueueSingleKernelName` performs 10,000 real
+heuristic joins after the change, not the near-instant no-op it would have become had
+the exec been left pid-less; and `BenchmarkTimelineSnapshotAllMisses` still drives the
+full candidate search.
+
+**That check is now in the suite, not in this report** (review Minor 1). The scaling
+test discarded its `Snapshot()` and asserted only `elapsed < 5s`, and this change gave
+it a brand-new way to go silently no-op: a guard that refuses every exec does *less*
+work, finishes *faster*, and passes *more* comfortably — a performance assertion that
+gets greener as the functionality disappears, which is precisely the green-when-worst
+shape this project keeps finding. The snapshot is now captured and the work pinned
+alongside the clock:
+
+```go
+require.Len(t, snap.Executions, misses)
+assert.Equal(t, uint64(misses), js.CorrelationlessExecutionCount, …)
+assert.Equal(t, uint64(misses), js.HeuristicExecutionJoinCount, …)
+assert.Zero(t, js.UnmatchedExecutionCount, …)
+assert.Zero(t, js.CrossProcessHeuristicBlockedCount, …)
+```
+
+Mutation-checked: forcing the process guard to refuse everything (`if execPID == 0` →
+`if true`) fails the test on three assertions. The timing bound passed under that same
+mutation, at 0.08s — the no-op is genuinely invisible to it, which is the whole point.
+
+## 8. Files
+
+| File | What changed |
+| --- | --- |
+| `gpu/timeline.go` | `candidateGroupKey` gains `pid`; `Snapshot` refuses a zero-pid heuristic and counts refusals; `anyProcessGroupKey` + `launchProcessID` + shared `groupLaunchesByTime` |
+| `gpu/types.go` | `CorrelationlessExecutionCount`, `CrossProcessHeuristicBlockedCount`; `GPUKernelExec` doc corrected |
+| `gpu/joinhealth.go` | Two new anomaly lines; existing heuristic line corrected |
+| `gpu/crossprocess_test.go` | Six regression tests for #52 |
+| `gpu/timeline_test.go`, `gpu/conformance_test.go`, `gpu/projection_test.go` | Correlation-less execs now name their process |
+| `gpuprobe/consumer.go` | `Stats.ZeroCorrelationExecs`, counted at the `kindExec` site |
+| `gpuprobe/consumer_test.go`, `gpuprobe/gate_test.go` | Counter tests; gate asserts it zero |
+| `docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md` | §10 records that both join rungs are process-qualified |

--- a/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
+++ b/docs/superpowers/specs/2026-08-16-gpu-profiling-v2-design.md
@@ -575,10 +575,22 @@ but the thing worth being adaptive about is the activity path.
 ## 10. Correlation and joins
 
 The join ladder from PR #10 `gpu/timeline.go` is kept: exact correlation ID first,
-then queue + kernel-name + bounded-time heuristic, with `Heuristic` and
+then process + queue + kernel-name + bounded-time heuristic, with `Heuristic` and
 `Ambiguous` marked per view and rolled into `JoinStats`. A guessed join is never
 presented as a vendor-provided one. NVIDIA will mostly take the exact path, but
 PC sample batches arrive late and need the honesty machinery.
+
+Both rungs are process-qualified, and neither may reach across processes (#36 for
+the exact rung, #52 for the heuristic one). The process rides on `CorrelationID.PID`,
+which is independent of `CorrelationID.Value`: `Present()` tests the value alone, so
+a backend with no vendor correlation to report still names the process that produced
+the record. An execution that names neither is refused rather than guessed at — it
+degrades to unattributed, keeping its measured GPU time but taking no launch's CPU
+stack and no launch's `pod_uid`/`container_id`. `JoinStats.CorrelationlessExecutionCount`
+counts every entry into the heuristic rung and
+`JoinStats.CrossProcessHeuristicBlockedCount` counts the refusals where a candidate
+otherwise qualified, so a guarded path that starts firing is visible rather than
+silent.
 
 PC samples are a special case the spike forced (§6.3, finding 3): in continuous
 mode they carry **no correlation ID**, so the exact-correlation rung is not

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -472,21 +472,30 @@ func driveCorrelationGaps(sink EventSink) error {
 	}
 
 	// Heuristic-recoverable group: launch and exec share a kernel name and
-	// queue, and the exec's Correlation is left at its zero value - review
-	// Critical 2 restricts the heuristic path to execs that never supplied a
+	// queue, and the exec's Correlation carries no value - review Critical 2
+	// restricts the heuristic path to execs that never supplied a
 	// correlation ID at all (the exact case this group models: a backend,
 	// like DRM, with no correlation concept), so only the heuristic join
 	// (kernel name + queue + causal timing) can attach a launch here.
+	//
+	// It does carry the producing process, matching launch()'s
+	// LaunchContext.PID. Issue #52 made that mandatory: an execution that
+	// names neither a correlation nor a process cannot be joined heuristically
+	// at all, because nothing would stop the guess from reaching into another
+	// process's launch - and its CPU stack and pod_uid/container_id tags. A
+	// correlation-less backend that wants this group's behavior has to say
+	// whose execution it is, which every probe-based producer can.
 	for i := 0; i < 3; i++ {
 		l := launch("gap-heur-"+strconv.Itoa(i), uint64(i*100)+1) // KernelName -> "k_gap-heur-<i>"
 		if err := sink.EmitLaunch(l); err != nil {
 			return err
 		}
 		e := GPUKernelExec{
-			KernelName: l.KernelName,
-			Queue:      l.Queue,
-			StartNs:    uint64(i*100) + 10,
-			EndNs:      uint64(i*100) + 20,
+			Correlation: CorrelationID{Backend: BackendCUPTI, PID: l.Launch.PID},
+			KernelName:  l.KernelName,
+			Queue:       l.Queue,
+			StartNs:     uint64(i*100) + 10,
+			EndNs:       uint64(i*100) + 20,
 		}
 		if err := sink.EmitExec(e); err != nil {
 			return err

--- a/gpu/crossprocess_test.go
+++ b/gpu/crossprocess_test.go
@@ -2,6 +2,7 @@ package gpu
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -348,4 +349,244 @@ func TestProjectionEmitsPidInSingleProcessMode(t *testing.T) {
 	for _, s := range samples {
 		assert.Equal(t, "4242", s.Labels["gpu_pid"])
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue #52: the heuristic join path.
+//
+// #36 process-qualified the EXACT join, and the tests above pin it. The
+// heuristic path was left process-blind: it runs only for an execution that
+// supplied no correlation, and the reasoning at the time was that such an
+// execution has no process to group by. That reasoning was wrong.
+// CorrelationID.Present() tests Value alone, so PID and Value are independent
+// and a record can name its process while carrying no correlation - which is
+// what TestCorrelationCarryingOnlyAProcessIsNotPresent above already
+// constructs. The heuristic therefore groups by process too, and refuses to
+// join an execution that names none.
+//
+// What was at stake is one step worse than #36's: a heuristic match takes the
+// chosen launch's CPUStack AND its Launch.Tags, which carry pod_uid and
+// container_id. A cross-process guess is a cross-CONTAINER billing error.
+// ---------------------------------------------------------------------------
+
+// heurExecIn is execIn for the heuristic path: it names the producing process
+// but carries no vendor correlation value, so Present() is false and the
+// execution takes the heuristic join. Everything else - queue, kernel name,
+// timing - is identical to launchIn's, so only the process can separate them.
+func heurExecIn(pid uint32, startNs, endNs uint64) GPUKernelExec {
+	return GPUKernelExec{
+		Correlation: CorrelationID{Backend: BackendCUPTI, PID: pid},
+		KernelName:  "hot_kernel",
+		StartNs:     startNs,
+		EndNs:       endNs,
+	}
+}
+
+// taggedLaunchIn is launchIn plus the container attribution a real launch
+// carries. These tags are the actual payload of the defect: a mis-joined
+// execution inherits them and bills its GPU time to a container that never
+// ran it.
+func taggedLaunchIn(pid uint32, value string, timeNs uint64, fn, pod string) GPUKernelLaunch {
+	l := launchIn(pid, value, timeNs, fn)
+	l.Launch.Tags = map[string]string{"pod_uid": pod, "container_id": "c-" + pod}
+	return l
+}
+
+// TestHeuristicJoinRefusesAnotherProcessLaunch is issue #52's motivating case.
+// Only pid 4242 ever launched anything; pid 5353's correlation-less execution
+// matches that launch on queue, kernel name and causal timing, which is
+// exactly the "plausible candidate" the old, process-blind grouping would
+// have handed over - along with a_work's call stack and pod-a's pod_uid.
+//
+// Mutation this catches: candidateGroupKey losing its pid field, or Snapshot
+// looking up the process-blind index for a join rather than only for the
+// blocked counter.
+func TestHeuristicJoinRefusesAnotherProcessLaunch(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(taggedLaunchIn(4242, "7", 10, "a_work", "pod-a")))
+	require.NoError(t, tl.EmitExec(heurExecIn(5353, 20, 30)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	view := snap.Executions[0]
+	assert.Nil(t, view.Launch,
+		"pid 5353 has no launch of its own; pid 4242's must not stand in for it")
+	assert.False(t, view.Heuristic, "a refused join is not a heuristic join")
+	assert.NotEqual(t, JoinHeuristic, view.Join)
+
+	js := snap.JoinStats
+	assert.Equal(t, uint64(1), js.CorrelationlessExecutionCount,
+		"entering the heuristic path at all must be counted, not just succeeding at it")
+	assert.Equal(t, uint64(1), js.CrossProcessHeuristicBlockedCount,
+		"a candidate did qualify on queue, kernel name and timing - the refusal is the process guard's, and must be visible")
+	assert.Equal(t, uint64(1), js.UnmatchedExecutionCount,
+		"the execution degrades to unattributed; it is not dropped")
+	assert.Zero(t, js.HeuristicExecutionJoinCount)
+	assert.Zero(t, js.ExactExecutionJoinCount)
+
+	// The GPU time survives, and carries none of pid 4242's container.
+	samples := ProjectExecutions(snap)
+	require.Len(t, samples, 1)
+	assert.Equal(t, "unmatched", samples[0].Labels["gpu_join"])
+	assert.NotContains(t, samples[0].Labels, "pod_uid",
+		"a refused join must not inherit the other container's attribution")
+	assert.NotContains(t, samples[0].Labels, "container_id")
+	assert.Equal(t, "5353", samples[0].Labels["gpu_pid"],
+		"the execution still knows which process produced it")
+	assert.NotContains(t, frameNames(samples[0].Stack), "a_work",
+		"a refused join must not inherit the other process's call path either")
+}
+
+// TestHeuristicJoinStaysWithinItsOwnProcess is the other half: with both
+// processes launching, each correlation-less execution must find its OWN
+// process's launch. Refusing everything would be a safe but useless guard;
+// this pins that the heuristic still works, process-scoped.
+//
+// The two launches are identical but for pid, stack and tags, and the
+// timestamps are interleaved (10 and 11, execs at 20 and 21) so that the
+// "most recent preceding launch" rule alone would pick pid 5353's for both.
+func TestHeuristicJoinStaysWithinItsOwnProcess(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(taggedLaunchIn(4242, "7", 10, "a_work", "pod-a")))
+	require.NoError(t, tl.EmitLaunch(taggedLaunchIn(5353, "7", 11, "b_work", "pod-b")))
+	require.NoError(t, tl.EmitExec(heurExecIn(4242, 20, 30)))
+	require.NoError(t, tl.EmitExec(heurExecIn(5353, 21, 31)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 2)
+
+	wantStack := map[uint32]string{4242: "a_work", 5353: "b_work"}
+	wantPod := map[uint32]string{4242: "pod-a", 5353: "pod-b"}
+	for _, view := range snap.Executions {
+		pid := view.Exec.Correlation.PID
+		require.NotNilf(t, view.Launch, "pid %d's own launch was available and must have been used", pid)
+		assert.Equalf(t, JoinHeuristic, view.Join, "pid %d: a guess must still be labelled a guess", pid)
+		assert.Truef(t, view.Heuristic, "pid %d", pid)
+		assert.Falsef(t, view.Ambiguous, "pid %d: one candidate per process, so nothing is ambiguous", pid)
+		assert.Equalf(t, pid, view.Launch.Launch.PID, "pid %d joined pid %d's launch", pid, view.Launch.Launch.PID)
+		assert.Equalf(t, []string{wantStack[pid]}, stackNames(view.Launch), "pid %d got the wrong call path", pid)
+		assert.Equalf(t, wantPod[pid], view.Launch.Launch.Tags["pod_uid"], "pid %d got the wrong container", pid)
+	}
+
+	js := snap.JoinStats
+	assert.Equal(t, uint64(2), js.HeuristicExecutionJoinCount)
+	assert.Equal(t, uint64(2), js.CorrelationlessExecutionCount,
+		"both executions entered the heuristic path, whether or not they succeeded")
+	assert.Zero(t, js.CrossProcessHeuristicBlockedCount,
+		"each process had its own candidate, so nothing was refused")
+	assert.Zero(t, js.UnmatchedExecutionCount)
+
+	// Every sample still says it is a guess. #52 must not be closed by
+	// quietly promoting the survivors to something they are not.
+	for _, s := range ProjectExecutions(snap) {
+		assert.Equal(t, "heuristic", s.Labels["gpu_join"],
+			"a process-scoped guess is still a guess")
+	}
+}
+
+// TestHeuristicJoinRefusedWhenExecutionNamesNoProcess is the shape gpuprobe
+// would actually produce if it ever violated spec §6: correlationOf(pid, 0)
+// returns the whole zero CorrelationID, discarding the pid, so the execution
+// names neither a correlation nor a process. There is nothing to group it by
+// and nothing to check a candidate against, so it must be refused - and the
+// refusal counted, because this is precisely the "reachable by accident" case
+// the issue is about.
+func TestHeuristicJoinRefusedWhenExecutionNamesNoProcess(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(taggedLaunchIn(4242, "7", 10, "a_work", "pod-a")))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		// Exactly gpuprobe's correlationOf(pid, 0) result: no value, no pid.
+		KernelName: "hot_kernel",
+		StartNs:    20, EndNs: 30,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Nil(t, snap.Executions[0].Launch,
+		"an execution that names no process cannot be shown to share one with any launch")
+
+	js := snap.JoinStats
+	assert.Equal(t, uint64(1), js.CorrelationlessExecutionCount)
+	assert.Equal(t, uint64(1), js.CrossProcessHeuristicBlockedCount,
+		"a candidate qualified on everything except a provable process, which is the whole point")
+	assert.Equal(t, uint64(1), js.UnmatchedExecutionCount)
+	assert.Zero(t, js.HeuristicExecutionJoinCount)
+
+	samples := ProjectExecutions(snap)
+	require.Len(t, samples, 1)
+	assert.Equal(t, "unmatched", samples[0].Labels["gpu_join"])
+	assert.NotContains(t, samples[0].Labels, "gpu_pid", "no process is known, so none may be named")
+	assert.NotContains(t, samples[0].Labels, "pod_uid")
+	assert.Equal(t, uint64(10), samples[0].Value,
+		"the measured GPU time is kept: this is degrade-to-unattributed, not drop")
+}
+
+// TestCorrelationlessExecutionIsCountedWithNoCandidateToRefuse separates the
+// two counters. Here the heuristic path is entered but no launch qualified at
+// all, so nothing was refused on process grounds - the blocked counter must
+// stay at zero while the path-entered counter still fires.
+//
+// This is the counter-honesty half of #52: if CrossProcessHeuristicBlockedCount
+// counted every correlation-less miss, it would read high for reasons that
+// have nothing to do with processes, and "N cross-container attributions
+// prevented" would stop meaning that.
+func TestCorrelationlessExecutionIsCountedWithNoCandidateToRefuse(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitExec(heurExecIn(5353, 20, 30)))
+
+	snap := tl.Snapshot()
+	js := snap.JoinStats
+	assert.Equal(t, uint64(1), js.CorrelationlessExecutionCount,
+		"the heuristic path was entered, and entering it is what #52 wants visible")
+	assert.Zero(t, js.CrossProcessHeuristicBlockedCount,
+		"no launch existed at all, so no cross-process join was prevented")
+	assert.Equal(t, uint64(1), js.UnmatchedExecutionCount)
+}
+
+// TestExactJoinsNeverEnterTheHeuristicCounters is the non-regression guard for
+// #36's path, which this change must not touch: an execution that supplies a
+// correlation takes the exact join (or an honest miss) and must not appear in
+// either of #52's counters, whatever the process layout.
+func TestExactJoinsNeverEnterTheHeuristicCounters(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(launchIn(4242, "7", 10, "a_work")))
+	require.NoError(t, tl.EmitLaunch(launchIn(5353, "7", 11, "b_work")))
+	require.NoError(t, tl.EmitExec(execIn(4242, "7", 20, 30)))
+	require.NoError(t, tl.EmitExec(execIn(5353, "7", 21, 31)))
+	// A correlation that exists only in another process: an honest miss.
+	require.NoError(t, tl.EmitExec(execIn(6464, "7", 22, 32)))
+
+	js := tl.Snapshot().JoinStats
+	assert.Equal(t, uint64(2), js.ExactExecutionJoinCount)
+	assert.Equal(t, uint64(1), js.UnmatchedExecutionCount)
+	assert.Zero(t, js.CorrelationlessExecutionCount,
+		"every execution here supplied a correlation, so none entered the heuristic path")
+	assert.Zero(t, js.CrossProcessHeuristicBlockedCount,
+		"the exact path's cross-process miss is not the heuristic guard's doing, and must not be credited to it")
+}
+
+// TestJoinHealthSurfacesTheHeuristicProcessGuard closes the loop #51 opens:
+// a counter nobody prints is a counter nobody reads. Both of #52's counters
+// must reach the operator-facing lines, and the healthy case must stay silent
+// about them.
+func TestJoinHealthSurfacesTheHeuristicProcessGuard(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitLaunch(taggedLaunchIn(4242, "7", 10, "a_work", "pod-a")))
+	require.NoError(t, tl.EmitExec(heurExecIn(5353, 20, 30)))
+
+	lines := JoinHealth(tl.Snapshot())
+	joined := strings.Join(lines, "\n")
+	assert.Contains(t, joined, "arrived with no vendor correlation",
+		"entering the heuristic path is a producer contract violation and must be said out loud")
+	assert.Contains(t, joined, "could not be shown to come from the same process",
+		"the prevented cross-container attribution must be reported, not merely counted")
+	assert.Contains(t, lines[0], "anomalies", "the summary must agree that something is wrong")
+
+	// Healthy run: exact joins only, and neither line appears.
+	clean := NewTimeline(TimelineConfig{})
+	require.NoError(t, clean.EmitLaunch(launchIn(4242, "7", 10, "a_work")))
+	require.NoError(t, clean.EmitExec(execIn(4242, "7", 20, 30)))
+	cleanLines := JoinHealth(clean.Snapshot())
+	require.Len(t, cleanLines, 1, "a healthy snapshot must stay one line: %v", cleanLines)
+	assert.Contains(t, cleanLines[0], "no anomalies")
 }

--- a/gpu/joinhealth.go
+++ b/gpu/joinhealth.go
@@ -165,8 +165,28 @@ func joinAnomalies(snap Snapshot) []string {
 	}
 	if js.HeuristicExecutionJoinCount > 0 {
 		add("%d of %d executions joined heuristically — matched on queue, kernel name and timing "+
-			"rather than vendor correlation; the CPU stack may be another launch's",
+			"rather than vendor correlation; the CPU stack may be another launch's from the same process",
 			js.HeuristicExecutionJoinCount, execs)
+	}
+	// Issue #52's two witnesses. The first fires whenever the heuristic path
+	// is entered at all, which on every backend shipping today means a
+	// producer broke spec §6's "every launch and execution carries a
+	// correlation" — the heuristic is meant to be dead code, and a dead path
+	// that reports nothing when it wakes up is indistinguishable from one
+	// nobody exercised. The second fires when the process guard actually
+	// stopped a join, i.e. counts the cross-container attributions that would
+	// have happened under the old, process-blind rule.
+	if js.CorrelationlessExecutionCount > 0 {
+		add("%d of %d executions arrived with no vendor correlation — spec §6 requires one on "+
+			"every execution, so a producer is violating its own contract; these can only be "+
+			"guessed at, never joined exactly",
+			js.CorrelationlessExecutionCount, execs)
+	}
+	if js.CrossProcessHeuristicBlockedCount > 0 {
+		add("%s refused because the candidate launch could not be shown to come from the same "+
+			"process — those executions are unattributed rather than billed to another process's "+
+			"call stack and container; have the producer set CorrelationID.PID",
+			plural(js.CrossProcessHeuristicBlockedCount, "heuristic join", "heuristic joins"))
 	}
 	if js.AmbiguousHeuristicMatchCount > 0 {
 		add("%s flagged ambiguous — more than one launch qualified and one was chosen; "+

--- a/gpu/projection_test.go
+++ b/gpu/projection_test.go
@@ -261,12 +261,19 @@ func TestProjectionEmitsGpuJoinHeuristicAndAmbiguous(t *testing.T) {
 		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "newer"},
 		KernelName:  "k_x",
 		TimeNs:      15,
-		Launch:      LaunchContext{PID: 2, TID: 2, TimeNs: 15},
+		// Same process as "older": issue #52 confines a heuristic join to one
+		// process, so two candidates from two processes are no longer
+		// ambiguous - they are in different candidate groups. The ambiguity
+		// this test is about is two launches from the SAME process, which is
+		// the only ambiguity the heuristic can still produce.
+		Launch: LaunchContext{PID: 1, TID: 1, TimeNs: 15},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		// Correlation deliberately zero-valued so the heuristic runs at all.
-		KernelName: "k_x",
-		StartNs:    20, EndNs: 30,
+		// No correlation value, so the heuristic runs at all; pid 1 so it is
+		// allowed to run against pid 1's launches (issue #52).
+		Correlation: noCorrelation(1),
+		KernelName:  "k_x",
+		StartNs:     20, EndNs: 30,
 	}))
 
 	samples := ProjectExecutions(tl.Snapshot())

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -553,10 +553,43 @@ func (t *Timeline) Snapshot() Snapshot {
 	// not a pathological input, it is what most workloads look like, and a
 	// linear scan there is still O(misses x candidates) even without a
 	// per-miss allocation.
+	//
+	// cacheEntries is read once and shared by both indexes below, so a
+	// snapshot that needs them both still pays LaunchCache.Entries() once.
+	stats := JoinStats{LaunchCount: launchCount}
+	var cacheEntries []GPUKernelLaunch
+	var cacheRead bool
+	entries := func() []GPUKernelLaunch {
+		if !cacheRead {
+			cacheEntries, cacheRead = t.cache.Entries(), true
+		}
+		return cacheEntries
+	}
 	var candidateIndex map[candidateGroupKey][]GPUKernelLaunch
+	// anyProcessIndex is the same grouping with the process dropped, and it
+	// exists ONLY to answer "would a process-blind join have matched here?"
+	// for CrossProcessHeuristicBlockedCount - never to produce a join. It is
+	// built lazily on the first refusal, so a snapshot with no
+	// correlation-less executions (every snapshot on every shipping backend)
+	// never allocates it, and one whose heuristic joins all land in their own
+	// process never allocates it either.
+	var anyProcessIndex map[anyProcessGroupKey][]GPUKernelLaunch
+	// noteBlockedHeuristic counts a refused heuristic join, but only when a
+	// candidate genuinely qualified: an execution that would have missed
+	// anyway is an ordinary miss, and counting it here would make the
+	// "cross-process attributions prevented" figure read high for reasons
+	// that have nothing to do with processes.
+	noteBlockedHeuristic := func(exec GPUKernelExec) {
+		if anyProcessIndex == nil {
+			anyProcessIndex = buildAnyProcessCandidateIndex(entries())
+		}
+		key := anyProcessGroupKey{queue: queueKeyOf(exec.Queue), kernelName: exec.KernelName}
+		if match := findLaunchHeuristic(anyProcessIndex[key], exec, t.joinWindowNs); match.launch != nil {
+			stats.CrossProcessHeuristicBlockedCount++
+		}
+	}
 
 	views := make([]ExecutionView, 0, len(execs))
-	stats := JoinStats{LaunchCount: launchCount}
 	matched := make(map[CorrelationID]struct{})
 	for i, exec := range execs {
 		view := ExecutionView{Exec: exec, PCSamples: execSamples[i]}
@@ -591,10 +624,36 @@ func (t *Timeline) Snapshot() Snapshot {
 			continue
 		}
 
-		if candidateIndex == nil {
-			candidateIndex = buildHeuristicCandidateIndex(t.cache.Entries())
+		// No correlation at all: the heuristic path (spec §10). Counted
+		// before anything else is decided, because this is the boundary
+		// issue #52 is about - see CorrelationlessExecutionCount.
+		stats.CorrelationlessExecutionCount++
+
+		// Issue #52: a heuristic join is only allowed within one process,
+		// and an execution that does not name its process cannot make one.
+		// The pid lives on the correlation even when the correlation carries
+		// no value (CorrelationID.Present tests Value alone), so "no vendor
+		// correlation" and "no process" are separate facts and a producer
+		// that knows the pid can always supply it. When it did not, refuse
+		// and degrade to unattributed rather than guess which process this
+		// GPU time - and the pod_uid/container_id it would inherit from the
+		// chosen launch's Tags - belongs to.
+		execPID := exec.Correlation.PID
+		if execPID == 0 {
+			stats.UnmatchedExecutionCount++
+			noteBlockedHeuristic(exec)
+			views = append(views, view)
+			continue
 		}
-		key := candidateGroupKey{queue: queueKeyOf(exec.Queue), kernelName: exec.KernelName}
+
+		if candidateIndex == nil {
+			candidateIndex = buildHeuristicCandidateIndex(entries())
+		}
+		key := candidateGroupKey{
+			pid:        execPID,
+			queue:      queueKeyOf(exec.Queue),
+			kernelName: exec.KernelName,
+		}
 		if match := findLaunchHeuristic(candidateIndex[key], exec, t.joinWindowNs); match.launch != nil {
 			view.Launch = match.launch
 			view.Join = JoinHeuristic
@@ -610,6 +669,15 @@ func (t *Timeline) Snapshot() Snapshot {
 			if match.outOfWindow {
 				stats.OutOfWindowDropCount++
 			}
+			// The execution named its process and its process had nothing
+			// for it. Another process might still have held a candidate that
+			// a process-blind join would have handed over - the exact
+			// misattribution issue #52 describes - so ask, and count it if
+			// so. A match found here is necessarily another process's: our
+			// own group is a subset of the process-blind one under the same
+			// window, so a candidate of ours that qualified there would have
+			// qualified above.
+			noteBlockedHeuristic(exec)
 		}
 		views = append(views, view)
 	}
@@ -659,17 +727,30 @@ func queueKeyOf(q GPUQueueRef) queueKey {
 	return queueKey{backend: q.Backend, queueID: q.QueueID}
 }
 
-// candidateGroupKey deliberately carries no process. It cannot: the heuristic
-// runs only for an execution that supplied no correlation at all, and since
-// issue #36 the correlation is the only place an execution's process
-// identity lives, so a correlation-less execution has no pid to group by.
-// A correlation-less backend in system-wide mode can therefore still match an
-// execution to another process's launch on (queue, kernel name, time) alone.
-// Closing that needs a process field on GPUKernelExec itself, which no
-// producer in the tree would populate today: the one shipping backend
-// (gpuprobe) supplies a correlation on every launch and execution, as spec §6
-// requires without exception, so nothing reaches this path. Left as a known,
-// documented gap rather than a field nobody writes.
+// candidateGroupKey carries the process, and that is issue #52's fix.
+//
+// It used to carry only (queue, kernel name), on the reasoning that a
+// correlation-less execution has no pid to group by - the heuristic runs only
+// when no correlation was supplied, and since issue #36 the correlation is
+// where an execution's process identity lives. That reasoning was wrong in
+// one specific way: CorrelationID.Present() tests Value alone, so PID and
+// Value are independent fields and a record can carry a process without
+// carrying a correlation (see CorrelationID.Present, and the
+// CorrelationID{Backend: BackendLinuxDRM, PID: 4242} shape the tests pin).
+// The pid #52 says would need a new field on GPUKernelExec was already there.
+//
+// So the heuristic groups by process too, and Timeline.Snapshot refuses the
+// join outright for an execution whose Correlation.PID is zero. The effect is
+// that a correlation-less execution can only ever be handed a launch from its
+// own process, and one that names no process is handed nothing at all - it
+// degrades to unattributed (spec §13) rather than inheriting another
+// process's CPU stack, pod_uid and container_id. Neither refusal is silent:
+// see JoinStats.CorrelationlessExecutionCount and
+// JoinStats.CrossProcessHeuristicBlockedCount.
+//
+// The launch's side of the pid is launchProcessID, not Correlation.PID alone,
+// because a launch carries LaunchContext.PID as well and producers populate
+// them independently.
 //
 // candidateGroupKey is the exact equivalence launchKernelNamesCompatible
 // defines (queue match plus kernel-name equality) turned into a map key.
@@ -684,8 +765,41 @@ func queueKeyOf(q GPUQueueRef) queueKey {
 // fallback design, at the cost of an O(prefix) scan per miss instead of
 // O(log candidates).
 type candidateGroupKey struct {
+	pid        uint32
 	queue      queueKey
 	kernelName string
+}
+
+// anyProcessGroupKey is candidateGroupKey with the process dropped: the
+// grouping the heuristic used BEFORE issue #52. It exists only so
+// Timeline.Snapshot can ask "would the old, process-blind rule have matched
+// here?" and count the answer in
+// JoinStats.CrossProcessHeuristicBlockedCount. Nothing looked up through this
+// key is ever attached to an ExecutionView.
+//
+// Keeping the old rule executable, rather than deleting it, is what stops the
+// guarded path from going dark: a refusal that produced no join and no
+// counter would be indistinguishable from a workload that never had a
+// candidate in the first place, and the whole point of the guard is to know
+// how often it fires.
+type anyProcessGroupKey struct {
+	queue      queueKey
+	kernelName string
+}
+
+// launchProcessID is the process a launch is attributed to, for heuristic
+// grouping. LaunchContext.PID is preferred because it is the host-side
+// observation of who submitted the work and every producer in the tree fills
+// it in; Correlation.PID is the fallback for a launch that carries the
+// process only on its correlation. Zero means the producer named no process,
+// and such a launch can never be a heuristic candidate: Snapshot refuses the
+// join for a zero-pid execution, so the zero group is only ever built, never
+// queried.
+func launchProcessID(l GPUKernelLaunch) uint32 {
+	if l.Launch.PID != 0 {
+		return l.Launch.PID
+	}
+	return l.Correlation.PID
 }
 
 // buildHeuristicCandidateIndex groups cache entries by candidateGroupKey and
@@ -698,9 +812,33 @@ type candidateGroupKey struct {
 // and a linear scan of that group per miss is the same quadratic shape this
 // phase exists to remove, just without the allocation on top.
 func buildHeuristicCandidateIndex(entries []GPUKernelLaunch) map[candidateGroupKey][]GPUKernelLaunch {
-	byGroup := make(map[candidateGroupKey][]GPUKernelLaunch, len(entries))
+	return groupLaunchesByTime(entries, func(l GPUKernelLaunch) candidateGroupKey {
+		return candidateGroupKey{
+			pid:        launchProcessID(l),
+			queue:      queueKeyOf(l.Queue),
+			kernelName: l.KernelName,
+		}
+	})
+}
+
+// buildAnyProcessCandidateIndex is buildHeuristicCandidateIndex without the
+// process in the key - the pre-#52 grouping, retained solely for counting
+// (see anyProcessGroupKey).
+func buildAnyProcessCandidateIndex(entries []GPUKernelLaunch) map[anyProcessGroupKey][]GPUKernelLaunch {
+	return groupLaunchesByTime(entries, func(l GPUKernelLaunch) anyProcessGroupKey {
+		return anyProcessGroupKey{queue: queueKeyOf(l.Queue), kernelName: l.KernelName}
+	})
+}
+
+// groupLaunchesByTime is the shared body of the two indexes above: bucket by
+// keyOf, then sort each bucket by TimeNs ascending so findLaunchHeuristic can
+// binary-search it. The two differ only in their key, and keeping one
+// implementation is what guarantees the "blocked" count is computed under
+// exactly the rule the join itself uses, minus the process.
+func groupLaunchesByTime[K comparable](entries []GPUKernelLaunch, keyOf func(GPUKernelLaunch) K) map[K][]GPUKernelLaunch {
+	byGroup := make(map[K][]GPUKernelLaunch, len(entries))
 	for _, l := range entries {
-		k := candidateGroupKey{queue: queueKeyOf(l.Queue), kernelName: l.KernelName}
+		k := keyOf(l)
 		byGroup[k] = append(byGroup[k], l)
 	}
 	for _, group := range byGroup {

--- a/gpu/timeline_test.go
+++ b/gpu/timeline_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// noCorrelation is the correlation a record carries when the vendor supplied
+// nothing to correlate on but the producer still knows which process fired
+// the probe: Value empty (so Present() is false and the record takes the
+// heuristic path) and PID set.
+//
+// It is not an exotic shape - it is what issue #52's fix requires of any
+// backend that wants a heuristic join at all. CorrelationID.Present() tests
+// Value alone, so "no correlation" and "no process" are independent
+// statements, and Timeline refuses to join an execution that makes both:
+// with no process there is nothing stopping the guess from crossing into
+// another container's launch, its CPU stack and its pod_uid/container_id
+// tags. Tests that want the heuristic to run therefore say whose execution
+// it is, exactly as a real correlation-less backend would have to.
+func noCorrelation(pid uint32) CorrelationID {
+	return CorrelationID{Backend: BackendCUPTI, PID: pid}
+}
+
 func execFor(value string, startNs, endNs uint64) GPUKernelExec {
 	return GPUKernelExec{
 		Correlation: CorrelationID{Backend: BackendCUPTI, Value: value},
@@ -402,9 +419,12 @@ func TestTimelineHeuristicJoinsSingleCandidate(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 10},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		// Correlation deliberately left at its zero value - see comment above.
-		KernelName: "k_x",
-		StartNs:    20, EndNs: 30,
+		// No correlation VALUE - see comment above - but the producing
+		// process is named, which issue #52 makes the price of admission to
+		// the heuristic path. It matches the candidate launch's PID.
+		Correlation: noCorrelation(1),
+		KernelName:  "k_x",
+		StartNs:     20, EndNs: 30,
 	}))
 
 	snap := tl.Snapshot()
@@ -442,10 +462,13 @@ func TestTimelineHeuristicMarksAmbiguousAndPicksMostRecent(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 15},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		// Correlation deliberately left at its zero value - see the
-		// single-candidate test above for why (review Critical 2 gate).
-		KernelName: "k_x",
-		StartNs:    20, EndNs: 30,
+		// No correlation value - see the single-candidate test above for why
+		// (review Critical 2's gate) - and pid 1, matching both candidates,
+		// so issue #52's process guard lets the ambiguity be the only thing
+		// under test.
+		Correlation: noCorrelation(1),
+		KernelName:  "k_x",
+		StartNs:     20, EndNs: 30,
 	}))
 
 	snap := tl.Snapshot()
@@ -479,8 +502,9 @@ func TestTimelineHeuristicRejectsLaunchAfterExecStart(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 100},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		KernelName: "k_x",
-		StartNs:    20, EndNs: 30,
+		Correlation: noCorrelation(1), // same process as the candidate: only causality may reject it
+		KernelName:  "k_x",
+		StartNs:     20, EndNs: 30,
 	}))
 
 	snap := tl.Snapshot()
@@ -488,6 +512,8 @@ func TestTimelineHeuristicRejectsLaunchAfterExecStart(t *testing.T) {
 	assert.Nil(t, snap.Executions[0].Launch,
 		"a launch that starts after the exec cannot have produced it")
 	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+	assert.Zero(t, snap.JoinStats.CrossProcessHeuristicBlockedCount,
+		"the rejection is causal, not a process guard - counting it as one would inflate #52's figure")
 }
 
 // TestTimelineHeuristicRejectsWrongQueueAndKernelName is the fourth
@@ -516,11 +542,14 @@ func TestTimelineHeuristicRejectsWrongQueueAndKernelName(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 10},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		// Queue and Correlation left zero-value: "wrong-queue"'s non-zero
-		// QueueID must not match, and a zero Correlation is required for the
-		// heuristic to run at all (review Critical 2's gate).
-		KernelName: "k_x",
-		StartNs:    20, EndNs: 30,
+		// Queue left zero-value: "wrong-queue"'s non-zero QueueID must not
+		// match. The correlation carries no value (required for the
+		// heuristic to run at all - review Critical 2's gate) but does carry
+		// pid 1, so both decoys are in the exec's own process and only the
+		// queue and kernel-name filters can reject them.
+		Correlation: noCorrelation(1),
+		KernelName:  "k_x",
+		StartNs:     20, EndNs: 30,
 	}))
 
 	snap := tl.Snapshot()
@@ -528,6 +557,8 @@ func TestTimelineHeuristicRejectsWrongQueueAndKernelName(t *testing.T) {
 	assert.Nil(t, snap.Executions[0].Launch,
 		"neither the wrong-queue nor the wrong-kernel-name launch should qualify")
 	assert.Equal(t, uint64(1), snap.JoinStats.UnmatchedExecutionCount)
+	assert.Zero(t, snap.JoinStats.CrossProcessHeuristicBlockedCount,
+		"both decoys are in the exec's own process; the process guard must not take credit for filtering them")
 }
 
 // BenchmarkTimelineSnapshotAllMisses is the regression benchmark for review
@@ -556,7 +587,9 @@ func BenchmarkTimelineSnapshotAllMisses(b *testing.B) {
 		// takes the full exact-miss + heuristic-scan path with zero result,
 		// the worst case for the candidate scan.
 		e := execFor("miss-"+strconv.Itoa(i), uint64(3000+i), uint64(3000+i+5))
-		e.Correlation = CorrelationID{}
+		// pid 1 matches launch()'s, so the process guard (issue #52) lets the
+		// candidate scan run; the kernel name is what makes every exec miss.
+		e.Correlation = noCorrelation(1)
 		if err := tl.EmitExec(e); err != nil {
 			b.Fatal(err)
 		}
@@ -592,8 +625,8 @@ func BenchmarkTimelineSnapshotAllMisses(b *testing.B) {
 // in milliseconds either way. This test pins the complexity directly, via a
 // generous wall-clock bound at a scale deliberately too large for a linear
 // scan to hide in: one queue, one kernel name (so every candidate lands in
-// the same group), 50,000 live launches, 10,000 exec misses that all share
-// that one group. That is 5*10^8 candidate comparisons for a linear scan -
+// the same group), 50,000 live launches, 10,000 exact-join misses that all
+// share that one group. That is 5*10^8 candidate comparisons for a linear scan -
 // which this exact setup measured in the tens of seconds against the
 // pre-fix code (see the round-3 report) - versus roughly
 // 10,000 * log2(50,000) ~= 170,000 comparisons for a binary search, which
@@ -603,12 +636,14 @@ func BenchmarkTimelineSnapshotAllMisses(b *testing.B) {
 // to a linear scan over the candidate group (or buildHeuristicCandidateIndex
 // grouping by queue alone again, without kernel name, or without sorting).
 //
-// Each exec's Correlation is explicitly zeroed: review Critical 2 gates the
-// heuristic path on a zero-value Correlation, and execFor always sets a
-// non-zero one. Left as execFor produces it, every exec here would miss the
-// exact lookup and then skip the heuristic entirely (Critical 2's intended
-// behavior for a non-zero, non-matching correlation), making this a
-// near-instant no-op that proves nothing about the binary-search fix.
+// Each exec's Correlation is replaced with noCorrelation(1): review
+// Critical 2 gates the heuristic path on an absent correlation VALUE (execFor
+// always sets one, and left as execFor produces it every exec here would miss
+// the exact lookup and then skip the heuristic entirely), while issue #52
+// gates it on a PRESENT process, matching launch()'s LaunchContext.PID. Get
+// either wrong and this is a near-instant no-op that proves nothing about the
+// binary-search fix - which is why the assertions after the timing bound pin
+// the number of searches that actually ran.
 func TestTimelineHeuristicScalesWithSingleQueueSingleKernelName(t *testing.T) {
 	const candidates = 50_000
 	const misses = 10_000
@@ -622,15 +657,20 @@ func TestTimelineHeuristicScalesWithSingleQueueSingleKernelName(t *testing.T) {
 	for i := 0; i < misses; i++ {
 		e := execFor("ghost-"+strconv.Itoa(i), uint64(i), uint64(i))
 		e.KernelName = "hot_kernel" // same group
-		e.Correlation = CorrelationID{}
+		// No correlation value (so the heuristic runs) but pid 1, matching
+		// launch()'s LaunchContext.PID - without it issue #52's process
+		// guard refuses every join before the search happens and this test
+		// becomes the near-instant no-op it exists to avoid.
+		e.Correlation = noCorrelation(1)
 		require.NoError(t, tl.EmitExec(e))
 	}
 
 	done := make(chan struct{})
 	var elapsed time.Duration
+	var snap Snapshot
 	go func() {
 		start := time.Now()
-		_ = tl.Snapshot()
+		snap = tl.Snapshot()
 		elapsed = time.Since(start)
 		close(done)
 	}()
@@ -643,6 +683,28 @@ func TestTimelineHeuristicScalesWithSingleQueueSingleKernelName(t *testing.T) {
 	case <-time.After(25 * time.Second):
 		t.Fatal("Snapshot did not return within 25s - the heuristic join is scanning its candidate group, not binary-searching it")
 	}
+
+	// A timing assertion must never stand alone: this test's failure mode is
+	// a Snapshot that is fast because it did no work, and every guard added
+	// ahead of the search is a fresh way to arrive there. Issue #52's process
+	// guard is exactly such a guard - refuse every exec before the binary
+	// search and this test finishes FASTER and passes more comfortably than
+	// before, while proving nothing at all. So pin the work as well as the
+	// clock.
+	//
+	// Every exec must join: exec i starts at TimeNs i and launch i was
+	// emitted at TimeNs i, so a qualifying candidate always precedes it
+	// (window unbounded here), and all of them share pid 1 with it.
+	js := snap.JoinStats
+	require.Len(t, snap.Executions, misses)
+	assert.Equal(t, uint64(misses), js.CorrelationlessExecutionCount,
+		"every exec must actually reach the heuristic path - a guard that skips it makes this test a fast no-op")
+	assert.Equal(t, uint64(misses), js.HeuristicExecutionJoinCount,
+		"every exec must actually complete a heuristic join; the elapsed bound above only means something if this many searches ran")
+	assert.Zero(t, js.UnmatchedExecutionCount,
+		"a candidate precedes every exec, so nothing may degrade to unattributed")
+	assert.Zero(t, js.CrossProcessHeuristicBlockedCount,
+		"one process throughout: the process guard must not be what ends these searches")
 }
 
 // TestTimelineSnapshotConsumesExecutions is the regression test for review
@@ -755,11 +817,14 @@ func TestTimelineHeuristicRespectsJoinWindow(t *testing.T) {
 		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "near"},
 		KernelName:  "k_x",
 		TimeNs:      95,
-		Launch:      LaunchContext{PID: 2, TID: 2, TimeNs: 95},
+		// Same pid as "far" and as the exec below, so issue #52's process
+		// guard cannot be what separates the two candidates - the window is.
+		Launch: LaunchContext{PID: 1, TID: 1, TimeNs: 95},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		KernelName: "k_x",
-		StartNs:    100, EndNs: 110,
+		Correlation: noCorrelation(1),
+		KernelName:  "k_x",
+		StartNs:     100, EndNs: 110,
 	}))
 
 	snap := tl.Snapshot()
@@ -790,8 +855,9 @@ func TestTimelineHeuristicOutOfWindowDropIsCounted(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 0},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		KernelName: "k_x",
-		StartNs:    100, EndNs: 110, // "far" (TimeNs=0) precedes this but is 100ns away, outside the 10ns window
+		Correlation: noCorrelation(1), // same process as "far": only the window may reject it
+		KernelName:  "k_x",
+		StartNs:     100, EndNs: 110, // "far" (TimeNs=0) precedes this but is 100ns away, outside the 10ns window
 	}))
 
 	snap := tl.Snapshot()
@@ -817,8 +883,9 @@ func TestTimelineHeuristicWindowZeroIsUnbounded(t *testing.T) {
 		Launch:      LaunchContext{PID: 1, TID: 1, TimeNs: 0},
 	}))
 	require.NoError(t, tl.EmitExec(GPUKernelExec{
-		KernelName: "k_x",
-		StartNs:    100, EndNs: 110,
+		Correlation: noCorrelation(1),
+		KernelName:  "k_x",
+		StartNs:     100, EndNs: 110,
 	}))
 
 	snap := tl.Snapshot()

--- a/gpu/types.go
+++ b/gpu/types.go
@@ -285,9 +285,16 @@ type GPUKernelLaunch struct {
 //
 // There is no separate PID field: the process that produced this execution is
 // carried by Correlation (see CorrelationID), which is the only identity the
-// join uses and therefore the only place it cannot be forgotten. An execution
-// that carried no correlation at all has no process either, and takes the
-// heuristic path.
+// join uses and therefore the only place it cannot be forgotten.
+//
+// An execution that carried no correlation VALUE takes the heuristic path,
+// but that does not make it process-less: Correlation.PID and
+// Correlation.Value are independent (Present() tests Value alone), so a
+// producer that knows which process fired the probe can - and must - say so
+// even when the vendor gave it nothing to correlate on. Issue #52: the
+// heuristic join uses exactly that field to refuse a match across processes,
+// so a record that leaves it zero cannot be joined heuristically at all and
+// degrades to unattributed instead.
 type GPUKernelExec struct {
 	Execution   GPUExecutionRef `json:"execution"`
 	Correlation CorrelationID   `json:"correlation"`
@@ -402,6 +409,52 @@ type JoinStats struct {
 	HeuristicExecutionJoinCount  uint64 `json:"heuristic_execution_join_count,omitempty"`
 	AmbiguousHeuristicMatchCount uint64 `json:"ambiguous_heuristic_match_count,omitempty"`
 	UnmatchedExecutionCount      uint64 `json:"unmatched_execution_count,omitempty"`
+	// CorrelationlessExecutionCount counts executions that arrived carrying
+	// no vendor correlation at all (CorrelationID.Present() == false) and
+	// were therefore routed to the heuristic join instead of the exact one.
+	//
+	// It is the witness that issue #52's path was entered. The heuristic is
+	// meant to be dead code on every backend shipping today: spec §6 makes a
+	// correlation mandatory on every launch and execution, and gpuprobe
+	// supplies one, so this counter reads zero on a healthy run. A path that
+	// is unreachable *by convention* and counts nothing is indistinguishable
+	// from a path nobody exercised; this makes the difference observable, so
+	// a future backend, a malformed record or an adapter written to a
+	// different assumption announces itself instead of quietly starting to
+	// guess.
+	//
+	// It deliberately OVERLAPS the three mutually-exclusive outcome
+	// counters: every execution counted here also lands in exactly one of
+	// HeuristicExecutionJoinCount or UnmatchedExecutionCount (never in
+	// ExactExecutionJoinCount, which by definition requires a correlation).
+	// It is not part of the sum joinAnomalies checks.
+	CorrelationlessExecutionCount uint64 `json:"correlationless_execution_count,omitempty"`
+	// CrossProcessHeuristicBlockedCount counts heuristic joins that were
+	// refused because the execution and the candidate launch could not be
+	// shown to come from the same process - issue #52.
+	//
+	// A candidate DID qualify on queue, kernel name and the time window: had
+	// the join been process-blind, as it was before this counter existed,
+	// this execution would have been handed that launch, along with its
+	// symbolized CPU stack and its Tags (pod_uid, container_id). Every
+	// increment is therefore one cross-container attribution that did not
+	// happen. "Cross-process" includes the case where the process is merely
+	// unknown on one side rather than known-and-different: an unproven
+	// match and a disproven one are refused identically, because a heuristic
+	// join is already a guess and a guess about *which process* is the one
+	// spec §4 forbids.
+	//
+	// The executions are not dropped. They degrade to unattributed - their
+	// measured GPU time stays in the profile under FrameLaunchUnsampled,
+	// carrying no stack and no tags - and are counted in
+	// UnmatchedExecutionCount like any other miss. This counter says why.
+	//
+	// The remedy for a backend that trips it is to populate
+	// CorrelationID.PID even on records that carry no vendor correlation
+	// value: PID and Value are independent there (see CorrelationID.Present),
+	// so "no correlation" and "no process" are separate statements and a
+	// producer that knows the pid can always say so.
+	CrossProcessHeuristicBlockedCount uint64 `json:"cross_process_heuristic_blocked_count,omitempty"`
 	// OutOfWindowDropCount counts heuristic-join misses caused specifically
 	// by LaunchEventJoinWindowNs excluding every candidate that would
 	// otherwise have qualified (i.e. at least one candidate preceded the

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -375,6 +375,28 @@ type Stats struct {
 	// counter exists because that demotion changes how confidently the join
 	// can be read, and a silent demotion is as bad as silent loss.
 	ZeroCorrelation uint64
+	// ZeroCorrelationExecs is the subset of ZeroCorrelation that arrived on a
+	// gpu_exec_v1 record, and it means something completely different from
+	// the rest of that counter — issue #52.
+	//
+	// A PC sample with no correlation is normal and expected (spec §6.3
+	// finding 3: continuous collection never populates it), and PC samples
+	// dominate the traffic, so ZeroCorrelation is large on a healthy run and
+	// a handful of correlation-less EXECUTIONS is invisible inside it. But an
+	// execution is exactly the record spec §6 says must always carry one: it
+	// is the anchor the exact join runs on, and without it the execution can
+	// only be guessed at (gpu.JoinStats.CorrelationlessExecutionCount is the
+	// consumer-side witness of the same event).
+	//
+	// This counter is therefore the shim contract, made checkable. It must
+	// read zero, and gate_test.go asserts that. Nothing is dropped when it
+	// does not: the execution is normalized and emitted with the zero
+	// correlation, which routes it to the timeline's heuristic join — where,
+	// since #52, it is refused rather than joined across processes, because
+	// correlationOf's zero value carries no pid either. Losing the record
+	// would lose measured GPU time, which is a worse failure than losing its
+	// stack.
+	ZeroCorrelationExecs uint64
 	// KernelDropped counts records the BPF program itself could not deliver:
 	// a batch bigger than one ringbuf reservation, a full ringbuf, or a
 	// faulting read of the producer's buffer. Read from the BPF `dropped`
@@ -1475,6 +1497,14 @@ func (c *Consumer) applyBatch(b batch) {
 	case kindExec:
 		for _, e := range b.Execs {
 			c.stats.Records++
+			if e.Correlation == 0 {
+				// Counted here rather than inside correlationOf, which is
+				// shared with the launch, PC-sample and sampled-stack paths
+				// and cannot tell them apart. See Stats.ZeroCorrelationExecs
+				// for why an execution's zero is a contract violation while a
+				// PC sample's is routine.
+				c.stats.ZeroCorrelationExecs++
+			}
 			ev := gpu.GPUKernelExec{
 				Correlation: c.correlationOf(b.PID, e.Correlation),
 				ClockDomain: gpu.ClockDomainCPUMonotonic,

--- a/gpuprobe/consumer_test.go
+++ b/gpuprobe/consumer_test.go
@@ -627,7 +627,42 @@ func TestZeroWireCorrelationOnExecs(t *testing.T) {
 
 	require.Len(t, sink.execs, 1)
 	assert.Equal(t, gpu.CorrelationID{}, sink.execs[0].Correlation)
-	assert.Equal(t, uint64(1), c.Stats().ZeroCorrelation)
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.ZeroCorrelation)
+	assert.Equal(t, uint64(1), st.ZeroCorrelationExecs,
+		"an execution's zero correlation is a spec §6 contract violation, and must be countable "+
+			"apart from the PC samples that make ZeroCorrelation large on a healthy run (issue #52)")
+}
+
+// TestZeroCorrelationExecsCountsOnlyExecutions is the separation itself.
+// ZeroCorrelation is an aggregate over every record kind, and the kinds mean
+// different things when they carry no correlation: for a PC sample in
+// continuous collection it is the documented normal case (spec §6.3 finding
+// 3) and for a launch it is at worst a lost anchor, while for an EXECUTION it
+// is the shim breaking spec §6 outright. The whole value of the narrow
+// counter is that it can be asserted zero while the aggregate cannot, so it
+// must not move for anything but an execution.
+func TestZeroCorrelationExecsCountsOnlyExecutions(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+
+	buf := make([]byte, batchHdrSize+48)
+	putU32(buf[0:], kindLaunch)
+	putU32(buf[4:], 1)
+	putU64(buf[24:], 48)
+	putU64(buf[batchHdrSize+0:], 0) // no correlation
+
+	b, err := decodeBatch(buf)
+	require.NoError(t, err)
+	c.applyBatch(b)
+	c.Flush()
+
+	require.Len(t, sink.launches, 1)
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.ZeroCorrelation, "the aggregate still sees it")
+	assert.Zero(t, st.ZeroCorrelationExecs,
+		"no execution arrived, so the contract-violation counter must stay clean - "+
+			"otherwise it would move for records whose zero correlation is not a violation at all")
 }
 
 // --- Phase 4a: the batch header carries a stack id -------------------------

--- a/gpuprobe/gate_test.go
+++ b/gpuprobe/gate_test.go
@@ -320,6 +320,8 @@ func TestStubDrivesThePipelineToPprofWithoutAGPU(t *testing.T) {
 		"records the BPF program could not deliver: an oversized batch, a full ringbuf, or a faulting read of the producer's buffer")
 	assert.Zero(t, stats.ZeroCorrelation,
 		"the stub never emits correlation 0, so no record may have been demoted to the heuristic join")
+	assert.Zero(t, stats.ZeroCorrelationExecs,
+		"spec §6 makes a correlation mandatory on every execution; a non-zero here is the shim breaking its own contract, and the execution can then only be guessed at (issue #52)")
 	assert.Zero(t, stats.StacksMissing,
 		"StacksMissing is BPF-side capture loss - no scratch, an empty walk, a full or unwritable gpu_stacks - none of which depends on how deep the walk got")
 	// StacksMissing says a capture failed; these say how it could have. All


### PR DESCRIPTION
Closes #52.

After #36 the **exact** join cannot match across processes. The **heuristic** path was left process-blind: `candidateGroupKey` and `buildHeuristicCandidateIndex(t.cache.Entries())` drew candidates from every process in the cache, so a correlation-less execution could be handed another process's launch — its `CPUStack` and its `Launch.Tags`, which carry `pod_uid` and `container_id`.

### The issue's premise was wrong, and the fix is better for it

#52 (and I, restating it) claimed this could not be fixed the way #36 fixed the exact path, because "the heuristic runs precisely when there is no correlation, and the correlation is the only place an execution's process lives".

`CorrelationID.Present()` tests `Value` alone. `PID` and `Value` are independent fields — a record can name its process while carrying no vendor correlation. `TestCorrelationCarryingOnlyAProcessIsNotPresent` (added by #36) constructs exactly that shape, and `labelPID` already reads it. **The pid that option 2 wanted to add to `GPUKernelExec` was already on the correlation.**

So this takes option 2's semantics at option 1's cost: `candidateGroupKey` gains a `pid`, and `Timeline.Snapshot` refuses the heuristic outright when `exec.Correlation.PID == 0`. Option 3 is subsumed — with the pid in the key, single-process safety falls out for free, and so does system-wide, which option 3 could not do.

### It was reachable in the test suite, not merely in theory

"Unreachable by convention" was thinner than it looked. Two existing tests asserted live cross-process heuristic joins **as correct**: `TestTimelineHeuristicRespectsJoinWindow` (PID 1 vs PID 2 candidates) and `TestProjectionEmitsGpuJoinHeuristicAndAmbiguous` (flagging ambiguity against another process's pod-tagged launch). Seven tests failed on first build; each now names the execution's process, and no assertion was weakened.

Measured against `origin/main`:

```
RESULT: pid 5353's execution joined pid 4242's launch; join="heuristic" heuristic=true
RESULT labels: gpu_join="heuristic" gpu_pid="4242" pod_uid="pod-a" container_id="c-pod-a"
RESULT frames: [a_work [gpu:launch] [gpu:kernel:hot_kernel]]
```

Note `gpu_pid="4242"` — `labelPID` prefers the launch's pid, so the sample also named the **wrong process as producer**, which is beyond what #52 described.

### Degrade, do not drop

I asked whether count-and-drop was honest enough. It is not: an execution is a measurement, and dropping it removes real GPU time from the profile with nothing in the output to say so — worse than removing its stack. It degrades to `unmatched`, and the degradation lives in `Timeline`, which owns the join decision and covers every producer, rather than in `gpuprobe`, which cannot express "emit this but do not guess at it" and covers one.

### Counters

- `CorrelationlessExecutionCount` — every entry into the guarded path, any producer. Zero on a healthy run per spec §6.
- `CrossProcessHeuristicBlockedCount` — refusals **where a candidate actually qualified**, by re-running the pre-#52 grouping through a shared helper so the two indexes cannot drift. Every increment is one cross-container attribution prevented, not an ordinary miss.
- `gpuprobe.Stats.ZeroCorrelationExecs` — the narrow counter option 1 wanted. `ZeroCorrelation` is large on a healthy run (zero is normal for PC samples), so a bad *execution* was invisible inside it; this one can be asserted zero, and the gate now does.

Both `JoinStats` counters get a `JoinHealth` anomaly line, per #51 — a counter nobody prints is a counter nobody reads. The existing heuristic line is corrected to "another launch's **from the same process**".

### Residue

A backend leaving `Correlation.PID` zero on both sides loses the heuristic entirely. Deliberate: such a producer claims no process identity anywhere, which is exactly the condition under which the guess crosses containers. The counter and the JoinHealth line name the one field that fixes it.