### PR TITLE
flamegraph: adopt Brendan Gregg's AI Flame Graph palette

### DIFF
--- a/.superpowers/sdd/flamegraph-gregg-report.md
+++ b/.superpowers/sdd/flamegraph-gregg-report.md
@@ -1,0 +1,208 @@
+# Recolouring the flame graph to Brendan Gregg's AI Flame Graph palette
+
+Branch `feat/flamegraph-gregg-palette`. One commit, touching
+`internal/flamegraph/{domain.go,assets.go,render.go}` plus a new
+`internal/flamegraph/palette_test.go`.
+
+Nothing structural changed. The renderer still colours by domain, still
+classifies from the profile's mapping first and the symbol name second, still
+draws and counts unsymbolized frames, still refuses to draw a degenerate
+profile, still emits one file with no network fetches. Only the palette, the
+domain→colour mapping and the legend vocabulary moved.
+
+## The mapping as built
+
+Gregg's layers are pink (application), red/yellow/orange (the CPU code paths
+that initiate GPU work: C, C++, kernel — in that order), grey (the boundary
+between CPU and accelerator), aqua (source of functions running on the
+accelerator), green (accelerator execution).
+
+| domain (`data-domain`) | legend label | Gregg layer | light `hsl()` | rendered light | rendered dark |
+|---|---|---|---|---|---|
+| `app` | application | pink | `335 78% 79%` | `#f3a0c2` | `#e778a7` |
+| `system` | CPU: process startup and libc | red (C) | `2 68% 78%` | `#eda3a1` | `#df7f7b` |
+| `vendor` | CPU: GPU runtime and driver | yellow (C++) | `50 88% 69%` | `#f6de6a` | `#e9ce44` |
+| `kernel` | CPU: kernel | orange (kernel) | `28 92% 70%` | `#f9ae6c` | `#ed9345` |
+| `unsym` | vendor, no symbols | — (see below) | `45 20% 77%` + hatch | `#d0cab9` | `#bab29c` |
+| `shim` | perf-agent | — (see below) | `215 15% 77%` + cool outline | `#bcc3cd` | `#9fa9b6` |
+| `boundary` | CPU→GPU boundary | grey | `0 0% 84%` + dark outline | `#d6d6d6` | `#bdbdbd` |
+| `boundary-unattributed` | GPU work with no CPU stack | grey | `0 0% 92%` + hatch + dashed outline | `#ebebeb` | `#d1d1d1` |
+| `gpu-kernel` | GPU kernel execution | green | `128 48% 67%` | `#82d38d` | `#62c16f` |
+| *(reserved)* | aqua | aqua | `184 52% 65%` | `#77ced4` | `#57bbc2` |
+| `root` | all (synthetic, never in the legend) | — | `30 8% 81%` | `#d2cfcb` | `#bab5b0` |
+
+The red/yellow/orange assignment follows Gregg's own convention rather than
+being invented: C is red, C++ is yellow, the kernel is orange. That means the
+previous colours for `kernel` and `vendor` swapped — `cudaLaunchKernel` is a
+C++ runtime frame and is now yellow, kernel-mode frames are now orange.
+
+`--fill-accel-source` (aqua) is declared and **no domain points at it**.
+It belongs to Gregg's accelerator *source* layer, which needs GPU PC sampling
+with SASS→source resolution; perf-agent does not emit those frames yet. The
+legend on every page says so in one sentence with a swatch, so the hue is
+visibly held open rather than silently missing. `TestAquaIsReservedAndUnused`
+fails if a domain ever takes it without meaning to.
+
+## The two domains Gregg has no layer for
+
+Neither gets a sixth hue. Both are drained almost to grey, which is the
+palette's own way of saying "this is not a layer of your computation", and
+they lean in opposite directions so they stay tellable apart from each other
+and from the pure-neutral boundary greys.
+
+**Vendor unsymbolized** (`unsym`) keeps the warm CPU band's hue at 20%
+saturation — a pale sand — and **keeps the hatch**. The hatch was carrying
+real information (the depth is real, the names are missing) and it survives
+unchanged; the recolour only gives the fill under it a reason. The reading is
+"right layer, no name": warm enough to sit with the CPU frames it is always
+sandwiched between, colourless enough never to be mistaken for one of the
+named CPU layers, and never stealing the pure grey the boundary owns.
+
+**perf-agent's own shim** (`shim`) gets the opposite drain: a cool slate at
+15% saturation with a cool outline. The instrument sits visibly outside the
+warm CPU band without claiming a hue. It was purple before, which was exactly
+the sixth hue the brief asked to avoid.
+
+The three near-greys are distinguished by temperature and outline, not by
+lightness alone: warm + hatched + no outline (`unsym`), cool + solid cool
+outline (`shim`), neutral + solid dark outline (`boundary`).
+
+## Keeping the two boundaries apart
+
+`[gpu:launch]` and `[gpu:launch unsampled]` mean different things — GPU time
+we have a CPU stack for versus GPU time we do not — so sharing Gregg's grey
+costs them a distinction the recolour must not lose. Three signals carry it:
+the unattributed one is 8 lightness points paler, it is hatched, and it is the
+only dashed outline on the page. `TestTheTwoBoundariesStayTellableApart`
+asserts all three.
+
+## Both themes, through the token system
+
+Every fill is one `hsl()` written once, at `:root`, with its **hue fixed**.
+The dark theme moves exactly two numbers:
+
+```css
+@media (prefers-color-scheme: dark){
+  :root{ --fill-dl:-9%; --fill-ds:.9; --hatch-ink:rgb(22 20 18 / .20); }
+}
+```
+
+`--fill-dl` shifts every fill's and every edge's lightness; `--fill-ds` scales
+every fill's saturation. No colour is defined inside the media block, so the
+two themes cannot drift into two designs.
+`TestDarkThemeMovesOnlyTheThemeKnobs` fails if a third property ever appears
+there, or if a second `@media` block does.
+
+Because the fills stay light in both themes, the label ink, the hover outline
+and the search-match outline do **not** follow the page theme —
+`--frame-ink` has no dark variant. The previous code used `var(--ink)` for the
+hover outline, which inverted with the page and went nearly invisible on a
+light fill in dark mode; that is fixed.
+
+Two mechanical consequences worth recording:
+
+- Colour now reaches a frame through `data-domain` and a CSS rule, not through
+  a `fill=` attribute. That is what makes it themeable. It also fixed a latent
+  bug: the old `stroke=` presentation attribute on the boundary frames was
+  being overridden by `g.frame rect.bg{stroke:…}` in the stylesheet, so the
+  boundary outline never actually rendered in the HTML page.
+- `RenderSVG` (standalone, for embedding) now emits the palette inside the
+  `<svg>`, so a graph pulled out of the page keeps its colours *and* its
+  theme response. `RenderHTML` does not duplicate it. Verified by rendering
+  the real profile to a bare `.svg` and sampling pixels: `#82d38d` green,
+  `#d6d6d6` boundary, `#bcc3cd` shim, `#d0cab9` unsym — the tokens exactly.
+
+## Contrast check
+
+Frame labels are 11px monospace in `--frame-ink` (`hsl(30 12% 9%)`) drawn on
+the fills. Computed WCAG 2.1 contrast for **every** fill in **both** themes,
+including the reserved aqua and the synthetic root. Two figures per fill: the
+plain fill, and the fill with the hatch ink composited over it at *full*
+coverage — the pessimistic reading, since the real stripes cover about a third
+of a frame.
+
+| fill | light plain | light hatched | dark plain | dark hatched |
+|---|---|---|---|---|
+| app | 9.02 | 5.41 | 6.75 | 4.71 |
+| system | 8.83 | 5.31 | **6.57** | **4.60** |
+| vendor | 13.27 | 7.64 | 11.48 | 7.66 |
+| kernel | 9.60 | 5.71 | 7.74 | 5.33 |
+| unsym | 10.93 | 6.42 | 8.70 | 5.95 |
+| shim | 10.04 | 5.96 | 7.75 | 5.35 |
+| boundary | 12.32 | 7.15 | 9.74 | 6.59 |
+| boundary-unattributed | 14.93 | 8.51 | 12.01 | 7.99 |
+| gpu-kernel | 9.94 | 5.89 | 8.11 | 5.56 |
+| accel-source (aqua) | 9.84 | 5.84 | 8.04 | 5.52 |
+| root | 11.48 | 6.71 | 9.04 | 6.16 |
+
+Worst case anywhere: **4.60:1**, on hatched red in the dark theme. WCAG AA for
+this text size is 4.5:1, so every pair passes with margin, including the two
+the brief flagged as risky: pink bottoms out at 4.71 and aqua at 5.52.
+
+This is not a one-off calculation. `TestLabelsStayLegibleOnEveryFillInBothThemes`
+parses `paletteCSS` back into numbers — reading the stylesheet, not a
+duplicate table in Go — applies the two theme knobs, and fails below 4.5:1.
+Red was the binding constraint and was lightened from `2 72% 73%` to
+`2 68% 78%` to clear it; the numbers above are the tuned palette. An
+independent Python implementation of the same computation agreed with the Go
+test to two decimal places.
+
+## Verification performed
+
+- `go build ./... && go vet ./... && go test ./... -count=1` — all packages
+  pass. `~/go/bin/golangci-lint run --timeout=5m` — 0 issues.
+- Rendered `/home/diego/gpu-cuda-45.pb.gz` (RTX 3090, 4000 samples, 3 distinct
+  stacks, max depth 16). Total unchanged: `data-total="5987854"`, header chip
+  reads 5.99 ms, and the synthetic root still carries the whole profile.
+- **Looked at it**, in Chrome headless, light and dark. The 16-frame joined
+  stack reads root-first exactly as intended: `_start`,
+  `__libc_start_main_alias_1`, `__libc_start_call_main` red → `main`,
+  `__device_stub__Z14perfagent_axpy…` pink → `cudaLaunchKernel` yellow → the
+  seven `0x7f2c…` frames pale sand + hatched → `(anonymous
+  namespace)::on_callback(…)` cool slate + outline → `[gpu:launch]` grey +
+  outline → `[gpu:kernel:_Z14perfagent_axpy…]` green. At the bottom,
+  `[gpu:launch unsampled]` is pale grey, hatched and dashed under the two wide
+  green kernel bars.
+- Sampled the rendered pixels rather than trusting the eye: every frame's
+  colour matches its token exactly (`#82d38d`, `#d6d6d6`, `#bcc3cd`,
+  `#f6de6a`, `#f3a0c2`, `#eda3a1`, `#d2cfcb` in light; the dark-theme values
+  from the table in dark).
+- Rendered the same page in **Firefox** headless and compared: identical. The
+  `hsl(H calc(S% * var(--ds)) calc(L% + var(--dl)))` construction that the
+  theme knobs depend on works in both engines.
+- Rendered a degenerate profile (zero samples). The explanatory panel is
+  intact in both themes: "No flame graph was drawn", the zero-samples
+  sentence, "This is the profile reporting on itself, not a rendering
+  failure", the `total: nothing to draw` chip, no `<svg>`, no `<script>`.
+- The `gpu_sample_period=8` note, the unsymbolized-frame counts, the
+  93.4%-under-`[gpu:launch unsampled]` note and the sample-labels table all
+  still render.
+
+## Cannot verify
+
+- **That the palette is Gregg's.** I mapped it from the layer list in the
+  brief (pink / red / yellow / orange / grey / aqua / green, with C, C++ and
+  kernel in that order) and from his long-standing mixed-mode convention. I
+  did not fetch https://www.brendangregg.com/blog/2024-10-29/ai-flame-graphs.html
+  and did not sample pixels from his published graphs, so the *hues* are the
+  right layers but the exact saturations and lightnesses are mine, chosen to
+  clear the contrast floor rather than to match his image.
+- **Rendering outside Chrome and Firefox.** Both were checked. Safari and
+  WebKit were not, and no browser older than the ones installed here was. The
+  page depends on `hsl()` with space-separated arguments, `calc()` inside it,
+  and custom properties — all long-baseline, none tested below current
+  versions.
+- **The dark theme in a real user's browser.** Chrome's dark rendering was
+  produced with `--blink-settings=preferredColorScheme=0`, and Firefox was
+  only screenshotted light. I read the dark page as an image, not on a
+  monitor; perceived glare or muddiness in the three near-greys is a judgement
+  a screenshot can support but not settle.
+- **Legibility of the hatched frames at real sizes under a real hatch.** The
+  4.5:1 floor is computed against a fully-covering hatch, which is stricter
+  than what is drawn; I did not measure the contrast of an actual rendered
+  glyph pixel against the pixel behind it.
+- **That no other consumer depended on the removed `fill=` attributes.**
+  `RenderSVG` is exported and its output shape changed (colour now arrives via
+  a `<style>` inside the `<svg>` rather than per-rect attributes). Nothing in
+  this repository calls it outside tests, but an external consumer that
+  post-processed the SVG by reading `fill=` would break.

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -14,11 +14,11 @@ package flamegraph
 const svgDefs = `<defs>
 <pattern id="p-gap" width="6" height="6" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
 <rect width="6" height="6" fill="none"/>
-<line x1="0" y1="0" x2="0" y2="6" stroke="rgba(20,20,20,.30)" stroke-width="2.2"/>
+<line class="hatch" x1="0" y1="0" x2="0" y2="6" stroke-width="2.2"/>
 </pattern>
 <pattern id="p-inferred" width="5" height="5" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
 <rect width="5" height="5" fill="none"/>
-<line x1="0" y1="0" x2="0" y2="5" stroke="rgba(10,10,10,.34)" stroke-width="1.6" stroke-dasharray="2 2"/>
+<line class="hatch" x1="0" y1="0" x2="0" y2="5" stroke-width="1.6" stroke-dasharray="2 2"/>
 </pattern>
 </defs>
 `
@@ -89,12 +89,8 @@ button:hover{border-color:var(--accent)}
 .detail{margin-top:4px;font-size:12.5px;min-height:1.4em}
 .chart{margin:12px 0;overflow-x:auto;border:1px solid var(--line);border-radius:10px;background:var(--panel)}
 svg.flame{display:block}
-svg.flame text{font:11px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;fill:#14120f;pointer-events:none}
-@media (prefers-color-scheme: dark){svg.flame text{fill:#100f14}}
+svg.flame text{font:11px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;pointer-events:none}
 g.frame{cursor:pointer}
-g.frame rect.bg{stroke:rgba(255,255,255,.55);stroke-width:.5}
-g.frame:hover rect.bg{stroke:var(--ink);stroke-width:1.4}
-g.frame.match rect.bg{stroke:#111;stroke-width:1.6}
 g.frame.dim{opacity:.15}
 .legend-list{list-style:none;margin:0;padding:0;display:grid;gap:5px;
   grid-template-columns:repeat(auto-fit,minmax(330px,1fr))}
@@ -102,10 +98,13 @@ g.frame.dim{opacity:.15}
 .legend-list b{margin-right:4px}
 .sw{display:inline-block;width:14px;height:14px;border-radius:3px;margin-right:7px;
   border:1px solid rgba(0,0,0,.3);vertical-align:-2px}
-.sw.hatched{background-image:repeating-linear-gradient(45deg,rgba(20,20,20,.34) 0 2px,transparent 2px 6px)}
-.sw.hatch{background:#c9c9c9;
-  background-image:repeating-linear-gradient(45deg,rgba(20,20,20,.45) 0 2px,transparent 2px 6px);
+.sw.hatched{background-image:repeating-linear-gradient(45deg,var(--hatch-ink) 0 2px,transparent 2px 6px)}
+/* The generic hatching row explains the pattern, not a domain, so its
+   swatch carries the pattern over nothing. */
+.sw.hatch{background:transparent;
+  background-image:repeating-linear-gradient(45deg,var(--muted) 0 2px,transparent 2px 6px);
   border-color:var(--muted)}
+.legend-note{margin:10px 0 0;max-width:90ch;font-size:12.5px}
 .depth-note{margin:10px 0 0;max-width:90ch;font-size:12.5px}
 .labels table{border-collapse:collapse;width:100%;font-size:12.5px}
 .labels th,.labels td{text-align:left;padding:5px 10px 5px 0;border-bottom:1px solid var(--line);
@@ -113,6 +112,93 @@ g.frame.dim{opacity:.15}
 .labels th{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
 .lv{display:inline-block;margin:0 8px 2px 0;white-space:nowrap}
 footer{color:var(--muted);font-size:11.5px;padding-top:6px}
+`
+
+// paletteCSS is the flame graph's own colours, kept apart from the page
+// chrome above because it is emitted in two places: after styleSheet in the
+// HTML page, and inside the <svg> itself when RenderSVG writes a standalone
+// graph. A graph embedded on its own must still be the right colours.
+//
+// The palette is Brendan Gregg's AI Flame Graph palette — pink application,
+// red/yellow/orange CPU, grey boundary, aqua accelerator source, green
+// accelerator execution — designed for a white page. It has to survive a
+// dark one too, and "survive" must not mean "become a different design", so
+// no colour is defined twice. Every fill is one hsl() written once, at
+// :root, with its hue fixed; the dark theme moves two numbers, --fill-dl and
+// --fill-ds, which shift every fill's lightness and scale its saturation
+// together. That is the whole of the dark theme's effect on the graph.
+//
+// Fills stay light in both themes, which is what makes a single near-black
+// label colour legible everywhere; --frame-ink therefore has no dark
+// variant, and neither do the hover and search outlines drawn on top of a
+// fill. (var(--ink) would be wrong there: it inverts with the page, not with
+// the frame.)
+const paletteCSS = `
+:root{
+  /* The two theme knobs. Nothing else about the palette changes. */
+  --fill-dl:0%;   /* lightness shift applied to every fill and every edge */
+  --fill-ds:1;    /* saturation multiplier applied to every fill */
+  --hatch-ink:rgb(22 20 18 / .26);
+
+  /* Gregg's layers. Hue is the meaning; it never moves. */
+  --fill-app:      hsl(335 calc(78% * var(--fill-ds)) calc(79% + var(--fill-dl)));
+  --fill-system:   hsl(  2 calc(68% * var(--fill-ds)) calc(78% + var(--fill-dl)));
+  --fill-vendor:   hsl( 50 calc(88% * var(--fill-ds)) calc(69% + var(--fill-dl)));
+  --fill-kernel:   hsl( 28 calc(92% * var(--fill-ds)) calc(70% + var(--fill-dl)));
+  --fill-boundary: hsl(  0                        0%  calc(84% + var(--fill-dl)));
+  --fill-boundary-unattributed: hsl(0             0%  calc(92% + var(--fill-dl)));
+  --fill-gpu-kernel: hsl(128 calc(48% * var(--fill-ds)) calc(67% + var(--fill-dl)));
+
+  /* Reserved. Gregg's aqua is the source of functions running ON the
+     accelerator; that needs GPU PC sampling with SASS→source resolution,
+     which perf-agent does not do yet. No domain points at this token, so
+     nothing on the page is aqua — the hue is held open, not spent. */
+  --fill-accel-source: hsl(184 calc(52% * var(--fill-ds)) calc(65% + var(--fill-dl)));
+
+  /* The two domains Gregg's scheme has no layer for. Drained to near-grey
+     rather than given a sixth hue: warm for "a CPU frame we cannot name",
+     cool for "not your program at all". */
+  --fill-unsym: hsl( 45 calc(20% * var(--fill-ds)) calc(77% + var(--fill-dl)));
+  --fill-shim:  hsl(215 calc(15% * var(--fill-ds)) calc(77% + var(--fill-dl)));
+
+  --fill-root: hsl(30 calc(8% * var(--fill-ds)) calc(81% + var(--fill-dl)));
+
+  /* Edges shift with the fills so each keeps its contrast against its own
+     frame rather than against the page. */
+  --edge-frame:        rgb(255 255 255 / .55);
+  --edge-boundary:     hsl(  0  0% calc(40% + var(--fill-dl)));
+  --edge-unattributed: hsl(  0  0% calc(55% + var(--fill-dl)));
+  --edge-shim:         hsl(215 24% calc(46% + var(--fill-dl)));
+
+  /* Ink on a fill. Fills are light in both themes, so this is too. */
+  --frame-ink: hsl(30 12% 9%);
+}
+@media (prefers-color-scheme: dark){
+  :root{ --fill-dl:-9%; --fill-ds:.9; --hatch-ink:rgb(22 20 18 / .20); }
+}
+
+svg.flame text{fill:var(--frame-ink)}
+pattern line.hatch{stroke:var(--hatch-ink)}
+
+g.frame rect.bg{stroke:var(--edge-frame);stroke-width:.5}
+g.frame[data-domain="root"] rect.bg{fill:var(--fill-root)}
+g.frame[data-domain="app"] rect.bg{fill:var(--fill-app)}
+g.frame[data-domain="system"] rect.bg{fill:var(--fill-system)}
+g.frame[data-domain="kernel"] rect.bg{fill:var(--fill-kernel)}
+g.frame[data-domain="vendor"] rect.bg{fill:var(--fill-vendor)}
+g.frame[data-domain="unsym"] rect.bg{fill:var(--fill-unsym)}
+g.frame[data-domain="gpu-kernel"] rect.bg{fill:var(--fill-gpu-kernel)}
+/* The three domains that are not the program's own computation get an
+   outline as well as a fill, so they read as themselves at one pixel wide.
+   The dashed one is [gpu:launch unsampled]: a boundary with no CPU stack
+   behind it, which must never be mistaken for [gpu:launch], which has one. */
+g.frame[data-domain="shim"] rect.bg{fill:var(--fill-shim);stroke:var(--edge-shim);stroke-width:1}
+g.frame[data-domain="boundary"] rect.bg{fill:var(--fill-boundary);stroke:var(--edge-boundary);stroke-width:1}
+g.frame[data-domain="boundary-unattributed"] rect.bg{fill:var(--fill-boundary-unattributed);stroke:var(--edge-unattributed);stroke-width:1;stroke-dasharray:3 2}
+
+/* Last, so hover and search win over any domain outline above. */
+g.frame:hover rect.bg{stroke:var(--frame-ink);stroke-width:1.4;stroke-dasharray:none}
+g.frame.match rect.bg{stroke:var(--frame-ink);stroke-width:1.8;stroke-dasharray:none}
 `
 
 const script = `

--- a/internal/flamegraph/domain.go
+++ b/internal/flamegraph/domain.go
@@ -11,18 +11,46 @@ import (
 // to. A hashed palette carries no information; these profiles have real
 // structure worth showing — application code, the CPU path that initiates
 // GPU work, an explicit boundary marker, and the accelerator side — so the
-// palette carries that instead. (The idea of colouring a mixed CPU/GPU flame
-// graph by domain is Brendan Gregg's.)
+// palette carries that instead.
 //
-// Two domains have no counterpart in that scheme and exist here because they
-// are honesty features rather than decoration:
+// The colours are Brendan Gregg's AI Flame Graph palette
+// (https://www.brendangregg.com/blog/2024-10-29/ai-flame-graphs.html), whose
+// layers map onto our domains like this:
+//
+//	pink    application code                DomainApplication
+//	red     C: process startup and libc     DomainSystem
+//	yellow  C++: the GPU runtime and driver DomainVendorRuntime
+//	orange  kernel                          DomainKernel
+//	grey    the CPU/accelerator boundary    DomainBoundary, …Unattributed
+//	aqua    accelerator source lines        (reserved — see below)
+//	green   accelerator execution           DomainGPUKernel
+//
+// Aqua is deliberately unused. It is Gregg's colour for the *source* of
+// functions running on the accelerator, which needs GPU PC sampling with a
+// SASS→source mapping; perf-agent does not emit those frames yet. Reserving
+// the hue now means the layer has a home when it arrives, and means nothing
+// on the page can be mistaken for it in the meantime. The token exists in
+// the stylesheet (--fill-accel-source) with no domain pointing at it, and
+// the legend says so.
+//
+// Two domains have no counterpart in Gregg's scheme and exist here because
+// they are honesty features rather than decoration. Neither gets a sixth
+// hue; both are drained almost to grey, which is the palette's way of
+// saying "this frame is not a layer of your computation":
 //
 //   - DomainUnsymbolized. These frames were unwound correctly; no symbol
 //     table could name them. That is a symbolization gap, not a hole in the
 //     stack, and the reader must be able to tell the difference at a glance.
+//     They keep the CPU band's warm hue drained to a pale sand, and keep the
+//     hatch: the layer is known, the name is not. Warm-but-colourless, so it
+//     never reads as one of the named CPU layers and never steals the pure
+//     grey the boundary markers own.
 //   - DomainProfilerShim. perf-agent's own injected callback appears in
 //     perf-agent's own profile. Colouring it as ordinary CPU work would bill
-//     the profiler's overhead to the program being profiled.
+//     the profiler's overhead to the program being profiled. It gets the
+//     opposite drain — a cool slate with a cool outline — so the instrument
+//     sits visibly outside the warm CPU band without claiming a hue of its
+//     own.
 //
 // Classification is INFERRED — from the mapping file when the profile
 // supplies one, otherwise from the symbol name. The legend says so. It is a
@@ -65,44 +93,44 @@ type DomainInfo struct {
 
 var domainInfo = [numDomains]DomainInfo{
 	DomainRoot: {
-		Key: "root", Label: "all", Fill: "hsl(30 8% 78%)",
+		Key: "root", Label: "all", Fill: "var(--fill-root)",
 		Desc: "Synthetic root. Its width is the whole profile.",
 	},
 	DomainApplication: {
-		Key: "app", Label: "application", Fill: "hsl(336 62% 74%)",
-		Desc: "Your program's own code, and compiler-generated glue in its binary.",
+		Key: "app", Label: "application", Fill: "var(--fill-app)",
+		Desc: "Your program's own code, and compiler-generated glue in its binary. Pink, Gregg's application layer.",
 	},
 	DomainSystem: {
-		Key: "system", Label: "process startup and libc", Fill: "hsl(4 62% 67%)",
-		Desc: "The C runtime, dynamic loader and thread entry that get to main.",
+		Key: "system", Label: "CPU: process startup and libc", Fill: "var(--fill-system)",
+		Desc: "The C runtime, dynamic loader and thread entry that get to main. Red, Gregg's C layer.",
 	},
 	DomainKernel: {
-		Key: "kernel", Label: "kernel", Fill: "hsl(48 82% 62%)",
-		Desc: "Kernel-mode frames, identified by the profile's [kernel] mapping.",
+		Key: "kernel", Label: "CPU: kernel", Fill: "var(--fill-kernel)",
+		Desc: "Kernel-mode frames, identified by the profile's [kernel] mapping. Orange, Gregg's kernel layer.",
 	},
 	DomainVendorRuntime: {
-		Key: "vendor", Label: "GPU runtime, CPU side", Fill: "hsl(26 88% 64%)",
-		Desc: "CUDA/HIP/HSA runtime and driver frames: the CPU path that initiates GPU work.",
+		Key: "vendor", Label: "CPU: GPU runtime and driver", Fill: "var(--fill-vendor)",
+		Desc: "CUDA/HIP/HSA runtime and driver frames: the CPU path that initiates GPU work. Yellow, Gregg's C++ layer.",
 	},
 	DomainUnsymbolized: {
-		Key: "unsym", Label: "unsymbolized", Fill: "hsl(214 10% 68%)", Overlay: "url(#p-gap)",
-		Desc: "Unwound correctly; no symbol table could name it. The depth here is real — the names are missing, usually because a stripped vendor library has no exported symbols.",
+		Key: "unsym", Label: "vendor, no symbols", Fill: "var(--fill-unsym)", Overlay: "url(#p-gap)",
+		Desc: "Unwound correctly; no symbol table could name it. The depth here is real — the names are missing, usually because a stripped vendor library has no exported symbols. The CPU band's hue, drained: right layer, no name.",
 	},
 	DomainProfilerShim: {
-		Key: "shim", Label: "perf-agent's own shim", Fill: "hsl(272 32% 70%)",
-		Desc: "The profiler observing itself: perf-agent's injected callback, not work your program asked for.",
+		Key: "shim", Label: "perf-agent", Fill: "var(--fill-shim)", Stroke: "var(--edge-shim)",
+		Desc: "The profiler observing itself: perf-agent's injected callback, not work your program asked for. Cool slate, outside the warm CPU band, because it is not part of your computation.",
 	},
 	DomainBoundary: {
-		Key: "boundary", Label: "CPU→GPU boundary", Fill: "hsl(0 0% 82%)", Stroke: "hsl(0 0% 42%)",
-		Desc: "[gpu:launch] — the launch this execution was joined to. Everything below it ran on the CPU; everything above it ran on the accelerator.",
+		Key: "boundary", Label: "CPU→GPU boundary", Fill: "var(--fill-boundary)", Stroke: "var(--edge-boundary)",
+		Desc: "[gpu:launch] — the launch this execution was joined to. Everything below it ran on the CPU; everything above it ran on the accelerator. Grey, Gregg's boundary marker.",
 	},
 	DomainBoundaryUnattributed: {
-		Key: "boundary-unattributed", Label: "GPU work with no CPU stack", Fill: "hsl(0 0% 88%)", Overlay: "url(#p-gap)", Stroke: "hsl(0 0% 55%)",
-		Desc: "[gpu:launch unsampled] — measured GPU time whose launch was not one of the sampled ones, so no CPU call path exists for it. Its duration is measured; its caller is unknown, and is not borrowed from a sampled sibling.",
+		Key: "boundary-unattributed", Label: "GPU work with no CPU stack", Fill: "var(--fill-boundary-unattributed)", Overlay: "url(#p-gap)", Stroke: "var(--edge-unattributed)",
+		Desc: "[gpu:launch unsampled] — measured GPU time whose launch was not one of the sampled ones, so no CPU call path exists for it. Its duration is measured; its caller is unknown, and is not borrowed from a sampled sibling. The same boundary grey, but paler, hatched and dashed, because it is a boundary with nothing behind it.",
 	},
 	DomainGPUKernel: {
-		Key: "gpu-kernel", Label: "GPU kernel execution", Fill: "hsl(142 44% 55%)",
-		Desc: "The kernel that ran on the accelerator, and how long it ran for.",
+		Key: "gpu-kernel", Label: "GPU kernel execution", Fill: "var(--fill-gpu-kernel)",
+		Desc: "The kernel that ran on the accelerator, and how long it ran for. Green, Gregg's accelerator-execution layer.",
 	},
 }
 

--- a/internal/flamegraph/palette_test.go
+++ b/internal/flamegraph/palette_test.go
@@ -1,0 +1,279 @@
+package flamegraph
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The palette now lives in CSS rather than in Go string literals, which buys
+// a theme-aware graph and costs a compile-time guarantee: a domain key and a
+// selector that no longer agree would produce a page of black rectangles and
+// nothing would fail to build. These tests are that guarantee, moved.
+
+var (
+	// hsl(H calc(S% * var(--fill-ds)) calc(L% + var(--fill-dl)))
+	fillTokenRe = regexp.MustCompile(
+		`--(fill-[a-z-]+): hsl\( ?(\d+) (?:calc\((\d+)% \* var\(--fill-ds\)\)|(\d+)%) calc\((\d+)% \+ var\(--fill-dl\)\)\);`)
+	darkBlockRe = regexp.MustCompile(`(?s)@media \(prefers-color-scheme: dark\)\{\s*:root\{([^}]*)\}`)
+)
+
+type hsl struct{ h, s, l float64 }
+
+// palette parses paletteCSS back into numbers. Reading the stylesheet is the
+// point: a test that re-declared the colours in Go would agree with itself
+// and not with the page.
+func palette(t *testing.T) map[string]hsl {
+	t.Helper()
+	flat := regexp.MustCompile(`\s+`).ReplaceAllString(paletteCSS, " ")
+	out := map[string]hsl{}
+	for _, m := range fillTokenRe.FindAllStringSubmatch(flat, -1) {
+		sat := m[3]
+		if sat == "" {
+			sat = m[4]
+		}
+		out[m[1]] = hsl{h: num(t, m[2]), s: num(t, sat), l: num(t, m[5])}
+	}
+	require.NotEmpty(t, out, "no fill tokens parsed out of paletteCSS")
+	return out
+}
+
+func num(t *testing.T, s string) float64 {
+	t.Helper()
+	v, err := strconv.ParseFloat(s, 64)
+	require.NoError(t, err)
+	return v
+}
+
+// themed applies the two knobs the dark theme is allowed to move.
+func (c hsl) themed(dl, ds float64) hsl { return hsl{c.h, c.s * ds, c.l + dl} }
+
+func (c hsl) rgb() (float64, float64, float64) {
+	h, s, l := math.Mod(c.h, 360)/360, c.s/100, c.l/100
+	if s == 0 {
+		return l, l, l
+	}
+	q := l + s - l*s
+	if l < 0.5 {
+		q = l * (1 + s)
+	}
+	p := 2*l - q
+	hue := func(t float64) float64 {
+		t = math.Mod(t+1, 1)
+		switch {
+		case t < 1.0/6:
+			return p + (q-p)*6*t
+		case t < 1.0/2:
+			return q
+		case t < 2.0/3:
+			return p + (q-p)*(2.0/3-t)*6
+		default:
+			return p
+		}
+	}
+	return hue(h + 1.0/3), hue(h), hue(h - 1.0/3)
+}
+
+func (c hsl) luminance() float64 {
+	lin := func(u float64) float64 {
+		if u <= 0.04045 {
+			return u / 12.92
+		}
+		return math.Pow((u+0.055)/1.055, 2.4)
+	}
+	r, g, b := c.rgb()
+	return 0.2126*lin(r) + 0.7152*lin(g) + 0.0722*lin(b)
+}
+
+func contrast(a, b hsl) float64 {
+	la, lb := a.luminance(), b.luminance()
+	if la < lb {
+		la, lb = lb, la
+	}
+	return (la + 0.05) / (lb + 0.05)
+}
+
+// overHatch composites the hatch ink over a fill at full coverage. The real
+// stripes cover about a third of a frame, so this is the pessimistic reading
+// of "what is behind the darkest pixel of a label".
+func overHatch(c hsl, alpha float64) hsl {
+	r, g, b := c.rgb()
+	mix := func(v, ink float64) float64 { return v*(1-alpha) + ink*alpha }
+	m := hsl{}
+	// Back to a luminance-only stand-in: contrast() only reads luminance,
+	// and mixing in sRGB then re-deriving lightness is what a browser draws.
+	rr, gg, bb := mix(r, 22.0/255), mix(g, 20.0/255), mix(b, 18.0/255)
+	maxc, minc := math.Max(rr, math.Max(gg, bb)), math.Min(rr, math.Min(gg, bb))
+	m.l = (maxc + minc) / 2 * 100
+	if maxc != minc {
+		d := maxc - minc
+		if m.l > 50 {
+			m.s = d / (2 - maxc - minc) * 100
+		} else {
+			m.s = d / (maxc + minc) * 100
+		}
+		switch maxc {
+		case rr:
+			m.h = math.Mod((gg-bb)/d, 6) * 60
+		case gg:
+			m.h = ((bb-rr)/d + 2) * 60
+		default:
+			m.h = ((rr-gg)/d + 4) * 60
+		}
+	}
+	return m
+}
+
+const (
+	frameInkH, frameInkS, frameInkL = 30, 12, 9
+	lightDL, lightDS, lightHatch    = 0.0, 1.0, 0.26
+	darkDL, darkDS, darkHatch       = -9.0, 0.9, 0.20
+)
+
+func TestPaletteDeclaresATokenForEveryDomain(t *testing.T) {
+	tokens := palette(t)
+	for d := Domain(0); d < numDomains; d++ {
+		info := d.Info()
+		name := strings.TrimSuffix(strings.TrimPrefix(info.Fill, "var(--"), ")")
+		assert.Contains(t, tokens, name, "domain %q names a fill token the stylesheet does not declare", info.Key)
+		if info.Stroke != "" {
+			assert.Contains(t, paletteCSS, strings.TrimSuffix(strings.TrimPrefix(info.Stroke, "var("), ")")+":",
+				"domain %q names a stroke token the stylesheet does not declare", info.Key)
+		}
+	}
+}
+
+// Colour reaches a frame through data-domain and nothing else, so a key that
+// no rule selects is a frame with no fill.
+func TestEveryDomainKeyIsSelectedByARule(t *testing.T) {
+	for d := Domain(0); d < numDomains; d++ {
+		info := d.Info()
+		sel := fmt.Sprintf(`g.frame[data-domain="%s"] rect.bg{fill:%s`, info.Key, info.Fill)
+		assert.Contains(t, paletteCSS, sel, "no rule paints domain %q", info.Key)
+	}
+}
+
+// Aqua is Gregg's accelerator-source layer. perf-agent cannot produce those
+// frames yet; the hue is held open rather than spent on something else, and
+// the page says so instead of leaving a silent gap in the palette.
+func TestAquaIsReservedAndUnused(t *testing.T) {
+	assert.Contains(t, palette(t), "fill-accel-source", "the reserved aqua token must exist")
+	assert.NotContains(t, paletteCSS, "rect.bg{fill:var(--fill-accel-source)",
+		"aqua must not paint any frame until accelerator source frames exist")
+	for d := Domain(0); d < numDomains; d++ {
+		assert.NotEqual(t, "var(--fill-accel-source)", d.Info().Fill, "domain %q took the reserved hue", d.Info().Key)
+	}
+}
+
+// The whole point of the token layout: the dark theme is a lightness and a
+// saturation adjustment, not a second palette. If a colour ever appears in
+// the media block, the two themes have started to drift into two designs.
+func TestDarkThemeMovesOnlyTheThemeKnobs(t *testing.T) {
+	m := darkBlockRe.FindStringSubmatch(paletteCSS)
+	require.Len(t, m, 2, "paletteCSS must have exactly one dark-theme block")
+	for _, decl := range strings.Split(m[1], ";") {
+		decl = strings.TrimSpace(decl)
+		if decl == "" {
+			continue
+		}
+		prop := strings.TrimSpace(strings.SplitN(decl, ":", 2)[0])
+		assert.Contains(t, []string{"--fill-dl", "--fill-ds", "--hatch-ink"}, prop,
+			"the dark theme may only move the knobs, but it sets %s", prop)
+	}
+	assert.Equal(t, 1, strings.Count(paletteCSS, "@media"), "one media block, or the themes are diverging")
+}
+
+// Gregg's layers are hues; the hue is the meaning. Anchor them, so a tweak
+// to a lightness cannot quietly turn the C++ layer green.
+func TestHuesAreTheGreggLayers(t *testing.T) {
+	tokens := palette(t)
+	for _, c := range []struct {
+		token   string
+		gregg   string
+		hue     float64
+		minSat  float64
+		tolHue  float64
+		neutral bool
+	}{
+		{token: "fill-app", gregg: "pink", hue: 335, minSat: 60, tolHue: 20},
+		{token: "fill-system", gregg: "red", hue: 2, minSat: 55, tolHue: 15},
+		{token: "fill-vendor", gregg: "yellow", hue: 50, minSat: 60, tolHue: 12},
+		{token: "fill-kernel", gregg: "orange", hue: 28, minSat: 60, tolHue: 12},
+		{token: "fill-gpu-kernel", gregg: "green", hue: 128, minSat: 30, tolHue: 25},
+		{token: "fill-accel-source", gregg: "aqua", hue: 184, minSat: 30, tolHue: 20},
+	} {
+		got, ok := tokens[c.token]
+		require.True(t, ok, c.token)
+		assert.InDelta(t, c.hue, got.h, c.tolHue, "%s is Gregg's %s layer", c.token, c.gregg)
+		assert.GreaterOrEqual(t, got.s, c.minSat, "%s must read as a hue, not as grey", c.token)
+	}
+	// The boundary markers are Gregg's grey: no hue at all, so they cannot
+	// be mistaken for a layer of the computation.
+	for _, n := range []string{"fill-boundary", "fill-boundary-unattributed"} {
+		assert.Zero(t, tokens[n].s, "%s must be a true grey", n)
+	}
+	// The two domains Gregg has no layer for are drained rather than given a
+	// sixth hue, and they lean opposite ways so they stay tellable apart.
+	assert.Less(t, tokens["fill-unsym"].s, 30.0, "unsymbolized must be near-grey, not a hue")
+	assert.Less(t, tokens["fill-shim"].s, 30.0, "the shim must be near-grey, not a hue")
+	assert.Less(t, tokens["fill-unsym"].h, 90.0, "unsymbolized leans warm, with the CPU band it belongs to")
+	assert.Greater(t, tokens["fill-shim"].h, 180.0, "the shim leans cool, away from the CPU band")
+}
+
+// [gpu:launch] and [gpu:launch unsampled] mean different things — GPU time we
+// have a CPU stack for, versus GPU time we do not. They share Gregg's grey,
+// so three other signals have to keep them apart.
+func TestTheTwoBoundariesStayTellableApart(t *testing.T) {
+	tokens := palette(t)
+	assert.Greater(t, tokens["fill-boundary-unattributed"].l, tokens["fill-boundary"].l+5,
+		"the unattributed boundary must be visibly paler")
+	assert.NotEmpty(t, DomainBoundaryUnattributed.Info().Overlay, "and hatched")
+	assert.Contains(t, paletteCSS, `g.frame[data-domain="boundary-unattributed"] rect.bg{fill:var(--fill-boundary-unattributed);stroke:var(--edge-unattributed);stroke-width:1;stroke-dasharray:3 2}`,
+		"and dashed, because there is nothing behind it")
+	assert.NotContains(t, paletteCSS, `data-domain="boundary"] rect.bg{fill:var(--fill-boundary);stroke:var(--edge-boundary);stroke-width:1;stroke-dasharray`)
+}
+
+// Frame labels are drawn on the fills. Gregg's palette was designed for a
+// white page; on a dark one the fills move, and "check, don't assume" means
+// computing the ratio rather than eyeballing it. 4.5:1 is WCAG AA for the
+// 11px label text, and the hatched figure assumes the worst pixel.
+func TestLabelsStayLegibleOnEveryFillInBothThemes(t *testing.T) {
+	require.Contains(t, paletteCSS,
+		fmt.Sprintf("--frame-ink: hsl(%d %d%% %d%%)", frameInkH, frameInkS, frameInkL),
+		"this test's ink must be the ink the page uses")
+	ink := hsl{frameInkH, frameInkS, frameInkL}
+
+	for _, theme := range []struct {
+		name          string
+		dl, ds, alpha float64
+	}{
+		{"light", lightDL, lightDS, lightHatch},
+		{"dark", darkDL, darkDS, darkHatch},
+	} {
+		for name, c := range palette(t) {
+			fill := c.themed(theme.dl, theme.ds)
+			assert.GreaterOrEqual(t, contrast(ink, fill), 4.5,
+				"%s theme: label ink on %s is %.2f:1", theme.name, name, contrast(ink, fill))
+			hatched := overHatch(fill, theme.alpha)
+			assert.GreaterOrEqual(t, contrast(ink, hatched), 4.5,
+				"%s theme: label ink on hatched %s is %.2f:1", theme.name, name, contrast(ink, hatched))
+		}
+	}
+}
+
+// A label drawn in a colour that flips with the page would be dark ink on a
+// dark fill in one theme. The fills stay light in both, so the ink must not
+// move at all — and neither must the outlines drawn on top of a fill.
+func TestInkAndFrameOutlinesDoNotFollowThePageTheme(t *testing.T) {
+	assert.NotContains(t, paletteCSS, "var(--ink)",
+		"the page's ink inverts with the page; a frame's does not")
+	assert.Contains(t, paletteCSS, "svg.flame text{fill:var(--frame-ink)}")
+	assert.Contains(t, paletteCSS, "g.frame:hover rect.bg{stroke:var(--frame-ink)")
+	assert.Contains(t, paletteCSS, "g.frame.match rect.bg{stroke:var(--frame-ink)")
+}

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -94,6 +94,7 @@ func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
 	ew.esc(opts.Title)
 	ew.s("</title>\n<style>\n")
 	ew.s(styleSheet)
+	ew.s(paletteCSS)
 	ew.s("</style>\n</head>\n<body>\n<main>\n")
 
 	writeHeader(ew, res, opts, degenerate)
@@ -104,7 +105,7 @@ func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
 	} else {
 		writeToolbar(ew)
 		ew.s("<div class=\"chart\">\n")
-		if err := writeSVG(ew, root, maxDepth, res, opts); err != nil {
+		if err := writeSVG(ew, root, maxDepth, res, opts, false); err != nil {
 			return err
 		}
 		ew.s("</div>\n")
@@ -124,10 +125,12 @@ func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
 	return ew.err
 }
 
-// RenderSVG writes just the graph, for embedding. It carries none of the
-// interactivity, none of the legend and none of the warning text, so it is
-// not a substitute for RenderHTML when the profile is degenerate: it returns
-// an error rather than emitting a blank canvas.
+// RenderSVG writes just the graph, for embedding. It carries its own copy of
+// the palette — a graph pulled out of the page must still be the right
+// colours, and must still follow the reader's light or dark theme — but none
+// of the interactivity, none of the legend and none of the warning text. It
+// is therefore not a substitute for RenderHTML when the profile is
+// degenerate: it returns an error rather than emitting a blank canvas.
 func RenderSVG(w io.Writer, res *foldedstacks.Result, opts Options) error {
 	opts = opts.withDefaults()
 	if res == nil {
@@ -139,7 +142,7 @@ func RenderSVG(w io.Writer, res *foldedstacks.Result, opts Options) error {
 	}
 	root, maxDepth := buildTree(res)
 	ew := &errWriter{w: w}
-	if err := writeSVG(ew, root, maxDepth, res, opts); err != nil {
+	if err := writeSVG(ew, root, maxDepth, res, opts, true); err != nil {
 		return err
 	}
 	return ew.err
@@ -234,7 +237,11 @@ func layout(n *node, x float64, scale float64) {
 	}
 }
 
-func writeSVG(ew *errWriter, root *node, maxDepth int, res *foldedstacks.Result, opts Options) error {
+// writeSVG draws the graph. standalone asks it to carry the palette inside
+// the <svg>, which RenderSVG needs and RenderHTML must not have: the page
+// already emitted paletteCSS in its <style>, and a second copy would be dead
+// weight in every file perf-agent writes.
+func writeSVG(ew *errWriter, root *node, maxDepth int, res *foldedstacks.Result, opts Options, standalone bool) error {
 	if root.value <= 0 {
 		return fmt.Errorf("flamegraph: tree total is %d", root.value)
 	}
@@ -246,6 +253,11 @@ func writeSVG(ew *errWriter, root *node, maxDepth int, res *foldedstacks.Result,
 	ew.f(`<svg class="flame" width="%d" height="%d" viewBox="0 0 %d %d" `, opts.Width, height, opts.Width, height)
 	ew.f(`xmlns="http://www.w3.org/2000/svg" data-total="%d" data-inexact="%d" data-unit="%s" data-side-pad="%d" data-plot-width="%.2f" data-min-text="%d" data-text-pad="%d" data-char-width="%.2f">`+"\n",
 		root.value, root.inexact, html.EscapeString(res.Unit), sidePad, plotWidth, minTextWidth, textPad, charWidth)
+	if standalone {
+		ew.s("<style>\n")
+		ew.s(paletteCSS)
+		ew.s("</style>\n")
+	}
 	ew.s(svgDefs)
 	writeNode(ew, root, maxDepth, res, "")
 	ew.s("</svg>\n")
@@ -258,13 +270,12 @@ func writeNode(ew *errWriter, n *node, maxDepth int, res *foldedstacks.Result, p
 	if parentPath != "" {
 		path = parentPath + " › " + n.name
 	}
-	info := n.domain.Info()
-
 	cls := "frame"
 	if n.inexact > 0 {
 		cls += " inexact"
 	}
 
+	info := n.domain.Info()
 	ew.f(`<g class="%s" data-name="%s" data-path="%s" data-domain="%s" data-domain-label="%s" data-value="%d" data-inexact="%d" data-orig-x="%.3f" data-orig-width="%.3f" data-depth="%d">`,
 		cls, html.EscapeString(n.name), html.EscapeString(path),
 		html.EscapeString(info.Key), html.EscapeString(info.Label),
@@ -273,12 +284,12 @@ func writeNode(ew *errWriter, n *node, maxDepth int, res *foldedstacks.Result, p
 	ew.esc(tooltip(n, res))
 	ew.s("</title>")
 
-	stroke := ""
-	if info.Stroke != "" {
-		stroke = fmt.Sprintf(` stroke="%s" stroke-width="0.8"`, info.Stroke)
-	}
-	ew.f(`<rect class="bg" x="%.3f" y="%.1f" width="%.3f" height="%d" rx="2" fill="%s"%s/>`,
-		n.x, y, n.width, frameHeight-1, info.Fill, stroke)
+	// No fill or stroke attribute: data-domain above selects both, from
+	// paletteCSS. A presentation attribute loses to any rule in the
+	// stylesheet, so a fill written here would have been overridden anyway
+	// — and a stroke written here silently was.
+	ew.f(`<rect class="bg" x="%.3f" y="%.1f" width="%.3f" height="%d" rx="2"/>`,
+		n.x, y, n.width, frameHeight-1)
 	if info.Overlay != "" {
 		ew.f(`<rect class="ov" x="%.3f" y="%.1f" width="%.3f" height="%d" rx="2" fill="%s"/>`,
 			n.x, y, n.width, frameHeight-1, info.Overlay)
@@ -503,6 +514,10 @@ func writeLegend(ew *errWriter, root *node) {
 	if present[DomainGPUKernel] {
 		ew.s("<p class=\"muted depth-note\">A <code>[gpu:kernel:…]</code> frame is one kernel and its duration.</p>\n")
 	}
+	// Say out loud that one colour of the palette is missing on purpose.
+	// Otherwise its absence looks like an oversight, and its arrival later
+	// looks like a new colour rather than a layer that finally has data.
+	ew.s("<p class=\"muted legend-note\">The colours are Brendan Gregg&rsquo;s AI Flame Graph palette. One of them, <span class=\"sw\" style=\"background-color:var(--fill-accel-source)\"></span><b>aqua</b>, is reserved and unused: it belongs to source lines of functions running on the accelerator, which needs per-instruction GPU sampling resolved back to source. perf-agent does not produce that yet, so no frame on this page is aqua.</p>\n")
 	ew.s("</section>\n")
 }
 


### PR DESCRIPTION
Recolours the HTML flame graph to [Brendan Gregg's AI Flame Graph](https://www.brendangregg.com/blog/2024-10-29/ai-flame-graphs.html) layer palette. The renderer already coloured by **domain** rather than by name hash; that structural decision stays — only the palette and the domain→colour mapping change.

| domain | legend | Gregg layer | light | dark |
|---|---|---|---|---|
| `app` | application | pink | `#f3a0c2` | `#e778a7` |
| `system` | CPU: process startup and libc | red (C) | `#eda3a1` | `#df7f7b` |
| `vendor` | CPU: GPU runtime and driver | yellow (C++) | `#f6de6a` | `#e9ce44` |
| `kernel` | CPU: kernel | orange | `#f9ae6c` | `#ed9345` |
| `unsym` | vendor, no symbols | drained warm + hatch | `#d0cab9` | `#bab29c` |
| `shim` | perf-agent | cool slate + outline | `#bcc3cd` | `#9fa9b6` |
| `boundary` | CPU→GPU boundary | grey | `#d6d6d6` | `#bdbdbd` |
| `boundary-unattributed` | GPU work with no CPU stack | grey, paler + hatch + dashed | `#ebebeb` | `#d1d1d1` |
| `gpu-kernel` | GPU kernel execution | green | `#82d38d` | `#62c16f` |
| *(reserved)* | aqua | aqua | `#77ced4` | `#57bbc2` |

C/C++/kernel follow Gregg's own ordering, so `kernel` and `vendor` swapped hues relative to the previous code.

### The two domains Gregg has no counterpart for

Neither gets a sixth hue. **Unsymbolized** keeps the warm CPU band's hue at 20% saturation and keeps its hatch — "right layer, no name". **The shim** takes the opposite drain to a cool slate with a cool outline; it was purple before, which is exactly the extra hue that fights the palette.

`[gpu:launch unsampled]` stays visually distinct from `[gpu:launch]` — paler, hatched, dashed — because they mean different things: GPU time we have a CPU stack for, versus GPU time we do not.

### Aqua is reserved and unused

That is Gregg's accelerator-*source* layer, which GPU PC sampling with SASS→source resolution will produce (planned, unbuilt). It is declared with a legend swatch saying why, and **a test fails if any domain takes it** — so the layer has a home rather than forcing a repaint later.

### Contrast is computed, not assumed

A test parses `paletteCSS` back into numbers and enforces 4.5:1 for label ink on every fill, in **both themes**, plain and with the hatch composited at full coverage. Worst case 4.60:1 (hatched red, dark); pink 4.71; aqua 5.52. Red was lightened to clear the floor.

Both themes come from one token set: every fill is a single `hsl()` at `:root` with the hue fixed, and the dark block moves only `--fill-dl`, `--fill-ds`, `--hatch-ink`. A test fails if a colour is ever defined inside the media block.

### Two bugs fixed in passing

The boundary frame's `stroke=` presentation attribute was silently overridden by the stylesheet and never rendered. The hover outline used `var(--ink)`, which inverts with the page, so it vanished on a light fill in dark mode.

### Verified

Rendered against the real RTX 3090 profile (`gpu-cuda-45.pb.gz`, 4000 samples, the 16-frame joined stack with 7 hex vendor frames): total unchanged at `data-total="5987854"`, each domain confirmed by sampling rendered pixels. Read in Chrome light and dark and in Firefox. Degenerate profile still renders its explanatory panel in both themes. `RenderSVG` keeps its colours standalone. `go build`/`vet`/`test ./...` pass, golangci-lint 0 issues.

**Not verified:** the palette was mapped from Gregg's layer list, not by sampling his images, so the hues are the right layers but the exact saturations and lightnesses are ours. No Safari/WebKit check. The dark theme was read from a screenshot rather than on a monitor.