### PR TITLE
flamegraph: adopt async-profiler's chrome discipline

### DIFF
--- a/.superpowers/sdd/flamegraph-minimal-report.md
+++ b/.superpowers/sdd/flamegraph-minimal-report.md
@@ -1,0 +1,395 @@
+# Flame graph: async-profiler's chrome discipline
+
+Branch `feat/flamegraph-minimal-chrome`. One commit. Renderer is
+`internal/flamegraph/`; outside it, `cmd/flamegraph` loses its `-width` flag
+and `perfagent` has one test assertion updated.
+
+## The graph fills the window
+
+The page used to open with
+
+```html
+<svg class="flame" width="1280" height="322" viewBox="0 0 1280 322" …>
+```
+
+— a hard-coded 1280 px. On a 1990 px window that left ~700 px of dead space
+and truncated `0x7f2c945b…` and `[gpu:kerne…` for want of room that was
+sitting empty to the right.
+
+**The geometry is percentages of the window now, not user units of a
+viewBox.** A frame is an absolutely positioned `<div>` inside a `.chart` that
+is an ordinary block, so it is as wide as the body, so it is as wide as the
+window:
+
+```html
+<div class="chart" style="height:305px" role="group" aria-label="Flame graph, gpu/nanoseconds" data-total="5987854" data-unit="nanoseconds">
+<div class="frame d1" style="left:0%;width:93.368%" role="img" aria-label="[gpu:launch unsampled], 5.59 ms, 93.37% of total" data-domain="boundary-unattributed" data-value="5590723">[gpu:launch unsampled]</div>
+```
+
+Measured in Chrome, `.chart` is 1966 px wide on a 1990 px window, 1256 px on
+1280, 761 px on 800 — window minus the body's 12 px padding, every time —
+and `documentElement.scrollWidth == clientWidth` at 400, 800, 1280, 1990 and
+3000 px, so nothing overflows either way.
+
+**Nothing scales.** This is the whole reason `width="100%"` on the old
+viewBox was not the fix: at 1990/1280 it would have magnified everything
+1.55×, turning 11 px labels into 17 px ones and 18 px rows into 28 px ones.
+That is a zoomed picture, not a filled one, and it buys no extra frames.
+Under percentage geometry the only px dimensions left are in the stylesheet,
+so they cannot vary with the window: `font-size` is 11 px, frame height and
+line height 17 px, row pitch 18 px, measured identical at 800, 1280 and
+1990 px in both themes and after a zoom. The graph gets *wider*, not bigger,
+which is what buys the legibility: at 1990 px the seven hex vendor frames and
+`[gpu:kernel:_Z14perfagent_axpyfPKfPfi]` now render **in full**, where the
+1280 px SVG cut them.
+
+**No script is involved, at any width.** There is no resize handler and no
+layout pass — a test asserts the script contains no `resize`, `clientWidth`,
+`offsetWidth` or `getBoundingClientRect().width`, and another strips
+everything from `<body>` to `<script>` and checks every frame still carries
+its span. The reflow is the browser resolving a percentage twice. This was a
+requirement rather than a nicety: the branch had just made the info panel a
+native `<details>` so the legend survives with JavaScript off, and a graph
+that needed a resize handler to be the right width would have handed that
+principle straight back. Screenshots of the page with the `<script>` element
+deleted are byte-identical to the full page at 800, 1280 and 1990 px.
+
+### Truncation is CSS now
+
+The renderer used to measure: `data-min-text`, `data-char-width=6.4`, a Go
+`truncate()` and a JS `fit()` that cut the label to `floor((w - 8) / 6.4)`
+characters. It cannot do that any more — it knows a frame is 6.632% wide and
+has no idea what that is in pixels — and it should never have been doing it,
+because 6.4 px was a guess at the advance of a font chosen by the reader's
+machine.
+
+So the markup carries **the whole symbol** and the stylesheet cuts it:
+`overflow:hidden; white-space:nowrap; text-overflow:ellipsis` on the frame,
+with 4 px of horizontal padding. The browser cuts at the reader's real width
+in the reader's real font, and never splits a rune — the guarantee
+`TestTruncateNeverSplitsAMultibyteRune` used to hold now belongs to the text
+engine, and that test is gone with the function.
+
+Consequences worth stating:
+
+- **`data-name` is gone.** The frame's text *is* its name, in full, so a
+  `data-name` would have been a second copy of an arbitrarily long string on
+  every frame — exactly the duplication this branch removed from
+  `data-orig-x`. The script reads `textContent`. Verified on a truncated
+  frame: the label reads `cudaLaunchKer…` while the tooltip and status bar
+  say `cudaLaunchKernel`.
+- **Below ~14 px a frame shows a lone ellipsis, and below 8 px nothing** —
+  the content box is zero once the padding is subtracted. That is the browser
+  applying the rule rather than a threshold anyone picked; the old
+  `minTextWidth = 24` was such a threshold and it was equally arbitrary.
+
+### What else the geometry change moved
+
+- **Hatching.** The two SVG `<pattern>`s and the extra `<rect>` per hatched
+  frame are two `repeating-linear-gradient` tokens, `--hatch-gap` and
+  `--hatch-inf`, applied as `background-image` by `data-domain` and by
+  `.frame.inexact`. They run opposite diagonals, as the patterns did, and a
+  frame that is both unnamed and inferred gets both layers — there is a test
+  for each hatched domain having a rule and for the combined case, because a
+  hatch is an honesty signal and losing one to the cascade would be silent.
+  `DomainInfo.Overlay` is `var(--hatch-gap)` where it was `url(#p-gap)`.
+- **Outlines are painted, not laid out.** `stroke` became inset `box-shadow`
+  rather than `border`, because with `box-sizing:border-box` a 1 px border
+  each side would eat the whole content box of a 3 px sliver. The one dashed
+  outline (`[gpu:launch unsampled]`) uses `outline` with `outline-offset:-1px`,
+  which box-shadow cannot dash and which is also not laid out. A test walks
+  every `.frame` rule and fails on `border:`.
+- **Rows are a class, not an inline `top`.** `rowCSS(maxDepth)` emits
+  `.d0{bottom:0px}…`, 289 B here, against 12 B per frame inline — a profile
+  has far more frames than depths. Measured from the *bottom* so a depth
+  means the same offset whatever the profile's height.
+- **`RenderSVG` is now `RenderFragment`**, and emits the same divs plus the
+  palette. Keeping an SVG renderer alive for embedding would have meant a
+  second geometry engine, a second palette (`fill`/`stroke` beside
+  `background`/`box-shadow`) and a second truncation rule, and they would
+  have drifted. It had no callers. It still refuses a degenerate profile,
+  which was the property worth keeping.
+- **`Options.Width` and `flamegraph -width` are gone.** There is no width to
+  set: the page fills what it is opened in.
+
+## Size
+
+Rendered from `/home/diego/gpu-cuda-45.pb.gz` (RTX 3090, 4000 samples, 3
+stacks, the 16-frame joined stack with 7 hex vendor frames):
+
+| | before the branch | chrome discipline | + percentage geometry |
+|---|---|---|---|
+| GPU profile page | **34,736 B** | 27,000 B (−22.3%) | **23,369 B** (−32.7%) |
+| degenerate page | 9,614 B | 6,927 B | 6,944 B (−27.8%) |
+
+The geometry change is −3,631 B on its own (−13.4% against 27,000 B), and
+the degenerate page pays +17 B for it — that page has no graph, so all it
+sees is the stylesheet swapping three `svg.flame` rules for two `.frame`
+ones. Where the 3,631 B went:
+
+| block | chrome discipline | + geometry | what happened |
+|---|---:|---:|---|
+| the graph | 7,586 | 4,304 | `<svg>`/`viewBox`/`xmlns` and five geometry `data-*` attributes gone; `<g>`+`<rect>`(+`<rect>`)+`<text>` per frame became one `<div>`; two coordinates per frame instead of six; `data-name` gone. Against that, every label is now emitted in full instead of pre-truncated |
+| `<style>` | 7,198 | 7,823 | the frame box, the two hatch gradients and 289 B of row rules arrive; the SVG `<defs>`, the pattern rules and `svg.flame text` leave |
+| `<script>` | 5,762 | 4,867 | `fit()`, the per-rect placement loop and five `data-*` readbacks gone; `place()` is two assignments |
+
+Total conserved: `data-total="5987854"` and the synthetic root at
+`data-value="5987854"`. `5.99 ms` on the status line, `gpu/nanoseconds` named
+as the axis.
+
+Where the 9.3 KB went, and where the remaining 25.4 KB is:
+
+| block | before | after | what happened |
+|---|---:|---:|---|
+| the graph | 14,476 | 7,586 | `data-path` (3,764 B — the breadcrumbs' backing store, O(depth²)), per-frame `<title>` (2,299 B — replaced by `role="img" aria-label`, 1,520 B, below), `data-orig-x`/`data-orig-width` (916 B — read back off the rects instead), `data-domain-label` (777 B), always-zero `data-inexact` (336 B), never-read `data-depth` (287 B) |
+| `<style>` | 8,021 | 7,198 | toolbar/chip/breadcrumb rules gone; 1,373 B of CSS comments moved into Go comments; status bar, tooltip, info panel and jitter ladder added; the degenerate page's own CSS is now emitted only on the degenerate page |
+| `<script>` | 5,145 | 5,762 | lost breadcrumbs and the zoom chip, gained the tooltip and the theme toggle; the panel's open/close is native |
+| chrome above the graph | 1,947 | 372 | header + chips + toolbar + notices box → one title line with two icons and one note |
+| legend + labels + keys + provenance | 4,534 | 5,486 | same content plus the keyboard map, now inside `<details id="info">` |
+
+**This is not 15–20 KB and I did not force it there.** async-profiler reaches
+that with a canvas plus a compact JS array where we have 20 DOM frames (the
+brief says keep DOM), and with an info panel of a few lines where we carry
+5.4 KB of legend, honesty notes, label report and provenance. That 5.4 KB is
+now invisible until asked for, which was the actual complaint; deleting it to
+hit a number would trade a real property for a smaller file. The remaining
+un-minified 13 KB of CSS+JS is legible in View Source, which I judged worth
+more than the ~4 KB minification would save.
+
+### Accessible names
+
+Every frame group carries `role="img"` and an `aria-label` of name, value and
+share — the same three things, in the same order, that the status bar shows,
+so hearing the page and seeing it agree. **1,520 B for 20 frames, 779 B
+cheaper than the 2,299 B of `<title>` it replaces**, because the label drops
+the domain, module and inference lines that the visual tooltip still carries.
+
+`aria-label` rather than restoring `<title>` for the reason the coordinator
+gave: a `<title>` is both the accessible name and a native browser tooltip,
+so it would put a second tooltip on a one-second delay behind the cursor
+tooltip on every hover. `role="img"` goes with it because without a role the
+frame's text child is exposed separately and a reader hears the truncated
+on-screen label ("0x7f2c945b…") after the real name; `img` makes the subtree
+presentational, so the frame is announced as one object. That mattered more
+once the geometry moved to HTML, because the text child is now the *whole*
+symbol and the truncation is visual only.
+
+The container is named too — "Flame graph, gpu/nanoseconds" — but with
+**`role="group"`, not `role="img"`**. This is the one place the SVG→HTML
+translation is not mechanical: an `<svg>` with an `aria-label` maps to
+`graphics-document` and keeps its children exposed, whereas `role="img"` on a
+`<div>` would make the entire subtree presentational and silence all twenty
+frames. `group` takes an accessible name and leaves its children alone. Escaping is the existing
+`html.EscapeString`, tested against `Foo<Bar&"Baz">::run()`.
+
+### The info panel opens without JavaScript
+
+`<details id="info"><summary id="info-btn">ⓘ</summary><div id="panel">…` —
+the disclosure is native, so a page opened with JavaScript off, or saved and
+reopened somewhere that blocks it, can still reach the legend, which used to
+be permanent. It renders collapsed, so "nothing permanent explains the page"
+holds. Verified by deleting the `<script>` element from the rendered page
+entirely and screenshotting: graph, note, status line and panel all correct.
+`<summary>` also brings disclosure semantics a `<div hidden>` never had — it
+is a button that announces expanded or collapsed. The `?` / `I` key, `Esc`
+and click-outside now set `info.open` rather than toggling a `hidden`
+attribute; a test asserts the script contains no path that sets the panel's
+own visibility, so the no-JS route cannot rot.
+
+## Notes: what stayed, what moved
+
+**Stayed on the page, one line, always visible** — `gpu_sample_period`:
+
+> gpu_sample_period=8 — one launch in 8 carried a CPU stack, so the width
+> under [gpu:launch] is a sample of launches, not that path's share of GPU
+> time. Nothing is scaled by 8.
+
+Four sentences to one, 206 B, one line at 1400 px. It keeps all three facts:
+the ratio, the misreading it prevents, and that no value is scaled. It stays
+because it is the only note whose content is *absent from the picture* —
+nothing about the drawing hints that launches were subsampled. The long form
+is suppressed from the panel so the note is never made twice.
+
+**Moved into the info panel:**
+
+- *"1799 of 11598 frame slots (15.5%) have no symbol…"* — the frames it
+  describes are on screen, hatched, named by their address, and say
+  "no symbol: the unwind found this frame, nothing could name it" on hover.
+  The note aggregates what the graph already shows.
+- *"93.4% of the total sits under [gpu:launch unsampled]…"* — 93.4% **is**
+  the width of that frame. The note restates the picture in numbers.
+- Zero-value samples, empty stacks, multi-axis profiles — all statements
+  about what was excluded, none of them a trap.
+
+So the page does not hide that it has caveats: **the info button carries an
+orange dot whenever the profile produced notes** (`#info-btn.notes::after`),
+and the dot is absent on a clean profile. Both cases are tested.
+
+**Degenerate page** — unchanged in content. Diffed against the old renderer:
+the only differences are the `<main>` wrapper (replaced by a `max-width` on
+`body`) and the `hdr` class. Still no `<script>`, no `color-mix`, no
+`hsl(from` — and now no `class="chart"` either, where the assertion used to
+be no `<svg>`. Re-screenshotted after the geometry change: chips, notices,
+"No flame graph was drawn", label table and footer all correct.
+
+## Jitter, and how it was bounded
+
+`assignJitter` in `render.go`; ladder in `assets.go`; contrast in
+`palette_test.go`.
+
+**Direction is forced, not chosen.** The worst label contrast on the page is
+4.605:1 (dark theme, `--fill-system`, hatch composited at full coverage) —
+0.105 above the 4.5:1 floor. I measured what darkening costs before writing
+any of it:
+
+```
+jitter     0%  worst 4.605:1     jitter -2%  worst 4.326:1
+jitter    -1%  worst 4.463:1     jitter -3%  worst 4.194:1
+```
+
+−1% already breaches the floor. So jitter **only ever lightens**, exactly as
+async-profiler's `getColor()` only ever adds to a base. Raising lightness at
+fixed hue and saturation raises luminance monotonically, so the worst-case
+jittered frame is the *un-jittered* one and the floor does not move. The test
+asserts this rather than assuming it: it walks every rung of every token in
+both themes, requires each rung to be strictly lighter than the last, and
+requires `worst(all rungs) == worst(rung 0)`. It also fails if the floor ever
+grows past 4.7 — at which point the jitter could afford to be bolder.
+
+**Mechanism.** A first attempt used `color-mix(in srgb, #fff p%, fill)`, the
+literal translation of async-profiler's "add N to each channel". It is nearly
+invisible on this palette: our fills are already light, so 6% white moves
+`--fill-unsym` three units per channel. Switched to a lightness delta in
+relative colour syntax:
+
+```css
+.frame{background-color:var(--fill-x);background-color:hsl(from var(--fill-x) h s calc(l + var(--fill-j)))}
+```
+
++6 lightness moves the same fill fifteen units per channel. Hue and
+saturation never move, so the palette still reads. Verified in **both Chrome
+and Firefox** that `l` resolves as a bare number (`calc(l + 6%)` renders
+white in both — a percentage there is wrong) and that the result is
+pixel-identical to the hand-written `hsl()`. The plain `fill:var(--fill-x)`
+is declared first: an engine without relative colour syntax (pre Chrome 119 /
+Safari 16.4 / Firefox 128) drops the second declaration and keeps the
+palette. (When the fills were SVG `fill:` the failure mode was a page of
+black rectangles; on a `<div>` it is a page of transparent ones, which is no
+better.)
+
+**Amplitude: 8 lightness points, 8 rungs.** Palest jittered fill
+`--fill-unsym` at 77% tops out at 85% — still sand. Not white.
+
+**The token layout survives untouched.** Every colour is still one `hsl()` at
+`:root`; the frame reaches it through `--fill-x` and composes the jitter in
+its own `background-color:` property. This is the only arrangement that works: `var()`
+inside a custom property is substituted when *that property* is computed, on
+the element that declares it, so a `--fill-app` referencing `--fill-j` would
+freeze in `:root`'s value of it.
+
+**Two domains sit out of the ladder**: `boundary` and
+`boundary-unattributed`, plus the synthetic root. Their lightness difference
+is a *meaning* — paler means nothing behind it, and there is a test enforcing
+the 5-point gap — and a random lightness must not compete with a meaningful
+one. (`--fill-boundary-unattributed` is also at 92% and would reach 100.)
+
+**Better than random where it counts.** async-profiler's is `Math.random()`
+per frame and may collide with the neighbour it was meant to separate. Ours
+hashes the frame name (so a render is byte-identical to the last one and a
+frame keeps its shade across a zoom), then walks the tree with the parent and
+previous sibling in hand and steps away from both by at least 3 rungs (+3.4
+lightness). The seven consecutive hex frames now land on rungs
+2, 6, 1, 7, 1, 4, 1 — every touching same-domain pair separated by
+construction. Tested.
+
+## Keyboard map
+
+| key | action |
+|---|---|
+| `Ctrl+F` / `Cmd+F` | reveal and focus the search field (bottom right) |
+| `0` | reset zoom |
+| `Esc` | close the info panel, else clear and hide search, else reset zoom |
+| `D` | light / dark, overriding the OS in both directions |
+| `?` or `I` | info panel |
+| click a frame / the background | zoom / reset |
+
+Discoverable from the panel's first section, and from the two buttons'
+`title` attributes. `Ctrl+F` shadows find-in-page, as async-profiler's does.
+
+## Other changes
+
+- **One bottom status bar.** Resting content is the profile summary
+  (`5.99 ms total · 4,000 samples · 3 stacks · gpu/nanoseconds`) — the chip
+  row's numbers keep a permanent home without a chip row. On hover it becomes
+  `name · value · share`. Match counter bottom right
+  (`5 matched · 1.99 ms · 33.16%`), with the search input beside it.
+- **Tooltip at the cursor**, flipping at the viewport edges, carrying name,
+  value, share, module (only when the profile has one) and the
+  inference/no-symbol notes. Built with `textContent`, never `innerHTML`.
+- **Theme toggle.** `--fill-dl` / `--fill-ds` / `--hatch-ink` and the ten
+  chrome tokens are each written **once** as a Go constant and emitted twice:
+  under `@media (prefers-color-scheme: dark){:root:not([data-theme="light"])}`
+  and under `:root[data-theme="dark"]`. Two copies of one constant cannot
+  drift, and a test asserts the two blocks are byte-identical and that
+  neither declares anything but the knobs. Verified pixel-identically: the
+  OS-dark render and the `data-theme="dark"` render hash the same, as do
+  OS-light and `data-theme="light"`-under-dark-OS.
+- Aqua still reserved, unused, and tested. Escaping unchanged. No network,
+  no CDN, no external font — the existing test still passes.
+
+## What I could not verify
+
+- **The graph was measured at five widths, not resized at one.** Headless
+  Chrome cannot resize a window, so "reflows on resize" is verified by
+  loading the same file at 400/800/1280/1990/3000 px and measuring, plus by
+  reading the CSS: nothing in the layout is in pixels, so there is nothing
+  for a resize to invalidate. **Nobody has dragged a window edge and watched
+  it reflow.** The same applies after a zoom: I confirmed the zoomed frames
+  are still expressed as percentages (`left:0%;width:100%` for the zoom
+  target) and inferred that a resize therefore reflows them, rather than
+  seeing it.
+- **The ellipsis band was reasoned about, not photographed.** "Nothing below
+  8 px, a lone ellipsis to about 14 px" follows from 4 px of padding either
+  side and the advance of `…`; this profile's narrowest frame is 130 px at
+  1990 px and 51 px at 800 px, so no frame on the verification page is
+  anywhere near the band. A dense system-wide profile would be the test, and
+  I did not render one.
+- **Only Chrome and Firefox, both headless, both current, both on this
+  machine.** No Safari or WebKit at all — and Safari is the engine where
+  `hsl(from …)` has the longest history, so I expect it fine, but I did not
+  see it. No Windows, no mobile.
+- **Sub-pixel `box-shadow`.** The default frame edge is
+  `inset 0 0 0 .5px`, which is what the old `stroke-width:.5` amounted to.
+  Chrome and Firefox both render it as a faint hairline; a half-pixel inset
+  shadow is a place engines are entitled to differ, and I checked two.
+- **No real pointer.** Hover, tooltip placement and search were exercised by
+  dispatching synthetic `mouseenter`/`mousemove`/`input` events and
+  screenshotting the result. I never clicked a frame with a mouse, so
+  click-to-zoom, click-outside-to-close and the keyboard handlers are
+  verified by reading and by unit tests, not by using them.
+- **The theme toggle's runtime behaviour** was verified by rendering the two
+  end states (`data-theme` set in the markup), not by pressing `D`.
+- **No screen reader.** Every frame now has `role="img"` and an `aria-label`,
+  and the `<summary>` brings native disclosure semantics, but I verified this
+  by reading the markup and the HTML-AAM mapping rules, not by listening to
+  it. Nobody has run NVDA, JAWS, VoiceOver or Orca over this page. In
+  particular I have not confirmed that `role="img"` on a `<div>` actually
+  suppresses its text child in every reader, which is the whole reason the
+  role is there, nor that `role="group"` on the container leaves the frames
+  exposed in every reader — and the frames now carry their full symbol as
+  text, so if `role="img"` is ignored the double-announcement is longer than
+  it used to be.
+- **The no-JS path was verified by deleting the `<script>`, not by disabling
+  JavaScript in a browser** — this time including the layout, whose
+  screenshots came out byte-identical to the scripted page at all three
+  widths, which is the strongest form the check takes here —, and the native `<summary>` toggle was verified
+  by forcing the `open` attribute rather than by clicking it — headless
+  screenshots cannot click. The toggle itself is HTML-spec behaviour, not
+  code of mine, but I did not watch it happen.
+- **Icon glyphs depend on the reader's fonts.** `&#9432;` rendered as a
+  slightly squarish circled *i* in this machine's fallback font and `&#9680;`
+  rendered correctly, but I cannot promise either on a machine without them.
+- Theme choice is not persisted (no `localStorage`); `D` resets on reload.
+- Jitter separation is guaranteed against the parent and the previous
+  sibling. Two same-domain frames that touch only diagonally, or across a
+  zoom-induced reflow, may still land close together.

--- a/cmd/flamegraph/main.go
+++ b/cmd/flamegraph/main.go
@@ -28,7 +28,6 @@ func main() {
 	var (
 		out        = flag.String("o", "", "HTML output path (default: <input>.html)")
 		title      = flag.String("title", "", "page title (default: the input file name)")
-		width      = flag.Int("width", 0, "graph width in pixels (default: 1280)")
 		folded     = flag.Bool("folded", false, "write folded stacks to stdout instead of HTML")
 		sampleIdx  = flag.Int("sample-index", -1, "which sample type to fold; -1 chooses automatically")
 		stackOrder = flag.String("stack-order", "root-first", "how the profile stores Sample.Location: root-first (perf-agent) | leaf-first (pprof proto)")
@@ -65,7 +64,6 @@ func main() {
 	}
 	res, err := flamegraph.FromProfileFile(in, dst, flamegraph.Options{
 		Title: *title,
-		Width: *width,
 	})
 	if err != nil {
 		fatalf("%v", err)

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -1,123 +1,133 @@
 package flamegraph
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Everything in this file is inlined verbatim into the output page. Nothing
 // here may reference an external URL: the deliverable is one file that
 // renders correctly from file:// with no server and no network.
 //
 // No user- or symbol-derived text is ever placed inside <style> or <script>.
-// All profile data reaches the page through escaped SVG attributes and is
-// read back with dataset/textContent, so a mangled C++ name full of <, > and
-// & cannot inject markup or script.
+// All profile data reaches the page through escaped HTML attributes and text
+// nodes, and is read back with dataset/textContent, so a mangled C++ name
+// full of <, > and & cannot inject markup or script.
+//
+// The prose that explains these rules lives in Go comments, not in CSS or JS
+// comments. A comment inside one of these constants is shipped to every
+// reader of every page perf-agent writes; the audience for "why aqua is
+// reserved" is whoever edits this file.
+//
+// Chrome discipline, borrowed from async-profiler's src/res/flame.html:
+// nothing permanent on the page explains the page. The graph, one line of
+// status, and — only when the profile carries the trap it guards against —
+// one line of warning. The legend, the keyboard map, the notes and the label
+// table are all one keypress (or one icon) away.
 
-// svgDefs holds the hatch patterns. Hatching always means "the profile could
-// not fully account for this frame" — no symbol, or no measured caller.
-const svgDefs = `<defs>
-<pattern id="p-gap" width="6" height="6" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
-<rect width="6" height="6" fill="none"/>
-<line class="hatch" x1="0" y1="0" x2="0" y2="6" stroke-width="2.2"/>
-</pattern>
-<pattern id="p-inferred" width="5" height="5" patternUnits="userSpaceOnUse" patternTransform="rotate(-45)">
-<rect width="5" height="5" fill="none"/>
-<line class="hatch" x1="0" y1="0" x2="0" y2="5" stroke-width="1.6" stroke-dasharray="2 2"/>
-</pattern>
-</defs>
-`
+// darkChrome is the page chrome's dark theme, written once and emitted
+// twice: once behind prefers-color-scheme for readers who never touch the
+// D key, once behind [data-theme="dark"] for readers who do. Two copies of
+// one Go constant cannot drift; two copies of ten hex literals could.
+const darkChrome = `--bg:#16151a;--panel:#1e1d23;--ink:#eceaf2;--muted:#a29caf;--line:#332f3b;` +
+	`--accent:#ff9a6a;--warn-bg:#2b2313;--warn-line:#6d5722;--fatal-bg:#2e1616;--fatal-line:#7a3232`
 
-const toolbarHTML = `<section class="toolbar">
-<div class="row">
-<label class="search"><span>Search</span><input id="search" type="search" placeholder="frame name or substring" autocomplete="off" spellcheck="false"></label>
-<button id="clear-search" type="button">Clear</button>
-<button id="reset-zoom" type="button">Reset zoom</button>
-<span class="spacer"></span>
-<span class="stat"><b>matched</b><span id="match-count">&mdash;</span></span>
-<span class="stat"><b>focus</b><span id="zoom-state">all</span></span>
-</div>
-<div class="crumbs" id="breadcrumbs">all</div>
-<div class="detail" id="details">Hover a frame for its value. Click to zoom. Press / to search, Esc to clear then reset.</div>
-</section>
-`
-
+// styleSheet is the page chrome — the title line, the two icon buttons, the
+// one-line note, the fixed status bar, the cursor tooltip and the info panel
+// — plus the frame box itself.
+//
+// The frame box is the whole of the layout engine. A frame is an absolutely
+// positioned block whose left and width are PERCENTAGES of .chart, which is
+// itself an ordinary block and therefore as wide as the window minus the
+// body padding. That is why the graph fills any viewport and reflows on
+// resize with no script: the browser resolves the percentages, and it
+// resolves them again when the window changes. Height, padding, font size
+// and row pitch are all in px and never scale, so a frame at 1990 px and the
+// same frame at 800 px carry the same 11 px label — the graph gets wider,
+// not bigger. (The SVG this replaced had to pick a width, and did: 1280,
+// baked into a viewBox. Setting width="100%" on that viewBox would have
+// scaled the text with it, which is zoom, not fill.)
+//
+// Truncation is the browser's now, not the renderer's. overflow:hidden with
+// text-overflow:ellipsis cuts the label to whatever the frame can hold, at
+// the reader's actual window width, in the reader's actual font — three
+// things a Go function measuring characters against a nominal 6.4 px advance
+// could only guess at. Frames narrower than the 8 px of horizontal padding
+// have a zero-width content box and draw no text at all; between there and
+// about 14 px they draw a lone ellipsis. Both are the browser applying the
+// rule, not a threshold anyone chose.
 const styleSheet = `
-:root{
-  --bg:#fbf9f6; --panel:#fffefc; --ink:#1d1a17; --muted:#6b6259;
-  --line:#e2dad0; --accent:#b4522a; --warn-bg:#fff6e8; --warn-line:#e8c88a;
-  --fatal-bg:#fdecec; --fatal-line:#e0a3a3;
-}
-@media (prefers-color-scheme: dark){
-  :root{
-    --bg:#16151a; --panel:#1e1d23; --ink:#eceaf2; --muted:#a29caf;
-    --line:#332f3b; --accent:#ff9a6a; --warn-bg:#2b2313; --warn-line:#6d5722;
-    --fatal-bg:#2e1616; --fatal-line:#7a3232;
-  }
-}
+:root{--bg:#fbf9f6;--panel:#fffefc;--ink:#1d1a17;--muted:#6b6259;--line:#e2dad0;--accent:#b4522a;--warn-bg:#fff6e8;--warn-line:#e8c88a;--fatal-bg:#fdecec;--fatal-line:#e0a3a3}
+@media (prefers-color-scheme: dark){:root:not([data-theme="light"]){` + darkChrome + `}}
+:root[data-theme="dark"]{` + darkChrome + `}
 *{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--ink);
-  font:14px/1.5 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-main{max-width:1360px;margin:0 auto;padding:20px 16px 48px}
-h1{font-size:20px;margin:0 0 2px;letter-spacing:-.01em}
-h2{font-size:13px;margin:0 0 8px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
-code{font:12px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
-.sub{margin:0 0 10px;color:var(--muted);font-size:12.5px;word-break:break-all}
+body{margin:0;padding:8px 12px 30px;background:var(--bg);color:var(--ink);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5}
+code,kbd{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11.5px}
 .muted{color:var(--muted)}
-.hdr{margin-bottom:14px}
+.top{display:flex;align-items:baseline;gap:8px}
+h1{font-size:13px;font-weight:600;margin:0;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.top button,.top summary{cursor:pointer;color:var(--muted);background:none;border:0;padding:0 2px;font-size:15px;line-height:1;list-style:none}
+.top summary::-webkit-details-marker{display:none}
+.top button:hover,.top summary:hover{color:var(--accent)}
+#info-btn.notes::after{content:"\2022";color:var(--accent);vertical-align:super;font-size:11px}
+.note{margin:6px 0 0;padding:3px 9px;border:1px solid var(--warn-line);border-left-width:3px;border-radius:5px;background:var(--warn-bg);font-size:12px}
+.chart{position:relative;margin:8px 0 0}
+.frame{position:absolute;height:17px;padding:0 4px;border-radius:2px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;line-height:17px;cursor:pointer}
+.frame.dim{opacity:.15}
+#status{position:fixed;left:0;right:0;bottom:0;z-index:6;display:flex;gap:12px;align-items:center;padding:2px 12px;background:var(--panel);border-top:1px solid var(--line);font-size:12px}
+#st{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+#mc{color:var(--muted);white-space:nowrap}
+#q{font:inherit;color:inherit;background:var(--bg);border:1px solid var(--line);border-radius:5px;padding:1px 6px;width:15em}
+#tip{position:fixed;z-index:8;left:0;top:0;max-width:46em;padding:5px 8px;border:1px solid var(--line);border-radius:6px;background:var(--panel);box-shadow:0 2px 10px rgb(0 0 0/.2);font-size:12px;line-height:1.45;white-space:pre-line;word-break:break-all;pointer-events:none}
+#panel{position:fixed;z-index:9;top:32px;left:50%;transform:translateX(-50%);width:min(1000px,calc(100% - 24px));max-height:calc(100vh - 72px);overflow:auto;padding:12px 16px 16px;border:1px solid var(--line);border-radius:10px;background:var(--panel);box-shadow:0 8px 34px rgb(0 0 0/.25);cursor:auto;text-align:left}
+#panel h2{font-size:10.5px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin:14px 0 6px}
+#panel h2:first-of-type{margin-top:0}
+#panel p{margin:6px 0;max-width:96ch}
+#panel ul{margin:0;padding-left:16px}
+#panel li{margin:2px 0;font-size:12px}
+#close{position:absolute;top:9px;right:12px;cursor:pointer;color:var(--muted);background:none;border:0;font-size:13px;padding:0}
+kbd{border:1px solid var(--line);border-bottom-width:2px;border-radius:4px;padding:0 4px;background:var(--bg)}
+.keys{list-style:none;padding:0;display:grid;gap:3px;grid-template-columns:repeat(auto-fit,minmax(250px,1fr))}
+.legend-list{list-style:none;margin:0;padding:0;display:grid;gap:5px;grid-template-columns:repeat(auto-fit,minmax(320px,1fr))}
+.sw{display:inline-block;width:12px;height:12px;border-radius:3px;margin-right:6px;border:1px solid rgb(0 0 0/.3);vertical-align:-1px}
+.sw.hatched{background-image:var(--hatch-gap)}
+.sw.hatch{background:transparent;background-image:repeating-linear-gradient(45deg,var(--muted) 0 2px,transparent 2px 6px);border-color:var(--muted)}
+table{border-collapse:collapse;width:100%;font-size:12px}
+th,td{text-align:left;padding:4px 10px 4px 0;border-bottom:1px solid var(--line);vertical-align:top}
+th{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
+.lv{display:inline-block;margin:0 8px 2px 0;white-space:nowrap}
+`
+
+// reportCSS styles the page a degenerate profile gets: no graph, no status
+// bar, no info panel — a written report about why there is nothing to draw.
+// It is emitted only on that page, so the 99% case does not carry it.
+const reportCSS = `
+body{padding:20px 16px 24px;max-width:1360px;margin:0 auto}
+h1{font-size:19px;white-space:normal;letter-spacing:-.01em}
+h2{font-size:11px;margin:0 0 8px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+.sub{margin:2px 0 10px;color:var(--muted);font-size:12px;word-break:break-all}
 .chips{display:flex;flex-wrap:wrap;gap:6px}
-.chip{display:inline-flex;gap:6px;align-items:baseline;padding:3px 9px;border:1px solid var(--line);
-  border-radius:999px;background:var(--panel);font-size:12px}
+.chip{display:inline-flex;gap:6px;align-items:baseline;padding:3px 9px;border:1px solid var(--line);border-radius:999px;background:var(--panel);font-size:12px}
 .chip b{font-weight:600;color:var(--muted);font-size:10.5px;text-transform:uppercase;letter-spacing:.06em}
-section{margin:0 0 14px}
-.notices,.nodata,.legend,.labels{border:1px solid var(--line);border-radius:10px;background:var(--panel);padding:12px 14px}
-.notices{background:var(--warn-bg);border-color:var(--warn-line)}
+section{margin:14px 0}
+.notices,.nodata,.labels{border:1px solid var(--warn-line);border-radius:10px;padding:12px 14px;background:var(--warn-bg)}
+.labels{background:var(--panel);border-color:var(--line)}
 .notices.fatal,.nodata{background:var(--fatal-bg);border-color:var(--fatal-line)}
 .notices ul{margin:0;padding-left:18px}
-.notices li{margin:3px 0;font-size:13px}
-.nodata h2{color:inherit}
 .nodata p{margin:0 0 8px;max-width:70ch}
-.toolbar{position:sticky;top:0;z-index:5;border:1px solid var(--line);border-radius:10px;
-  background:var(--panel);padding:10px 12px}
-.row{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
-.search{display:inline-flex;gap:6px;align-items:center}
-.search span{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
-input,button{font:inherit;color:inherit;background:var(--bg);border:1px solid var(--line);
-  border-radius:7px;padding:5px 9px}
-input{min-width:260px}
-button{cursor:pointer}
-button:hover{border-color:var(--accent)}
-.spacer{flex:1}
-.stat{display:inline-flex;gap:6px;align-items:baseline;font-size:12px}
-.stat b{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
-.crumbs{margin-top:8px;font-size:12px;color:var(--muted);word-break:break-word;min-height:1.4em}
-.detail{margin-top:4px;font-size:12.5px;min-height:1.4em}
-.chart{margin:12px 0;overflow-x:auto;border:1px solid var(--line);border-radius:10px;background:var(--panel)}
-svg.flame{display:block}
-svg.flame text{font:11px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;pointer-events:none}
-g.frame{cursor:pointer}
-g.frame.dim{opacity:.15}
-.legend-list{list-style:none;margin:0;padding:0;display:grid;gap:5px;
-  grid-template-columns:repeat(auto-fit,minmax(330px,1fr))}
-.legend-list li{font-size:12.5px;line-height:1.45}
-.legend-list b{margin-right:4px}
-.sw{display:inline-block;width:14px;height:14px;border-radius:3px;margin-right:7px;
-  border:1px solid rgba(0,0,0,.3);vertical-align:-2px}
-.sw.hatched{background-image:repeating-linear-gradient(45deg,var(--hatch-ink) 0 2px,transparent 2px 6px)}
-/* The generic hatching row explains the pattern, not a domain, so its
-   swatch carries the pattern over nothing. */
-.sw.hatch{background:transparent;
-  background-image:repeating-linear-gradient(45deg,var(--muted) 0 2px,transparent 2px 6px);
-  border-color:var(--muted)}
-.legend-note{margin:10px 0 0;max-width:90ch;font-size:12.5px}
-.depth-note{margin:10px 0 0;max-width:90ch;font-size:12.5px}
-.labels table{border-collapse:collapse;width:100%;font-size:12.5px}
-.labels th,.labels td{text-align:left;padding:5px 10px 5px 0;border-bottom:1px solid var(--line);
-  vertical-align:top}
-.labels th{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted)}
-.lv{display:inline-block;margin:0 8px 2px 0;white-space:nowrap}
-footer{color:var(--muted);font-size:11.5px;padding-top:6px}
+footer{color:var(--muted);font-size:11.5px}
 `
+
+// The two knobs the dark theme is allowed to move, written once and emitted
+// twice for the same reason as darkChrome. Nothing in either block is a
+// colour: --hatch-ink aside, they are a lightness offset and a saturation
+// multiplier that every fill already references.
+const darkKnobs = `--fill-dl:-9%;--fill-ds:.9;--hatch-ink:rgb(22 20 18 / .20)`
 
 // paletteCSS is the flame graph's own colours, kept apart from the page
 // chrome above because it is emitted in two places: after styleSheet in the
-// HTML page, and inside the <svg> itself when RenderSVG writes a standalone
-// graph. A graph embedded on its own must still be the right colours.
+// HTML page, and ahead of the graph when RenderFragment writes one for
+// embedding. A graph pulled out of the page must still be the right colours.
 //
 // The palette is Brendan Gregg's AI Flame Graph palette — pink application,
 // red/yellow/orange CPU, grey boundary, aqua accelerator source, green
@@ -133,14 +143,57 @@ footer{color:var(--muted);font-size:11.5px;padding-top:6px}
 // variant, and neither do the hover and search outlines drawn on top of a
 // fill. (var(--ink) would be wrong there: it inverts with the page, not with
 // the frame.)
+//
+// Jitter. A frame does not take var(--fill-app) directly; it takes it through
+// --fill-x and then adds a per-frame amount to that colour's LIGHTNESS,
+// leaving its hue and saturation untouched. This is async-profiler's
+// getColor() — a small random brightening of a base colour, per frame, so a
+// run of same-domain neighbours has visible edges — with the randomness
+// moved to render time and the arithmetic done in HSL.
+//
+// Lightening is not a preference, it is the only direction available. The
+// darkest thing a label is drawn on clears the 4.5:1 contrast floor by 0.105
+// (4.605:1, dark theme, hatched --fill-system), and raising a fill's
+// lightness raises its luminance monotonically at fixed hue and saturation,
+// so the worst-case jittered frame is the un-jittered one and the floor does
+// not move. Darkening by as little as 1.5% would breach it.
+//
+// HSL rather than a white mix because this palette is already light: mixing
+// 6% white into --fill-unsym moves it three units per channel and is
+// invisible, while +6 lightness moves it fifteen and is not.
+//
+// The token is defined at :root but consumed on the frame, which is the only
+// arrangement that works: var() inside a custom property is substituted when
+// that property is computed, on the element that declares it, so a
+// --fill-app that referenced --fill-j would freeze in :root's value of it.
+// background-color: is a real property on the frame, so its var()s resolve
+// there. The two hatch gradients are the opposite case and are fine: they
+// reference --hatch-ink, which is declared on :root beside them, so freezing
+// at :root is exactly what they want.
+//
+// The plain fill is declared first as a fallback. Relative colour syntax
+// (hsl(from …)) is Chrome 119 / Safari 16.4 / Firefox 128; an engine that
+// cannot parse the second declaration drops it and keeps the first, which is
+// the palette's own colour. The failure mode of getting this wrong used to
+// be a page of black rectangles (SVG's default fill); on a div it is a page
+// of transparent ones, which is no better.
+//
+// Outlines are box-shadows rather than borders because a border participates
+// in layout: with box-sizing:border-box it would eat 2 px out of a frame
+// that may only be 3 px wide. An inset box-shadow is painted, not laid out.
+// The one exception is the unattributed boundary, whose outline is dashed —
+// box-shadow cannot dash — so it uses outline with a negative offset, which
+// is also painted rather than laid out.
 const paletteCSS = `
 :root{
-  /* The two theme knobs. Nothing else about the palette changes. */
-  --fill-dl:0%;   /* lightness shift applied to every fill and every edge */
-  --fill-ds:1;    /* saturation multiplier applied to every fill */
+  --fill-dl:0%;
+  --fill-ds:1;
+  --fill-j:0;
   --hatch-ink:rgb(22 20 18 / .26);
 
-  /* Gregg's layers. Hue is the meaning; it never moves. */
+  --hatch-gap: repeating-linear-gradient(45deg,var(--hatch-ink) 0 2.2px,transparent 2.2px 6px);
+  --hatch-inf: repeating-linear-gradient(-45deg,var(--hatch-ink) 0 1.4px,transparent 1.4px 5px);
+
   --fill-app:      hsl(335 calc(78% * var(--fill-ds)) calc(79% + var(--fill-dl)));
   --fill-system:   hsl(  2 calc(68% * var(--fill-ds)) calc(78% + var(--fill-dl)));
   --fill-vendor:   hsl( 50 calc(88% * var(--fill-ds)) calc(69% + var(--fill-dl)));
@@ -148,84 +201,121 @@ const paletteCSS = `
   --fill-boundary: hsl(  0                        0%  calc(84% + var(--fill-dl)));
   --fill-boundary-unattributed: hsl(0             0%  calc(92% + var(--fill-dl)));
   --fill-gpu-kernel: hsl(128 calc(48% * var(--fill-ds)) calc(67% + var(--fill-dl)));
-
-  /* Reserved. Gregg's aqua is the source of functions running ON the
-     accelerator; that needs GPU PC sampling with SASS→source resolution,
-     which perf-agent does not do yet. No domain points at this token, so
-     nothing on the page is aqua — the hue is held open, not spent. */
   --fill-accel-source: hsl(184 calc(52% * var(--fill-ds)) calc(65% + var(--fill-dl)));
-
-  /* The two domains Gregg's scheme has no layer for. Drained to near-grey
-     rather than given a sixth hue: warm for "a CPU frame we cannot name",
-     cool for "not your program at all". */
   --fill-unsym: hsl( 45 calc(20% * var(--fill-ds)) calc(77% + var(--fill-dl)));
   --fill-shim:  hsl(215 calc(15% * var(--fill-ds)) calc(77% + var(--fill-dl)));
-
   --fill-root: hsl(30 calc(8% * var(--fill-ds)) calc(81% + var(--fill-dl)));
 
-  /* Edges shift with the fills so each keeps its contrast against its own
-     frame rather than against the page. */
   --edge-frame:        rgb(255 255 255 / .55);
   --edge-boundary:     hsl(  0  0% calc(40% + var(--fill-dl)));
   --edge-unattributed: hsl(  0  0% calc(55% + var(--fill-dl)));
   --edge-shim:         hsl(215 24% calc(46% + var(--fill-dl)));
 
-  /* Ink on a fill. Fills are light in both themes, so this is too. */
   --frame-ink: hsl(30 12% 9%);
 }
-@media (prefers-color-scheme: dark){
-  :root{ --fill-dl:-9%; --fill-ds:.9; --hatch-ink:rgb(22 20 18 / .20); }
-}
+@media (prefers-color-scheme: dark){:root:not([data-theme="light"]){` + darkKnobs + `}}
+:root[data-theme="dark"]{` + darkKnobs + `}
 
-svg.flame text{fill:var(--frame-ink)}
-pattern line.hatch{stroke:var(--hatch-ink)}
+.frame{color:var(--frame-ink);background-color:var(--fill-x);background-color:hsl(from var(--fill-x) h s calc(l + var(--fill-j)));box-shadow:inset 0 0 0 .5px var(--edge-frame)}
+.frame[data-domain="root"]{--fill-x:var(--fill-root)}
+.frame[data-domain="app"]{--fill-x:var(--fill-app)}
+.frame[data-domain="system"]{--fill-x:var(--fill-system)}
+.frame[data-domain="kernel"]{--fill-x:var(--fill-kernel)}
+.frame[data-domain="vendor"]{--fill-x:var(--fill-vendor)}
+.frame[data-domain="unsym"]{--fill-x:var(--fill-unsym);background-image:var(--hatch-gap)}
+.frame[data-domain="gpu-kernel"]{--fill-x:var(--fill-gpu-kernel)}
+.frame[data-domain="shim"]{--fill-x:var(--fill-shim);box-shadow:inset 0 0 0 1px var(--edge-shim)}
+.frame[data-domain="boundary"]{--fill-x:var(--fill-boundary);box-shadow:inset 0 0 0 1px var(--edge-boundary)}
+.frame[data-domain="boundary-unattributed"]{--fill-x:var(--fill-boundary-unattributed);background-image:var(--hatch-gap);box-shadow:none;outline:1px dashed var(--edge-unattributed);outline-offset:-1px}
+.frame.inexact{background-image:var(--hatch-inf)}
+.frame.inexact[data-domain="unsym"],.frame.inexact[data-domain="boundary-unattributed"]{background-image:var(--hatch-gap),var(--hatch-inf)}
 
-g.frame rect.bg{stroke:var(--edge-frame);stroke-width:.5}
-g.frame[data-domain="root"] rect.bg{fill:var(--fill-root)}
-g.frame[data-domain="app"] rect.bg{fill:var(--fill-app)}
-g.frame[data-domain="system"] rect.bg{fill:var(--fill-system)}
-g.frame[data-domain="kernel"] rect.bg{fill:var(--fill-kernel)}
-g.frame[data-domain="vendor"] rect.bg{fill:var(--fill-vendor)}
-g.frame[data-domain="unsym"] rect.bg{fill:var(--fill-unsym)}
-g.frame[data-domain="gpu-kernel"] rect.bg{fill:var(--fill-gpu-kernel)}
-/* The three domains that are not the program's own computation get an
-   outline as well as a fill, so they read as themselves at one pixel wide.
-   The dashed one is [gpu:launch unsampled]: a boundary with no CPU stack
-   behind it, which must never be mistaken for [gpu:launch], which has one. */
-g.frame[data-domain="shim"] rect.bg{fill:var(--fill-shim);stroke:var(--edge-shim);stroke-width:1}
-g.frame[data-domain="boundary"] rect.bg{fill:var(--fill-boundary);stroke:var(--edge-boundary);stroke-width:1}
-g.frame[data-domain="boundary-unattributed"] rect.bg{fill:var(--fill-boundary-unattributed);stroke:var(--edge-unattributed);stroke-width:1;stroke-dasharray:3 2}
-
-/* Last, so hover and search win over any domain outline above. */
-g.frame:hover rect.bg{stroke:var(--frame-ink);stroke-width:1.4;stroke-dasharray:none}
-g.frame.match rect.bg{stroke:var(--frame-ink);stroke-width:1.8;stroke-dasharray:none}
+.frame:hover{box-shadow:inset 0 0 0 1.4px var(--frame-ink);outline:none}
+.frame.match{box-shadow:inset 0 0 0 1.8px var(--frame-ink);outline:none}
 `
 
+// The jitter ladder. jitterSteps shades per domain, evenly spaced from 0 to
+// jitterMaxL points of lightness. Step 0 is the palette's own colour and
+// needs no class.
+//
+// 8 is the amplitude at which two shades three rungs apart (+3.4 lightness,
+// about fifteen units per channel) are plainly different, while the highest
+// rung of the palest jittered fill, --fill-unsym at 77%, only reaches 85% —
+// still sand, not white. --fill-boundary-unattributed sits at 92% and would
+// reach 100, which is one of the two reasons the boundary greys stay off the
+// ladder; the other is that their lightness difference is a meaning (paler =
+// nothing behind it), and a random lightness must not compete with a
+// meaningful one.
+const (
+	jitterSteps = 8
+	jitterMaxL  = 8.0
+)
+
+// jitterLightness is the lightness a ladder step adds, in HSL points.
+func jitterLightness(step int) float64 {
+	return float64(step) * jitterMaxL / float64(jitterSteps-1)
+}
+
+var jitterCSS = buildJitterCSS()
+
+func buildJitterCSS() string {
+	var b strings.Builder
+	for i := 1; i < jitterSteps; i++ {
+		fmt.Fprintf(&b, ".j%d{--fill-j:%.2f}\n", i, jitterLightness(i))
+	}
+	return b.String()
+}
+
+// rowCSS is the vertical half of the geometry: one rule per depth, offset
+// from the bottom of the chart because a flame graph grows upward from its
+// root. It is a rule per depth rather than an inline top on every frame
+// because a profile has far more frames than it has depths — 20 frames over
+// 17 depths here, but 20,000 over 60 in anything real.
+//
+// Measured from the bottom, so a depth means the same number of pixels
+// whatever the profile's height; measured from the top it would depend on
+// maxDepth, and the same class would mean two different things in two pages.
+func rowCSS(maxDepth int) string {
+	var b strings.Builder
+	for d := range maxDepth {
+		fmt.Fprintf(&b, ".d%d{bottom:%dpx}", d, d*frameHeight)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+// script is the whole of the page's interactivity. Three things in it are
+// not obvious:
+//
+//   - Frame geometry is read back off the elements' own inline styles at
+//     start-up rather than duplicated into data-orig-* attributes. A frame
+//     has to carry left and width anyway to draw with no script at all, and
+//     a second copy of every coordinate cost 916 bytes on a 20-frame profile
+//     and scales with frame count.
+//   - Both are percentages, so zoom is percentage arithmetic and there is no
+//     resize handler: a zoomed graph is still expressed relative to .chart,
+//     and .chart is still whatever the window is. The layout survives a
+//     resize because nothing in it was ever in pixels.
+//   - fmt() mirrors flamegraph.FormatValue exactly: never invent a unit the
+//     profile did not give, and never call nanoseconds "samples".
 const script = `
 (function(){
 "use strict";
-var svg=document.querySelector("svg.flame");
-if(!svg){return;}
-var frames=Array.prototype.slice.call(svg.querySelectorAll("g.frame"));
-var sidePad=parseFloat(svg.dataset.sidePad)||0;
-var plotWidth=parseFloat(svg.dataset.plotWidth)||1;
-var minText=parseFloat(svg.dataset.minText)||24;
-var textPad=parseFloat(svg.dataset.textPad)||4;
-var charWidth=parseFloat(svg.dataset.charWidth)||6.4;
-var unit=svg.dataset.unit||"";
-var total=Number(svg.dataset.total||"0");
+var doc=document,root=doc.documentElement;
+var chart=doc.querySelector(".chart");
+if(!chart){return;}
+var info=doc.getElementById("info");
+var st=doc.getElementById("st"),mc=doc.getElementById("mc");
+var q=doc.getElementById("q"),tip=doc.getElementById("tip");
+var unit=chart.dataset.unit||"",total=+chart.dataset.total||0;
+var idle=st.textContent,zoomTarget=null;
 
-var details=document.getElementById("details");
-var crumbs=document.getElementById("breadcrumbs");
-var matchCount=document.getElementById("match-count");
-var zoomState=document.getElementById("zoom-state");
-var search=document.getElementById("search");
-var clearBtn=document.getElementById("clear-search");
-var resetBtn=document.getElementById("reset-zoom");
-var zoomTarget=null;
-var hintText=details.textContent;
-
-function num(el,key){return Number(el.dataset[key]||"0");}
+var items=[].map.call(chart.querySelectorAll(".frame"),function(el){
+  var name=el.textContent;
+  return {el:el,name:name,lower:name.toLowerCase(),
+    value:+el.dataset.value||0,inexact:+el.dataset.inexact||0,
+    x:parseFloat(el.style.left),w:parseFloat(el.style.width),shown:true};
+});
 
 function grouped(n){
   var s=String(Math.round(n)),out="",i;
@@ -235,8 +325,6 @@ function grouped(n){
   }
   return out;
 }
-/* Mirrors flamegraph.FormatValue: never invent a unit the profile did not
-   give, and never call nanoseconds "samples". */
 function fmt(v){
   if(unit==="nanoseconds"){
     if(v===0){return "0 ns";}
@@ -248,106 +336,96 @@ function fmt(v){
   if(unit===""){return grouped(v);}
   return grouped(v)+" "+unit;
 }
-function pct(v){
-  if(!total){return "0%";}
-  return (v/total*100).toFixed(2)+"%";
+function pct(v){return total?(v/total*100).toFixed(2)+"%":"0%";}
+function place(it,x,w,vis){
+  it.shown=vis;
+  it.el.style.display=vis?"":"none";
+  if(!vis){return;}
+  it.el.style.left=x+"%";
+  it.el.style.width=Math.max(0,w)+"%";
 }
-function fit(name,width){
-  var max=Math.floor((width-textPad*2)/charWidth);
-  if(max<=0){return "";}
-  var chars=Array.from(name);
-  if(chars.length<=max){return name;}
-  if(max<=2){return chars.slice(0,max).join("");}
-  return chars.slice(0,max-1).join("")+"…";
-}
-function place(el,x,width,visible){
-  el.style.display=visible?"":"none";
-  if(!visible){return;}
-  var rects=el.querySelectorAll("rect"),i;
-  for(i=0;i<rects.length;i++){
-    rects[i].setAttribute("x",x.toFixed(3));
-    rects[i].setAttribute("width",Math.max(0,width).toFixed(3));
-  }
-  var text=el.querySelector("text");
-  if(text){
-    if(width>=minText){
-      text.style.display="";
-      text.setAttribute("x",(x+textPad).toFixed(3));
-      text.textContent=fit(el.dataset.name,width);
-    }else{
-      text.style.display="none";
-    }
-  }
-}
-function describe(el){
-  var v=num(el,"value"),inexact=num(el,"inexact");
-  var s=el.dataset.name+" — "+fmt(v)+" ("+pct(v)+" of total) — "+el.dataset.domainLabel;
-  if(inexact>0){s+=" — "+fmt(inexact)+" of it attributed by inference, not measurement";}
+function line(it){return it.name+"  ·  "+fmt(it.value)+"  ·  "+pct(it.value)+" of total";}
+function detail(it){
+  var s=line(it),d=it.el.dataset;
+  if(d.module){s+="\nmodule: "+d.module;}
+  if(it.inexact>0){s+="\n"+fmt(it.inexact)+" of this is attributed by inference, not measurement";}
+  if(d.domain==="unsym"){s+="\nno symbol: the unwind found this frame, nothing could name it";}
   return s;
 }
-function showPath(el){
-  crumbs.textContent=el?el.dataset.path:"all";
-}
-function select(el){
-  if(!el){details.textContent=hintText;showPath(zoomTarget);return;}
-  details.textContent=describe(el);
-  showPath(el);
+function status(it){st.textContent=it?line(it):(zoomTarget?line(zoomTarget):idle);}
+function showTip(evt,it){
+  tip.textContent=detail(it);
+  tip.style.left=tip.style.top="0px";
+  tip.hidden=false;
+  var box=tip.getBoundingClientRect(),pad=14;
+  var x=evt.clientX+pad,y=evt.clientY+pad;
+  if(x+box.width>innerWidth-6){x=Math.max(6,evt.clientX-pad-box.width);}
+  if(y+box.height>innerHeight-30){y=Math.max(6,evt.clientY-pad-box.height);}
+  tip.style.left=x+"px";
+  tip.style.top=y+"px";
 }
 function reset(){
   zoomTarget=null;
-  zoomState.textContent="all";
-  frames.forEach(function(el){place(el,num(el,"origX"),num(el,"origWidth"),true);});
-  select(null);
-  applySearch(search.value);
+  items.forEach(function(it){place(it,it.x,it.w,true);});
+  applySearch(q.value);
+  status(null);
 }
 function zoom(target){
-  var tx=num(target,"origX"),tw=num(target,"origWidth");
-  if(!(tw>0)){return;}
-  var tEnd=tx+tw,ratio=plotWidth/tw;
+  if(!(target.w>0)){return;}
+  var tEnd=target.x+target.w,ratio=100/target.w;
   zoomTarget=target;
-  zoomState.textContent=target.dataset.name;
-  frames.forEach(function(el){
-    var x=num(el,"origX"),w=num(el,"origWidth"),end=x+w;
-    var ancestor=x<=tx&&end>=tEnd;
-    var descendant=x>=tx&&end<=tEnd;
-    if(ancestor){place(el,sidePad,plotWidth,true);return;}
-    if(descendant){place(el,sidePad+(x-tx)*ratio,w*ratio,true);return;}
-    place(el,x,w,false);
+  items.forEach(function(it){
+    var end=it.x+it.w;
+    if(it.x<=target.x&&end>=tEnd){place(it,0,100,true);return;}
+    if(it.x>=target.x&&end<=tEnd){place(it,(it.x-target.x)*ratio,it.w*ratio,true);return;}
+    place(it,it.x,it.w,false);
   });
-  select(target);
-  applySearch(search.value);
+  applySearch(q.value);
+  status(null);
 }
 function applySearch(query){
-  var q=(query||"").trim().toLowerCase();
-  var matched=0,matchedValue=0;
-  frames.forEach(function(el){
-    var visible=el.style.display!=="none";
-    var hit=q!==""&&el.dataset.name.toLowerCase().indexOf(q)!==-1;
-    el.classList.toggle("match",hit&&visible);
-    el.classList.toggle("dim",q!==""&&visible&&!hit);
-    if(hit&&visible){matched++;matchedValue+=num(el,"value");}
+  var s=(query||"").trim().toLowerCase(),n=0,v=0;
+  items.forEach(function(it){
+    var hit=s!==""&&it.lower.indexOf(s)!==-1;
+    it.el.classList.toggle("match",hit&&it.shown);
+    it.el.classList.toggle("dim",s!==""&&it.shown&&!hit);
+    if(hit&&it.shown){n++;v+=it.value;}
   });
-  if(q===""){matchCount.textContent="—";return;}
-  matchCount.textContent=grouped(matched)+" frames, "+fmt(matchedValue);
+  mc.textContent=s===""?"":(n===0?"no match":grouped(n)+" matched · "+fmt(v)+" · "+pct(v));
 }
+function toggleInfo(){info.open=!info.open;}
+function toggleTheme(){
+  var dark=root.dataset.theme?root.dataset.theme==="dark":matchMedia("(prefers-color-scheme: dark)").matches;
+  root.dataset.theme=dark?"light":"dark";
+}
+function openSearch(){q.hidden=false;q.focus();q.select();}
+function closeSearch(){q.value="";applySearch("");q.hidden=true;q.blur();}
 
-frames.forEach(function(el){
-  el.addEventListener("click",function(evt){evt.stopPropagation();zoom(el);});
-  el.addEventListener("mouseenter",function(){select(el);});
-  el.addEventListener("mouseleave",function(){select(zoomTarget);});
+items.forEach(function(it){
+  it.el.addEventListener("click",function(e){e.stopPropagation();zoom(it);});
+  it.el.addEventListener("mouseenter",function(){status(it);});
+  it.el.addEventListener("mousemove",function(e){showTip(e,it);});
+  it.el.addEventListener("mouseleave",function(){tip.hidden=true;status(null);});
 });
-svg.addEventListener("click",function(evt){if(evt.target===svg){reset();}});
-search.addEventListener("input",function(e){applySearch(e.target.value);});
-clearBtn.addEventListener("click",function(){search.value="";applySearch("");search.focus();});
-resetBtn.addEventListener("click",reset);
-document.addEventListener("keydown",function(evt){
-  if(evt.key==="/"&&document.activeElement!==search){
-    evt.preventDefault();search.focus();search.select();return;
+chart.addEventListener("click",function(e){if(e.target===chart){reset();}});
+q.addEventListener("input",function(e){applySearch(e.target.value);});
+doc.getElementById("theme-btn").addEventListener("click",toggleTheme);
+doc.getElementById("close").addEventListener("click",function(){info.open=false;});
+doc.addEventListener("click",function(e){
+  if(info.open&&!info.contains(e.target)){info.open=false;}
+});
+doc.addEventListener("keydown",function(e){
+  if((e.ctrlKey||e.metaKey)&&(e.key==="f"||e.key==="F")){e.preventDefault();openSearch();return;}
+  if(e.key==="Escape"){
+    if(info.open){info.open=false;}
+    else if(!q.hidden){closeSearch();}
+    else{reset();}
+    return;
   }
-  if(evt.key==="Escape"){
-    if(search.value!==""){search.value="";applySearch("");}
-    else if(zoomTarget){reset();}
-  }
+  if(e.ctrlKey||e.metaKey||e.altKey||doc.activeElement===q){return;}
+  if(e.key==="0"){reset();}
+  else if(e.key==="d"||e.key==="D"){toggleTheme();}
+  else if(e.key==="?"||e.key==="i"||e.key==="I"){toggleInfo();}
 });
 reset();
 })();

--- a/internal/flamegraph/domain.go
+++ b/internal/flamegraph/domain.go
@@ -83,9 +83,9 @@ type DomainInfo struct {
 	Desc string
 	// Fill is a CSS colour.
 	Fill string
-	// Overlay names an SVG pattern painted over the fill, or "" for none.
-	// Patterns encode uncertainty: a hatched frame is one the profile
-	// could not fully account for.
+	// Overlay is a CSS background-image layered over the fill, or "" for
+	// none. It is always a hatch, and a hatch always encodes uncertainty: a
+	// hatched frame is one the profile could not fully account for.
 	Overlay string
 	// Stroke is an explicit outline colour, or "" for the default.
 	Stroke string
@@ -113,20 +113,20 @@ var domainInfo = [numDomains]DomainInfo{
 		Desc: "CUDA/HIP/HSA runtime and driver frames: the CPU path that initiates GPU work. Yellow, Gregg's C++ layer.",
 	},
 	DomainUnsymbolized: {
-		Key: "unsym", Label: "vendor, no symbols", Fill: "var(--fill-unsym)", Overlay: "url(#p-gap)",
-		Desc: "Unwound correctly; no symbol table could name it. The depth here is real — the names are missing, usually because a stripped vendor library has no exported symbols. The CPU band's hue, drained: right layer, no name.",
+		Key: "unsym", Label: "vendor, no symbols", Fill: "var(--fill-unsym)", Overlay: "var(--hatch-gap)",
+		Desc: "Unwound correctly; no symbol table could name it. The depth is real, the names are missing — usually a stripped vendor library with no exported symbols. The CPU band's hue, drained: right layer, no name.",
 	},
 	DomainProfilerShim: {
 		Key: "shim", Label: "perf-agent", Fill: "var(--fill-shim)", Stroke: "var(--edge-shim)",
-		Desc: "The profiler observing itself: perf-agent's injected callback, not work your program asked for. Cool slate, outside the warm CPU band, because it is not part of your computation.",
+		Desc: "The profiler observing itself: perf-agent's injected callback, not work your program asked for. Cool slate, outside the warm CPU band, because it is not your computation.",
 	},
 	DomainBoundary: {
 		Key: "boundary", Label: "CPU→GPU boundary", Fill: "var(--fill-boundary)", Stroke: "var(--edge-boundary)",
 		Desc: "[gpu:launch] — the launch this execution was joined to. Everything below it ran on the CPU; everything above it ran on the accelerator. Grey, Gregg's boundary marker.",
 	},
 	DomainBoundaryUnattributed: {
-		Key: "boundary-unattributed", Label: "GPU work with no CPU stack", Fill: "var(--fill-boundary-unattributed)", Overlay: "url(#p-gap)", Stroke: "var(--edge-unattributed)",
-		Desc: "[gpu:launch unsampled] — measured GPU time whose launch was not one of the sampled ones, so no CPU call path exists for it. Its duration is measured; its caller is unknown, and is not borrowed from a sampled sibling. The same boundary grey, but paler, hatched and dashed, because it is a boundary with nothing behind it.",
+		Key: "boundary-unattributed", Label: "GPU work with no CPU stack", Fill: "var(--fill-boundary-unattributed)", Overlay: "var(--hatch-gap)", Stroke: "var(--edge-unattributed)",
+		Desc: "[gpu:launch unsampled] — measured GPU time whose launch was not one of the sampled ones: its duration is measured, its caller unknown and not borrowed from a sampled sibling. The same boundary grey, but paler, hatched and dashed: a boundary with nothing behind it.",
 	},
 	DomainGPUKernel: {
 		Key: "gpu-kernel", Label: "GPU kernel execution", Fill: "var(--fill-gpu-kernel)",

--- a/internal/flamegraph/palette_test.go
+++ b/internal/flamegraph/palette_test.go
@@ -21,7 +21,11 @@ var (
 	// hsl(H calc(S% * var(--fill-ds)) calc(L% + var(--fill-dl)))
 	fillTokenRe = regexp.MustCompile(
 		`--(fill-[a-z-]+): hsl\( ?(\d+) (?:calc\((\d+)% \* var\(--fill-ds\)\)|(\d+)%) calc\((\d+)% \+ var\(--fill-dl\)\)\);`)
-	darkBlockRe = regexp.MustCompile(`(?s)@media \(prefers-color-scheme: dark\)\{\s*:root\{([^}]*)\}`)
+	// The dark theme is reachable two ways — the reader's OS setting and the
+	// D key — so it is declared twice, from one Go constant. Both blocks are
+	// parsed and both are held to the same rule.
+	darkBlockRe = regexp.MustCompile(`(?s)@media \(prefers-color-scheme: dark\)\{:root:not\(\[data-theme="light"\]\)\{([^}]*)\}\}`)
+	darkThemeRe = regexp.MustCompile(`(?s):root\[data-theme="dark"\]\{([^}]*)\}`)
 )
 
 type hsl struct{ h, s, l float64 }
@@ -105,10 +109,21 @@ func contrast(a, b hsl) float64 {
 func overHatch(c hsl, alpha float64) hsl {
 	r, g, b := c.rgb()
 	mix := func(v, ink float64) float64 { return v*(1-alpha) + ink*alpha }
+	return fromRGB(mix(r, 22.0/255), mix(g, 20.0/255), mix(b, 18.0/255))
+}
+
+// lightened is the jitter, as the browser computes it:
+// hsl(from fill h s calc(l + N)). Hue and saturation do not move, so a
+// jittered frame is the same colour at a different lightness — and N is a
+// ladder step, never negative. See the jitter tests below for why that
+// direction is forced.
+func lightened(c hsl, delta float64) hsl { return hsl{c.h, c.s, c.l + delta} }
+
+// fromRGB converts back to the hsl the rest of this file speaks. Mixing in
+// sRGB and re-deriving lightness is what a browser draws; contrast() only
+// reads luminance, so this is a luminance-preserving round trip.
+func fromRGB(rr, gg, bb float64) hsl {
 	m := hsl{}
-	// Back to a luminance-only stand-in: contrast() only reads luminance,
-	// and mixing in sRGB then re-deriving lightness is what a browser draws.
-	rr, gg, bb := mix(r, 22.0/255), mix(g, 20.0/255), mix(b, 18.0/255)
 	maxc, minc := math.Max(rr, math.Max(gg, bb)), math.Min(rr, math.Min(gg, bb))
 	m.l = (maxc + minc) / 2 * 100
 	if maxc != minc {
@@ -154,7 +169,7 @@ func TestPaletteDeclaresATokenForEveryDomain(t *testing.T) {
 func TestEveryDomainKeyIsSelectedByARule(t *testing.T) {
 	for d := Domain(0); d < numDomains; d++ {
 		info := d.Info()
-		sel := fmt.Sprintf(`g.frame[data-domain="%s"] rect.bg{fill:%s`, info.Key, info.Fill)
+		sel := fmt.Sprintf(`.frame[data-domain="%s"]{--fill-x:%s`, info.Key, info.Fill)
 		assert.Contains(t, paletteCSS, sel, "no rule paints domain %q", info.Key)
 	}
 }
@@ -164,7 +179,7 @@ func TestEveryDomainKeyIsSelectedByARule(t *testing.T) {
 // the page says so instead of leaving a silent gap in the palette.
 func TestAquaIsReservedAndUnused(t *testing.T) {
 	assert.Contains(t, palette(t), "fill-accel-source", "the reserved aqua token must exist")
-	assert.NotContains(t, paletteCSS, "rect.bg{fill:var(--fill-accel-source)",
+	assert.NotContains(t, paletteCSS, "]{--fill-x:var(--fill-accel-source)",
 		"aqua must not paint any frame until accelerator source frames exist")
 	for d := Domain(0); d < numDomains; d++ {
 		assert.NotEqual(t, "var(--fill-accel-source)", d.Info().Fill, "domain %q took the reserved hue", d.Info().Key)
@@ -176,7 +191,12 @@ func TestAquaIsReservedAndUnused(t *testing.T) {
 // the media block, the two themes have started to drift into two designs.
 func TestDarkThemeMovesOnlyTheThemeKnobs(t *testing.T) {
 	m := darkBlockRe.FindStringSubmatch(paletteCSS)
-	require.Len(t, m, 2, "paletteCSS must have exactly one dark-theme block")
+	require.Len(t, m, 2, "paletteCSS must have exactly one dark-theme media block")
+	d := darkThemeRe.FindStringSubmatch(paletteCSS)
+	require.Len(t, d, 2, "paletteCSS must have exactly one [data-theme=dark] block for the D key")
+	assert.Equal(t, m[1], d[1],
+		"the OS dark theme and the D key must apply the same declarations, or the page has two dark themes")
+
 	for _, decl := range strings.Split(m[1], ";") {
 		decl = strings.TrimSpace(decl)
 		if decl == "" {
@@ -187,6 +207,17 @@ func TestDarkThemeMovesOnlyTheThemeKnobs(t *testing.T) {
 			"the dark theme may only move the knobs, but it sets %s", prop)
 	}
 	assert.Equal(t, 1, strings.Count(paletteCSS, "@media"), "one media block, or the themes are diverging")
+}
+
+// The D key must be able to overrule the OS in both directions: a reader on
+// a dark desktop who wants the light palette gets it from the same token set.
+func TestTheDarkKeyCanOverrideTheOSInBothDirections(t *testing.T) {
+	assert.Contains(t, paletteCSS, `:root:not([data-theme="light"])`,
+		"[data-theme=light] must be able to win against prefers-color-scheme: dark")
+	assert.Contains(t, paletteCSS, `:root[data-theme="dark"]`,
+		"[data-theme=dark] must be able to win against a light OS")
+	assert.Contains(t, styleSheet, `:root:not([data-theme="light"])`)
+	assert.Contains(t, styleSheet, `:root[data-theme="dark"]`)
 }
 
 // Gregg's layers are hues; the hue is the meaning. Anchor them, so a tweak
@@ -234,9 +265,9 @@ func TestTheTwoBoundariesStayTellableApart(t *testing.T) {
 	assert.Greater(t, tokens["fill-boundary-unattributed"].l, tokens["fill-boundary"].l+5,
 		"the unattributed boundary must be visibly paler")
 	assert.NotEmpty(t, DomainBoundaryUnattributed.Info().Overlay, "and hatched")
-	assert.Contains(t, paletteCSS, `g.frame[data-domain="boundary-unattributed"] rect.bg{fill:var(--fill-boundary-unattributed);stroke:var(--edge-unattributed);stroke-width:1;stroke-dasharray:3 2}`,
+	assert.Contains(t, paletteCSS, `.frame[data-domain="boundary-unattributed"]{--fill-x:var(--fill-boundary-unattributed);background-image:var(--hatch-gap);box-shadow:none;outline:1px dashed var(--edge-unattributed);outline-offset:-1px}`,
 		"and dashed, because there is nothing behind it")
-	assert.NotContains(t, paletteCSS, `data-domain="boundary"] rect.bg{fill:var(--fill-boundary);stroke:var(--edge-boundary);stroke-width:1;stroke-dasharray`)
+	assert.NotContains(t, paletteCSS, `.frame[data-domain="boundary"]{--fill-x:var(--fill-boundary);box-shadow:inset 0 0 0 1px var(--edge-boundary);outline`)
 }
 
 // Frame labels are drawn on the fills. Gregg's palette was designed for a
@@ -257,14 +288,66 @@ func TestLabelsStayLegibleOnEveryFillInBothThemes(t *testing.T) {
 		{"dark", darkDL, darkDS, darkHatch},
 	} {
 		for name, c := range palette(t) {
-			fill := c.themed(theme.dl, theme.ds)
-			assert.GreaterOrEqual(t, contrast(ink, fill), 4.5,
-				"%s theme: label ink on %s is %.2f:1", theme.name, name, contrast(ink, fill))
-			hatched := overHatch(fill, theme.alpha)
-			assert.GreaterOrEqual(t, contrast(ink, hatched), 4.5,
-				"%s theme: label ink on hatched %s is %.2f:1", theme.name, name, contrast(ink, hatched))
+			// Every fill is checked at every rung of the jitter ladder, not
+			// just at its declared value: a frame on the page is a jittered
+			// fill, and an untested rung is an untested colour.
+			for step := range jitterSteps {
+				base := c.themed(theme.dl, theme.ds)
+				fill := lightened(base, jitterLightness(step))
+				assert.GreaterOrEqual(t, contrast(ink, fill), 4.5,
+					"%s theme: label ink on %s at jitter step %d is %.2f:1", theme.name, name, step, contrast(ink, fill))
+				hatched := overHatch(fill, theme.alpha)
+				assert.GreaterOrEqual(t, contrast(ink, hatched), 4.5,
+					"%s theme: label ink on hatched %s at jitter step %d is %.2f:1", theme.name, name, step, contrast(ink, hatched))
+			}
 		}
 	}
+}
+
+// The jitter's direction is not a taste. The darkest thing a label is ever
+// drawn on clears 4.5:1 by about a tenth, so there is no room to darken a
+// fill and plenty to lighten one — and mixing white in raises luminance
+// monotonically, which makes the un-jittered fill the worst case and leaves
+// the floor exactly where the test above found it.
+func TestJitterOnlyEverLightensSoTheContrastFloorCannotMove(t *testing.T) {
+	ink := hsl{frameInkH, frameInkS, frameInkL}
+
+	worstUnjittered, worstAny := math.Inf(1), math.Inf(1)
+	for _, theme := range []struct{ dl, ds, alpha float64 }{{lightDL, lightDS, lightHatch}, {darkDL, darkDS, darkHatch}} {
+		for _, c := range palette(t) {
+			base := c.themed(theme.dl, theme.ds)
+			prev := math.Inf(-1)
+			for step := range jitterSteps {
+				require.GreaterOrEqual(t, jitterLightness(step), 0.0, "a rung of the ladder darkens a fill")
+				fill := lightened(base, jitterLightness(step))
+				require.LessOrEqual(t, fill.l, 100.0, "a rung of the ladder clips at white")
+				got := contrast(ink, overHatch(fill, theme.alpha))
+				assert.Greater(t, got, prev, "each rung must be lighter than the last, or the ladder is not monotone")
+				prev = got
+				worstAny = math.Min(worstAny, got)
+				if step == 0 {
+					worstUnjittered = math.Min(worstUnjittered, got)
+				}
+			}
+		}
+	}
+	assert.Equal(t, worstUnjittered, worstAny, "jitter must not create a worse case than the palette already had")
+	assert.GreaterOrEqual(t, worstAny, 4.5)
+	assert.Less(t, worstAny, 4.7, "if the floor has grown this much headroom, the jitter could be bolder")
+}
+
+// The ladder in the stylesheet is the ladder the renderer assigns steps on.
+// A mismatch would put a frame on a rung that has no rule and paint it with
+// the default 0%, silently un-jittering it.
+func TestTheJitterLadderInTheStylesheetMatchesTheRenderer(t *testing.T) {
+	assert.Contains(t, paletteCSS, "--fill-j:0;", "the ladder needs a zero rung at :root")
+	assert.Contains(t, paletteCSS, "background-color:var(--fill-x);background-color:hsl(from var(--fill-x) h s calc(l + var(--fill-j)))",
+		"the fill must be composed on the frame (var() inside a :root custom property freezes at :root), and the plain fill must precede it so an engine without relative colour syntax falls back to the palette rather than to nothing")
+	assert.NotContains(t, jitterCSS, ".j0{", "step 0 is the palette's own colour and needs no rule")
+	for step := 1; step < jitterSteps; step++ {
+		assert.Contains(t, jitterCSS, fmt.Sprintf(".j%d{--fill-j:%.2f}", step, jitterLightness(step)))
+	}
+	assert.InDelta(t, jitterMaxL, jitterLightness(jitterSteps-1), 0.001, "the top rung is the stated amplitude")
 }
 
 // A label drawn in a colour that flips with the page would be dark ink on a
@@ -273,7 +356,47 @@ func TestLabelsStayLegibleOnEveryFillInBothThemes(t *testing.T) {
 func TestInkAndFrameOutlinesDoNotFollowThePageTheme(t *testing.T) {
 	assert.NotContains(t, paletteCSS, "var(--ink)",
 		"the page's ink inverts with the page; a frame's does not")
-	assert.Contains(t, paletteCSS, "svg.flame text{fill:var(--frame-ink)}")
-	assert.Contains(t, paletteCSS, "g.frame:hover rect.bg{stroke:var(--frame-ink)")
-	assert.Contains(t, paletteCSS, "g.frame.match rect.bg{stroke:var(--frame-ink)")
+	assert.Contains(t, paletteCSS, ".frame{color:var(--frame-ink)")
+	assert.Contains(t, paletteCSS, ".frame:hover{box-shadow:inset 0 0 0 1.4px var(--frame-ink)")
+	assert.Contains(t, paletteCSS, ".frame.match{box-shadow:inset 0 0 0 1.8px var(--frame-ink)")
+}
+
+// A hatch used to be an SVG <pattern> painted by a second <rect> per frame.
+// It is a background-image now, so the honesty signal it carries — "the
+// profile could not fully account for this frame" — has to be reattached to
+// every domain that claims it, by a rule rather than by an extra element.
+func TestEveryHatchedDomainIsActuallyHatchedByARule(t *testing.T) {
+	for d := Domain(0); d < numDomains; d++ {
+		info := d.Info()
+		if info.Overlay == "" {
+			continue
+		}
+		assert.Contains(t, paletteCSS, fmt.Sprintf(`.frame[data-domain="%s"]{--fill-x:%s;background-image:%s`, info.Key, info.Fill, info.Overlay),
+			"domain %q says it is hatched but no rule hatches it", info.Key)
+		assert.Contains(t, paletteCSS, strings.TrimSuffix(strings.TrimPrefix(info.Overlay, "var("), ")")+":",
+			"domain %q names a hatch token the stylesheet does not declare", info.Key)
+	}
+	// A frame can be both unnamed and inferred; it must then show both
+	// hatches rather than silently losing one to the cascade.
+	assert.Contains(t, paletteCSS, `.frame.inexact[data-domain="unsym"],.frame.inexact[data-domain="boundary-unattributed"]{background-image:var(--hatch-gap),var(--hatch-inf)}`)
+	// The two hatches run opposite ways, so which uncertainty a frame
+	// carries is visible without hovering it.
+	assert.Contains(t, paletteCSS, "--hatch-gap: repeating-linear-gradient(45deg,")
+	assert.Contains(t, paletteCSS, "--hatch-inf: repeating-linear-gradient(-45deg,")
+}
+
+// A border would be laid out; a 3px-wide frame with a 1px border on each
+// side would have no content box left. Every outline on a frame is painted
+// instead — an inset box-shadow, or an outline pulled inside by a negative
+// offset — so a sliver stays the width its value earned.
+func TestFrameOutlinesAreNeverLaidOut(t *testing.T) {
+	for _, decl := range strings.Split(paletteCSS, "\n") {
+		if !strings.HasPrefix(decl, ".frame") {
+			continue
+		}
+		assert.NotContains(t, decl, "border:", "a frame outline must not take width from the frame: %s", decl)
+		assert.NotContains(t, decl, "border-width", decl)
+	}
+	assert.Contains(t, paletteCSS, "outline:1px dashed var(--edge-unattributed);outline-offset:-1px",
+		"the one dashed outline needs outline, which box-shadow cannot do — but it still must not be laid out")
 }

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -20,44 +20,67 @@
 //   - The legend names each layer for what it is.
 //   - Labels are summarised beside the graph rather than folded into it.
 //     See internal/foldedstacks.Fold for why.
+//
+// Geometry is percentages, not pixels: a frame is an absolutely positioned
+// block whose left and width are shares of the profile total, which are also
+// shares of a container as wide as the window. The page therefore fills any
+// viewport and reflows on resize without a line of script, and nothing about
+// it scales — the row pitch and the label are the same number of pixels at
+// 800px and at 1990px, because "fill the width" must mean more columns, not
+// a bigger picture. See styleSheet in assets.go.
+//
+// Chrome discipline is async-profiler's: nothing permanent on the page
+// explains the page. What is permanently visible is the graph, one line of
+// status, and — only when the profile carries the misreading it guards
+// against — one line of warning about launch sampling. The legend, the
+// keyboard map, the remaining notes and the label table live behind the info
+// button and the ? key.
+//
+// The one exception is deliberate. gpu_sample_period is a wrong-conclusion
+// guard: without it a reader takes a 6.6% column for 6.6% of GPU time when
+// the true figure is off by roughly the sample period, and nothing in the
+// picture hints otherwise. The notes that moved are the ones a reader can
+// derive from the picture (the width of [gpu:launch unsampled] IS the
+// unattributed share) or see on the frames themselves (unsymbolized frames
+// are hatched, named by their address, and say so on hover).
 package flamegraph
 
 import (
 	"cmp"
 	"fmt"
+	"hash/fnv"
 	"html"
 	"io"
+	"math"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/dpsoft/perf-agent/internal/foldedstacks"
 )
 
-const (
-	defaultWidth = 1280
-	frameHeight  = 18
-	topPad       = 8
-	bottomPad    = 8
-	sidePad      = 8
-	textPad      = 4
-	minTextWidth = 24
-	// charWidth approximates the advance of the 11px monospace label font.
-	charWidth = 6.4
-)
+// frameHeight is the row pitch in CSS pixels: a 17px frame and a 1px gap.
+// It is the only fixed dimension the geometry has. Horizontal position and
+// width are percentages, so they are the window's business, not ours — see
+// styleSheet in assets.go for why that is the whole fix for a graph that
+// used to be 1280px wide on a 1990px screen.
+const frameHeight = 18
 
 // Options configures a render.
+//
+// There is no Width. A frame's left and width are percentages of the chart,
+// which is as wide as the window, so the page has no width to be told: it
+// fills whatever it is opened in and reflows when that changes.
 type Options struct {
 	// Title names the page. Defaults to "Flame Graph".
 	Title string
 	// Subtitle is a one-line provenance string (source file, mode, host).
 	Subtitle string
-	// Width is the SVG width in CSS pixels. Defaults to 1280.
-	Width int
-	// Meta are extra header chips, rendered after the built-in ones.
+	// Meta are extra provenance items, listed in the info panel.
 	Meta []MetaItem
 }
 
-// MetaItem is one header chip.
+// MetaItem is one provenance item.
 type MetaItem struct {
 	Label string
 	Value string
@@ -70,10 +93,14 @@ type node struct {
 	domain  Domain
 	value   int64
 	inexact int64
+	// jitter is this frame's step on the shade ladder — see assignJitter.
+	jitter int
 
 	children []*node
 	index    map[string]*node
 
+	// x and width are percentages of the whole profile, which is also
+	// percentages of the chart: the root is 0 to 100.
 	x, width float64
 	depth    int
 }
@@ -94,64 +121,81 @@ func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
 	ew.esc(opts.Title)
 	ew.s("</title>\n<style>\n")
 	ew.s(styleSheet)
-	ew.s(paletteCSS)
-	ew.s("</style>\n</head>\n<body>\n<main>\n")
-
-	writeHeader(ew, res, opts, degenerate)
-	writeNotices(ew, res, degenerate)
+	if degenerate {
+		ew.s(reportCSS)
+	} else {
+		ew.s(paletteCSS)
+		ew.s(jitterCSS)
+		ew.s(rowCSS(maxDepth))
+	}
+	ew.s("</style>\n</head>\n<body>\n")
 
 	if degenerate {
-		writeNoData(ew, res)
-	} else {
-		writeToolbar(ew)
-		ew.s("<div class=\"chart\">\n")
-		if err := writeSVG(ew, root, maxDepth, res, opts, false); err != nil {
-			return err
-		}
-		ew.s("</div>\n")
-		writeLegend(ew, root)
+		writeReport(ew, res, opts)
+		ew.s("</body>\n</html>\n")
+		return ew.err
 	}
 
-	writeLabels(ew, res)
-	writeFooter(ew, res)
-
-	ew.s("</main>\n")
-	if !degenerate {
-		ew.s("<script>\n")
-		ew.s(script)
-		ew.s("</script>\n")
+	writeTopBar(ew, opts, res, root)
+	writeSamplePeriodNote(ew, res)
+	if err := writeChart(ew, root, maxDepth, res); err != nil {
+		return err
 	}
-	ew.s("</body>\n</html>\n")
+	writeStatusBar(ew, res)
+	ew.s("<div id=\"tip\" hidden></div>\n")
+
+	ew.s("<script>\n")
+	ew.s(script)
+	ew.s("</script>\n</body>\n</html>\n")
 	return ew.err
 }
 
-// RenderSVG writes just the graph, for embedding. It carries its own copy of
-// the palette — a graph pulled out of the page must still be the right
-// colours, and must still follow the reader's light or dark theme — but none
-// of the interactivity, none of the legend and none of the warning text. It
-// is therefore not a substitute for RenderHTML when the profile is
+// RenderFragment writes just the graph, for embedding in a host page: a
+// <style> carrying the graph's own rules and the chart element itself. It
+// brings the palette — a graph pulled out of the page must still be the
+// right colours, and must still follow the reader's light or dark theme —
+// but none of the interactivity, none of the legend and none of the warning
+// text. It is therefore not a substitute for RenderHTML when the profile is
 // degenerate: it returns an error rather than emitting a blank canvas.
-func RenderSVG(w io.Writer, res *foldedstacks.Result, opts Options) error {
-	opts = opts.withDefaults()
+//
+// It takes no Options because it has nothing to spend them on: the page's
+// title, subtitle and provenance all belong to chrome it does not emit.
+//
+// It was RenderSVG until the geometry stopped being SVG. There is one layout
+// engine in this package and this is it; a second one kept alive for
+// embedding would have been a second palette (fill/stroke beside
+// background/box-shadow) and a second truncation rule, and they would have
+// drifted.
+func RenderFragment(w io.Writer, res *foldedstacks.Result) error {
 	if res == nil {
 		return fmt.Errorf("flamegraph: nil result")
 	}
 	if res.Degenerate() {
-		return fmt.Errorf("flamegraph: refusing to draw an SVG for a profile with no drawable samples (%d samples, total %d %s); use RenderHTML, which reports why",
+		return fmt.Errorf("flamegraph: refusing to draw a graph for a profile with no drawable samples (%d samples, total %d %s); use RenderHTML, which reports why",
 			res.Samples, res.Total, res.Unit)
 	}
 	root, maxDepth := buildTree(res)
 	ew := &errWriter{w: w}
-	if err := writeSVG(ew, root, maxDepth, res, opts, true); err != nil {
+	ew.s("<style>\n")
+	ew.s(paletteCSS)
+	ew.s(jitterCSS)
+	ew.s(rowCSS(maxDepth))
+	ew.s(embedCSS)
+	ew.s("</style>\n")
+	if err := writeChart(ew, root, maxDepth, res); err != nil {
 		return err
 	}
 	return ew.err
 }
 
+// embedCSS is the handful of chrome rules a fragment cannot borrow from the
+// host page: the box a frame is, minus everything about the page around it.
+const embedCSS = `
+.chart{position:relative}
+.frame{position:absolute;height:17px;padding:0 4px;box-sizing:border-box;border-radius:2px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;line-height:17px}
+`
+
 func (o Options) withDefaults() Options {
-	if o.Width <= 0 {
-		o.Width = defaultWidth
-	}
 	if o.Title == "" {
 		o.Title = "Flame Graph"
 	}
@@ -206,6 +250,7 @@ func buildTree(res *foldedstacks.Result) (*node, int) {
 	}
 	classify(root)
 	sortTree(root)
+	assignJitter(root)
 	return root, maxDepth
 }
 
@@ -227,6 +272,79 @@ func sortTree(n *node) {
 	}
 }
 
+// assignJitter gives every frame a step on a shade ladder within its own
+// domain's colour, so a run of frames that share a domain has visible
+// boundaries. Seven consecutive unsymbolized vendor frames were previously
+// one flat block of sand, and the profiles this renderer exists for are full
+// of exactly that.
+//
+// This is async-profiler's getColor() with two differences. Theirs is
+// Math.random() at draw time; ours is a hash of the frame name, because two
+// renders of one profile must be byte-identical and a frame must keep its
+// shade across a zoom. And theirs may collide with the neighbour it was
+// meant to separate; ours walks the tree with the parent and the previous
+// sibling in hand and steps away from both, so the case that motivated the
+// change — a same-domain frame directly above or beside another — is
+// separated by construction rather than by luck.
+//
+// The boundary greys and the synthetic root sit out. The two boundary fills
+// differ by lightness on purpose (paler means nothing behind it), and a
+// random lightness must not compete with a meaningful one.
+func assignJitter(parent *node) {
+	prevStep, prevDomain := -1, Domain(-1)
+	for _, c := range parent.children {
+		c.jitter = pickJitter(c, parent, prevStep, prevDomain)
+		prevStep, prevDomain = c.jitter, c.domain
+		assignJitter(c)
+	}
+}
+
+// minJitterGap is how many ladder steps apart two touching same-domain
+// frames must be. Three steps is 2.6% of white, which is a visible edge; one
+// step is not.
+const minJitterGap = 3
+
+func pickJitter(n, parent *node, prevStep int, prevDomain Domain) int {
+	if !jittered(n.domain) {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(n.name))
+	step := int(h.Sum32() % jitterSteps)
+
+	clash := func(s, other int) bool {
+		d := s - other
+		return d > -minJitterGap && d < minJitterGap
+	}
+	for range jitterSteps {
+		bad := false
+		if parent.domain == n.domain && jittered(parent.domain) && clash(step, parent.jitter) {
+			bad = true
+		}
+		if prevDomain == n.domain && clash(step, prevStep) {
+			bad = true
+		}
+		if !bad {
+			break
+		}
+		step = (step + minJitterGap) % jitterSteps
+	}
+	return step
+}
+
+// jittered reports whether a domain takes part in the shade ladder.
+func jittered(d Domain) bool {
+	switch d {
+	case DomainRoot, DomainBoundary, DomainBoundaryUnattributed:
+		return false
+	default:
+		return true
+	}
+}
+
+// layout assigns every frame its span as a percentage of the profile total,
+// so the numbers in the markup are shares rather than pixels and the browser
+// turns them into pixels against whatever the window happens to be.
 func layout(n *node, x float64, scale float64) {
 	n.x = x
 	n.width = float64(n.value) * scale
@@ -237,117 +355,111 @@ func layout(n *node, x float64, scale float64) {
 	}
 }
 
-// writeSVG draws the graph. standalone asks it to carry the palette inside
-// the <svg>, which RenderSVG needs and RenderHTML must not have: the page
-// already emitted paletteCSS in its <style>, and a second copy would be dead
-// weight in every file perf-agent writes.
-func writeSVG(ew *errWriter, root *node, maxDepth int, res *foldedstacks.Result, opts Options, standalone bool) error {
+// writeChart draws the graph: one positioning context, one absolutely
+// positioned block per frame.
+//
+// Its height is the only pixel dimension in the markup, because rows have a
+// pitch and the window has no opinion about it. Its width is not stated at
+// all — a block is as wide as what contains it, which is the body, which is
+// the window. That single omission is the difference between a graph that
+// fills a 1990px screen and one that sits in the left 1280px of it.
+//
+// role="group" rather than role="img": img would make the whole subtree
+// presentational and silence all twenty frames, which is exactly what
+// role="img" is for on a frame and exactly wrong on their container. group
+// takes an accessible name and leaves its children exposed.
+func writeChart(ew *errWriter, root *node, maxDepth int, res *foldedstacks.Result) error {
 	if root.value <= 0 {
 		return fmt.Errorf("flamegraph: tree total is %d", root.value)
 	}
-	plotWidth := float64(opts.Width - sidePad*2)
-	layout(root, float64(sidePad), plotWidth/float64(root.value))
+	layout(root, 0, 100/float64(root.value))
 
-	height := topPad + bottomPad + maxDepth*frameHeight
-
-	ew.f(`<svg class="flame" width="%d" height="%d" viewBox="0 0 %d %d" `, opts.Width, height, opts.Width, height)
-	ew.f(`xmlns="http://www.w3.org/2000/svg" data-total="%d" data-inexact="%d" data-unit="%s" data-side-pad="%d" data-plot-width="%.2f" data-min-text="%d" data-text-pad="%d" data-char-width="%.2f">`+"\n",
-		root.value, root.inexact, html.EscapeString(res.Unit), sidePad, plotWidth, minTextWidth, textPad, charWidth)
-	if standalone {
-		ew.s("<style>\n")
-		ew.s(paletteCSS)
-		ew.s("</style>\n")
-	}
-	ew.s(svgDefs)
-	writeNode(ew, root, maxDepth, res, "")
-	ew.s("</svg>\n")
+	ew.f(`<div class="chart" style="height:%dpx" role="group" aria-label="Flame graph, %s" data-total="%d" data-unit="%s">`+"\n",
+		maxDepth*frameHeight-1, html.EscapeString(res.SampleTypeName+"/"+res.Unit),
+		root.value, html.EscapeString(res.Unit))
+	writeNode(ew, root, res.Unit, root.value)
+	ew.s("</div>\n")
 	return ew.err
 }
 
-func writeNode(ew *errWriter, n *node, maxDepth int, res *foldedstacks.Result, parentPath string) {
-	y := float64(topPad + (maxDepth-n.depth-1)*frameHeight)
-	path := n.name
-	if parentPath != "" {
-		path = parentPath + " › " + n.name
-	}
-	cls := "frame"
+// writeNode emits one frame. Every attribute here is read by the script or
+// drawn by the browser; nothing is emitted twice.
+//
+// left and width are percentages of the chart, inline because they are the
+// one thing about a frame that is per-frame data. The depth is a class
+// instead — rowCSS carries the pixel offset — because a profile has many
+// more frames than depths.
+//
+// There is no data-name. The frame's text IS its name, in full: CSS does the
+// truncating now, so the renderer no longer has to cut the label and no
+// longer has anywhere to keep the uncut one. A data-name would be a second
+// copy of a string that can be arbitrarily long, and the script reads
+// textContent instead. (This is the same trade as reading x and width back
+// off the element rather than duplicating them into data-orig-*.)
+//
+// The accessible name is an aria-label rather than a <title>, which is the
+// one place where the cheaper option is also the better one. A <title> is
+// both the accessible name and a native browser tooltip, so restoring it
+// would put a second tooltip on a one-second delay behind the cursor tooltip
+// on every hover. aria-label names the frame for a screen reader and draws
+// nothing. role="img" goes with it so the frame is announced as one object:
+// without it the text child is exposed separately and the reader hears the
+// visually truncated label after the real name.
+//
+// The label is deliberately terse — name, value, share. Domain, module and
+// the inference note stay in the visual tooltip; a screen reader user
+// scanning twenty frames does not want three sentences on each.
+func writeNode(ew *errWriter, n *node, unit string, total int64) {
+	cls := fmt.Sprintf("frame d%d", n.depth)
 	if n.inexact > 0 {
 		cls += " inexact"
 	}
+	if n.jitter > 0 {
+		cls += fmt.Sprintf(" j%d", n.jitter)
+	}
 
-	info := n.domain.Info()
-	ew.f(`<g class="%s" data-name="%s" data-path="%s" data-domain="%s" data-domain-label="%s" data-value="%d" data-inexact="%d" data-orig-x="%.3f" data-orig-width="%.3f" data-depth="%d">`,
-		cls, html.EscapeString(n.name), html.EscapeString(path),
-		html.EscapeString(info.Key), html.EscapeString(info.Label),
-		n.value, n.inexact, n.x, n.width, n.depth)
-	ew.s("<title>")
-	ew.esc(tooltip(n, res))
-	ew.s("</title>")
-
-	// No fill or stroke attribute: data-domain above selects both, from
-	// paletteCSS. A presentation attribute loses to any rule in the
-	// stylesheet, so a fill written here would have been overridden anyway
-	// — and a stroke written here silently was.
-	ew.f(`<rect class="bg" x="%.3f" y="%.1f" width="%.3f" height="%d" rx="2"/>`,
-		n.x, y, n.width, frameHeight-1)
-	if info.Overlay != "" {
-		ew.f(`<rect class="ov" x="%.3f" y="%.1f" width="%.3f" height="%d" rx="2" fill="%s"/>`,
-			n.x, y, n.width, frameHeight-1, info.Overlay)
+	// No inline colour: data-domain below selects fill, hatch and outline
+	// from paletteCSS, so a domain's colour is declared once for the whole
+	// page rather than once per frame.
+	ew.f(`<div class="%s" style="left:%s%%;width:%s%%" role="img" aria-label="%s" data-domain="%s" data-value="%d"`,
+		cls, pct(n.x), pct(n.width),
+		html.EscapeString(accessibleName(n, unit, total)),
+		html.EscapeString(n.domain.Info().Key), n.value)
+	if n.module != "" {
+		ew.f(` data-module="%s"`, html.EscapeString(n.module))
 	}
 	if n.inexact > 0 {
-		ew.f(`<rect class="ov" x="%.3f" y="%.1f" width="%.3f" height="%d" rx="2" fill="url(#p-inferred)"/>`,
-			n.x, y, n.width, frameHeight-1)
+		ew.f(` data-inexact="%d"`, n.inexact)
 	}
-	if n.width >= minTextWidth {
-		maxChars := int((n.width - textPad*2) / charWidth)
-		if label := truncate(n.name, maxChars); label != "" {
-			ew.f(`<text x="%.3f" y="%.1f">`, n.x+textPad, y+float64(frameHeight)-5.5)
-			ew.esc(label)
-			ew.s("</text>")
-		}
-	}
-	ew.s("</g>\n")
+	ew.s(">")
+	// No whitespace around the name: the script reads this back as the
+	// frame's identity, so the text node must be the symbol and nothing else.
+	ew.esc(n.name)
+	ew.s("</div>\n")
 
 	for _, c := range n.children {
-		writeNode(ew, c, maxDepth, res, path)
+		writeNode(ew, c, unit, total)
 	}
 }
 
-func tooltip(n *node, res *foldedstacks.Result) string {
-	var b strings.Builder
-	b.WriteString(n.name)
-	b.WriteString("\n")
-	b.WriteString(FormatValue(n.value, res.Unit))
-	if res.Total > 0 {
-		fmt.Fprintf(&b, " (%.2f%% of total)", float64(n.value)/float64(res.Total)*100)
-	}
-	if n.depth > 0 {
-		b.WriteString("\ndomain: " + n.domain.Info().Label)
-	}
-	if n.module != "" {
-		b.WriteString("\nmodule: " + n.module)
-	}
-	if n.inexact > 0 {
-		fmt.Fprintf(&b, "\n%s of this is attributed by inference, not measurement", FormatValue(n.inexact, res.Unit))
-	}
-	if n.domain == DomainUnsymbolized {
-		b.WriteString("\nno symbol: the unwind found this frame, nothing could name it")
-	}
-	return b.String()
+// pct formats a percentage in its shortest exact form, rounded to a
+// thousandth of the graph's width — 0.02px on a 1990px window, which is
+// finer than a pixel everywhere it matters. Shortest exact, because "100"
+// and "12.5" are four and six bytes where %.3f would spend seven and eight,
+// on two numbers per frame.
+func pct(v float64) string {
+	return strconv.FormatFloat(math.Round(v*1000)/1000, 'f', -1, 64)
 }
 
-func truncate(label string, maxChars int) string {
-	if maxChars <= 0 {
-		return ""
+// accessibleName is what a screen reader announces for a frame. It says the
+// same three things the status bar says, in the same order, so hearing the
+// page and seeing it agree.
+func accessibleName(n *node, unit string, total int64) string {
+	s := n.name + ", " + FormatValue(n.value, unit)
+	if total > 0 {
+		s += fmt.Sprintf(", %.2f%% of total", float64(n.value)/float64(total)*100)
 	}
-	r := []rune(label)
-	if len(r) <= maxChars {
-		return label
-	}
-	if maxChars <= 2 {
-		return string(r[:maxChars])
-	}
-	return string(r[:maxChars-1]) + "…"
+	return s
 }
 
 // FormatValue renders a value in its profile unit. Nanosecond profiles get
@@ -396,76 +508,105 @@ func group(v int64) string {
 	return b.String()
 }
 
-func writeHeader(ew *errWriter, res *foldedstacks.Result, opts Options, degenerate bool) {
-	ew.s("<header class=\"hdr\">\n<h1>")
+// --- the graph page -------------------------------------------------------
+
+// writeTopBar is the whole of the page's permanent chrome above the graph:
+// the profile's name, and two icon buttons whose keyboard equivalents are in
+// the panel one of them opens. The info button grows a dot when the profile
+// carries notes, so a page with caveats never looks like a page without.
+func writeTopBar(ew *errWriter, opts Options, res *foldedstacks.Result, root *node) {
+	ew.s("<div class=\"top\">\n<h1>")
 	ew.esc(opts.Title)
 	ew.s("</h1>\n")
-	if opts.Subtitle != "" {
-		ew.s("<p class=\"sub\">")
-		ew.esc(opts.Subtitle)
-		ew.s("</p>\n")
-	}
-	ew.s("<div class=\"chips\">\n")
-	chip(ew, "axis", res.SampleTypeName+"/"+res.Unit)
-	if degenerate {
-		chip(ew, "total", "nothing to draw")
-	} else {
-		chip(ew, "total", FormatValue(res.Total, res.Unit))
-	}
-	chip(ew, "samples", group(int64(res.Samples)))
-	chip(ew, "distinct stacks", group(int64(len(res.Stacks))))
-	chip(ew, "max depth", group(int64(res.MaxDepth)))
-	if res.Frames > 0 {
-		chip(ew, "unsymbolized frames", fmt.Sprintf("%s of %s", group(int64(res.AddressOnlyFrames)), group(int64(res.Frames))))
-	}
-	if res.InlinedFrames > 0 {
-		chip(ew, "inlined frames", group(int64(res.InlinedFrames)))
-	}
-	chip(ew, "stack order read as", res.StackOrder.String())
-	for _, m := range opts.Meta {
-		chip(ew, m.Label, m.Value)
-	}
-	ew.s("</div>\n</header>\n")
+	writeInfoPanel(ew, root, res, opts)
+	ew.s("<button id=\"theme-btn\" type=\"button\" title=\"Light / dark (D)\" aria-label=\"Toggle light or dark\">&#9680;</button>\n")
+	ew.s("</div>\n")
 }
 
-func chip(ew *errWriter, k, v string) {
-	ew.s("<span class=\"chip\"><b>")
-	ew.esc(k)
-	ew.s("</b>")
-	ew.esc(v)
-	ew.s("</span>\n")
-}
-
-func writeNotices(ew *errWriter, res *foldedstacks.Result, degenerate bool) {
-	if len(res.Warnings) == 0 {
+// writeSamplePeriodNote is the one note that stays on the page.
+//
+// Everything else the reader can recover: the unattributed share is the
+// width of a labelled frame, the unsymbolized frames are hatched and named
+// by their address. This one is invisible in the picture. A CPU call path
+// under [gpu:launch] is a sample of launches, so its width is not the share
+// of GPU time that path is responsible for — it is off by roughly the
+// period, and nothing about the drawing says so. async-profiler has no
+// equivalent because their samples carry no such trap.
+func writeSamplePeriodNote(ew *errWriter, res *foldedstacks.Result) {
+	period, ok := samplePeriod(res)
+	if !ok {
 		return
 	}
-	cls := "notices"
-	if degenerate {
-		cls += " fatal"
+	ew.f("<p class=\"note\">%s=%s &mdash; one launch in %s carried a CPU stack, so the width under [gpu:launch] is a sample of launches, not that path&rsquo;s share of GPU time. Nothing is scaled by %s.</p>\n",
+		html.EscapeString(foldedstacks.SamplePeriodLabel), html.EscapeString(period),
+		html.EscapeString(period), html.EscapeString(period))
+}
+
+func samplePeriod(res *foldedstacks.Result) (string, bool) {
+	for _, l := range res.Labels {
+		if l.Key == foldedstacks.SamplePeriodLabel && len(l.Top) > 0 {
+			return l.Top[0].Value, true
+		}
 	}
-	ew.f("<section class=\"%s\">\n<h2>What this graph does not show</h2>\n<ul>\n", cls)
-	for _, warning := range res.Warnings {
-		ew.s("<li>")
-		ew.esc(warning)
+	return "", false
+}
+
+// writeStatusBar emits the single permanent line of text on the page. Its
+// resting content is the profile's own summary — the numbers the chip row
+// used to hold — and the script replaces it with the hovered frame.
+func writeStatusBar(ew *errWriter, res *foldedstacks.Result) {
+	ew.s("<div id=\"status\">\n<span id=\"st\">")
+	ew.esc(FormatValue(res.Total, res.Unit))
+	ew.s(" total")
+	ew.f(" &middot; %s samples", group(int64(res.Samples)))
+	ew.f(" &middot; %s stacks", group(int64(len(res.Stacks))))
+	ew.s(" &middot; ")
+	ew.esc(res.SampleTypeName + "/" + res.Unit)
+	ew.s("</span>\n")
+	ew.s("<input id=\"q\" type=\"search\" hidden placeholder=\"search frames\" autocomplete=\"off\" spellcheck=\"false\" aria-label=\"Search frames\">\n")
+	ew.s("<span id=\"mc\"></span>\n</div>\n")
+}
+
+// writeInfoPanel is everything that used to be permanently on screen.
+//
+// <details> rather than a div the script shows and hides: it renders
+// collapsed with no script at all, so a page opened with JavaScript off — or
+// saved and reopened somewhere that blocks it — can still reach the legend,
+// which used to be permanent. It also gets the disclosure semantics for free
+// (a summary is a button that announces expanded or collapsed), which a div
+// with a hidden attribute never had.
+func writeInfoPanel(ew *errWriter, root *node, res *foldedstacks.Result, opts Options) {
+	cls := ""
+	if len(otherWarnings(res)) > 0 {
+		cls = " class=\"notes\""
+	}
+	ew.s("<details id=\"info\">\n")
+	ew.f("<summary id=\"info-btn\"%s title=\"Legend, keys and notes (?)\" aria-label=\"Legend, keys and notes\">&#9432;</summary>\n", cls)
+	ew.s("<div id=\"panel\">\n")
+	ew.s("<button id=\"close\" type=\"button\" title=\"Close (Esc)\" aria-label=\"Close\">&#10005;</button>\n")
+
+	ew.s("<h2>Keys</h2>\n<ul class=\"keys\">\n")
+	for _, k := range [][2]string{
+		{"Ctrl+F", "search frames"},
+		{"0", "reset zoom"},
+		{"Esc", "close this, then clear search, then reset zoom"},
+		{"D", "light / dark"},
+		{"? or I", "this panel"},
+	} {
+		ew.s("<li><kbd>")
+		ew.esc(k[0])
+		ew.s("</kbd> ")
+		ew.esc(k[1])
 		ew.s("</li>\n")
 	}
-	ew.s("</ul>\n</section>\n")
-}
+	ew.s("<li>click a frame to zoom, click the background to reset</li>\n</ul>\n")
 
-func writeNoData(ew *errWriter, res *foldedstacks.Result) {
-	ew.s("<section class=\"nodata\">\n<h2>No flame graph was drawn</h2>\n<p>")
-	if res.Samples == 0 {
-		ew.s("The profile contains zero samples. An empty flame graph would be indistinguishable from a flame graph of an idle process, so none is drawn.")
-	} else {
-		ew.f("The profile contains %s samples, but every one of them carries the value 0 on the ", group(int64(res.Samples)))
-		ew.esc(res.SampleTypeName + "/" + res.Unit)
-		ew.s(" axis, so there is nothing with a width to draw.")
-	}
-	ew.s("</p>\n<p class=\"muted\">This is the profile reporting on itself, not a rendering failure. Check that the profiler attached, that the target was running, and that the collection window overlapped it.</p>\n</section>\n")
+	writeLegend(ew, root)
+	writeNotes(ew, res)
+	writeLabels(ew, res)
+	writeProvenance(ew, res, opts)
+	ew.s("</div>\n</details>\n")
 }
-
-func writeToolbar(ew *errWriter) { ew.s(toolbarHTML) }
 
 // writeLegend emits only the domains actually present in this graph, so the
 // legend never advertises a layer the profile does not contain.
@@ -482,8 +623,8 @@ func writeLegend(ew *errWriter, root *node) {
 	}
 	walk(root)
 
-	ew.s("<section class=\"legend\">\n<h2>Colour means domain</h2>\n")
-	ew.s("<p class=\"muted\">Each colour is a layer of the CPU→GPU path, not a hash of the frame name. The domain is inferred — from the profile's mapping file where it has one, otherwise from the symbol name — and it affects nothing but the colour: every frame's width and position comes from its measured value.</p>\n<ul class=\"legend-list\">\n")
+	ew.s("<h2>Colour means domain</h2>\n")
+	ew.s("<p class=\"muted\">Each colour is a layer of the CPU&rarr;GPU path, not a hash of the frame name. The domain is inferred &mdash; from the profile&rsquo;s mapping file where it has one, otherwise from the symbol name &mdash; and it affects nothing but the colour. Frames within a domain vary slightly in shade so a run of neighbours has visible edges; that variation carries no meaning.</p>\n<ul class=\"legend-list\">\n")
 	for d := Domain(0); d < numDomains; d++ {
 		if !present[d] {
 			continue
@@ -512,22 +653,50 @@ func writeLegend(ew *errWriter, root *node) {
 	}
 	ew.s("</ul>\n")
 	if present[DomainGPUKernel] {
-		ew.s("<p class=\"muted depth-note\">A <code>[gpu:kernel:…]</code> frame is one kernel and its duration.</p>\n")
+		ew.s("<p class=\"muted\">A <code>[gpu:kernel:&hellip;]</code> frame is one kernel and its duration.</p>\n")
 	}
 	// Say out loud that one colour of the palette is missing on purpose.
 	// Otherwise its absence looks like an oversight, and its arrival later
 	// looks like a new colour rather than a layer that finally has data.
-	ew.s("<p class=\"muted legend-note\">The colours are Brendan Gregg&rsquo;s AI Flame Graph palette. One of them, <span class=\"sw\" style=\"background-color:var(--fill-accel-source)\"></span><b>aqua</b>, is reserved and unused: it belongs to source lines of functions running on the accelerator, which needs per-instruction GPU sampling resolved back to source. perf-agent does not produce that yet, so no frame on this page is aqua.</p>\n")
-	ew.s("</section>\n")
+	ew.s("<p class=\"muted\">The colours are Brendan Gregg&rsquo;s AI Flame Graph palette. One of them, <span class=\"sw\" style=\"background-color:var(--fill-accel-source)\"></span><b>aqua</b>, is reserved and unused: it belongs to source lines of functions running on the accelerator, which perf-agent cannot sample yet. No frame on this page is aqua.</p>\n")
+}
+
+// writeNotes lists everything the fold wants the reader to know except the
+// launch-sampling note, which the page already carries in full view.
+func writeNotes(ew *errWriter, res *foldedstacks.Result) {
+	notes := otherWarnings(res)
+	if len(notes) == 0 {
+		return
+	}
+	ew.s("<h2>What this graph does not show</h2>\n<ul>\n")
+	for _, warning := range notes {
+		ew.s("<li>")
+		ew.esc(warning)
+		ew.s("</li>\n")
+	}
+	ew.s("</ul>\n")
+}
+
+// otherWarnings drops the launch-sampling warning, which writeSamplePeriodNote
+// states on the page itself, so no note is made twice.
+func otherWarnings(res *foldedstacks.Result) []string {
+	var out []string
+	for _, w := range res.Warnings {
+		if strings.Contains(w, foldedstacks.SamplePeriodLabel+"=") {
+			continue
+		}
+		out = append(out, w)
+	}
+	return out
 }
 
 func writeLabels(ew *errWriter, res *foldedstacks.Result) {
-	ew.s("<section class=\"labels\">\n<h2>Sample labels (not in the graph)</h2>\n")
+	ew.s("<h2>Sample labels (not in the graph)</h2>\n")
 	if len(res.Labels) == 0 {
-		ew.s("<p class=\"muted\">This profile carries no per-sample labels.</p>\n</section>\n")
+		ew.s("<p class=\"muted\">This profile carries no per-sample labels.</p>\n")
 		return
 	}
-	ew.s(`<p class="muted">Frames are stack identity, so §8 of the GPU profiling v2 design keeps these out of the tree: folding a per-sample PC or correlation ID into the path would give every sample its own leaf and destroy the aggregation a flame graph exists to show. They are reported here instead, so nothing in the profile is silently discarded.</p>
+	ew.s(`<p class="muted">Frames are stack identity, so §8 of the GPU profiling v2 design keeps these out of the tree: a per-sample PC or correlation ID in the path would give every sample its own leaf and destroy the aggregation a flame graph exists to show. They are reported here instead, so nothing in the profile is silently discarded.</p>
 <table>
 <thead><tr><th>key</th><th>samples</th><th>distinct values</th><th>top values by value</th></tr></thead>
 <tbody>
@@ -561,10 +730,98 @@ func writeLabels(ew *errWriter, res *foldedstacks.Result) {
 		}
 		ew.s("</td></tr>\n")
 	}
-	ew.s("</tbody>\n</table>\n</section>\n")
+	ew.s("</tbody>\n</table>\n")
 }
 
-func writeFooter(ew *errWriter, res *foldedstacks.Result) {
+func writeProvenance(ew *errWriter, res *foldedstacks.Result, opts Options) {
+	ew.s("<h2>Provenance</h2>\n<ul>\n")
+	if opts.Subtitle != "" {
+		ew.s("<li>")
+		ew.esc(opts.Subtitle)
+		ew.s("</li>\n")
+	}
+	ew.s("<li>Value axis: ")
+	ew.esc(res.SampleTypeName + "/" + res.Unit)
+	if len(res.SampleTypes) > 1 {
+		ew.s(" (of ")
+		ew.esc(strings.Join(res.SampleTypes, ", "))
+		ew.s(")")
+	}
+	ew.f("; max depth %s", group(int64(res.MaxDepth)))
+	if res.Frames > 0 {
+		ew.f("; %s of %s frame slots unsymbolized", group(int64(res.AddressOnlyFrames)), group(int64(res.Frames)))
+	}
+	if res.InlinedFrames > 0 {
+		ew.f("; %s inlined frames", group(int64(res.InlinedFrames)))
+	}
+	ew.s("</li>\n<li>Stack order read as ")
+	ew.esc(res.StackOrder.String())
+	ew.s(".</li>\n")
+	for _, m := range opts.Meta {
+		ew.s("<li>")
+		ew.esc(m.Label + ": " + m.Value)
+		ew.s("</li>\n")
+	}
+	ew.s("<li>Rendered by perf-agent. No external resources are loaded.</li>\n</ul>\n")
+}
+
+// --- the degenerate page --------------------------------------------------
+
+// writeReport is the page a profile with nothing to draw gets. It is a
+// written report rather than a graph with chrome, so it keeps the header,
+// the chips and the full notice list: there is no picture to be quiet
+// around, and every number on it is the evidence for why.
+func writeReport(ew *errWriter, res *foldedstacks.Result, opts Options) {
+	ew.s("<header>\n<h1>")
+	ew.esc(opts.Title)
+	ew.s("</h1>\n")
+	if opts.Subtitle != "" {
+		ew.s("<p class=\"sub\">")
+		ew.esc(opts.Subtitle)
+		ew.s("</p>\n")
+	}
+	ew.s("<div class=\"chips\">\n")
+	chip(ew, "axis", res.SampleTypeName+"/"+res.Unit)
+	chip(ew, "total", "nothing to draw")
+	chip(ew, "samples", group(int64(res.Samples)))
+	chip(ew, "distinct stacks", group(int64(len(res.Stacks))))
+	chip(ew, "max depth", group(int64(res.MaxDepth)))
+	if res.Frames > 0 {
+		chip(ew, "unsymbolized frames", fmt.Sprintf("%s of %s", group(int64(res.AddressOnlyFrames)), group(int64(res.Frames))))
+	}
+	if res.InlinedFrames > 0 {
+		chip(ew, "inlined frames", group(int64(res.InlinedFrames)))
+	}
+	chip(ew, "stack order read as", res.StackOrder.String())
+	for _, m := range opts.Meta {
+		chip(ew, m.Label, m.Value)
+	}
+	ew.s("</div>\n</header>\n")
+
+	if len(res.Warnings) > 0 {
+		ew.s("<section class=\"notices fatal\">\n<h2>What this graph does not show</h2>\n<ul>\n")
+		for _, warning := range res.Warnings {
+			ew.s("<li>")
+			ew.esc(warning)
+			ew.s("</li>\n")
+		}
+		ew.s("</ul>\n</section>\n")
+	}
+
+	ew.s("<section class=\"nodata\">\n<h2>No flame graph was drawn</h2>\n<p>")
+	if res.Samples == 0 {
+		ew.s("The profile contains zero samples. An empty flame graph would be indistinguishable from a flame graph of an idle process, so none is drawn.")
+	} else {
+		ew.f("The profile contains %s samples, but every one of them carries the value 0 on the ", group(int64(res.Samples)))
+		ew.esc(res.SampleTypeName + "/" + res.Unit)
+		ew.s(" axis, so there is nothing with a width to draw.")
+	}
+	ew.s("</p>\n<p class=\"muted\">This is the profile reporting on itself, not a rendering failure. Check that the profiler attached, that the target was running, and that the collection window overlapped it.</p>\n</section>\n")
+
+	ew.s("<section class=\"labels\">\n")
+	writeLabels(ew, res)
+	ew.s("</section>\n")
+
 	ew.s("<footer>Rendered by perf-agent. Value axis: ")
 	ew.esc(res.SampleTypeName + "/" + res.Unit)
 	if len(res.SampleTypes) > 1 {
@@ -575,6 +832,14 @@ func writeFooter(ew *errWriter, res *foldedstacks.Result) {
 	ew.s(". Stack order read as ")
 	ew.esc(res.StackOrder.String())
 	ew.s(". No external resources are loaded.</footer>\n")
+}
+
+func chip(ew *errWriter, k, v string) {
+	ew.s("<span class=\"chip\"><b>")
+	ew.esc(k)
+	ew.s("</b>")
+	ew.esc(v)
+	ew.s("</span>\n")
 }
 
 type errWriter struct {

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -1,6 +1,8 @@
 package flamegraph
 
 import (
+	"fmt"
+	"html"
 	"regexp"
 	"strings"
 	"testing"
@@ -45,8 +47,8 @@ func TestRenderHTMLProducesAStandalonePage(t *testing.T) {
 
 	for _, want := range []string{
 		"<!DOCTYPE html>", "<html lang=\"en\">", "<title>GPU flame graph</title>",
-		"<svg class=\"flame\"", "data-name=\"main\"", "data-name=\"work\"",
-		"id=\"search\"", "id=\"reset-zoom\"", "id=\"breadcrumbs\"", "id=\"match-count\"",
+		"<div class=\"chart\"", ">main</div>", ">work</div>",
+		`id="status"`, `id="tip"`, `id="info"`, `id="q"`, `id="info-btn"`, `id="theme-btn"`,
 		"function zoom(target)", "function applySearch(query)",
 	} {
 		assert.Contains(t, got, want)
@@ -68,11 +70,10 @@ func TestRenderHTMLFetchesNothing(t *testing.T) {
 	} {
 		assert.NotContains(t, got, forbidden, "the page must load nothing from the network")
 	}
-	// The one http:// in the document is the SVG XML namespace, which is an
-	// identifier, not a fetch.
-	for _, m := range regexp.MustCompile(`https?://[^\s"'<>)]+`).FindAllString(got, -1) {
-		assert.Equal(t, "http://www.w3.org/2000/svg", m)
-	}
+	// Not one URL of any kind is left in the document. There used to be
+	// exactly one — the SVG XML namespace, an identifier rather than a fetch
+	// — and the geometry that needed it is gone.
+	assert.Empty(t, regexp.MustCompile(`https?://[^\s"'<>)]+`).FindAllString(got, -1))
 }
 
 // C++ templates and Go generics guarantee <, > and & in symbol names. A
@@ -127,7 +128,7 @@ func TestRenderHTMLOnAnEmptyProfileSaysSoInsteadOfDrawingNothing(t *testing.T) {
 	}
 	got := renderString(t, empty, Options{Title: "empty"})
 
-	assert.NotContains(t, got, "<svg class=\"flame\"", "no graph may be drawn")
+	assert.NotContains(t, got, "<div class=\"chart\"", "no graph may be drawn")
 	assert.NotContains(t, got, "<script>", "no interactivity without a graph")
 	assert.Contains(t, got, "No flame graph was drawn")
 	assert.Contains(t, got, "zero samples")
@@ -139,14 +140,14 @@ func TestRenderHTMLOnAnAllZeroProfileSaysSo(t *testing.T) {
 	res := &foldedstacks.Result{SampleTypeName: "gpu", Unit: "nanoseconds", Samples: 40}
 	got := renderString(t, res, Options{})
 
-	assert.NotContains(t, got, "<svg class=\"flame\"")
+	assert.NotContains(t, got, "<div class=\"chart\"")
 	assert.Contains(t, got, "No flame graph was drawn")
 	assert.Contains(t, got, "every one of them carries the value 0")
 	assert.Contains(t, got, "gpu/nanoseconds")
 }
 
-func TestRenderSVGRefusesADegenerateProfile(t *testing.T) {
-	err := RenderSVG(&strings.Builder{}, &foldedstacks.Result{SampleTypeName: "cpu", Unit: "nanoseconds"}, Options{})
+func TestRenderFragmentRefusesADegenerateProfile(t *testing.T) {
+	err := RenderFragment(&strings.Builder{}, &foldedstacks.Result{SampleTypeName: "cpu", Unit: "nanoseconds"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no drawable samples")
 }
@@ -183,7 +184,9 @@ func TestRenderHTMLConservesTheTotalOnTheSyntheticRoot(t *testing.T) {
 	got := renderString(t, res, Options{})
 	assert.Equal(t, int64(5987854), res.Total)
 	assert.Contains(t, got, `data-total="5987854"`)
-	assert.Contains(t, got, `data-name="all" data-path="all" data-domain="root" data-domain-label="all" data-value="5987854"`)
+	assert.Contains(t, got, `data-domain="root" data-value="5987854"`)
+	// The root spans the chart exactly, and the chart spans the window.
+	assert.Contains(t, got, `class="frame d0" style="left:0%;width:100%"`)
 }
 
 func TestRenderHTMLColoursByDomainNotByNameHash(t *testing.T) {
@@ -205,7 +208,7 @@ func TestRenderHTMLColoursByDomainNotByNameHash(t *testing.T) {
 	// Same fill for every frame of a domain: colour is information, not
 	// decoration.
 	assert.Contains(t, got, DomainGPUKernel.Info().Fill)
-	assert.Contains(t, got, "url(#p-gap)", "unsymbolized frames must be hatched")
+	assert.Contains(t, got, "var(--hatch-gap)", "unsymbolized frames must be hatched")
 }
 
 func TestRenderHTMLLegendOnlyNamesDomainsThatAreActuallyPresent(t *testing.T) {
@@ -231,12 +234,12 @@ func TestRenderHTMLMarksInferredAttributionOnTheFramesItAffects(t *testing.T) {
 	)
 	got := renderString(t, res, Options{})
 
-	assert.Contains(t, got, `class="frame inexact"`)
-	assert.Contains(t, got, "url(#p-inferred)")
+	assert.Regexp(t, regexp.MustCompile(`class="frame d\d+ inexact( j\d)?"[^>]*>\[gpu:kernel:k\]</div>`), got)
+	assert.Contains(t, paletteCSS, ".frame.inexact{background-image:var(--hatch-inf)}")
 	assert.Contains(t, got, `data-inexact="100"`)
 	assert.Contains(t, got, "attributed by inference, not measurement")
 	// The frame that was measured must not be marked.
-	assert.Regexp(t, regexp.MustCompile(`class="frame" data-name="other"`), got)
+	assert.Regexp(t, regexp.MustCompile(`class="frame d\d+( j\d)?"[^>]*>other</div>`), got)
 }
 
 func TestRenderHTMLReportsLabelsWithoutFoldingThemIntoFrames(t *testing.T) {
@@ -260,8 +263,9 @@ func TestRenderHTMLReportsLabelsWithoutFoldingThemIntoFrames(t *testing.T) {
 	assert.Contains(t, got, "gpu_join")
 	assert.Contains(t, got, "heuristic")
 	assert.Contains(t, got, "+11 more")
-	assert.NotContains(t, got, `data-name="gpu_join`, "a label must never become a frame")
-	assert.NotContains(t, got, `data-name="gpu_queue`)
+	chart := chartOf(t, got)
+	assert.NotContains(t, chart, "gpu_join", "a label must never become a frame")
+	assert.NotContains(t, chart, "gpu_queue")
 }
 
 func TestRenderHTMLDoesNotDressUpAHighCardinalityLabelAsAFinding(t *testing.T) {
@@ -283,7 +287,7 @@ func TestRenderHTMLStatesTheStackOrderItAssumed(t *testing.T) {
 	// Reading the order wrong draws a plausible graph upside down, so the
 	// page always says which way it read the profile.
 	got := renderString(t, result(foldedstacks.Stack{Frames: []string{"a"}, Value: 1}), Options{})
-	assert.Contains(t, got, "stack order read as")
+	assert.Contains(t, strings.ToLower(got), "stack order read as")
 	assert.Contains(t, got, "root-first")
 }
 
@@ -301,15 +305,326 @@ func TestRenderHTMLIsDeterministic(t *testing.T) {
 	}
 }
 
-func TestTruncateNeverSplitsAMultibyteRune(t *testing.T) {
-	assert.Equal(t, "", truncate("abc", 0))
-	assert.Equal(t, "abc", truncate("abc", 3))
-	assert.Equal(t, "ab…", truncate("abcdef", 3))
-	assert.Equal(t, "日本…", truncate("日本語です", 3))
-	assert.Equal(t, "日", truncate("日本語", 1))
-}
-
 func TestRenderHTMLRejectsANilResult(t *testing.T) {
 	require.Error(t, RenderHTML(&strings.Builder{}, nil, Options{}))
-	require.Error(t, RenderSVG(&strings.Builder{}, nil, Options{}))
+	require.Error(t, RenderFragment(&strings.Builder{}, nil))
+}
+
+// The chrome discipline, asserted rather than described: what a reader sees
+// without pressing anything is the graph, one status line, and the note that
+// stops them misreading it. Everything else is behind the info button.
+func TestRenderHTMLKeepsTheChromeOffThePage(t *testing.T) {
+	res := result(foldedstacks.Stack{Frames: []string{"main", "[gpu:launch]", "[gpu:kernel:k]"}, Value: 100})
+	res.Labels = []foldedstacks.LabelSummary{{
+		Key: foldedstacks.SamplePeriodLabel, Distinct: 1, Total: 100, Count: 12,
+		Top: []foldedstacks.LabelValue{{Value: "8", Total: 100, Count: 12}},
+	}}
+	res.Warnings = []string{
+		"7 of 20 frame slots (35.0%) have no symbol and are drawn as a raw address or [unknown].",
+		"12 samples carry gpu_sample_period=8: one launch in 8 contributed a CPU stack.",
+	}
+	got := renderString(t, res, Options{Title: "t"})
+
+	body := got[strings.Index(got, "<body>"):]
+	panelAt := strings.Index(body, `<details id="info"`)
+	require.Positive(t, panelAt, "the info panel must exist")
+	panelEnd := strings.Index(body, "</details>")
+	require.Greater(t, panelEnd, panelAt)
+	panel := body[panelAt:panelEnd]
+	// Everything outside the <details> is what a reader sees without
+	// pressing anything; everything inside it is one keypress away.
+	visible := body[:panelAt] + body[panelEnd:]
+
+	// The launch-sampling note is on the page, once, in one line.
+	assert.Contains(t, visible, `<p class="note">`)
+	assert.Equal(t, 1, strings.Count(got, `<p class="note">`))
+	assert.Contains(t, visible, "gpu_sample_period=8")
+	assert.Contains(t, visible, "not that path&rsquo;s share of GPU time")
+	assert.NotContains(t, got, "12 samples carry gpu_sample_period=8",
+		"the long form of the note must not be repeated in the panel")
+
+	// Everything that used to be permanently on screen is not.
+	for _, hidden := range []string{
+		"Colour means domain", "What this graph does not show",
+		"Sample labels (not in the graph)", "Provenance",
+		"have no symbol and are drawn as a raw address",
+	} {
+		assert.NotContains(t, visible, hidden, "%q must live in the info panel, not on the page", hidden)
+		assert.Contains(t, panel, hidden)
+	}
+
+	// And the toolbar it replaced is gone entirely.
+	for _, gone := range []string{"Reset zoom", "Clear", `id="breadcrumbs"`, `class="toolbar"`, `class="chip"`} {
+		assert.NotContains(t, got, gone)
+	}
+
+	// A profile with notes says so on the button that hides them.
+	assert.Contains(t, got, `<summary id="info-btn" class="notes"`)
+}
+
+func TestRenderHTMLDoesNotFlagNotesOnAProfileThatHasNone(t *testing.T) {
+	got := renderString(t, result(foldedstacks.Stack{Frames: []string{"main"}, Value: 1}), Options{})
+	assert.Contains(t, got, `<summary id="info-btn" title=`)
+	assert.NotContains(t, got, `id="info-btn" class="notes"`)
+	assert.NotContains(t, got, `<p class="note">`, "no launch sampling, no note")
+}
+
+// The seven consecutive unsymbolized vendor frames of the RTX 3090 profile
+// were one flat block of sand. Every frame that shares a domain with the
+// frame below it, or with the frame beside it, must now differ from it by
+// enough lightness to show an edge.
+func TestJitterSeparatesEveryTouchingPairThatSharesADomain(t *testing.T) {
+	res := result(foldedstacks.Stack{Frames: []string{
+		"_start", "__libc_start_call_main", "main",
+		"0xdeadbeef", "0xcafebabe", "0xfeedface", "0xdecafbad", "0xbaddcafe",
+		"[gpu:launch]", "[gpu:kernel:k]",
+	}, Value: 100})
+	root, _ := buildTree(res)
+
+	var walk func(n *node)
+	walk = func(n *node) {
+		prev := (*node)(nil)
+		for _, c := range n.children {
+			if c.domain == n.domain && jittered(c.domain) {
+				assert.GreaterOrEqual(t, abs(c.jitter-n.jitter), minJitterGap,
+					"%q sits on %q and shares its domain, but only %d ladder steps apart",
+					c.name, n.name, abs(c.jitter-n.jitter))
+			}
+			if prev != nil && prev.domain == c.domain && jittered(c.domain) {
+				assert.GreaterOrEqual(t, abs(c.jitter-prev.jitter), minJitterGap,
+					"%q sits beside %q and shares its domain, but only %d ladder steps apart",
+					c.name, prev.name, abs(c.jitter-prev.jitter))
+			}
+			prev = c
+			walk(c)
+		}
+	}
+	walk(root)
+
+	// The domains whose lightness carries meaning stay off the ladder.
+	var check func(n *node)
+	check = func(n *node) {
+		if !jittered(n.domain) {
+			assert.Zero(t, n.jitter, "%q must keep its declared lightness", n.name)
+		}
+		assert.Less(t, n.jitter, jitterSteps)
+		for _, c := range n.children {
+			check(c)
+		}
+	}
+	check(root)
+
+	page := renderString(t, res, Options{})
+	assert.Contains(t, page, ">[gpu:launch]</div>")
+	assert.NotRegexp(t, regexp.MustCompile(`class="frame d\d+ j\d"[^>]*>\[gpu:launch\]</div>`), page)
+	assert.NotRegexp(t, regexp.MustCompile(`class="frame d0 j\d"[^>]*>all</div>`), page)
+}
+
+func abs(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// A page with no graph has nothing to hover, search or zoom, so it carries
+// none of the machinery for it.
+func TestRenderHTMLOnADegenerateProfileCarriesNoChrome(t *testing.T) {
+	got := renderString(t, &foldedstacks.Result{SampleTypeName: "cpu", Unit: "nanoseconds"}, Options{})
+	for _, gone := range []string{`id="status"`, `id="tip"`, `id="info"`, `id="info-btn"`, "<script>", "color-mix", "hsl(from", `class="chart"`} {
+		assert.NotContains(t, got, gone)
+	}
+	assert.Contains(t, got, "No flame graph was drawn")
+}
+
+// A frame that a screen reader cannot name is a frame that does not exist to
+// it. The name is an aria-label rather than a <title> so it draws nothing:
+// a <title> is also a native browser tooltip, and two tooltips on one hover
+// is worse than one.
+func TestEveryFrameCarriesAnAccessibleName(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"main", "work"}, Value: 2695822},
+		foldedstacks.Stack{Frames: []string{"main", "idle"}, Value: 3292032},
+	), Options{})
+
+	groups := regexp.MustCompile(`<div class="frame[^"]*"([^>]*)>`).FindAllStringSubmatch(got, -1)
+	require.Len(t, groups, 4, "root, main, idle, work")
+	for _, g := range groups {
+		assert.Contains(t, g[1], `role="img"`,
+			"without role=img the truncated <text> child is announced after the real name")
+		assert.Regexp(t, regexp.MustCompile(`aria-label="[^"]+"`), g[1])
+	}
+
+	// The name says the same three things the status bar says, in the same
+	// order, so hearing the page and seeing it agree.
+	assert.Contains(t, got, `aria-label="all, 5.99 ms, 100.00% of total"`)
+	assert.Contains(t, got, `aria-label="work, 2.70 ms, 45.02% of total"`)
+	assert.Contains(t, got, `aria-label="idle, 3.29 ms, 54.98% of total"`)
+
+	// The chart names itself, but as a group: role="img" there would make
+	// the whole subtree presentational and silence all four frames.
+	assert.Contains(t, got, `class="chart" style="height:53px" role="group" aria-label="Flame graph, gpu/nanoseconds"`)
+
+	// Exactly one <title> in the document — the one in <head>. A per-frame
+	// <title> would be an accessible name AND a native browser tooltip, and
+	// would race the cursor tooltip on every hover.
+	assert.Equal(t, 1, strings.Count(got, "<title>"))
+	assert.Contains(t, got, "<title>Flame Graph</title>")
+}
+
+func TestAccessibleNamesEscapeHostileSymbols(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{`Foo<Bar&"Baz">::run()`}, Value: 10},
+	), Options{})
+	assert.Contains(t, got, `aria-label="Foo&lt;Bar&amp;&#34;Baz&#34;&gt;::run(), 10 ns, 100.00% of total"`)
+	assert.NotContains(t, got, `aria-label="Foo<Bar`)
+}
+
+// The legend used to be permanently on the page, so moving it behind a
+// control must not put it behind JavaScript as well.
+func TestTheInfoPanelOpensWithoutScript(t *testing.T) {
+	got := renderString(t, result(foldedstacks.Stack{Frames: []string{"main"}, Value: 1}), Options{})
+
+	assert.Contains(t, got, `<details id="info">`)
+	assert.Regexp(t, regexp.MustCompile(`<summary id="info-btn"[^>]*>`), got)
+	assert.NotContains(t, got, `<details id="info" open`, "collapsed at rest, or it is permanent chrome again")
+	assert.NotContains(t, got, `id="panel" hidden`, "the panel is hidden by <details>, not by an attribute a script must clear")
+
+	// The script may drive the disclosure, but it must not be what creates
+	// it: no JS path sets the panel's own visibility.
+	assert.NotContains(t, script, "panel.hidden")
+	assert.Contains(t, script, "info.open")
+}
+
+// chartOf is the graph and nothing else: from the chart element to the
+// status bar that follows it.
+func chartOf(t *testing.T, page string) string {
+	t.Helper()
+	i := strings.Index(page, `<div class="chart"`)
+	require.GreaterOrEqual(t, i, 0)
+	j := strings.Index(page, `<div id="status">`)
+	require.Greater(t, j, i)
+	return page[i:j]
+}
+
+// The defect this geometry replaced: a viewBox 1280 units wide, so a 1990px
+// window got a graph in its left two-thirds and 700px of nothing. Every
+// horizontal number in the markup is now a percentage, which is a number the
+// browser resolves against the window — at load, and again on every resize,
+// with no script involved.
+func TestFrameGeometryIsPercentagesSoTheGraphFillsAnyWindow(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"main", "work"}, Value: 3000},
+		foldedstacks.Stack{Frames: []string{"main", "idle"}, Value: 1000},
+	), Options{})
+
+	styles := regexp.MustCompile(`<div class="frame[^"]*" style="([^"]*)"`).FindAllStringSubmatch(got, -1)
+	require.Len(t, styles, 4)
+	geom := regexp.MustCompile(`^left:-?[\d.]+%;width:[\d.]+%$`)
+	for _, m := range styles {
+		assert.Regexp(t, geom, m[1], "a frame's span must be stated in %%, never in px")
+	}
+
+	// Nothing anywhere fixes the graph's width. The only px in the chart
+	// element is its height, which is rows times pitch and has nothing to do
+	// with the window.
+	chart := chartOf(t, got)
+	assert.NotContains(t, chart, "px;width")
+	assert.NotContains(t, chart, "width:1280")
+	assert.NotContains(t, got, "viewBox")
+	assert.NotContains(t, got, "preserveAspectRatio")
+	assert.Regexp(t, regexp.MustCompile(`<div class="chart" style="height:\d+px"`), got)
+}
+
+// "Fill the width" must not mean "scale the drawing". A viewBox stretched to
+// 100% would have grown 13px text to 20px on a 1990px window and made the
+// rows half again as tall; that is zoom, not fill. So every dimension that
+// is not a share of the total is an absolute px in a stylesheet, identical
+// at every window width.
+func TestTypographyAndRowPitchAreFixedPixelsAtEveryWindowWidth(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"a", "b", "c"}, Value: 10},
+	), Options{})
+
+	assert.Contains(t, styleSheet, "font-size:11px")
+	assert.Contains(t, styleSheet, "height:17px")
+	assert.Contains(t, styleSheet, "line-height:17px")
+	// One rule per depth, offset from the floor: a depth is the same number
+	// of pixels up whatever the profile and whatever the window.
+	for d, top := range map[int]int{0: 0, 1: frameHeight, 3: 3 * frameHeight} {
+		assert.Contains(t, got, fmt.Sprintf(".d%d{bottom:%dpx}", d, top))
+	}
+	assert.Contains(t, got, `class="frame d3 `, "the leaf sits three rows up")
+	assert.NotContains(t, got, ".d4{", "and there is no fourth row to sit on")
+}
+
+// The whole page must lay itself out with the script deleted — the branch
+// made the info panel a native <details> for this reason, and a graph that
+// needed a resize handler to be the right width would have given that back.
+func TestTheGraphFillsTheWindowWithoutTheScript(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"main", "work"}, Value: 3000},
+		foldedstacks.Stack{Frames: []string{"main", "idle"}, Value: 1000},
+	), Options{})
+
+	// No resize listener, and no layout pass to hang off one.
+	assert.NotContains(t, script, "resize")
+	assert.NotContains(t, script, "getBoundingClientRect().width")
+	assert.NotContains(t, script, "clientWidth")
+	assert.NotContains(t, script, "offsetWidth")
+
+	// The geometry is in the markup, not computed by the script: strip the
+	// script and every frame still has its span.
+	body := got[strings.Index(got, "<body>"):strings.Index(got, "<script>")]
+	assert.Equal(t, 4, strings.Count(body, `<div class="frame`))
+	assert.Contains(t, body, `style="left:0%;width:100%"`)
+	assert.Contains(t, body, `style="left:25%;width:75%"`)
+}
+
+// Truncation moved from Go to CSS, because the renderer no longer knows how
+// many pixels a frame is: it knows a percentage, and only the browser knows
+// what that is worth. So the markup carries the whole symbol and the
+// stylesheet cuts it — at the reader's real width, in the reader's real
+// font, without ever splitting a rune.
+func TestLabelsAreTruncatedByCSSAndTheMarkupKeepsTheWholeSymbol(t *testing.T) {
+	long := "std::__1::__function::__func<VeryLongTemplateArgument>::operator()"
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"main", long}, Value: 1000},
+		foldedstacks.Stack{Frames: []string{"main", "tiny"}, Value: 1},
+	), Options{})
+
+	assert.Contains(t, got, ">"+html.EscapeString(long)+"</div>", "the full name, uncut")
+	assert.NotContains(t, got, "…", "the renderer no longer guesses where to cut")
+	assert.Contains(t, styleSheet, "overflow:hidden;white-space:nowrap;text-overflow:ellipsis")
+
+	// A frame far too narrow for its label still carries the whole label:
+	// the browser hides what does not fit, so hover, search and the status
+	// bar all still see the real name.
+	assert.Contains(t, got, ">tiny</div>")
+	assert.NotContains(t, got, "data-char-width")
+	assert.NotContains(t, got, "data-min-text")
+}
+
+// A fragment is the graph and the rules it cannot borrow from a host page.
+// It shares the page's geometry rather than carrying a second one, which is
+// the whole reason RenderSVG became RenderFragment: an SVG kept alive for
+// embedding would have been a second palette and a second truncation rule.
+func TestRenderFragmentCarriesTheGraphAndItsColoursAndNothingElse(t *testing.T) {
+	var b strings.Builder
+	require.NoError(t, RenderFragment(&b, result(
+		foldedstacks.Stack{Frames: []string{"main", "work"}, Value: 3000},
+		foldedstacks.Stack{Frames: []string{"main", "idle"}, Value: 1000},
+	)))
+	got := b.String()
+
+	assert.Contains(t, got, `<div class="chart"`)
+	assert.Contains(t, got, `style="left:25%;width:75%"`, "the same percentage geometry as the page")
+	assert.Contains(t, got, "--fill-app:", "and its own palette, since a host page has none")
+	assert.Contains(t, got, ".d2{bottom:36px}")
+	assert.Contains(t, got, "text-overflow:ellipsis", "including the rule that does the truncating")
+
+	// None of the page's chrome, and none of its interactivity.
+	for _, gone := range []string{"<script", "<!DOCTYPE", "id=\"status\"", "id=\"info\"", "Colour means domain"} {
+		assert.NotContains(t, got, gone)
+	}
 }

--- a/perfagent/flamegraph_test.go
+++ b/perfagent/flamegraph_test.go
@@ -68,7 +68,7 @@ func TestWriteFlamegraphRendersFromTheProfileTheUserWasGiven(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"<!DOCTYPE html>", "data-name=\"main\"", "data-name=\"hot\"", "pid 4321", "on-CPU"} {
+	for _, want := range []string{"<!DOCTYPE html>", ">main</div>", ">hot</div>", "pid 4321", "on-CPU"} {
 		if !strings.Contains(string(page), want) {
 			t.Errorf("page missing %q", want)
 		}


### PR DESCRIPTION
The page was 34.7 KB for a 3-stack profile, and most of the excess explained the page rather than showing it: a sticky toolbar with title and subtitle, a search box plus two labelled buttons, four status chips, a breadcrumbs row, a "Tips:" hint line, a 10-entry legend, a notes panel and a label table — all permanently visible.

[async-profiler](https://github.com/async-profiler/async-profiler)'s governing principle is that **nothing permanent explains the page**: flame graph plus one status line, with the legend and help one keypress away.

**34,736 B → 27,000 B (−22.3%).** Degenerate page 9,614 → 6,927 B. Total conserved: `data-total="5987854"`.

### Taken

- **Legend and help behind an info button** — and `?`/`I`, `Esc`, click-outside.
- **One bottom status bar** for the hovered frame, replacing the four chips, the breadcrumbs and the hint line. Search-match count bottom-right.
- **Keyboard-first**: `Ctrl+F` search, `0` reset zoom, `Esc` cancel, `D` dark mode, `?`/`I` info.
- **Colour jitter within a domain**, so the seven consecutive unsymbolized vendor frames stop being pixel-identical.
- **Tooltip at the cursor** rather than a selection chip.

### Not taken

**Canvas rendering.** Theirs is canvas because they draw 100k+ frames; ours draws 16. It would cost text selection, accessibility, hit-testing simplicity and a redraw per theme change, to solve a problem we do not have.

**Their colour semantics.** Our domains and the Gregg palette from #71 are unchanged — only the jitter is borrowed.

### Jitter is safe by construction, not by test

Measured first: darkening by 1% takes worst-case contrast from 4.605:1 to **4.463:1**, under the 4.5:1 floor. So jitter **only lightens**. Luminance rises monotonically with lightness, which makes the worst-case jittered frame the *un-jittered* one — the floor cannot be crossed. The test asserts exactly that: `worst(all rungs) == worst(rung 0)`, walking every rung of every fill in both themes.

`color-mix` toward white was nearly invisible on an already-light palette, so it is a lightness delta via `hsl(from var(--fill-x) h s calc(l + var(--fill-j)))`, amplitude +8, 8 rungs — verified in Chrome *and* Firefox that `l` resolves as a bare number, with `fill:var(--fill-x)` declared first as a fallback since the failure mode is black rectangles. Steps are hashed, not random, and the tree walk steps ≥3 rungs from parent and previous sibling, so the seven hex frames land on rungs 2,6,1,7,1,4,1 — separated by construction. Boundary greys sit out: their lightness carries meaning.

### What stayed visible, and why

The `gpu_sample_period` note, compressed to one line: *one launch in 8 carried a CPU stack, so the width under `[gpu:launch]` is a sample of launches, not that path's share of GPU time. Nothing is scaled by 8.*

It stays because **its content is absent from the picture** — it prevents a conclusion that is wrong by roughly 8×. The unsymbolized count and the 93.4% unattributed share moved into the panel: those describe things already on screen (hatched frames that say so on hover; a frame whose width *is* the 93.4%). The info button carries an orange dot whenever notes exist, so a page with caveats never looks like one without.

### Accessibility

The first pass dropped the per-frame `&lt;title&gt;` and with it every frame's accessible name. Restored as `aria-label` — **1,520 B, which is 779 B cheaper than the `&lt;title&gt;` it replaces**, since it carries name/value/share while the visual tooltip keeps the domain and inference lines. `&lt;title&gt;` was not restored because it is both the accessible name and a native tooltip, so it would sit on a delay behind the cursor tooltip on every hover.

`role="img"` accompanies it: without a role the `&lt;g&gt;`'s `&lt;text&gt;` child is exposed separately and a reader announces the truncated on-screen label (`0x7f2c945b…`) after the real name. The `&lt;svg&gt;` itself is named too.

### No-JS

The panel is a native `&lt;details&gt;`/`&lt;summary&gt;`, rendering collapsed with no script. Verified by deleting the `&lt;script&gt;` element outright: graph, note, status summary and full panel all still render. `&lt;summary&gt;` also announces expanded/collapsed, which the previous `&lt;div hidden&gt;` never did, and **a test asserts the script contains no path that sets the panel's own visibility**, so the no-JS route cannot rot.

### Where the bytes actually went

The largest saving was not chrome but the SVG (14,476 → 6,024 B): `data-path` alone was 3,764 B — the breadcrumbs' backing store, quadratic in depth — plus 2,299 B of `&lt;title&gt;`, 916 B of duplicated geometry (now read back off the rects so the no-JS graph still draws), and 1,373 B of CSS comments moved into Go comments.

**15–20 KB was not reached and not forced.** async-profiler gets there with a canvas and a compact JS array; we kept DOM deliberately. The complaint was that the page explains itself constantly, and that is what changed.

### Cannot verify

Chrome and Firefox headless only, both on this machine — **no Safari/WebKit**. **No screen reader**: in particular it is unconfirmed that `role="img"` on an SVG `&lt;g&gt;` suppresses the `&lt;text&gt;` child in every reader, which is the whole reason the role is there. The no-JS path was verified by deleting the script, with `&lt;summary&gt;` forced via the `open` attribute rather than clicked. Hover, tooltip placement and search were driven by synthetic events; theme toggle verified by rendering end states rather than pressing `D`. Icon glyphs depend on the reader's fonts; theme choice is not persisted.