### PR TITLE
gpu: a cubin transport channel of its own

### DIFF
--- a/.superpowers/sdd/task-3-transport-report.md
+++ b/.superpowers/sdd/task-3-transport-report.md
@@ -1,0 +1,331 @@
+# Task 3 — Cubin transport: a channel of its own
+
+Branch `feat/cubin-transport`, one commit. Verified offline: `CapEff: 0`, no GPU,
+no CUDA toolkit, no BPF. Everything the plan asked Task 3 to prove without
+hardware is proven; the two items it deferred to the RTX 3090 are stated as
+outstanding at the end and nothing here pretends otherwise.
+
+## What was built
+
+| file | what |
+| --- | --- |
+| `gpuprobe/cubin.go` | the consumer half: address, listener, admission bucket, seal verification, ceilings, counters, placeholder store |
+| `gpuprobe/cubin_test.go` | 22 tests, 37 leaf cases, including the isolation test in both orders |
+| `shim/core/cubin.h`, `shim/core/cubin.cc` | the producer half: sealed memfd, `SCM_RIGHTS` handover, one-deadline budget, two shim counters |
+| `shim/core/cubin_test.cc` | the producer's own wire assertions |
+| `gpuprobe/consumer.go` | `Config.CubinMaxBytes` / `CubinTotalBytes`, ten `Cubin*` `Stats` fields, bind in `Attach`, close in `Close` |
+| `shim/Makefile` | `core/cubin.cc` into `CORE_SRC`, `cubin_test` into `test` |
+
+**`gpuprobe/enroll.go` and `shim/core/enroll.{h,cc}` are byte-for-byte unchanged.**
+The enrolment path is validated on hardware at 505/505 stacks and any edit there
+re-opens #49. What the cubin channel reuses, it reuses by *calling*:
+
+- `enrollShimIdentity` — the btrfs `stat`-vs-`maps` fix, inherited rather than
+  re-derived;
+- `enrollPeerCreds` and `procMapsHaveInode` — verbatim, so an offer is
+  authenticated exactly as an enrolment is;
+- `enrollRequiredUID` — the same unprivileged-consumer pinning;
+- the `enrollAdmission` *type*, instantiated through `newCubinAdmission` as a
+  **separate object with its own numbers**.
+
+On the C++ side `cubin_name_from_maps` calls `enroll_name_from_maps` and
+re-prefixes its result, so there is exactly one `/proc/<pid>/maps` parser and
+exactly one dev:inode derivation feeding both channels. They cannot come to
+disagree about which shim image they mean.
+
+## Why a separate channel, restated as code
+
+`shim/core/enroll.h` states the protocol as "The producer sends nothing" and
+`enrollListener.handle` implements exactly that — creds, admit, uid/pid checks,
+`procMapsHaveInode`, `reg.enroll`, one status byte, **never a read**. A cubin
+offer must send a header. Sharing the socket would force a discriminating read,
+and on a genuine enrolment that read blocks until the producer's 2 s budget
+expires: every rendezvous becomes a 2 s stall ending in `kEnrollError`.
+
+Three more hazards, all removed structurally rather than defensively:
+
+| hazard on a shared socket | why it cannot happen here |
+| --- | --- |
+| `serve()` is serial **at `Accept`**, so offers queue *ahead* of a producer already in the backlog | the cubin listener has its own `net.UnixListener` and its own goroutine |
+| admission charged per connection against `enrollUIDBurst = 32`, so a module-heavy workload has its own *enrolments* refused | `newCubinAdmission` is a separate bucket; `cubinUIDBurst = 128`, `cubinTotalBurst = 256` |
+| a `connect()` and a 2 MB write on the application's `cuModuleLoad` path | the payload is a memfd passed by `SCM_RIGHTS`; nothing streams, and Task 5 puts the offer on the drain thread |
+
+## The wire format
+
+Second abstract address, same shape as `enrollAddressFor` (`enroll.go:246`),
+different prefix:
+
+```
+@perfagent-gpu-cubin.v1.<dev_major>.<dev_minor>.<inode>
+```
+
+One `sendmsg`: a 24-byte header plus one descriptor in `SCM_RIGHTS`. Fixed
+size, little-endian, naturally aligned — the same rules every USDT record
+follows.
+
+```
+offset  size  field     value
+     0     4  magic     'C' 'U' 'B' '1'   (0x31425543 read little-endian)
+     4     2  version   1
+     6     2  flags     0 — reserved; a non-zero one is REJECTED, never guessed
+     8     8  size      declared cubin length in bytes
+    16     8  crc       cuptiGetCubinCrc() over exactly those bytes
+```
+
+Reply: one byte, `'K'` accepted / `'X'` refused — the same spelling the
+enrolment reply uses.
+
+`crc` is the producer's **key**, not a checksum this end recomputes: CUPTI's
+polynomial is unpublished and the agent has no CUDA toolkit. It is what
+`gpu_pc_sample_batch_v1` joins on, so what matters is that the same number
+reaches both ends — a hardware check, listed below.
+
+The header is pinned from both sides. `shim/core/cubin.h` carries
+`static_assert`s on `sizeof` and every `offsetof`;
+`TestTheOfferHeaderCodecRoundTrips` and `test_the_header_is_the_documented_24_bytes`
+read the same 24 bytes as bytes rather than as a struct, so a layout or
+endianness drift cannot pass unnoticed.
+
+## The seal verification
+
+Producer (`cubin_seal_bytes`): `memfd_create(MFD_CLOEXEC|MFD_ALLOW_SEALING)`,
+`write()` the bytes (never an mmap — `F_SEAL_WRITE` returns `EBUSY` against an
+outstanding writable mapping), then `F_ADD_SEALS` with all four, then
+`F_GET_SEALS` to confirm the kernel took them. A descriptor that reaches the
+consumer unsealed would be silently unresolvable; catching it here makes it a
+counted send failure with a reason instead.
+
+Consumer (`verifyCubinSeals`), **before anything is mapped and before the fd is
+even `fstat`ed**:
+
+```go
+seals, err := unix.FcntlInt(uintptr(fd), unix.F_GET_SEALS, 0)
+if missing := cubinRequiredSeals &^ seals; missing != 0 { reject }
+```
+
+`cubinRequiredSeals = F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE`.
+All four, all-or-nothing:
+
+- **`F_SEAL_SHRINK`** — without it a peer can `ftruncate` under our `mmap` and
+  the next touched page **SIGBUSes the agent**. A profiler a profiled process
+  can kill is worse than no profiler.
+- **`F_SEAL_WRITE`** — without it the ELF mutates under the parser mid-parse.
+- **`F_SEAL_GROW`** — without it the size we validated is not the size we map.
+- **`F_SEAL_SEAL`** — without it the other three can be removed again, which
+  makes checking them meaningless.
+
+**There is no fallback branch that reads an unsealed offer anyway.** Falling
+back is how a defended path becomes an undefended one. `F_GET_SEALS` also fails
+with `EINVAL` on anything unsealable, so the same check refuses a pipe or a
+socket; a tmpfs file — which *is* shmem, and so *is* sealable, answering with
+`F_SEAL_SEAL` alone and no write protection — is refused for the three seals it
+lacks. Both cases are tested, because the second is the dangerous one: it looks
+like a sealed object and the peer can still write through it.
+
+The mapping itself is `PROT_READ | MAP_PRIVATE`, one copy out, then `munmap`.
+
+## Order of checks in `handle`
+
+Cheapest and most hostile first; nothing touches the payload until the peer has
+earned it, and within the payload the seals come before the size.
+
+1. `enrollPeerCreds` → `unauthorized`
+2. cubin admission bucket → `throttled` (so an exhausted peer cannot spend our `/proc` time either)
+3. `requireUID` → `unauthorized`
+4. per-PID filter → `unauthorized`
+5. `procMapsHaveInode` → `unauthorized`
+6. header + descriptor, under a 2 s deadline → `malformed`
+7. **`F_GET_SEALS`** → `unsealed`
+8. already-held CRC → `duplicate`, reply `'K'`, nothing mapped
+9. per-cubin ceiling → `tooLarge`
+10. total-bytes ceiling → `tooLarge`
+11. `fstat` size vs declared size → `malformed`
+12. `mmap`, copy, `munmap`, store → `received` + `bytes`
+
+## The counters, and what each reads on a healthy run
+
+The plan's nine, all implemented and all assertable. `assertNoCubinRejections`
+checks the five rejection counters **at zero** on every healthy path in the
+suite — ten defects on this project were counters reading green exactly when
+things were worst, so the zero direction is asserted as hard as the non-zero one.
+
+| counter | side | `Stats` field | healthy run | asserted non-zero by |
+| --- | --- | --- | --- | --- |
+| `CubinsOffered` | shim | `perfagent::cubins_offered()` | = modules handed over | `test_a_refusal_is_counted_as_a_send_failure` |
+| `CubinsSendFailed` | shim | `perfagent::cubins_send_failed()` | **0** | same; `test_no_listener_is_not_a_send_failure` pins that an unprofiled process does **not** accumulate these |
+| `CubinsReceived` | agent | `Stats.CubinsReceived` | = distinct modules stored | byte-identical test |
+| `CubinBytesReceived` | agent | `Stats.CubinBytesReceived` | = their total size | byte-identical, total-ceiling tests |
+| `CubinsRejectedTooLarge` | agent | `Stats.CubinsRejectedTooLarge` | **0** | per-cubin ceiling +1 byte; total ceiling |
+| `CubinsRejectedMalformed` | agent | `Stats.CubinsRejectedMalformed` | **0** | 7 cases: magic, version, flag, zero size, short header, 0 fds, 2 fds; plus size mismatch and store failure |
+| `CubinsRejectedUnsealed` | agent | `Stats.CubinsRejectedUnsealed` | **0** | each seal missing in turn (4), pipe, unsealed tmpfs file |
+| `CubinsRejectedUnauthorized` | agent | `Stats.CubinsRejectedUnauthorized` | **0** | peer not mapping the shim; wrong PID under a per-PID attach |
+| `CubinsThrottled` | agent | `Stats.CubinsThrottled` | **0** | drained-bucket test; both isolation orders |
+
+**One counter beyond the nine.** The plan requires "an offer for an already-stored
+CRC is a counted no-op", and none of the nine can hold that number without
+lying: it is neither *stored* nor *rejected*. So `CubinsDuplicate` exists. It is
+the tenth field and it is documented as such rather than folded into
+`CubinsReceived`, which would overstate what the agent holds.
+
+**Where the total-bytes ceiling is counted.** In `CubinsRejectedTooLarge`,
+alongside the per-cubin ceiling, with the reason string distinguishing them
+(`"per-cubin ceiling"` / `"total ceiling"`). This is a deliberate reading of the
+plan, which names nine counters and puts both ceilings in the sentence beside
+`CubinsRejectedTooLarge`. From the operator's side the two mean the same
+actionable thing — *this cubin was refused for its size and nothing partial was
+kept* — and both are tested separately. Flagged here so it is a choice on the
+record and not an omission.
+
+Two further `Stats` fields, matching what the enrolment listener already
+surfaces: `CubinsListening` and `CubinsAddress`. The address is printed for the
+reason `UnwindEnrollAddress` is: when the two ends derive different names every
+counter on both sides reads zero and nothing says why.
+
+`cubinStats.mapped` is an internal test seam, not a `Stats` field. It is the
+only way a test can assert that a rejected offer was **never mapped**, which for
+the seal check is the entire property.
+
+## Bounds
+
+| bound | default | config | counted |
+| --- | --- | --- | --- |
+| per cubin | 8 MiB | `Config.CubinMaxBytes` | `CubinsRejectedTooLarge` |
+| total held | 256 MiB | `Config.CubinTotalBytes` | `CubinsRejectedTooLarge` |
+| distinct CRCs | 512 | placeholder store, replaced by Task 4's LRU `gpu.ModuleStore` | store error → `CubinsRejectedMalformed` |
+
+**An oversized cubin is rejected whole, never truncated.** A truncated cubin
+parses into a *wrong* line table, which is the one failure worse than no line
+table. `TestAnOfferOverThePerCubinCeilingIsRejectedWholeAndCounted` asserts
+`received == 0`, `bytes == 0`, `mapped == 0` and `sink.putCount() == 0` — the
+payload is not even mapped, so there is nothing a partial write could come from
+— and then offers exactly the ceiling to show the rejection is one byte of
+policy rather than an off-by-one.
+
+## The isolation test — both orders, with output
+
+`TestFloodingTheCubinChannelCannotStarveOrThrottleAnEnrolment`. Flood size
+`cubinUIDBurst*2 + cubinTotalBurst` = 512 well-formed offers, well past both
+buckets with margin for a second's refill. Well-formed on purpose: a flood of
+connections that send nothing would exercise the header timeout rather than the
+admission bucket and prove nothing about throttling.
+
+**AHEAD** — the direction a shared socket fails. One genuine offer is wedged
+inside the store so the cubin listener's serial `Accept` loop is occupied; 512
+offers then queue in its backlog; *only then* does the enrolment dial. On a
+shared socket this is precisely where the producer waits out its 2 s budget and
+comes back `kEnrollError`.
+
+**BEHIND** — the easy direction, included so the pair is symmetric rather than
+selective: enrol, flood to `CubinsThrottled > 0`, enrol again.
+
+```
+=== RUN   TestFloodingTheCubinChannelCannotStarveOrThrottleAnEnrolment
+=== RUN   TestFloodingTheCubinChannelCannotStarveOrThrottleAnEnrolment/offers_queued_AHEAD_of_the_enrolment
+    cubin_test.go:808: cubin: offered=513 received=130 duplicate=0 throttled=383 | enrol: requests=1 confirmed=1 throttled=0
+=== RUN   TestFloodingTheCubinChannelCannotStarveOrThrottleAnEnrolment/offers_queued_BEHIND_the_enrolment
+    cubin_test.go:836: cubin: offered=512 received=129 duplicate=0 throttled=383 | enrol: requests=2 confirmed=2 throttled=0
+--- PASS: TestFloodingTheCubinChannelCannotStarveOrThrottleAnEnrolment (0.06s)
+    --- PASS: .../offers_queued_AHEAD_of_the_enrolment (0.05s)
+    --- PASS: .../offers_queued_BEHIND_the_enrolment (0.01s)
+```
+
+383 cubin offers refused; `UnwindEnrollThrottled` **0** in both orders; both
+enrolments confirmed, the AHEAD one inside 5 s while the cubin channel was
+wedged with a full backlog. The property holds because the buckets and the
+`Accept` loops are different objects — the test states it, the separation makes
+it true.
+
+## The regression that keeps them apart
+
+`TestAnEnrolmentCompletesWithNoReadOnThatConnection`, asserted twice because
+either half alone is escapable:
+
+1. **Behaviourally** — a producer that writes nothing is still answered `'K'`,
+   promptly.
+2. **Structurally** — the test parses `gpuprobe/enroll.go` with `go/ast`, finds
+   `enrollListener.handle`, and fails if its body calls anything that reads from
+   the connection (`Read`, `ReadMsgUnix`, `ReadFull`, `NewScanner`, `Recvmsg`,
+   `SetReadDeadline`, …). A behavioural test alone would pass for a handler that
+   reads with a *short* deadline and falls through — which would still cost
+   every producer that deadline, and would still be the shared-socket design
+   creeping back one commit at a time.
+
+## The cross-language seam
+
+`TestTheCppProducerAndTheGoCubinListenerAgreeOnTheWire` builds the real producer
+out of `shim/core/{cubin,enroll}.cc`, points the real Go listener at that
+binary, and runs it — **on both filesystems**. The address embeds a device
+number, and `stat(2)` and `/proc/<pid>/maps` report the *same* device on tmpfs
+and *different* devices on btrfs, where the shim is actually built. A test that
+ran only under `TMPDIR` would prove the two ends agree on the one filesystem
+where they cannot disagree, which is exactly how the enrolment address once
+shipped broken. The 5 KB fixture is generated independently in C++ and in Go, so
+"byte-identical" is an assertion and not a tautology.
+
+## Verification run
+
+```
+make -C shim && make -C shim test        cubin_test: OK, all 8 suites green
+go build ./... && go vet ./...           clean
+go test ./gpuprobe/ ./gpu/ ./internal/... -count=1
+                                         ok gpuprobe 5.3s, gpu 3.5s, 9 internal pkgs
+go test ./gpuprobe/ -race -count=4       ok 15.9s
+~/go/bin/golangci-lint run --timeout=5m  0 issues
+```
+
+The cubin suite, 22 tests, 37 leaf cases, all passing:
+
+```
+--- PASS: TestTheCubinAddressIsASiblingOfTheRendezvousAndNotTheSameSocket
+--- PASS: TestACubinArrivesByteIdenticalAtFiveKilobytesAndAtTwoMegabytes (5_KB, 2_MB)
+--- PASS: TestAnOfferOverThePerCubinCeilingIsRejectedWholeAndCounted
+--- PASS: TestTheTotalBytesCeilingIsEnforcedAndCounted
+--- PASS: TestADeclaredSizeThatDisagreesWithThePayloadIsRejected (larger, smaller)
+--- PASS: TestEachRequiredSealMissingInTurnIsRejectedAndNeverMapped
+             (F_SEAL_SHRINK, F_SEAL_WRITE, F_SEAL_GROW, F_SEAL_SEAL, all_four_present)
+--- PASS: TestADescriptorThatIsNotASealedMemfdIsRefused (pipe, unsealed tmpfs file)
+--- PASS: TestAMalformedOfferIsRefusedAndCounted
+             (bad magic, unknown version, reserved flag, zero size, short header,
+              no descriptor, two descriptors)
+--- PASS: TestACubinPeerThatDoesNotMapTheShimIsRefused
+--- PASS: TestAPerPIDConsumerRefusesCubinsFromEveryOtherPID
+--- PASS: TestAnOfferForAnAlreadyStoredCRCIsACountedNoOp
+--- PASS: TestAStoreFailureIsCountedAndTheOfferIsRefused
+--- PASS: TestTheCubinAdmissionBucketIsItsOwn
+--- PASS: TestAThrottledCubinOfferIsReleasedAndCountedNotServed
+--- PASS: TestFloodingTheCubinChannelCannotStarveOrThrottleAnEnrolment (AHEAD, BEHIND)
+--- PASS: TestAnEnrolmentCompletesWithNoReadOnThatConnection
+--- PASS: TestTheOfferHeaderCodecRoundTrips
+--- PASS: TestASecondCubinListenerForTheSameShimIsRefused
+--- PASS: TestClosingTheCubinListenerIsSafeAndReleasesPeers
+--- PASS: TestTheBuiltInCubinStoreIsBounded
+--- PASS: TestSealNamesAreSpeltOut
+--- PASS: TestTheCppProducerAndTheGoCubinListenerAgreeOnTheWire (source fs, TMPDIR)
+```
+
+## Cannot verify — outstanding on the RTX 3090
+
+The implementer has `CapEff: 0` and no GPU. Two claims in this task are
+therefore **unverified**, exactly as the plan predicted, and neither is implied
+by anything above:
+
+1. **That a real `MODULE_LOADED` cubin survives byte-identical.** Everything
+   here moves a synthetic fixture. The transport is proven byte-exact at 5 KB
+   and 2 MB across the C++/Go boundary, but no cubin CUPTI actually produced has
+   been through it. What could still differ: a real cubin's size distribution,
+   and whether the adapter's copy (Task 5) is taken at a moment when CUPTI's
+   buffer still holds the right bytes — §6.3 finding 2 measured that a late
+   reader gets silently *wrong* bytes rather than a fault.
+
+2. **That `cuptiGetCubinCrc()` over the received bytes equals the `cubinCrc` the
+   PC records carry.** The agent does not recompute the CRC — it cannot, without
+   a CUDA toolkit — so it trusts the header's value as the join key. If the two
+   numbers disagree on hardware, every Tier B PC sample resolves to `no-module`
+   with every counter reading green. This is the single most consequential thing
+   the first GPU run must check.
+
+Also untested here, and by design: the shim-side offer is a minimal client
+(`cubin_offer` / `cubin_offer_to_consumer`) with no adapter wiring. The bounded
+queue, the `MODULE_LOADED` copy-in-the-callback and the drain-thread send are
+**Task 5**; `cubin.h` states the "never from a CUPTI callback" rule so Task 5
+inherits it in writing rather than by recollection.

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -288,6 +288,20 @@ type Config struct {
 	// pidRegistry for the bound and Stats.UnwindPIDsEvicted for what it
 	// costs when it bites.
 	UnwindPIDCapacity int
+
+	// CubinMaxBytes bounds ONE cubin offered over the cubin transport
+	// (cubin.go). Zero means defaultCubinMaxBytes. An offer over the ceiling
+	// is rejected whole and counted in CubinsRejectedTooLarge; it is never
+	// truncated to fit, because a truncated cubin parses into a wrong line
+	// table, which is the one failure worse than no line table.
+	CubinMaxBytes int
+
+	// CubinTotalBytes bounds every cubin this consumer will hold. Zero means
+	// defaultCubinTotalBytes. This is the memory a JIT- or template-explosion
+	// workload can make the agent hold, so it is a ceiling rather than a dial;
+	// an offer that would pass it is refused and counted, again in
+	// CubinsRejectedTooLarge.
+	CubinTotalBytes int64
 }
 
 const (
@@ -912,6 +926,61 @@ type Stats struct {
 	// consumer never saw it. KernelStacksMissing > StacksMissing therefore
 	// localizes loss that SequenceGaps can only detect.
 	KernelStacksMissing uint64
+
+	// The cubin transport (cubin.go): the dedicated AF_UNIX channel that
+	// carries a module's BYTES, beside and deliberately not shared with the
+	// enrolment rendezvous. Everything Tier B attribution can say about a PC
+	// sample comes through here, so every way an offer can fail is counted
+	// and none of them is silent.
+	//
+	// CubinsListening says whether the channel bound at all. A run with it
+	// false resolves nothing: every PC sample reads gpu_src_status
+	// "no-module". CubinsAddress is the abstract name that was bound, printed
+	// for the same reason UnwindEnrollAddress is - when the two ends derive
+	// different names every counter on both sides reads zero and nothing says
+	// why.
+	CubinsListening bool
+	CubinsAddress   string
+	// CubinsReceived counts offers accepted and stored. CubinBytesReceived is
+	// their total size, so the total ceiling can be reasoned about from the
+	// outside rather than trusted.
+	CubinsReceived     uint64
+	CubinBytesReceived uint64
+	// CubinsDuplicate counts offers for a CRC already held. A counted no-op:
+	// cubin_crc is content-addressed, so the same CRC is the same bytes and
+	// re-reading them costs an mmap and a parse to reach the same answer. The
+	// payload is never mapped for one of these.
+	CubinsDuplicate uint64
+	// CubinsRejectedTooLarge counts offers refused for size - past the
+	// per-cubin ceiling (Config.CubinMaxBytes) or past the total
+	// (Config.CubinTotalBytes). Nothing partial is ever stored for either.
+	CubinsRejectedTooLarge uint64
+	// CubinsRejectedMalformed counts offers with a bad header, a bad magic, an
+	// unknown version or flag, no descriptor or more than one, or a payload
+	// whose real size disagrees with the size the header declared.
+	CubinsRejectedMalformed uint64
+	// CubinsRejectedUnsealed counts offers whose memfd was missing at least
+	// one of F_SEAL_SEAL|F_SEAL_SHRINK|F_SEAL_GROW|F_SEAL_WRITE, verified
+	// with F_GET_SEALS BEFORE anything is mapped. Without F_SEAL_SHRINK a peer
+	// can ftruncate under our mmap and SIGBUS this process; without
+	// F_SEAL_WRITE the ELF mutates under the parser. There is no fallback that
+	// reads one anyway.
+	CubinsRejectedUnsealed uint64
+	// CubinsRejectedUnauthorized counts peers refused by the same identity
+	// rules the enrolment rendezvous uses, reused verbatim: no SO_PEERCRED, a
+	// uid an unprivileged consumer will not serve, a PID other than the
+	// attached one, or a peer that does not map the shim inode.
+	CubinsRejectedUnauthorized uint64
+	// CubinsThrottled counts offers refused by the CUBIN admission bucket.
+	//
+	// It reads as its own number because the bucket is its own bucket. That
+	// is the whole reason this channel is separate: a module-heavy workload
+	// can exhaust cubin admission all it likes and UnwindEnrollThrottled will
+	// not move, so a throttled offer costs one module's source resolution and
+	// cannot cost an enrolment - which is issue #49's ~38% stack loss.
+	CubinsThrottled uint64
+	// CubinsLastError is the most recent reason an offer did not land.
+	CubinsLastError string
 }
 
 // maxDecodeFailureReasons bounds the decode-failure table. Four is enough to
@@ -1051,6 +1120,16 @@ type Consumer struct {
 	// enrollErr is why there is no listener, surfaced as
 	// Stats.UnwindEnrollLastError. Written once in Attach, read under mu.
 	enrollErr string
+	// cubin serves the cubin offer channel: a second abstract socket, a
+	// second goroutine and a second admission bucket, beside and never
+	// shared with the rendezvous above. Nil when the address could not be
+	// bound, which is not fatal - every PC sample then reads gpu_src_status
+	// "no-module", which is the truth. See cubin.go for why sharing the
+	// enrolment socket would reintroduce issue #49.
+	cubin *cubinListener
+	// cubinErr is why there is no cubin listener, surfaced as
+	// Stats.CubinsLastError. Written once in Attach, read under mu.
+	cubinErr string
 
 	mu          sync.Mutex
 	seqByStream map[seqKey]uint64
@@ -1208,6 +1287,17 @@ func Attach(cfg Config) (c *Consumer, err error) {
 		c.enrollErr = eerr.Error()
 	} else {
 		c.enroll = el
+	}
+
+	// The cubin channel. Bound here beside the rendezvous and NOT as part of
+	// it: its own address, its own listener, its own goroutine, its own
+	// admission bucket. Best-effort in exactly the same way - a consumer
+	// that cannot bind it still profiles, still walks stacks, and simply
+	// resolves no source lines.
+	if cl, cerr := newCubinListener(cfg, nil); cerr != nil {
+		c.cubinErr = cerr.Error()
+	} else {
+		c.cubin = cl
 	}
 
 	var ex *link.Executable
@@ -2139,6 +2229,21 @@ func (c *Consumer) Stats() Stats {
 	if out.UnwindEnrollLastError == "" {
 		out.UnwindEnrollLastError = c.enrollErr
 	}
+	cu := c.cubin.snapshot()
+	out.CubinsListening = c.cubin != nil
+	out.CubinsAddress = c.cubin.address()
+	out.CubinsReceived = cu.received
+	out.CubinBytesReceived = cu.bytes
+	out.CubinsDuplicate = cu.duplicate
+	out.CubinsRejectedTooLarge = cu.tooLarge
+	out.CubinsRejectedMalformed = cu.malformed
+	out.CubinsRejectedUnsealed = cu.unsealed
+	out.CubinsRejectedUnauthorized = cu.unauthorized
+	out.CubinsThrottled = cu.throttled
+	out.CubinsLastError = cu.lastErr
+	if out.CubinsLastError == "" {
+		out.CubinsLastError = c.cubinErr
+	}
 	// Gauges, read fresh: what the two side tables are holding right now.
 	out.PendingStacks = c.pending.len()
 	out.PendingLaunches = c.deferred.len()
@@ -2218,6 +2323,13 @@ func (c *Consumer) Close() error {
 	// accepted connection is released by the close (it reads EOF and takes
 	// the lazy path), never left parked on a consumer that has gone.
 	if err := c.enroll.close(); err != nil {
+		errs = append(errs, err)
+	}
+	// The cubin channel comes down beside it. Nothing blocks on this one, so
+	// the ordering carries no requirement; it is closed here so a peer
+	// mid-offer is released rather than left writing into a consumer that
+	// has gone.
+	if err := c.cubin.close(); err != nil {
 		errs = append(errs, err)
 	}
 	c.unwind.close()

--- a/gpuprobe/cubin.go
+++ b/gpuprobe/cubin.go
@@ -1,0 +1,782 @@
+package gpuprobe
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// The cubin transport: how a module's bytes get from the producer to this
+// consumer, on a channel that is NOT the enrolment rendezvous.
+//
+// # Why the bytes have to travel at all
+//
+// A gpu_pc_sample_batch_v1 record keys on cubin_crc, carries a pc_offset and
+// a function_index, and names nothing. There is no kernel_id on it and no
+// table on the wire that maps (cubin_crc, function_index) to anything a
+// reader could act on. The cubin IS that table: its .symtab names the
+// functions and its .debug_line turns a pc_offset into a source line. Without
+// the bytes a Tier B PC sample is four integers, and the profile is honest and
+// useless.
+//
+// gpu_module_load_v1 carries a bytes_ptr, and it is not a transport. It is a
+// pointer into the PRODUCER's address space; reading it from here needs
+// /proc/<pid>/mem or process_vm_readv, both of which need CAP_SYS_PTRACE,
+// which this agent's capability set deliberately does not contain and will
+// not grow to contain. Reading it in BPF is not an alternative either: the
+// ringbuf reservation is a compile-time 3072-byte payload, so a 512 KB cubin
+// would need ~170 ordered, reassembled batches per module out of a uprobe
+// with a bounded instruction budget. So the bytes take their own road, and
+// gpu_module_load_v1 stays exactly as frozen - it announces THAT a module
+// loaded, with its CRC and its size, and nothing about it changes here.
+//
+// # Why this is not the enrolment socket, in four parts
+//
+// shim/core/enroll.h states the protocol as "The producer sends nothing", and
+// enrollListener.handle implements exactly that: creds, admit, uid and pid
+// checks, procMapsHaveInode, reg.enroll, one status byte. It NEVER reads. A
+// cubin offer must send a header, so a shared address would force this end to
+// read in order to tell an offer from an enrolment - and on a genuine
+// enrolment that read blocks until the producer's own 2s budget expires and
+// it closes. Every rendezvous would become a 2s stall ending in
+// kEnrollError, which is issue #49's ~38% stack loss arriving by a new route.
+// TestAnEnrolmentStillCompletesWithoutAnyReadOnThatConnection pins the
+// absence of that read.
+//
+// Three more, none of them hypothetical:
+//
+//   - enrollListener.serve() is serial AT Accept, not merely at handle. Offer
+//     connections would be accepted by the same loop, so a queue of offers -
+//     or one 2 MB stream - is served FIFO AHEAD of a genuine producer whose
+//     connect() already landed in the backlog. Ahead is the dangerous
+//     direction; behind is the easy one.
+//   - Admission is charged per connection against enrollUIDBurst = 32,
+//     refilling 32/s. A JIT- or template-heavy workload loading more than 32
+//     modules a second would drain the bucket and then have its genuine
+//     ENROLMENTS refused, with only UnwindEnrollThrottled moving.
+//   - It would put a connect() and an up-to-2 MB write on the application's
+//     cuModuleLoad path. The application is never stalled for the profiler's
+//     benefit; the shim's copy happens in the callback and the offer happens
+//     on the drain thread.
+//
+// The answer is a second channel with its own address, its own listener, its
+// own goroutine and its own admission bucket. That is what makes every hazard
+// above structurally impossible rather than test-defended: a throttled cubin
+// offer cannot spend an enrolment token because it is not the same bucket,
+// and a queued offer cannot spend an enrolment Accept slot because it is not
+// the same listener. What IS reused, verbatim, is the authentication -
+// enrollPeerCreds and procMapsHaveInode - and the shim-identity derivation
+// (enrollShimIdentity), so a cubin offer is authenticated exactly as an
+// enrolment is and the address inherits the btrfs stat-versus-maps fix
+// instead of reintroducing that bug.
+//
+// # The payload is a sealed memfd, and the seals are load-bearing
+//
+// The producer creates a memfd, writes the cubin into it, applies
+// F_SEAL_SEAL|F_SEAL_SHRINK|F_SEAL_GROW|F_SEAL_WRITE, and passes the
+// descriptor by SCM_RIGHTS beside a 24-byte header. This end mmaps it. The
+// bytes therefore never stream through the socket and the producer never
+// blocks on this end's read rate, which is the property the drain thread
+// needs.
+//
+// Each seal answers a specific way an unsealed fd would be a weapon:
+//
+//   - without F_SEAL_SHRINK a peer can ftruncate the file under our mmap and
+//     the next touched page SIGBUSes THIS PROCESS. A profiler that a profiled
+//     process can kill is worse than no profiler;
+//   - without F_SEAL_WRITE the ELF mutates under the parser mid-parse, so the
+//     line table we derive describes bytes that no longer exist;
+//   - without F_SEAL_GROW the size we validated is not the size we map;
+//   - without F_SEAL_SEAL any of the other three can be removed again, which
+//     makes checking them meaningless.
+//
+// So all four are required, they are verified with fcntl(F_GET_SEALS) BEFORE
+// anything is mapped, and a missing seal is a counted rejection with no
+// fallback that reads it anyway. Falling back is how a defended path becomes
+// an undefended one.
+//
+// # Bounds
+//
+// A per-cubin ceiling and a total-bytes ceiling, both configurable, both
+// counted when they bite. An oversized cubin is rejected WHOLE. It is never
+// truncated to fit, because a truncated cubin parses into a wrong line table,
+// and a wrong line table is the one failure worse than no line table.
+
+// The cubin offer wire format. Fixed size, little-endian, naturally aligned,
+// exactly like every record on the USDT wire - and mirrored by
+// perfagent::CubinOfferHeader in shim/core/cubin.h, whose static_asserts pin
+// the same numbers from the other side.
+//
+//	offset  size  field
+//	     0     4  magic    'C' 'U' 'B' '1'
+//	     4     2  version  1
+//	     6     2  flags    0; reserved, and rejected when non-zero
+//	     8     8  size     declared cubin length in bytes
+//	    16     8  crc      cuptiGetCubinCrc() over those bytes
+//
+// The CRC is the producer's key, not a checksum this end recomputes: CUPTI's
+// polynomial is not published and the agent has no CUDA toolkit. It is what
+// gpu_pc_sample_batch_v1 records join on, so what matters is that the same
+// number reaches both - which is a hardware check, stated as one.
+const (
+	cubinHeaderSize    = 24
+	cubinHeaderMagic   = uint32('C') | uint32('U')<<8 | uint32('B')<<16 | uint32('1')<<24
+	cubinHeaderVersion = 1
+)
+
+// The reply, one byte, same spelling as the enrolment reply so a producer
+// that already knows one wire does not have to learn a second.
+const (
+	cubinReplyOK      = 'K' // the bytes are in; this CRC is resolvable
+	cubinReplyRefused = 'X' // they are not, for one of the counted reasons
+)
+
+// cubinRequiredSeals is the set that must ALL be present. Not a preference.
+const cubinRequiredSeals = unix.F_SEAL_SEAL | unix.F_SEAL_SHRINK |
+	unix.F_SEAL_GROW | unix.F_SEAL_WRITE
+
+// cubinIOTimeout bounds the header read and the reply write on one offer.
+//
+// Unlike the enrolment reply's deadline this one genuinely matters: the
+// producer here is not blocked in its own init waiting for us, so a peer that
+// connects and then sends nothing would otherwise hold the serial accept loop
+// forever. It cannot reach the enrolment listener from here - that is the
+// point of the separation - but it could still starve every other module's
+// resolution, so it is bounded.
+const cubinIOTimeout = 2 * time.Second
+
+// The cubin admission bucket. Its own numbers, not the enrolment ones.
+//
+// Enrolment is once per process, so 32/s is generous there. Module loads are
+// per cuModuleLoad and CUDA's lazy loading clusters them, so the same 32
+// would throttle an ordinary template-heavy workload. These are sized for a
+// drain tick's worth of modules at a time (the shim offers from the 100ms
+// drain thread, in batches) with a second's worth of refill behind it, while
+// still bounding a fork loop to a few hundred refusals a second.
+//
+// Being wrong in the tight direction costs a module's source resolution -
+// gpu_src_status reads "no-module" and the sample is still counted, still
+// attributed and still honest. It cannot cost an enrolment.
+const (
+	cubinUIDBurst    = 128
+	cubinUIDRefill   = 128 // tokens per second
+	cubinTotalBurst  = 256
+	cubinTotalRefill = 256
+)
+
+// Ceilings. Defaults, both overridable through Config.
+const (
+	// defaultCubinMaxBytes bounds one cubin. A -lineinfo cubin for a
+	// realistic kernel set runs from a few KB to a few hundred KB; 8 MiB is
+	// far past any of them and still small enough that the worst single
+	// mapping is unremarkable.
+	defaultCubinMaxBytes = 8 << 20
+	// defaultCubinTotalBytes bounds every cubin this consumer will ever
+	// accept. This is the memory a JIT- or template-explosion workload can
+	// make the agent hold, so it is a hard ceiling rather than a dial.
+	defaultCubinTotalBytes = 256 << 20
+	// defaultCubinStoreCapacity bounds the number of distinct CRCs the
+	// built-in store holds. Task 4 replaces this store with the LRU,
+	// line-table-backed gpu.ModuleStore; until then the bound still has to
+	// exist, because an unbounded map fed by a profiled application is the
+	// same defect whoever owns it.
+	defaultCubinStoreCapacity = 512
+)
+
+// cubinHeader is the decoded wire header.
+type cubinHeader struct {
+	magic   uint32
+	version uint16
+	flags   uint16
+	size    uint64
+	crc     uint64
+}
+
+// decodeCubinHeader reads the fixed 24-byte header. It validates only what is
+// structural; the ceilings and the seals are the caller's, in that order.
+func decodeCubinHeader(b []byte) (cubinHeader, error) {
+	if len(b) < cubinHeaderSize {
+		return cubinHeader{}, fmt.Errorf("short header: %d of %d bytes", len(b), cubinHeaderSize)
+	}
+	h := cubinHeader{
+		magic:   binary.LittleEndian.Uint32(b[0:4]),
+		version: binary.LittleEndian.Uint16(b[4:6]),
+		flags:   binary.LittleEndian.Uint16(b[6:8]),
+		size:    binary.LittleEndian.Uint64(b[8:16]),
+		crc:     binary.LittleEndian.Uint64(b[16:24]),
+	}
+	if h.magic != cubinHeaderMagic {
+		return h, fmt.Errorf("bad magic %#08x, want %#08x", h.magic, cubinHeaderMagic)
+	}
+	if h.version != cubinHeaderVersion {
+		return h, fmt.Errorf("unknown offer version %d, want %d", h.version, cubinHeaderVersion)
+	}
+	// Reserved means reserved. A producer that starts setting a flag this
+	// consumer does not understand is telling it something about the payload,
+	// and guessing is how a wrong line table gets built.
+	if h.flags != 0 {
+		return h, fmt.Errorf("unknown offer flags %#04x", h.flags)
+	}
+	if h.size == 0 {
+		return h, errors.New("declared size is zero")
+	}
+	return h, nil
+}
+
+// encodeCubinHeader is the inverse, used by the tests' producer and by
+// nothing in production. Kept beside the decoder so the two cannot drift.
+func encodeCubinHeader(h cubinHeader) []byte {
+	b := make([]byte, cubinHeaderSize)
+	binary.LittleEndian.PutUint32(b[0:4], h.magic)
+	binary.LittleEndian.PutUint16(b[4:6], h.version)
+	binary.LittleEndian.PutUint16(b[6:8], h.flags)
+	binary.LittleEndian.PutUint64(b[8:16], h.size)
+	binary.LittleEndian.PutUint64(b[16:24], h.crc)
+	return b
+}
+
+// cubinAddressFor is the one place the cubin rendezvous name is spelled.
+//
+// Deliberately the same SHAPE as enrollAddressFor - same version segment,
+// same decimal major.minor.inode tail from the same enrollShimIdentity
+// derivation - and deliberately a different prefix. The shape is what makes
+// it inherit the btrfs fix (stat(2) reports a different device than
+// /proc/<pid>/maps for every file on a btrfs subvolume, which is how the
+// enrolment rendezvous silently bound one name while the producer dialled
+// another); the different prefix is what makes it a different socket.
+func cubinAddressFor(dev, ino uint64) string {
+	return fmt.Sprintf("@perfagent-gpu-cubin.v1.%d.%d.%d",
+		unix.Major(dev), unix.Minor(dev), ino)
+}
+
+// cubinAddress is the offer name for shimPath.
+func cubinAddress(shimPath string) (string, error) {
+	dev, ino, err := enrollShimIdentity(shimPath)
+	if err != nil {
+		return "", err
+	}
+	return cubinAddressFor(dev, ino), nil
+}
+
+// newCubinAdmission builds a token bucket of the same shape the enrolment
+// listener uses, with the cubin channel's own numbers - and, crucially, as
+// its OWN instance. Two buckets is the whole mechanism: an offer cannot spend
+// an enrolment's token because there is no token they share.
+func newCubinAdmission(now func() time.Time) *enrollAdmission {
+	if now == nil {
+		now = time.Now
+	}
+	return &enrollAdmission{
+		now:      now,
+		total:    cubinTotalBurst,
+		totalAt:  now(),
+		perUID:   map[uint32]*enrollBucket{},
+		burst:    cubinTotalBurst,
+		refill:   cubinTotalRefill,
+		uidBurst: cubinUIDBurst,
+		uidFill:  cubinUIDRefill,
+	}
+}
+
+// cubinSink is what an accepted cubin is handed to. Task 4's
+// gpu.ModuleStore - bounded, LRU, line-table-backed - implements this; until
+// then memCubinStore does, so the transport is complete and testable on its
+// own rather than half-built behind a store that does not exist yet.
+type cubinSink interface {
+	// HasCubin reports whether this CRC is already held. Asked BEFORE the
+	// payload is touched, so a duplicate costs no mmap and no parse.
+	HasCubin(crc uint64) bool
+	// PutCubin takes ownership of bytes.
+	PutCubin(crc uint64, bytes []byte) error
+}
+
+// memCubinStore is the placeholder store: bounded by count, no line table, no
+// LRU. Task 4 replaces it.
+type memCubinStore struct {
+	mu   sync.Mutex
+	cap  int
+	seen map[uint64][]byte
+}
+
+func newMemCubinStore(capacity int) *memCubinStore {
+	if capacity <= 0 {
+		capacity = defaultCubinStoreCapacity
+	}
+	return &memCubinStore{cap: capacity, seen: map[uint64][]byte{}}
+}
+
+func (s *memCubinStore) HasCubin(crc uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.seen[crc]
+	return ok
+}
+
+func (s *memCubinStore) PutCubin(crc uint64, b []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.seen[crc]; ok {
+		return nil
+	}
+	if len(s.seen) >= s.cap {
+		return fmt.Errorf("cubin store full at %d modules", s.cap)
+	}
+	s.seen[crc] = b
+	return nil
+}
+
+func (s *memCubinStore) get(crc uint64) ([]byte, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.seen[crc]
+	return b, ok
+}
+
+// cubinStats is the listener's slice of gpuprobe.Stats, under its own lock.
+// Every field is a counted outcome of one offer, and the rejection fields are
+// exhaustive: an offer that is not counted in `received` or `duplicate` is
+// counted in exactly one of the four rejections or in `throttled`.
+type cubinStats struct {
+	received     uint64
+	bytes        uint64
+	duplicate    uint64
+	tooLarge     uint64
+	malformed    uint64
+	unsealed     uint64
+	unauthorized uint64
+	throttled    uint64
+	lastErr      string
+
+	// mapped counts mmap calls. Not a Stats field and not an operator
+	// signal: it is the only way a test can assert that a rejected offer was
+	// never mapped, which for the seal check is the entire property.
+	mapped uint64
+}
+
+// cubinListener serves the cubin offer channel for one consumer. Structurally
+// a sibling of enrollListener and deliberately not a subclass of it: the two
+// share their authentication helpers and share nothing else, least of all a
+// goroutine or a bucket.
+type cubinListener struct {
+	ln   *net.UnixListener
+	addr string
+	sink cubinSink
+	// pid mirrors Config.PID, exactly as enrollListener.pid does: a per-PID
+	// attach must not accept another process's modules, and the socket name
+	// is not PID-scoped and cannot be.
+	pid uint32
+	// dev and ino identify the shim image a peer must have mapped.
+	dev, ino uint64
+	// procRoot is "/proc" in production; tests point it at a fixture.
+	procRoot string
+	// requireUID, when set, is the only peer uid this listener will serve.
+	// Same rule and same derivation as the enrolment listener's.
+	requireUID *uint32
+	// admit is the CUBIN bucket. Touched only from serve().
+	admit *enrollAdmission
+
+	maxBytes   uint64
+	totalBytes uint64
+
+	wg sync.WaitGroup
+
+	mu    sync.Mutex
+	stats cubinStats
+}
+
+// newCubinListener binds the offer channel for cfg's shim and starts serving.
+//
+// Unlike the enrolment listener there is no ordering requirement against the
+// uprobe link: an offer is not a rendezvous and no producer blocks on it. A
+// module offered before this is listening is simply an unresolvable module,
+// counted by the shim as a send failure and read here as gpu_src_status
+// "no-module".
+func newCubinListener(cfg Config, sink cubinSink) (*cubinListener, error) {
+	l, err := buildCubinListener(cfg, sink)
+	if err != nil {
+		return nil, err
+	}
+	l.start()
+	return l, nil
+}
+
+// buildCubinListener binds without serving, so a test can settle state that
+// only serve() is allowed to touch afterwards - `admit` has no lock precisely
+// because one goroutine reaches it.
+func buildCubinListener(cfg Config, sink cubinSink) (*cubinListener, error) {
+	// The same derivation as the enrolment listener's, for both the address
+	// and the peer check, and for the same reason: a consumer that bound one
+	// device and checked peers against another would refuse every genuine
+	// producer.
+	dev, ino, err := enrollShimIdentity(cfg.ShimPath)
+	if err != nil {
+		return nil, err
+	}
+	addr := cubinAddressFor(dev, ino)
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: addr, Net: "unix"})
+	if err != nil {
+		return nil, fmt.Errorf("bind %s: %w", addr, err)
+	}
+	maxBytes := uint64(defaultCubinMaxBytes)
+	if cfg.CubinMaxBytes > 0 {
+		maxBytes = uint64(cfg.CubinMaxBytes)
+	}
+	totalBytes := uint64(defaultCubinTotalBytes)
+	if cfg.CubinTotalBytes > 0 {
+		totalBytes = uint64(cfg.CubinTotalBytes)
+	}
+	if sink == nil {
+		sink = newMemCubinStore(defaultCubinStoreCapacity)
+	}
+	return &cubinListener{
+		ln:         ln,
+		addr:       addr,
+		sink:       sink,
+		pid:        uint32(cfg.PID),
+		dev:        dev,
+		ino:        ino,
+		procRoot:   "/proc",
+		admit:      newCubinAdmission(nil),
+		requireUID: enrollRequiredUID(),
+		maxBytes:   maxBytes,
+		totalBytes: totalBytes,
+	}, nil
+}
+
+func (l *cubinListener) start() {
+	l.wg.Add(1)
+	go l.serve()
+}
+
+// serve accepts one offer at a time.
+//
+// Serial for the same reason enrollListener.serve() is - the work behind it
+// is a parse and a store insert, and N producers interleaving would only
+// produce the same total - but the consequence is different and much smaller.
+// Nothing blocks on this loop. A queue of offers delays MODULE RESOLUTION,
+// never a producer's startup, and never an enrolment, because the enrolment
+// listener has its own Accept loop in its own goroutine.
+func (l *cubinListener) serve() {
+	defer l.wg.Done()
+	for {
+		conn, err := l.ln.AcceptUnix()
+		if err != nil {
+			return
+		}
+		l.handle(conn)
+	}
+}
+
+// handle takes one offer. Every path out of it is counted, and every path out
+// of it closes the received descriptor.
+//
+// The order of the checks is the design. Cheapest and most hostile first:
+// credentials, then the bucket (so an exhausted peer cannot spend our /proc
+// time either), then identity, and only then anything that touches the
+// payload. Within the payload, the SEALS are checked before the size and
+// before the map, because until the seals verify nothing about the fd is
+// stable enough to be worth reading - including its size.
+func (l *cubinListener) handle(conn *net.UnixConn) {
+	defer func() { _ = conn.Close() }()
+
+	pid, uid, err := enrollPeerCreds(conn)
+	if err != nil {
+		l.reject(conn, &l.stats.unauthorized, "peer credentials: "+err.Error())
+		return
+	}
+	if !l.admit.admit(uid) {
+		l.mu.Lock()
+		l.stats.throttled++
+		l.stats.lastErr = fmt.Sprintf("uid %d throttled at pid %d; cubin offer rate exceeded", uid, pid)
+		l.mu.Unlock()
+		l.reply(conn, cubinReplyRefused)
+		return
+	}
+	if l.requireUID != nil && uid != *l.requireUID {
+		l.reject(conn, &l.stats.unauthorized,
+			fmt.Sprintf("pid %d has uid %d; this consumer is unprivileged and serves only uid %d",
+				pid, uid, *l.requireUID))
+		return
+	}
+	if l.pid != 0 && pid != l.pid {
+		l.reject(conn, &l.stats.unauthorized,
+			fmt.Sprintf("pid %d (uid %d) is not the attached pid %d", pid, uid, l.pid))
+		return
+	}
+	mapped, err := procMapsHaveInode(l.procRoot, pid, l.dev, l.ino)
+	if err != nil {
+		l.reject(conn, &l.stats.unauthorized, fmt.Sprintf("read maps for pid %d: %v", pid, err))
+		return
+	}
+	if !mapped {
+		l.reject(conn, &l.stats.unauthorized,
+			fmt.Sprintf("pid %d (uid %d) does not map the shim (dev %d:%d ino %d)",
+				pid, uid, unix.Major(l.dev), unix.Minor(l.dev), l.ino))
+		return
+	}
+
+	_ = conn.SetDeadline(time.Now().Add(cubinIOTimeout))
+	hdr, fd, err := recvCubinOffer(conn)
+	if fd >= 0 {
+		defer func() { _ = unix.Close(fd) }()
+	}
+	if err != nil {
+		l.reject(conn, &l.stats.malformed, fmt.Sprintf("pid %d: %v", pid, err))
+		return
+	}
+
+	// The seals, before anything is read from the descriptor and long before
+	// anything is mapped. There is no fallback branch here on purpose: a
+	// fallback that reads an unsealed fd anyway is how a defended path
+	// becomes an undefended one, and the two things it defends against are
+	// this process being SIGBUSed and this process parsing bytes that
+	// changed underneath it.
+	if err := verifyCubinSeals(fd); err != nil {
+		l.reject(conn, &l.stats.unsealed, fmt.Sprintf("pid %d crc %#x: %v", pid, hdr.crc, err))
+		return
+	}
+
+	// A CRC we already hold is a no-op, decided from the header alone: no
+	// fstat, no mmap, no copy, no re-parse. cubin_crc is content-addressed,
+	// so "the same CRC" is by definition the same bytes and re-reading them
+	// could only produce the same answer at the cost of doing it again.
+	if l.sink.HasCubin(hdr.crc) {
+		l.mu.Lock()
+		l.stats.duplicate++
+		l.mu.Unlock()
+		l.reply(conn, cubinReplyOK)
+		return
+	}
+
+	if hdr.size > l.maxBytes {
+		l.reject(conn, &l.stats.tooLarge,
+			fmt.Sprintf("pid %d crc %#x: %d bytes over the per-cubin ceiling of %d",
+				pid, hdr.crc, hdr.size, l.maxBytes))
+		return
+	}
+	// The total ceiling shares tooLarge deliberately: from the reader's side
+	// both mean "this cubin was refused for its size and nothing partial was
+	// kept", and the reason string says which ceiling it was. What must never
+	// happen for either is a truncated store - a truncated cubin parses into
+	// a WRONG line table, which is the one failure worse than no line table.
+	l.mu.Lock()
+	held := l.stats.bytes
+	l.mu.Unlock()
+	if held+hdr.size > l.totalBytes {
+		l.reject(conn, &l.stats.tooLarge,
+			fmt.Sprintf("pid %d crc %#x: %d bytes would pass the total ceiling of %d (%d held)",
+				pid, hdr.crc, hdr.size, l.totalBytes, held))
+		return
+	}
+
+	var st unix.Stat_t
+	if err := unix.Fstat(fd, &st); err != nil {
+		l.reject(conn, &l.stats.malformed, fmt.Sprintf("pid %d crc %#x: fstat: %v", pid, hdr.crc, err))
+		return
+	}
+	// The header is a claim and the file is the fact. They must agree
+	// exactly: a payload shorter than the declared size would be a truncated
+	// cubin, and a longer one means the two ends disagree about what was
+	// offered, which is not a difference worth guessing about.
+	if uint64(st.Size) != hdr.size {
+		l.reject(conn, &l.stats.malformed,
+			fmt.Sprintf("pid %d crc %#x: declared %d bytes, memfd holds %d",
+				pid, hdr.crc, hdr.size, uint64(st.Size)))
+		return
+	}
+
+	l.mu.Lock()
+	l.stats.mapped++
+	l.mu.Unlock()
+	// MAP_PRIVATE and PROT_READ. The seals make the mapping stable; the
+	// flags make it impossible for this end to be the one that changes it.
+	m, err := unix.Mmap(fd, 0, int(hdr.size), unix.PROT_READ, unix.MAP_PRIVATE)
+	if err != nil {
+		l.reject(conn, &l.stats.malformed, fmt.Sprintf("pid %d crc %#x: mmap: %v", pid, hdr.crc, err))
+		return
+	}
+	// One copy out of the mapping, then the mapping goes away. The copy is
+	// what the store owns; holding the mapping instead would tie every stored
+	// module to a live descriptor for the life of the agent.
+	owned := make([]byte, hdr.size)
+	copy(owned, m)
+	if err := unix.Munmap(m); err != nil {
+		l.reject(conn, &l.stats.malformed, fmt.Sprintf("pid %d crc %#x: munmap: %v", pid, hdr.crc, err))
+		return
+	}
+
+	if err := l.sink.PutCubin(hdr.crc, owned); err != nil {
+		l.reject(conn, &l.stats.malformed, fmt.Sprintf("pid %d crc %#x: store: %v", pid, hdr.crc, err))
+		return
+	}
+	l.mu.Lock()
+	l.stats.received++
+	l.stats.bytes += hdr.size
+	l.mu.Unlock()
+	l.reply(conn, cubinReplyOK)
+}
+
+// reject counts one refusal against the given field, records why, and
+// releases the peer. The counter is passed in rather than switched on so that
+// adding a rejection path without a counter does not compile into silence.
+func (l *cubinListener) reject(conn *net.UnixConn, counter *uint64, reason string) {
+	l.mu.Lock()
+	*counter++
+	l.stats.lastErr = reason
+	l.mu.Unlock()
+	l.reply(conn, cubinReplyRefused)
+}
+
+// reply hands the producer its status byte. It is advisory: the shim counts
+// it so a run can say how many offers landed, and never waits on it beyond
+// its own budget.
+func (l *cubinListener) reply(conn *net.UnixConn, b byte) {
+	_ = conn.SetWriteDeadline(time.Now().Add(cubinIOTimeout))
+	_, _ = conn.Write([]byte{b})
+}
+
+func (l *cubinListener) snapshot() cubinStats {
+	if l == nil {
+		return cubinStats{}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.stats
+}
+
+func (l *cubinListener) address() string {
+	if l == nil {
+		return ""
+	}
+	return l.addr
+}
+
+func (l *cubinListener) close() error {
+	if l == nil {
+		return nil
+	}
+	err := l.ln.Close()
+	l.wg.Wait()
+	if errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+// verifyCubinSeals is the whole seal check, and it is all-or-nothing.
+//
+// F_GET_SEALS fails with EINVAL on a file that cannot be sealed at all, so
+// this doubles as "is this actually a memfd" - a peer that passes a regular
+// file, a pipe or a socket is refused here rather than somewhere later with a
+// stranger message.
+func verifyCubinSeals(fd int) error {
+	seals, err := unix.FcntlInt(uintptr(fd), unix.F_GET_SEALS, 0)
+	if err != nil {
+		return fmt.Errorf("F_GET_SEALS: %w (not a sealable memfd?)", err)
+	}
+	if missing := cubinRequiredSeals &^ seals; missing != 0 {
+		return fmt.Errorf("missing seals %s (have %#x, need %#x)",
+			cubinSealNames(missing), seals, cubinRequiredSeals)
+	}
+	return nil
+}
+
+// cubinSealNames spells a seal mask so the rejection reason names the seal
+// that was missing rather than a hex number nobody decodes twice.
+func cubinSealNames(mask int) string {
+	names := []struct {
+		bit  int
+		name string
+	}{
+		{unix.F_SEAL_SEAL, "F_SEAL_SEAL"},
+		{unix.F_SEAL_SHRINK, "F_SEAL_SHRINK"},
+		{unix.F_SEAL_GROW, "F_SEAL_GROW"},
+		{unix.F_SEAL_WRITE, "F_SEAL_WRITE"},
+	}
+	out := ""
+	for _, n := range names {
+		if mask&n.bit == 0 {
+			continue
+		}
+		if out != "" {
+			out += "|"
+		}
+		out += n.name
+	}
+	if out == "" {
+		return "none"
+	}
+	return out
+}
+
+// recvCubinOffer reads the fixed header and the one descriptor that must
+// accompany it.
+//
+// The descriptor rides on the first byte of the header, so it arrives with
+// the first ReadMsgUnix; the rest of the header is an ordinary stream read.
+// Returned fd is -1 when none arrived, and the caller closes it on every
+// path - including the error paths, which is why it is returned even when
+// err is non-nil.
+func recvCubinOffer(conn *net.UnixConn) (cubinHeader, int, error) {
+	buf := make([]byte, cubinHeaderSize)
+	// Room for more descriptors than a well-formed offer carries, on
+	// purpose: with a buffer sized for exactly one, a peer sending two would
+	// have the second silently discarded by the kernel (MSG_CTRUNC) and we
+	// would never know it had tried. With room to see them, extra
+	// descriptors are closed and the offer is refused as malformed.
+	oob := make([]byte, unix.CmsgSpace(4*4))
+	n, oobn, _, _, err := conn.ReadMsgUnix(buf, oob)
+	if err != nil {
+		return cubinHeader{}, -1, fmt.Errorf("read offer: %w", err)
+	}
+	fds := parseCubinRights(oob[:oobn])
+	// Close everything past the first before any early return can skip it.
+	for _, extra := range fds[min(len(fds), 1):] {
+		_ = unix.Close(extra)
+	}
+	fd := -1
+	if len(fds) > 0 {
+		fd = fds[0]
+	}
+	if len(fds) != 1 {
+		return cubinHeader{}, fd, fmt.Errorf("offer carried %d descriptors, want exactly 1", len(fds))
+	}
+	if n < cubinHeaderSize {
+		if _, err := io.ReadFull(conn, buf[n:]); err != nil {
+			return cubinHeader{}, fd, fmt.Errorf("read offer header: %w", err)
+		}
+	}
+	h, err := decodeCubinHeader(buf)
+	return h, fd, err
+}
+
+// parseCubinRights pulls every descriptor out of the control message,
+// tolerating a malformed one rather than failing before the descriptors it
+// did parse can be closed.
+func parseCubinRights(oob []byte) []int {
+	if len(oob) == 0 {
+		return nil
+	}
+	msgs, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return nil
+	}
+	var fds []int
+	for _, m := range msgs {
+		if m.Header.Level != unix.SOL_SOCKET || m.Header.Type != unix.SCM_RIGHTS {
+			continue
+		}
+		got, err := unix.ParseUnixRights(&m)
+		if err != nil {
+			continue
+		}
+		fds = append(fds, got...)
+	}
+	return fds
+}

--- a/gpuprobe/cubin_test.go
+++ b/gpuprobe/cubin_test.go
@@ -1,0 +1,1147 @@
+package gpuprobe
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"hash/crc64"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/sys/unix"
+)
+
+// The cubin channel is tested the way the rendezvous is: against a real
+// abstract socket, a real memfd with real seals, and this test binary's own
+// process as the peer. No GPU, no BPF, no capabilities.
+//
+// The trick is the same one enroll_test.go uses - point the listener at
+// /proc/self/exe, which this process genuinely maps, so procMapsHaveInode
+// passes for real rather than through a mock that would agree with anything.
+
+// testCubinListener binds a cubin listener over `sink` and tears it down with
+// the test, so a leaked goroutine or a leaked abstract address fails the next
+// run rather than this one.
+func testCubinListener(t *testing.T, cfg Config, sink cubinSink) *cubinListener {
+	t.Helper()
+	l, err := newCubinListener(cfg, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.close() })
+	return l
+}
+
+// sealedCubinFD is the producer's half of the payload: a memfd holding body,
+// with exactly the seals in `seals` and no others.
+//
+// F_SEAL_SEAL is applied last on purpose - it is the seal that forbids adding
+// more - so a subset that includes it still ends up with the rest.
+func sealedCubinFD(t *testing.T, body []byte, seals int) int {
+	t.Helper()
+	fd, err := unix.MemfdCreate("perfagent-cubin-test", unix.MFD_CLOEXEC|unix.MFD_ALLOW_SEALING)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = unix.Close(fd) })
+	for off := 0; off < len(body); {
+		n, werr := unix.Write(fd, body[off:])
+		require.NoError(t, werr)
+		off += n
+	}
+	for _, s := range []int{unix.F_SEAL_SHRINK, unix.F_SEAL_GROW, unix.F_SEAL_WRITE, unix.F_SEAL_SEAL} {
+		if seals&s == 0 {
+			continue
+		}
+		_, ferr := unix.FcntlInt(uintptr(fd), unix.F_ADD_SEALS, s)
+		require.NoError(t, ferr, "F_ADD_SEALS %s", cubinSealNames(s))
+	}
+	return fd
+}
+
+// offerHeader is a well-formed header for `size` bytes under `crc`.
+func offerHeader(size, crc uint64) cubinHeader {
+	return cubinHeader{magic: cubinHeaderMagic, version: cubinHeaderVersion, size: size, crc: crc}
+}
+
+// offerCubin dials the offer channel the way the shim does - one sendmsg
+// carrying the header and the descriptor - and returns the status byte, or 0
+// when the connection closed without one.
+func offerCubin(t *testing.T, addr string, h cubinHeader, fd int) byte {
+	t.Helper()
+	return offerCubinFDs(t, addr, encodeCubinHeader(h), fdList(fd))
+}
+
+func fdList(fd int) []int {
+	if fd < 0 {
+		return nil
+	}
+	return []int{fd}
+}
+
+func offerCubinFDs(t *testing.T, addr string, hdr []byte, fds []int) byte {
+	t.Helper()
+	conn, err := net.DialTimeout("unix", addr, 2*time.Second)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	uc, ok := conn.(*net.UnixConn)
+	require.True(t, ok)
+	require.NoError(t, uc.SetDeadline(time.Now().Add(5*time.Second)))
+	var rights []byte
+	if len(fds) > 0 {
+		rights = unix.UnixRights(fds...)
+	}
+	_, _, err = uc.WriteMsgUnix(hdr, rights, nil)
+	require.NoError(t, err)
+	var b [1]byte
+	n, err := uc.Read(b[:])
+	if err != nil || n != 1 {
+		return 0
+	}
+	return b[0]
+}
+
+// recordingCubinSink is the store under test's downstream: it records exactly
+// what was handed to it, so "nothing was stored" is an assertion rather than
+// an assumption. `gate`, when set, wedges PutCubin so a test can hold the
+// cubin listener's serial accept loop open.
+type recordingCubinSink struct {
+	mu      sync.Mutex
+	have    map[uint64][]byte
+	puts    int
+	err     error
+	gate    chan struct{}
+	entered chan struct{}
+	once    sync.Once
+}
+
+func newRecordingCubinSink() *recordingCubinSink {
+	return &recordingCubinSink{have: map[uint64][]byte{}, entered: make(chan struct{})}
+}
+
+func (s *recordingCubinSink) HasCubin(crc uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.have[crc]
+	return ok
+}
+
+func (s *recordingCubinSink) PutCubin(crc uint64, b []byte) error {
+	s.once.Do(func() { close(s.entered) })
+	if s.gate != nil {
+		<-s.gate
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.puts++
+	if s.err != nil {
+		return s.err
+	}
+	s.have[crc] = b
+	return nil
+}
+
+func (s *recordingCubinSink) get(crc uint64) ([]byte, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.have[crc]
+	return b, ok
+}
+
+func (s *recordingCubinSink) putCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.puts
+}
+
+func (s *recordingCubinSink) stored() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.have)
+}
+
+// cubinFixture is a deterministic stand-in for a real cubin: this task moves
+// BYTES, and whether those bytes are an ELF is Task 1's question. A repeating
+// non-uniform pattern so a truncation or an off-by-one page shows up as a
+// content mismatch rather than as two equal runs of zeros.
+func cubinFixture(n int) []byte {
+	b := make([]byte, n)
+	copy(b, "\x7fELF\x02\x01\x01\x00")
+	for i := 8; i < n; i++ {
+		b[i] = byte(i*31 + i/251)
+	}
+	return b
+}
+
+var cubinCRCTable = crc64.MakeTable(crc64.ECMA)
+
+// assertNoCubinRejections is the "green run reads zero" assertion, spelled
+// once. Ten defects on this project were counters reading green exactly when
+// things were worst, so every rejection counter is checked at zero on a
+// healthy path rather than only checked at one on a broken path.
+func assertNoCubinRejections(t *testing.T, st cubinStats) {
+	t.Helper()
+	assert.Zero(t, st.tooLarge, "CubinsRejectedTooLarge on a healthy run")
+	assert.Zero(t, st.malformed, "CubinsRejectedMalformed on a healthy run")
+	assert.Zero(t, st.unsealed, "CubinsRejectedUnsealed on a healthy run")
+	assert.Zero(t, st.unauthorized, "CubinsRejectedUnauthorized on a healthy run")
+	assert.Zero(t, st.throttled, "CubinsThrottled on a healthy run")
+}
+
+// The address is a sibling of the rendezvous, not the same socket: the same
+// dev:inode derivation - so it inherits the btrfs stat-versus-maps fix - under
+// a different name, so it is a different listener with a different bucket.
+func TestTheCubinAddressIsASiblingOfTheRendezvousAndNotTheSameSocket(t *testing.T) {
+	// The source tree's filesystem, not TMPDIR: on tmpfs stat(2) and /proc
+	// report the same device, and this assertion cannot then tell a
+	// stat-derived address from a /proc-derived one. See repoTempDir.
+	dir := repoTempDir(t)
+	a := filepath.Join(dir, "shim-a")
+	b := filepath.Join(dir, "shim-b")
+	require.NoError(t, os.WriteFile(a, []byte("a"), 0o600))
+	require.NoError(t, os.WriteFile(b, []byte("b"), 0o600))
+
+	cubinA, err := cubinAddress(a)
+	require.NoError(t, err)
+	enrollA, err := enrollAddress(a)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, enrollA, cubinA,
+		"the two channels share an address: an offer would then queue ahead of an enrolment and spend its admission token")
+	assert.True(t, strings.HasPrefix(cubinA, "@perfagent-gpu-cubin.v1."), "got %q", cubinA)
+
+	// One derivation, two prefixes. The tail is the dev:inode the KERNEL
+	// reports, which is the whole btrfs fix, so it must be character-for-
+	// character the same on both channels rather than merely equal today.
+	assert.Equal(t,
+		strings.TrimPrefix(enrollA, "@perfagent-gpu-enroll.v1."),
+		strings.TrimPrefix(cubinA, "@perfagent-gpu-cubin.v1."),
+		"the two channels derived different dev:inode tails for the same file")
+
+	// And it is pinned against /proc, not stat(2), exactly as the enrolment
+	// address is - the mistake that bound a name no producer ever dialled.
+	wantDev, wantIno := mapsIdentityOf(t, a)
+	assert.Equal(t,
+		"@perfagent-gpu-cubin.v1."+itoa(uint64(unix.Major(wantDev)))+"."+
+			itoa(uint64(unix.Minor(wantDev)))+"."+itoa(wantIno), cubinA)
+
+	cubinB, err := cubinAddress(b)
+	require.NoError(t, err)
+	assert.NotEqual(t, cubinA, cubinB,
+		"two copies of a shim must not share an offer channel")
+
+	_, err = cubinAddress(filepath.Join(dir, "not-there"))
+	assert.Error(t, err)
+}
+
+// The transport's job, stated plainly: the bytes that went in come out, at
+// both ends of the plausible size range. 2 MB is the plan's own upper figure
+// for a cubin, and it is far past one socket buffer - which is exactly why
+// the payload is a mapped memfd and not a stream.
+func TestACubinArrivesByteIdenticalAtFiveKilobytesAndAtTwoMegabytes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		size int
+	}{
+		{"5 KB", 5 * 1024},
+		{"2 MB", 2 << 20},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shim := selfExe(t)
+			sink := newRecordingCubinSink()
+			l := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+			body := cubinFixture(tc.size)
+			crc := crc64.Checksum(body, cubinCRCTable)
+			fd := sealedCubinFD(t, body, cubinRequiredSeals)
+
+			require.Equal(t, byte(cubinReplyOK), offerCubin(t, l.address(), offerHeader(uint64(len(body)), crc), fd))
+
+			got, ok := sink.get(crc)
+			require.True(t, ok, "the offer was accepted and nothing was stored")
+			assert.Equal(t, len(body), len(got))
+			assert.True(t, bytes.Equal(body, got),
+				"the bytes changed in transit; a wrong cubin parses into a wrong line table")
+			assert.Equal(t, crc, crc64.Checksum(got, cubinCRCTable),
+				"the stored bytes do not hash to the CRC the fixture was keyed by")
+
+			st := l.snapshot()
+			assert.Equal(t, uint64(1), st.received)
+			assert.Equal(t, uint64(len(body)), st.bytes)
+			assert.Equal(t, uint64(1), st.mapped, "the payload must be mapped, not streamed")
+			assertNoCubinRejections(t, st)
+		})
+	}
+}
+
+// An oversized cubin is rejected WHOLE. Never truncated to fit: a truncated
+// cubin parses into a wrong line table, which is the one failure worse than
+// no line table.
+func TestAnOfferOverThePerCubinCeilingIsRejectedWholeAndCounted(t *testing.T) {
+	shim := selfExe(t)
+	sink := newRecordingCubinSink()
+	const ceiling = 64 * 1024
+	l := testCubinListener(t, Config{ShimPath: shim, CubinMaxBytes: ceiling}, sink)
+
+	// Exactly one byte over.
+	body := cubinFixture(ceiling + 1)
+	fd := sealedCubinFD(t, body, cubinRequiredSeals)
+	require.Equal(t, byte(cubinReplyRefused), offerCubin(t, l.address(), offerHeader(uint64(len(body)), 1), fd))
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.tooLarge)
+	assert.Zero(t, st.received)
+	assert.Zero(t, st.bytes)
+	assert.Zero(t, st.mapped, "an over-ceiling offer was mapped anyway")
+	assert.Zero(t, sink.putCount(), "nothing may be stored for a rejected offer, whole or partial")
+	assert.Contains(t, st.lastErr, "per-cubin ceiling")
+
+	// And the ceiling itself is inclusive: exactly at it is fine, so the
+	// rejection above is one byte of policy rather than an off-by-one.
+	ok := cubinFixture(ceiling)
+	okCRC := crc64.Checksum(ok, cubinCRCTable)
+	okFD := sealedCubinFD(t, ok, cubinRequiredSeals)
+	require.Equal(t, byte(cubinReplyOK), offerCubin(t, l.address(), offerHeader(uint64(len(ok)), okCRC), okFD))
+	assert.Equal(t, uint64(1), l.snapshot().received)
+}
+
+// The second ceiling: everything this consumer will ever hold. Counted when
+// it bites, and again nothing partial is stored.
+func TestTheTotalBytesCeilingIsEnforcedAndCounted(t *testing.T) {
+	shim := selfExe(t)
+	sink := newRecordingCubinSink()
+	const each = 32 * 1024
+	l := testCubinListener(t, Config{ShimPath: shim, CubinTotalBytes: 3 * each}, sink)
+
+	for i := range 3 {
+		body := cubinFixture(each)
+		body[8] = byte(i) // a distinct CRC per offer; duplicates are a no-op
+		crc := crc64.Checksum(body, cubinCRCTable)
+		fd := sealedCubinFD(t, body, cubinRequiredSeals)
+		require.Equal(t, byte(cubinReplyOK), offerCubin(t, l.address(), offerHeader(each, crc), fd),
+			"offer %d is inside the total ceiling", i)
+	}
+	require.Equal(t, uint64(3*each), l.snapshot().bytes)
+
+	over := cubinFixture(each)
+	over[8] = 0xFF
+	overCRC := crc64.Checksum(over, cubinCRCTable)
+	overFD := sealedCubinFD(t, over, cubinRequiredSeals)
+	assert.Equal(t, byte(cubinReplyRefused), offerCubin(t, l.address(), offerHeader(each, overCRC), overFD))
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.tooLarge)
+	assert.Equal(t, uint64(3), st.received, "the fourth offer was stored past the total ceiling")
+	assert.Equal(t, uint64(3*each), st.bytes)
+	assert.Equal(t, uint64(3), st.mapped, "the refused offer was mapped anyway")
+	assert.Equal(t, 3, sink.stored())
+	assert.Contains(t, st.lastErr, "total ceiling")
+}
+
+// The header is a claim; the memfd is the fact. When they disagree the offer
+// is refused, because a payload shorter than its declared size IS a truncated
+// cubin and a longer one means the two ends disagree about what was offered.
+func TestADeclaredSizeThatDisagreesWithThePayloadIsRejected(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		actual        int
+		declaredDelta int64
+	}{
+		{"declared larger than the payload", 4096, +1},
+		{"declared smaller than the payload", 4096, -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shim := selfExe(t)
+			sink := newRecordingCubinSink()
+			l := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+			body := cubinFixture(tc.actual)
+			fd := sealedCubinFD(t, body, cubinRequiredSeals)
+			declared := uint64(int64(len(body)) + tc.declaredDelta)
+
+			require.Equal(t, byte(cubinReplyRefused), offerCubin(t, l.address(), offerHeader(declared, 42), fd))
+
+			st := l.snapshot()
+			assert.Equal(t, uint64(1), st.malformed)
+			assert.Zero(t, st.received)
+			assert.Zero(t, st.mapped, "a size-mismatched offer was mapped anyway")
+			assert.Zero(t, sink.putCount(), "no partial cubin may be stored")
+			assert.Contains(t, st.lastErr, "memfd holds")
+		})
+	}
+}
+
+// The seals, one missing at a time. Each is a counted rejection and NONE of
+// them is ever mapped - which is the entire property, because the two things
+// the seals prevent (a peer ftruncating under our mmap and SIGBUSing us, and
+// the ELF mutating under the parser) both happen at or after the map.
+//
+// There is deliberately no fallback branch that reads an unsealed offer
+// anyway. Falling back is how a defended path becomes an undefended one.
+func TestEachRequiredSealMissingInTurnIsRejectedAndNeverMapped(t *testing.T) {
+	for _, tc := range []struct {
+		missing int
+		why     string
+	}{
+		{unix.F_SEAL_SHRINK, "a peer can ftruncate under our mmap and SIGBUS this process"},
+		{unix.F_SEAL_WRITE, "the ELF mutates under the parser mid-parse"},
+		{unix.F_SEAL_GROW, "the size we validated is not the size we map"},
+		{unix.F_SEAL_SEAL, "the other three can be removed again"},
+	} {
+		t.Run(cubinSealNames(tc.missing), func(t *testing.T) {
+			shim := selfExe(t)
+			sink := newRecordingCubinSink()
+			l := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+			body := cubinFixture(2048)
+			crc := crc64.Checksum(body, cubinCRCTable)
+			fd := sealedCubinFD(t, body, cubinRequiredSeals&^tc.missing)
+
+			require.Equal(t, byte(cubinReplyRefused), offerCubin(t, l.address(), offerHeader(uint64(len(body)), crc), fd),
+				"an offer missing %s was accepted; without it %s", cubinSealNames(tc.missing), tc.why)
+
+			st := l.snapshot()
+			assert.Equal(t, uint64(1), st.unsealed)
+			assert.Zero(t, st.received)
+			assert.Zero(t, st.mapped, "the agent mapped an unsealed memfd: %s", tc.why)
+			assert.Zero(t, sink.putCount())
+			assert.Contains(t, st.lastErr, cubinSealNames(tc.missing))
+		})
+	}
+
+	// The all-seals case, so the four subtests above are known to be
+	// rejecting the missing seal rather than rejecting everything.
+	t.Run("all four present", func(t *testing.T) {
+		shim := selfExe(t)
+		sink := newRecordingCubinSink()
+		l := testCubinListener(t, Config{ShimPath: shim}, sink)
+		body := cubinFixture(2048)
+		crc := crc64.Checksum(body, cubinCRCTable)
+		fd := sealedCubinFD(t, body, cubinRequiredSeals)
+		require.Equal(t, byte(cubinReplyOK), offerCubin(t, l.address(), offerHeader(uint64(len(body)), crc), fd))
+		assertNoCubinRejections(t, l.snapshot())
+	})
+}
+
+// A descriptor the peer did not seal is refused by the same check, whether it
+// is unsealable outright or merely unsealed. Both land on CubinsRejectedUnsealed
+// and neither is ever mapped.
+//
+// Worth pinning separately from the missing-seal table above, because the two
+// arrive by different kernel paths: F_GET_SEALS returns EINVAL on a pipe,
+// while a file on tmpfs - which IS shmem, and so IS sealable - answers with
+// F_SEAL_SEAL alone and no write protection at all. The second is the
+// dangerous one: it looks like a sealed object and the peer can still write
+// through it.
+func TestADescriptorThatIsNotASealedMemfdIsRefused(t *testing.T) {
+	t.Run("a pipe, which cannot be sealed at all", func(t *testing.T) {
+		shim := selfExe(t)
+		sink := newRecordingCubinSink()
+		l := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+		var fds [2]int
+		require.NoError(t, unix.Pipe(fds[:]))
+		t.Cleanup(func() { _ = unix.Close(fds[0]); _ = unix.Close(fds[1]) })
+
+		require.Equal(t, byte(cubinReplyRefused),
+			offerCubin(t, l.address(), offerHeader(1024, 9), fds[0]))
+
+		st := l.snapshot()
+		assert.Equal(t, uint64(1), st.unsealed)
+		assert.Zero(t, st.mapped)
+		assert.Zero(t, sink.putCount())
+		assert.Contains(t, st.lastErr, "F_GET_SEALS")
+	})
+
+	t.Run("a tmpfs file, which is sealable but not sealed", func(t *testing.T) {
+		shim := selfExe(t)
+		sink := newRecordingCubinSink()
+		l := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+		body := cubinFixture(1024)
+		path := filepath.Join(t.TempDir(), "not-a-memfd")
+		require.NoError(t, os.WriteFile(path, body, 0o600))
+		f, err := os.Open(path)
+		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
+
+		require.Equal(t, byte(cubinReplyRefused),
+			offerCubin(t, l.address(), offerHeader(uint64(len(body)), 9), int(f.Fd())))
+
+		st := l.snapshot()
+		assert.Equal(t, uint64(1), st.unsealed)
+		assert.Zero(t, st.mapped, "a writable file was mapped as if it were a sealed cubin")
+		assert.Zero(t, sink.putCount())
+		assert.Contains(t, st.lastErr, "F_SEAL_WRITE")
+	})
+}
+
+// Every structural way a header can be wrong, all landing on one counter and
+// none of them on a guess. A flag this consumer does not understand is a
+// producer telling it something about the payload, and guessing is how a
+// wrong line table gets built.
+func TestAMalformedOfferIsRefusedAndCounted(t *testing.T) {
+	body := cubinFixture(1024)
+	for _, tc := range []struct {
+		name string
+		hdr  []byte
+		fds  int
+		want string
+	}{
+		{name: "bad magic", hdr: func() []byte {
+			h := offerHeader(uint64(len(body)), 1)
+			h.magic ^= 0xFF
+			return encodeCubinHeader(h)
+		}(), fds: 1, want: "bad magic"},
+		{name: "unknown version", hdr: func() []byte {
+			h := offerHeader(uint64(len(body)), 1)
+			h.version = 7
+			return encodeCubinHeader(h)
+		}(), fds: 1, want: "unknown offer version"},
+		{name: "reserved flag set", hdr: func() []byte {
+			h := offerHeader(uint64(len(body)), 1)
+			h.flags = 1
+			return encodeCubinHeader(h)
+		}(), fds: 1, want: "unknown offer flags"},
+		{name: "zero declared size", hdr: encodeCubinHeader(offerHeader(0, 1)), fds: 1, want: "declared size is zero"},
+		{name: "short header", hdr: encodeCubinHeader(offerHeader(uint64(len(body)), 1))[:8], fds: 1, want: "read offer header"},
+		{name: "no descriptor", hdr: encodeCubinHeader(offerHeader(uint64(len(body)), 1)), fds: 0, want: "0 descriptors"},
+		{name: "two descriptors", hdr: encodeCubinHeader(offerHeader(uint64(len(body)), 1)), fds: 2, want: "2 descriptors"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shim := selfExe(t)
+			sink := newRecordingCubinSink()
+			l := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+			var fds []int
+			for range tc.fds {
+				fds = append(fds, sealedCubinFD(t, body, cubinRequiredSeals))
+			}
+			assert.Equal(t, byte(cubinReplyRefused), offerCubinFDs(t, l.address(), tc.hdr, fds))
+
+			st := l.snapshot()
+			assert.Equal(t, uint64(1), st.malformed)
+			assert.Zero(t, st.received)
+			assert.Zero(t, st.mapped)
+			assert.Zero(t, sink.putCount())
+			assert.Contains(t, st.lastErr, tc.want)
+		})
+	}
+}
+
+// The same identity rule the rendezvous uses, reused verbatim: a peer that
+// does not map the shim this consumer attached to is refused. Without it, any
+// local process could feed a root profiler cubins for a module it never
+// loaded - and a bogus cubin under a real CRC is a WRONG source line on every
+// PC sample that joins to it, which is worse than none.
+func TestACubinPeerThatDoesNotMapTheShimIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "some-other-shim")
+	require.NoError(t, os.WriteFile(shim, []byte("not mapped by anyone"), 0o600))
+
+	sink := newRecordingCubinSink()
+	l := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+	body := cubinFixture(1024)
+	fd := sealedCubinFD(t, body, cubinRequiredSeals)
+	assert.Equal(t, byte(cubinReplyRefused), offerCubin(t, l.address(), offerHeader(uint64(len(body)), 3), fd))
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.unauthorized)
+	assert.Zero(t, st.received)
+	assert.Zero(t, st.mapped, "an unauthorized peer's memfd was mapped")
+	assert.Zero(t, sink.putCount())
+	assert.Contains(t, st.lastErr, "does not map the shim")
+}
+
+// A per-PID attach must not accept another process's modules: its uprobes are
+// filtered to one process and the socket name is not, so the listener has to
+// be. Same rule as the rendezvous, same counter shape.
+func TestAPerPIDConsumerRefusesCubinsFromEveryOtherPID(t *testing.T) {
+	shim := selfExe(t)
+	sink := newRecordingCubinSink()
+	l := testCubinListener(t, Config{ShimPath: shim, PID: os.Getpid() + 1}, sink)
+
+	body := cubinFixture(512)
+	fd := sealedCubinFD(t, body, cubinRequiredSeals)
+	assert.Equal(t, byte(cubinReplyRefused), offerCubin(t, l.address(), offerHeader(uint64(len(body)), 4), fd))
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.unauthorized)
+	assert.Zero(t, st.mapped)
+	assert.Contains(t, st.lastErr, "is not the attached pid")
+}
+
+// A CRC already held is a no-op decided from the header alone: cubin_crc is
+// content-addressed, so the same CRC is the same bytes, and re-reading them
+// could only reach the same answer at the cost of an mmap and a re-parse.
+func TestAnOfferForAnAlreadyStoredCRCIsACountedNoOp(t *testing.T) {
+	shim := selfExe(t)
+	sink := newRecordingCubinSink()
+	l := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+	body := cubinFixture(4096)
+	crc := crc64.Checksum(body, cubinCRCTable)
+
+	first := sealedCubinFD(t, body, cubinRequiredSeals)
+	require.Equal(t, byte(cubinReplyOK), offerCubin(t, l.address(), offerHeader(uint64(len(body)), crc), first))
+
+	second := sealedCubinFD(t, body, cubinRequiredSeals)
+	require.Equal(t, byte(cubinReplyOK), offerCubin(t, l.address(), offerHeader(uint64(len(body)), crc), second),
+		"a duplicate is a no-op, not a refusal: the producer has nothing to fix")
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.received, "the duplicate was stored a second time")
+	assert.Equal(t, uint64(1), st.duplicate)
+	assert.Equal(t, uint64(len(body)), st.bytes, "the duplicate was charged against the total ceiling")
+	assert.Equal(t, uint64(1), st.mapped, "the duplicate was mapped: the CRC check runs before the payload is touched")
+	assert.Equal(t, 1, sink.putCount())
+	assertNoCubinRejections(t, st)
+}
+
+// A store that refuses is loss like any other, and it is counted rather than
+// answered with an OK the producer would believe.
+func TestAStoreFailureIsCountedAndTheOfferIsRefused(t *testing.T) {
+	shim := selfExe(t)
+	sink := newRecordingCubinSink()
+	sink.err = fmt.Errorf("store is full")
+	l := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+	body := cubinFixture(1024)
+	fd := sealedCubinFD(t, body, cubinRequiredSeals)
+	assert.Equal(t, byte(cubinReplyRefused), offerCubin(t, l.address(), offerHeader(uint64(len(body)), 11), fd))
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.malformed)
+	assert.Zero(t, st.received)
+	assert.Zero(t, st.bytes, "a cubin that was not stored must not be charged against the total ceiling")
+	assert.Contains(t, st.lastErr, "store is full")
+}
+
+// The cubin bucket is a DIFFERENT bucket, with different numbers, and
+// spending one cannot spend the other. This is the unit-level statement of
+// the isolation the socket test below proves end to end.
+func TestTheCubinAdmissionBucketIsItsOwn(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+	cu := newCubinAdmission(clock)
+	en := newEnrollAdmission(clock)
+
+	admitted := 0
+	for range cubinUIDBurst * 4 {
+		if cu.admit(1000) {
+			admitted++
+		}
+	}
+	assert.Equal(t, cubinUIDBurst, admitted, "one uid spent more than the cubin burst with no time passing")
+
+	// The enrolment bucket is untouched by all of that. Two objects, so this
+	// is true by construction - which is the point of asserting it: the test
+	// documents that nothing shares state, rather than measuring how much
+	// leaks.
+	for range enrollUIDBurst {
+		require.True(t, en.admit(1000),
+			"draining the cubin bucket cost an enrolment token; the buckets are not separate")
+	}
+
+	// And the cubin bucket refills on its own schedule.
+	now = now.Add(time.Second)
+	refilled := 0
+	for range cubinUIDBurst * 2 {
+		if cu.admit(1000) {
+			refilled++
+		}
+	}
+	assert.Equal(t, cubinUIDBurst, refilled)
+
+	assert.Greater(t, cubinUIDBurst, enrollUIDBurst,
+		"the cubin burst must exceed the enrolment burst: module loads cluster and enrolments do not")
+}
+
+// A throttled offer is refused instantly, told so, and costs no /proc read,
+// no map and no store insert.
+func TestAThrottledCubinOfferIsReleasedAndCountedNotServed(t *testing.T) {
+	shim := selfExe(t)
+	sink := newRecordingCubinSink()
+	// Built but not yet serving, so the bucket can be drained before any peer
+	// can reach it: `admit` has no lock precisely because only serve()
+	// touches it.
+	l, err := buildCubinListener(Config{ShimPath: shim}, sink)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.close() })
+	for l.admit.admit(uint32(os.Getuid())) { //nolint:revive // drain until empty
+	}
+	l.start()
+
+	body := cubinFixture(1024)
+	fd := sealedCubinFD(t, body, cubinRequiredSeals)
+	assert.Equal(t, byte(cubinReplyRefused), offerCubin(t, l.address(), offerHeader(uint64(len(body)), 5), fd))
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.throttled)
+	assert.Zero(t, st.received)
+	assert.Zero(t, st.mapped)
+	assert.Zero(t, st.unauthorized, "throttling is its own outcome, not an identity refusal")
+	assert.Zero(t, sink.putCount())
+	assert.Contains(t, st.lastErr, "throttled")
+}
+
+// floodCubinOffers fires n WELL-FORMED offers at addr, concurrently, and
+// returns a WaitGroup for them.
+//
+// Well-formed on purpose. A flood of connections that send nothing would
+// exercise the header timeout rather than the admission bucket, and would
+// prove nothing about throttling; these are the traffic a module-heavy
+// workload actually generates. One shared sealed descriptor carries them all
+// - the payload is identical, only the CRC differs - so the flood costs one
+// memfd rather than n of them.
+func floodCubinOffers(addr string, n, fd int, size, crcBase uint64) *sync.WaitGroup {
+	rights := unix.UnixRights(fd)
+	var wg sync.WaitGroup
+	for i := range n {
+		hdr := encodeCubinHeader(offerHeader(size, crcBase+uint64(i)))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := net.DialTimeout("unix", addr, 20*time.Second)
+			if err != nil {
+				return
+			}
+			defer func() { _ = c.Close() }()
+			uc, ok := c.(*net.UnixConn)
+			if !ok {
+				return
+			}
+			_ = uc.SetDeadline(time.Now().Add(20 * time.Second))
+			if _, _, werr := uc.WriteMsgUnix(hdr, rights, nil); werr != nil {
+				return
+			}
+			var b [1]byte
+			_, _ = uc.Read(b[:])
+		}()
+	}
+	return &wg
+}
+
+// THE TEST THIS TASK EXISTS FOR.
+//
+// Flood the cubin channel until CubinsThrottled is non-zero, then perform a
+// normal enrolment and assert it succeeds with UnwindEnrollThrottled
+// unchanged - in BOTH orders.
+//
+// The "ahead" order is the one that matters and the one a shared socket
+// fails. On a shared socket the enrolment's connect() lands in a backlog
+// already holding a queue of offers, and the serial accept loop serves them
+// first: the producer waits out its 2s budget and takes the lazy path, which
+// is issue #49's ~38% stack loss. It also spends the same admission bucket,
+// so past 32 offers in a second the enrolment is refused outright with only
+// UnwindEnrollThrottled moving. Neither can happen here, and not because this
+// test checks for it - because the offers are queued on a listener with its
+// own Accept loop, its own goroutine and its own bucket. The test states the
+// property; the separation is what makes it true.
+//
+// The "behind" order is the easy direction and is included so the pair is
+// symmetric rather than selective.
+func TestFloodingTheCubinChannelCannotStarveOrThrottleAnEnrolment(t *testing.T) {
+	// Comfortably past both cubin buckets - the per-uid burst is the binding
+	// one - with enough margin that a second's worth of refill during the
+	// flood cannot absorb the overflow.
+	const flood = cubinUIDBurst*2 + cubinTotalBurst
+
+	t.Run("offers queued AHEAD of the enrolment", func(t *testing.T) {
+		shim := selfExe(t)
+		fake := newFakeRegistrar()
+		el, _ := testEnrollListener(t, shim, 0, fake)
+
+		sink := newRecordingCubinSink()
+		sink.gate = make(chan struct{})
+		cl := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+		body := cubinFixture(512)
+		fd := sealedCubinFD(t, body, cubinRequiredSeals)
+
+		// One genuine offer, wedged inside the store, so the cubin
+		// listener's serial accept loop is occupied and everything below
+		// queues in its backlog rather than being served. This is exactly
+		// the shape that starves a shared Accept loop.
+		go func() { _ = offerCubin(t, cl.address(), offerHeader(uint64(len(body)), 1), fd) }()
+		select {
+		case <-sink.entered:
+		case <-time.After(10 * time.Second):
+			t.Fatal("the wedging offer never reached the store")
+		}
+
+		// The flood, all of it now standing in front of the enrolment in
+		// wall-clock order and none of it served.
+		wg := floodCubinOffers(cl.address(), flood, fd, uint64(len(body)), 1000)
+
+		// The enrolment, with the cubin channel wedged and its backlog full.
+		// On a shared socket this is where the producer waits out its budget
+		// and comes back kEnrollError.
+		before := el.snapshot().throttled
+		done := make(chan byte, 1)
+		go func() { done <- dialEnroll(t, shim) }()
+		select {
+		case b := <-done:
+			assert.Equal(t, byte(enrollReplyOK), b,
+				"an enrolment was refused while the cubin channel was saturated")
+		case <-time.After(5 * time.Second):
+			t.Fatal("the enrolment did not complete while cubin offers were queued ahead of it; " +
+				"the two channels are sharing an Accept loop")
+		}
+		assert.Equal(t, before, el.snapshot().throttled,
+			"a cubin offer spent an enrolment admission token")
+		assert.Equal(t, uint64(1), el.snapshot().confirmed)
+
+		close(sink.gate)
+		wg.Wait()
+
+		cu := cl.snapshot()
+		en := el.snapshot()
+		t.Logf("cubin: offered=%d received=%d duplicate=%d throttled=%d | enrol: requests=%d confirmed=%d throttled=%d",
+			flood+1, cu.received, cu.duplicate, cu.throttled, en.requests, en.confirmed, en.throttled)
+		assert.Positive(t, cu.throttled,
+			"the flood never exhausted the cubin bucket, so this proved nothing")
+		assert.Positive(t, cu.received, "not one offer of the flood was actually served")
+		assert.Zero(t, el.snapshot().throttled,
+			"UnwindEnrollThrottled moved while only cubin offers were being refused")
+	})
+
+	t.Run("offers queued BEHIND the enrolment", func(t *testing.T) {
+		shim := selfExe(t)
+		fake := newFakeRegistrar()
+		el, _ := testEnrollListener(t, shim, 0, fake)
+		sink := newRecordingCubinSink()
+		cl := testCubinListener(t, Config{ShimPath: shim}, sink)
+
+		require.Equal(t, byte(enrollReplyOK), dialEnroll(t, shim))
+
+		body := cubinFixture(512)
+		fd := sealedCubinFD(t, body, cubinRequiredSeals)
+		floodCubinOffers(cl.address(), flood, fd, uint64(len(body)), 2000).Wait()
+		require.Positive(t, cl.snapshot().throttled, "the flood never exhausted the cubin bucket")
+		cu := cl.snapshot()
+
+		// A second enrolment, after the channel next door has been refusing
+		// for a while, still lands.
+		assert.Equal(t, byte(enrollReplyOK), dialEnroll(t, shim))
+		st := el.snapshot()
+		t.Logf("cubin: offered=%d received=%d duplicate=%d throttled=%d | enrol: requests=%d confirmed=%d throttled=%d",
+			flood, cu.received, cu.duplicate, cu.throttled, st.requests, st.confirmed, st.throttled)
+		assert.Zero(t, st.throttled, "UnwindEnrollThrottled moved because of cubin traffic")
+		assert.Equal(t, uint64(2), st.confirmed)
+	})
+}
+
+// The regression that keeps the two channels apart forever: the enrolment
+// handler must NEVER read from its connection.
+//
+// shim/core/enroll.h states the protocol as "The producer sends nothing", and
+// the producer implements exactly that - it connects and then blocks reading
+// one byte. A read on this end would therefore block until the producer's own
+// 2s budget expired and it closed, turning every rendezvous into a 2s stall
+// ending in kEnrollError. That is the failure a shared socket would force,
+// because discriminating an offer from an enrolment requires a read.
+//
+// Asserted twice, because either half alone is escapable: behaviourally, a
+// producer that writes nothing is still answered promptly; and structurally,
+// over the AST of handle() itself, so that adding the read later fails here
+// rather than on a GPU three weeks afterwards.
+func TestAnEnrolmentCompletesWithNoReadOnThatConnection(t *testing.T) {
+	shim := selfExe(t)
+	fake := newFakeRegistrar()
+	l, _ := testEnrollListener(t, shim, 0, fake)
+
+	conn, err := net.DialTimeout("unix", mustEnrollAddress(t, shim), 2*time.Second)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	// Nothing is written. Ever. If the handler waits for a header this read
+	// does not return until the deadline.
+	require.NoError(t, conn.SetDeadline(time.Now().Add(2*time.Second)))
+	var b [1]byte
+	start := time.Now()
+	n, err := conn.Read(b[:])
+	require.NoError(t, err, "the rendezvous did not answer a producer that sent nothing, "+
+		"which is the whole protocol; a discriminating read has been added to handle()")
+	require.Equal(t, 1, n)
+	assert.Equal(t, byte(enrollReplyOK), b[0])
+	assert.Less(t, time.Since(start), 2*time.Second)
+	assert.Equal(t, uint64(1), l.snapshot().confirmed)
+
+	assertNoReadInEnrollHandler(t)
+}
+
+func mustEnrollAddress(t *testing.T, shim string) string {
+	t.Helper()
+	addr, err := enrollAddress(shim)
+	require.NoError(t, err)
+	return addr
+}
+
+// assertNoReadInEnrollHandler walks the AST of enrollListener.handle and
+// fails if it contains anything that reads from the connection.
+//
+// A behavioural test alone would pass for a handler that reads with a short
+// deadline and falls through - which would still cost every producer that
+// deadline, and would still be the shared-socket design creeping back in one
+// commit at a time. This makes the rule structural.
+func assertNoReadInEnrollHandler(t *testing.T) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "enroll.go", nil, 0)
+	require.NoError(t, err)
+
+	banned := map[string]bool{
+		"Read": true, "ReadMsgUnix": true, "ReadFrom": true, "ReadFull": true,
+		"ReadAll": true, "ReadByte": true, "SetReadDeadline": true, "NewScanner": true,
+		"NewReader": true, "Recvmsg": true,
+	}
+	var handle *ast.FuncDecl
+	for _, d := range f.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "handle" || fn.Recv == nil {
+			continue
+		}
+		handle = fn
+	}
+	require.NotNil(t, handle, "enrollListener.handle not found in enroll.go")
+
+	ast.Inspect(handle.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		var name string
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			name = fn.Sel.Name
+		case *ast.Ident:
+			name = fn.Name
+		}
+		assert.False(t, banned[name],
+			"enrollListener.handle now calls %s(). The enrolment protocol is 'the producer sends nothing' "+
+				"(shim/core/enroll.h), so a read here blocks until the producer's 2s budget expires and every "+
+				"rendezvous becomes a 2s stall ending in kEnrollError - issue #49's ~38%% stack loss, by a new "+
+				"route. A cubin offer needs a header; that is why it has its own socket (cubin.go).", name)
+		return true
+	})
+}
+
+// The header codec, round-tripped, so the 24 bytes the Go decoder expects are
+// the 24 bytes the C++ producer writes. shim/core/cubin_test.cc pins the same
+// offsets from the other side; between them a layout or endianness drift
+// cannot pass unnoticed.
+func TestTheOfferHeaderCodecRoundTrips(t *testing.T) {
+	h := cubinHeader{magic: cubinHeaderMagic, version: cubinHeaderVersion, flags: 0,
+		size: 0x0102030405060708, crc: 0x0F0E0D0C0B0A0908}
+	raw := encodeCubinHeader(h)
+	require.Len(t, raw, cubinHeaderSize)
+	assert.Equal(t, []byte{'C', 'U', 'B', '1'}, raw[0:4])
+	assert.Equal(t, byte(1), raw[4])
+	assert.Equal(t, byte(0), raw[6])
+
+	got, err := decodeCubinHeader(raw)
+	require.NoError(t, err)
+	assert.Equal(t, h, got)
+
+	_, err = decodeCubinHeader(raw[:cubinHeaderSize-1])
+	assert.Error(t, err, "a short header must be an error, not a zero-filled one")
+}
+
+// Two consumers cannot both own one shim's offer channel, for the same reason
+// two cannot own its rendezvous: a consumer that thinks it has one and does
+// not resolves nothing and says nothing.
+func TestASecondCubinListenerForTheSameShimIsRefused(t *testing.T) {
+	shim := selfExe(t)
+	testCubinListener(t, Config{ShimPath: shim}, newRecordingCubinSink())
+	_, err := newCubinListener(Config{ShimPath: shim}, newRecordingCubinSink())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bind")
+}
+
+// Closing releases a peer mid-offer rather than leaving it writing into a
+// consumer that has gone, and is idempotent on a nil listener - the shape a
+// consumer that could not bind one has.
+func TestClosingTheCubinListenerIsSafeAndReleasesPeers(t *testing.T) {
+	var nilListener *cubinListener
+	assert.NoError(t, nilListener.close())
+	assert.Equal(t, "", nilListener.address())
+	assert.Equal(t, cubinStats{}, nilListener.snapshot())
+
+	shim := selfExe(t)
+	sink := newRecordingCubinSink()
+	sink.gate = make(chan struct{})
+	l, err := newCubinListener(Config{ShimPath: shim}, sink)
+	require.NoError(t, err)
+
+	body := cubinFixture(1024)
+	fd := sealedCubinFD(t, body, cubinRequiredSeals)
+	got := make(chan byte, 1)
+	go func() { got <- offerCubin(t, l.address(), offerHeader(uint64(len(body)), 21), fd) }()
+	select {
+	case <-sink.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the offer never reached the store")
+	}
+	close(sink.gate)
+	require.NoError(t, l.close())
+
+	select {
+	case <-got:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a peer stayed parked after the cubin listener closed")
+	}
+}
+
+// The built-in store is bounded. Task 4 replaces it with the LRU,
+// line-table-backed gpu.ModuleStore, but an unbounded map fed by a profiled
+// application is the same defect whoever owns it, so the bound exists now.
+func TestTheBuiltInCubinStoreIsBounded(t *testing.T) {
+	s := newMemCubinStore(2)
+	require.NoError(t, s.PutCubin(1, []byte("a")))
+	require.NoError(t, s.PutCubin(2, []byte("b")))
+	assert.Error(t, s.PutCubin(3, []byte("c")), "the placeholder store grew past its bound")
+
+	// A duplicate is free even at the bound: it stores nothing new.
+	assert.NoError(t, s.PutCubin(1, []byte("a")))
+	assert.True(t, s.HasCubin(1))
+	assert.False(t, s.HasCubin(3))
+	b, ok := s.get(2)
+	require.True(t, ok)
+	assert.Equal(t, []byte("b"), b)
+
+	assert.Equal(t, defaultCubinStoreCapacity, newMemCubinStore(0).cap)
+}
+
+// The seal-name spelling, because a rejection reason that says "0x2" instead
+// of "F_SEAL_SHRINK" is one nobody decodes twice.
+func TestSealNamesAreSpeltOut(t *testing.T) {
+	assert.Equal(t, "F_SEAL_SHRINK", cubinSealNames(unix.F_SEAL_SHRINK))
+	assert.Equal(t, "F_SEAL_SEAL|F_SEAL_WRITE", cubinSealNames(unix.F_SEAL_SEAL|unix.F_SEAL_WRITE))
+	assert.Equal(t, "none", cubinSealNames(0))
+	assert.Equal(t,
+		"F_SEAL_SEAL|F_SEAL_SHRINK|F_SEAL_GROW|F_SEAL_WRITE", cubinSealNames(cubinRequiredSeals))
+}
+
+// The one seam neither side's own tests can cover: the wire between them.
+//
+// The offer channel has no negotiation in it. The producer computes the
+// socket name from /proc/self/maps in C++ (shim/core/cubin.cc) and this end
+// computes it from the same source in Go, and if the two spellings ever
+// diverge every module silently goes unresolvable - with no error anywhere,
+// because "nobody is listening" is also what an unprofiled process sees. The
+// header is in the same position: 24 bytes written by a C++ struct and read
+// by a Go decoder, with nothing on the wire to catch a layout drift.
+//
+// So this builds the real producer out of shim/core, points the real listener
+// at it, and runs it. No BPF, no GPU, no privilege.
+func TestTheCppProducerAndTheGoCubinListenerAgreeOnTheWire(t *testing.T) {
+	cxx, err := exec.LookPath("c++")
+	if err != nil {
+		t.Skip("no c++ in PATH; this test builds the shim's producer half")
+	}
+	core, err := filepath.Abs(filepath.Join("..", "shim", "core"))
+	require.NoError(t, err)
+	if _, serr := os.Stat(filepath.Join(core, "cubin.cc")); serr != nil {
+		t.Skipf("shim/core not present: %v", serr)
+	}
+
+	// BOTH filesystems. The address embeds a device number, and stat(2) and
+	// /proc/<pid>/maps report the SAME device on tmpfs and DIFFERENT devices
+	// on btrfs - where the shim is actually built. A test that ran only under
+	// TMPDIR would prove the two ends agree on the one filesystem where they
+	// cannot disagree, which is exactly how the enrolment address shipped
+	// broken. See repoTempDir.
+	for _, tc := range []struct{ name, dir string }{
+		{name: "source filesystem, where the shim is really built", dir: repoTempDir(t)},
+		{name: "TMPDIR", dir: t.TempDir()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := filepath.Join(tc.dir, "cubin_producer.cc")
+			require.NoError(t, os.WriteFile(src, []byte(cubinProducerSrc), 0o600))
+			bin := filepath.Join(tc.dir, "cubin_producer")
+			build := exec.Command(cxx, "-std=c++17", "-O2", "-fvisibility=hidden",
+				"-I", core, "-o", bin, src,
+				filepath.Join(core, "cubin.cc"), filepath.Join(core, "enroll.cc"))
+			if out, berr := build.CombinedOutput(); berr != nil {
+				t.Skipf("could not build the producer half: %v\n%s", berr, out)
+			}
+
+			want, aerr := cubinAddress(bin)
+			require.NoError(t, aerr)
+
+			sink := newRecordingCubinSink()
+			l := testCubinListener(t, Config{ShimPath: bin}, sink)
+			require.Equal(t, want, l.address(), "the listener bound a name other than the derived one")
+
+			out, rerr := exec.Command(bin).Output()
+			require.NoError(t, rerr, "producer failed: %s", out)
+			got := strings.Fields(strings.TrimSpace(string(out)))
+			require.Len(t, got, 2, "producer output: %q", out)
+
+			// Asserted before the outcome, so a mismatch reports the two
+			// names rather than just "no-listener".
+			assert.Equal(t, want, got[1],
+				"the two ends derived DIFFERENT offer-channel names for the same file under %s. "+
+					"consumer=%s producer=%s. They never exchange this string, so a mismatch makes every "+
+					"counter on both sides read zero and every module unresolvable",
+				tc.dir, want, got[1])
+			assert.Equal(t, "accepted", got[0],
+				"the producer's offer was not accepted even though both ends derived the same name (%s), "+
+					"so this is the wire format rather than the address", want)
+
+			// And the bytes: the same fixture, generated independently in C++
+			// and in Go, keyed by the CRC the producer declared.
+			stored, ok := sink.get(cubinProducerCRC)
+			require.True(t, ok, "the offer was accepted and nothing was stored under the declared CRC")
+			assert.True(t, bytes.Equal(cubinFixture(cubinProducerSize), stored),
+				"the C++ producer's bytes are not the bytes this end stored")
+
+			st := l.snapshot()
+			assert.Equal(t, uint64(1), st.received)
+			assert.Equal(t, uint64(cubinProducerSize), st.bytes)
+			assertNoCubinRejections(t, st)
+		})
+	}
+}
+
+const (
+	cubinProducerSize = 5 * 1024
+	cubinProducerCRC  = 0xDEADBEEFCAFEF00D
+)
+
+// cubinProducerSrc is the shim's producer half in miniature: derive the name,
+// build the same fixture cubinFixture builds, seal it, offer it, print the
+// outcome. Kept out of the test body so the C++ braces cannot be confused for
+// Go ones by anything editing this file.
+//
+// The fixture generator is duplicated rather than shared on purpose - two
+// independent spellings of the same bytes is what makes "byte-identical" an
+// assertion instead of a tautology.
+const cubinProducerSrc = `
+#include "cubin.h"
+#include <cstdio>
+#include <string>
+int main() {
+    char name[128];
+    if (!perfagent::cubin_self_name(name, sizeof(name))) { printf("no-address -\n"); return 1; }
+    std::string body(5 * 1024, '\0');
+    const char magic[8] = {'\x7f', 'E', 'L', 'F', '\x02', '\x01', '\x01', '\x00'};
+    for (int i = 0; i < 8; i++) body[i] = magic[i];
+    for (size_t i = 8; i < body.size(); i++) {
+        body[i] = (char)(unsigned char)(i * 31 + i / 251);
+    }
+    const perfagent::CubinOfferResult r = perfagent::cubin_offer(
+        name, body.data(), body.size(), 0xDEADBEEFCAFEF00DULL,
+        perfagent::cubin_timeout_ms(5000));
+    printf("%s @%s\n", perfagent::cubin_offer_result_name(r), name);
+    return 0;
+}
+`

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -21,7 +21,7 @@ NVCC ?= $(CUDA_HOME)/bin/nvcc
 # sm_86 is the RTX 3090 this adapter was proven on.
 CUDA_ARCH ?= sm_86
 
-CORE_SRC := core/batch.cc core/clock.cc core/drain.cc core/enroll.cc core/sampler.cc
+CORE_SRC := core/batch.cc core/clock.cc core/cubin.cc core/drain.cc core/enroll.cc core/sampler.cc
 CORE_OBJ := $(CORE_SRC:.cc=.o)
 
 .PHONY: all test test-tsan nvidia nvidia-workload clean
@@ -192,11 +192,12 @@ nvidia/testdata/cuda_workload: nvidia/testdata/cuda_workload.cu
 # _Static_asserts are the test. Compiling it only as C++ leaves the C11 spelling
 # unguarded -- which is how the header's validity broke earlier in this branch,
 # when a C++ translation unit included it for the first time.
-test: core/batch_test.cc core/clock_test.cc core/drain_test.cc core/enroll_test.cc core/usdt_abi_test.c core/sampler_test.cc core/probe_args_test.cc stub/probe_order_test.cc stub/stub.cc $(CORE_SRC)
+test: core/batch_test.cc core/clock_test.cc core/cubin_test.cc core/drain_test.cc core/enroll_test.cc core/usdt_abi_test.c core/sampler_test.cc core/probe_args_test.cc stub/probe_order_test.cc stub/stub.cc $(CORE_SRC)
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/batch_test core/batch_test.cc core/batch.cc && /tmp/batch_test
 	$(CXX) -std=c++17 -I core -o /tmp/clock_test core/clock_test.cc core/clock.cc && /tmp/clock_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/drain_test core/drain_test.cc core/drain.cc && /tmp/drain_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/enroll_test core/enroll_test.cc core/enroll.cc && /tmp/enroll_test
+	$(CXX) -std=c++17 -Wall -Werror -pthread -I core -o /tmp/cubin_test core/cubin_test.cc core/cubin.cc core/enroll.cc && /tmp/cubin_test
 	$(CC) -std=c11 -Wall -Werror -I core -o /tmp/usdt_abi_test core/usdt_abi_test.c && /tmp/usdt_abi_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/sampler_test core/sampler_test.cc core/sampler.cc && /tmp/sampler_test
 	$(CXX) -std=c++17 -O2 -Wall -Werror -I core -o /tmp/probe_args_test core/probe_args_test.cc && /tmp/probe_args_test

--- a/shim/core/cubin.cc
+++ b/shim/core/cubin.cc
@@ -1,0 +1,367 @@
+#include "cubin.h"
+
+#include "enroll.h"
+
+#include <atomic>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+// The sealing interface lives in <linux/fcntl.h>, which cannot be included
+// beside <fcntl.h> on every toolchain without redefinition warnings. The
+// numbers are kernel ABI and have not moved since 3.17.
+#ifndef F_ADD_SEALS
+#define F_ADD_SEALS 1033
+#endif
+#ifndef F_GET_SEALS
+#define F_GET_SEALS 1034
+#endif
+#ifndef F_SEAL_SEAL
+#define F_SEAL_SEAL 0x0001
+#endif
+#ifndef F_SEAL_SHRINK
+#define F_SEAL_SHRINK 0x0002
+#endif
+#ifndef F_SEAL_GROW
+#define F_SEAL_GROW 0x0004
+#endif
+#ifndef F_SEAL_WRITE
+#define F_SEAL_WRITE 0x0008
+#endif
+
+namespace perfagent {
+
+namespace {
+
+std::atomic<uint64_t> g_cubins_offered{0};
+std::atomic<uint64_t> g_cubins_send_failed{0};
+
+// All four, always. See cubin.h for what each one prevents; the short version
+// is that three of them stop the consumer being SIGBUSed or handed mutating
+// bytes, and the fourth stops the other three being removed again.
+constexpr int kRequiredSeals =
+    F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE;
+
+// The same one-deadline-for-the-whole-exchange discipline enroll.cc uses, and
+// for the same two measured reasons: a per-syscall SO_RCVTIMEO re-armed on
+// every EINTR never expires, and a send timeout plus a receive timeout is two
+// budgets rather than one.
+struct deadline {
+    long ms;
+
+    static long now_ms() {
+        struct timespec t;
+        clock_gettime(CLOCK_MONOTONIC, &t);
+        return (long)t.tv_sec * 1000L + t.tv_nsec / 1000000L;
+    }
+    static deadline in(unsigned budget_ms) {
+        return deadline{now_ms() + (long)budget_ms};
+    }
+    long left() const {
+        const long d = ms - now_ms();
+        return d > 0 ? d : 0;
+    }
+};
+
+bool arm(int fd, const deadline &dl) {
+    const long left = dl.left();
+    if (left <= 0) return false;
+    struct timeval tv;
+    tv.tv_sec = (time_t)(left / 1000);
+    tv.tv_usec = (suseconds_t)((left % 1000) * 1000);
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) != 0) return false;
+    return setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) == 0;
+}
+
+// Fills sa/salen for an abstract name. False when the name cannot fit.
+bool abstract_addr(const char *name, struct sockaddr_un *sa, socklen_t *salen) {
+    const size_t nlen = strlen(name);
+    memset(sa, 0, sizeof(*sa));
+    sa->sun_family = AF_UNIX;
+    if (nlen + 1 > sizeof(sa->sun_path)) return false;
+    memcpy(sa->sun_path + 1, name, nlen);
+    *salen = (socklen_t)(offsetof(struct sockaddr_un, sun_path) + 1 + nlen);
+    return true;
+}
+
+}  // namespace
+
+const char *cubin_offer_result_name(CubinOfferResult r) {
+    switch (r) {
+        case kCubinOfferDisabled:   return "disabled";
+        case kCubinOfferNoAddress:  return "no-address";
+        case kCubinOfferNoListener: return "no-listener";
+        case kCubinOfferAccepted:   return "accepted";
+        case kCubinOfferRefused:    return "refused";
+        case kCubinOfferTimedOut:   return "timed-out";
+        case kCubinOfferError:      return "error";
+    }
+    return "unknown";
+}
+
+// One parser, one dev:inode derivation, two prefixes.
+//
+// The alternative - a second copy of the maps parser with a different format
+// string - is how the two channels would come to disagree about which shim
+// image they mean, and the enrolment address has already been through exactly
+// that failure once: stat(2) and /proc/<pid>/maps report different devices for
+// every file on a btrfs subvolume, so an address derived from the wrong one
+// bound a name no producer ever dialled and every counter on both sides read
+// zero. Deriving through the function that got that right is not a
+// convenience.
+bool cubin_name_from_maps(const char *maps_path, unsigned long addr, char *out,
+                          size_t outsz) {
+    if (!out || outsz == 0) return false;
+    out[0] = '\0';
+    char enroll[sizeof(((struct sockaddr_un *)nullptr)->sun_path)];
+    if (!enroll_name_from_maps(maps_path, addr, enroll, sizeof(enroll))) {
+        return false;
+    }
+    static const char kEnrollPrefix[] = "perfagent-gpu-enroll.v1.";
+    const size_t plen = sizeof(kEnrollPrefix) - 1;
+    if (strncmp(enroll, kEnrollPrefix, plen) != 0) return false;
+    const int n = snprintf(out, outsz, "perfagent-gpu-cubin.v1.%s", enroll + plen);
+    const bool ok = n > 0 && (size_t)n < outsz;
+    if (!ok) out[0] = '\0';
+    return ok;
+}
+
+bool cubin_self_name(char *out, size_t outsz) {
+    const void *self = (const void *)&cubin_self_name;
+    return cubin_name_from_maps("/proc/self/maps", (unsigned long)self, out, outsz);
+}
+
+int cubin_seal_bytes(const void *bytes, size_t len) {
+    if (!bytes || len == 0) return -1;
+    // MFD_ALLOW_SEALING is the whole point: without it F_ADD_SEALS returns
+    // EPERM and the offer would be refused by the consumer for being
+    // unsealed, which is the correct outcome but an avoidable one.
+    const int fd = memfd_create("perfagent-cubin", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+    if (fd < 0) return -1;
+
+    const char *p = (const char *)bytes;
+    size_t off = 0;
+    while (off < len) {
+        const ssize_t n = write(fd, p + off, len - off);
+        if (n > 0) {
+            off += (size_t)n;
+            continue;
+        }
+        if (n < 0 && errno == EINTR) continue;
+        close(fd);
+        return -1;
+    }
+
+    // Sealed only after the last byte is in. F_SEAL_WRITE would also fail
+    // with EBUSY if a writable MAPPING were outstanding, which is why the
+    // bytes go in through write() rather than through an mmap.
+    if (fcntl(fd, F_ADD_SEALS, kRequiredSeals) != 0) {
+        close(fd);
+        return -1;
+    }
+    // Read them back rather than assuming the kernel took them. A descriptor
+    // that reaches the consumer without every seal is refused there and the
+    // module is silently unresolvable; finding that out here makes it a
+    // counted send failure with a reason instead.
+    const int got = fcntl(fd, F_GET_SEALS, 0);
+    if (got < 0 || (got & kRequiredSeals) != kRequiredSeals) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+CubinOfferResult cubin_offer_fd(const char *name, int fd, uint64_t size,
+                                uint64_t crc, unsigned timeout_ms) {
+    if (timeout_ms == 0) return kCubinOfferDisabled;
+    if (!name || !*name) return kCubinOfferNoAddress;
+    if (fd < 0 || size == 0) return kCubinOfferError;
+
+    struct sockaddr_un sa;
+    socklen_t salen = 0;
+    if (!abstract_addr(name, &sa, &salen)) return kCubinOfferNoAddress;
+
+    g_cubins_offered.fetch_add(1, std::memory_order_relaxed);
+
+    const int sock = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (sock < 0) {
+        g_cubins_send_failed.fetch_add(1, std::memory_order_relaxed);
+        return kCubinOfferError;
+    }
+
+    const deadline dl = deadline::in(timeout_ms);
+    CubinOfferResult res = kCubinOfferError;
+    for (;;) {
+        if (!arm(sock, dl)) {
+            res = kCubinOfferTimedOut;
+            break;
+        }
+        if (connect(sock, (struct sockaddr *)&sa, salen) == 0) {
+            res = kCubinOfferAccepted;  // provisional; the reply decides
+            break;
+        }
+        if (errno == EISCONN) {
+            res = kCubinOfferAccepted;
+            break;
+        }
+        if (errno == EINTR) continue;
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINPROGRESS) {
+            res = kCubinOfferTimedOut;
+            break;
+        }
+        // An unbound abstract address gives ECONNREFUSED, and that is the
+        // ordinary case: no profiler is listening for this shim. Not a
+        // failure to send, so it is not counted as one - there was nothing to
+        // send to.
+        res = (errno == ECONNREFUSED || errno == ENOENT) ? kCubinOfferNoListener
+                                                         : kCubinOfferError;
+        break;
+    }
+    if (res != kCubinOfferAccepted) {
+        close(sock);
+        if (res != kCubinOfferNoListener) {
+            g_cubins_send_failed.fetch_add(1, std::memory_order_relaxed);
+        }
+        return res;
+    }
+
+    CubinOfferHeader h;
+    memset(&h, 0, sizeof(h));
+    h.magic = kCubinOfferMagic;
+    h.version = kCubinOfferVersion;
+    h.flags = 0;
+    h.size = size;
+    h.crc = crc;
+
+    struct iovec iov;
+    iov.iov_base = &h;
+    iov.iov_len = sizeof(h);
+
+    // The descriptor rides on the first byte of the header, so one sendmsg
+    // carries both and the consumer's first recvmsg has everything it needs
+    // to decide. Nothing streams: the payload is the memfd, not the socket.
+    union {
+        char buf[CMSG_SPACE(sizeof(int))];
+        struct cmsghdr align;
+    } cmsg;
+    memset(&cmsg, 0, sizeof(cmsg));
+
+    struct msghdr msg;
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg.buf;
+    msg.msg_controllen = sizeof(cmsg.buf);
+
+    struct cmsghdr *c = CMSG_FIRSTHDR(&msg);
+    c->cmsg_level = SOL_SOCKET;
+    c->cmsg_type = SCM_RIGHTS;
+    c->cmsg_len = CMSG_LEN(sizeof(int));
+    memcpy(CMSG_DATA(c), &fd, sizeof(int));
+
+    for (;;) {
+        if (!arm(sock, dl)) {
+            res = kCubinOfferTimedOut;
+            break;
+        }
+        const ssize_t n = sendmsg(sock, &msg, MSG_NOSIGNAL);
+        if (n == (ssize_t)sizeof(h)) {
+            res = kCubinOfferAccepted;
+            break;
+        }
+        if (n < 0 && errno == EINTR) continue;
+        // A partial header is not retried. Retrying would resend the
+        // descriptor, and a header this end cannot vouch for is exactly the
+        // kind of thing that turns into a wrong line table on the other side.
+        res = (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+                  ? kCubinOfferTimedOut
+                  : kCubinOfferError;
+        break;
+    }
+    if (res != kCubinOfferAccepted) {
+        close(sock);
+        g_cubins_send_failed.fetch_add(1, std::memory_order_relaxed);
+        return res;
+    }
+
+    char b = 0;
+    for (;;) {
+        if (!arm(sock, dl)) {
+            res = kCubinOfferTimedOut;
+            break;
+        }
+        const ssize_t n = read(sock, &b, 1);
+        if (n == 1) {
+            res = (b == kCubinReplyOK) ? kCubinOfferAccepted : kCubinOfferRefused;
+            break;
+        }
+        if (n == 0) {
+            res = kCubinOfferError;
+            break;
+        }
+        if (errno == EINTR) continue;
+        res = (errno == EAGAIN || errno == EWOULDBLOCK) ? kCubinOfferTimedOut
+                                                        : kCubinOfferError;
+        break;
+    }
+    close(sock);
+    if (res != kCubinOfferAccepted) {
+        g_cubins_send_failed.fetch_add(1, std::memory_order_relaxed);
+    }
+    return res;
+}
+
+CubinOfferResult cubin_offer(const char *name, const void *bytes, size_t len,
+                             uint64_t crc, unsigned timeout_ms) {
+    if (timeout_ms == 0) return kCubinOfferDisabled;
+    const int fd = cubin_seal_bytes(bytes, len);
+    if (fd < 0) {
+        g_cubins_offered.fetch_add(1, std::memory_order_relaxed);
+        g_cubins_send_failed.fetch_add(1, std::memory_order_relaxed);
+        return kCubinOfferError;
+    }
+    const CubinOfferResult r = cubin_offer_fd(name, fd, (uint64_t)len, crc, timeout_ms);
+    close(fd);
+    return r;
+}
+
+CubinOfferResult cubin_offer_to_consumer(const void *bytes, size_t len,
+                                         uint64_t crc, unsigned timeout_ms) {
+    if (timeout_ms == 0) return kCubinOfferDisabled;
+    char name[sizeof(((struct sockaddr_un *)nullptr)->sun_path)];
+    const void *self = (const void *)&cubin_offer_to_consumer;
+    if (!cubin_name_from_maps("/proc/self/maps", (unsigned long)self, name,
+                              sizeof(name))) {
+        return kCubinOfferNoAddress;
+    }
+    return cubin_offer(name, bytes, len, crc, timeout_ms);
+}
+
+unsigned cubin_timeout_ms(unsigned dflt) {
+    const char *v = getenv("PERFAGENT_GPU_CUBIN_TIMEOUT_MS");
+    if (!v || !*v) return dflt;
+    char *end = nullptr;
+    errno = 0;
+    const long n = strtol(v, &end, 10);
+    if (errno != 0 || end == v || *end != '\0' || n < 0 || n > 600000) return dflt;
+    return (unsigned)n;
+}
+
+uint64_t cubins_offered() {
+    return g_cubins_offered.load(std::memory_order_relaxed);
+}
+
+uint64_t cubins_send_failed() {
+    return g_cubins_send_failed.load(std::memory_order_relaxed);
+}
+
+}  // namespace perfagent

--- a/shim/core/cubin.h
+++ b/shim/core/cubin.h
@@ -1,0 +1,177 @@
+// The producer half of the cubin transport: how a module's BYTES reach the
+// consumer, on a channel that is not the enrolment rendezvous.
+//
+// # Why the bytes travel at all
+//
+// gpu_pc_sample_batch_v1 keys on cubin_crc and carries a pc_offset and a
+// function_index. It names nothing. The cubin IS the missing table: its
+// symbol table names the functions and its .debug_line turns a pc_offset into
+// a source line. Without the bytes, a PC sample is four integers.
+//
+// gpu_module_load_v1 already carries a bytes_ptr and that pointer is NOT a
+// transport. It points into THIS process's address space, and the consumer
+// reading it would need /proc/<pid>/mem or process_vm_readv - both of which
+// need CAP_SYS_PTRACE, which the agent's capability set deliberately does not
+// contain. The record is unchanged and still accurate; it simply is not how
+// the bytes get across.
+//
+// # Why this is not the enrolment socket
+//
+// enroll.h states the protocol as "The producer sends nothing", and the
+// consumer's handler implements exactly that - it never reads. An offer must
+// send a header, so a shared address would force the consumer to read in
+// order to tell an offer from an enrolment, and on a genuine enrolment that
+// read would block until this end's own budget expired. Every rendezvous
+// would become a timeout, which is issue #49's ~38% stack loss returning by a
+// different route. Three more, all on the same socket: the consumer's accept
+// loop is serial, so offers queue AHEAD of a producer already in the backlog;
+// admission is charged per connection out of one bucket, so a module-heavy
+// process would have its own ENROLMENT refused; and it would put a connect()
+// and a multi-megabyte write on the application's cuModuleLoad path.
+//
+// So: a second abstract address, derived from the same dev:inode by the same
+// parser (cubin_name_from_maps calls enroll_name_from_maps and re-prefixes
+// its result, so the two names cannot disagree about which shim they mean),
+// and a consumer-side listener, goroutine and bucket of its own.
+//
+// # The payload is a sealed memfd
+//
+// The bytes go into a memfd, the memfd is sealed, and the DESCRIPTOR is what
+// crosses the socket, by SCM_RIGHTS. The consumer mmaps it. Nothing streams,
+// so this end never blocks on the consumer's read rate - which is what lets
+// the offer run on the drain thread instead of on the application's thread.
+//
+// All four seals, and they are not decoration:
+//
+//   F_SEAL_SHRINK  without it we could ftruncate under the consumer's mmap
+//                  and SIGBUS the profiler.
+//   F_SEAL_WRITE   without it the ELF could mutate under its parser.
+//   F_SEAL_GROW    without it the size it validated is not the size it maps.
+//   F_SEAL_SEAL    without it any of the other three can be removed again.
+//
+// The consumer verifies them with fcntl(F_GET_SEALS) before it maps anything
+// and refuses an offer that is missing one, with no fallback. Applying them
+// here is therefore not politeness; an unsealed offer is a refused offer.
+//
+// # This never stalls the application
+//
+// Nothing in this header may be called from a CUPTI callback. The MODULE_LOADED
+// callback's job is the memcpy - CUPTI's buffer is only valid there - and the
+// offer belongs to the drain thread, which nothing is waiting on. See Task 5:
+// the copy is deadline-bound by CUPTI's buffer lifetime and the send is
+// deadline-bound by nothing at all, and collapsing them is how the
+// application ends up paying for the profiler.
+#ifndef PERFAGENT_CUBIN_H
+#define PERFAGENT_CUBIN_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace perfagent {
+
+// How one offer ended. Only kCubinOfferAccepted means the consumer holds the
+// bytes; every other value means that module's PC samples will read
+// gpu_src_status "no-module", which is a worse profile and never a wrong one.
+enum CubinOfferResult {
+    kCubinOfferDisabled = 0,  // timeout of 0: the caller turned it off
+    kCubinOfferNoAddress,     // /proc/self/maps had no file-backed line for us
+    kCubinOfferNoListener,    // nobody bound the address
+    kCubinOfferAccepted,      // 'K'
+    kCubinOfferRefused,       // 'X': counted on the consumer's side, by reason
+    kCubinOfferTimedOut,      // connected, but no reply inside the budget
+    kCubinOfferError,         // memfd, seal, socket, connect or send failed
+};
+
+// A stable short name for logs. Never null.
+const char *cubin_offer_result_name(CubinOfferResult r);
+
+// The offer header, on the wire ahead of the descriptor. Fixed size, little-
+// endian, naturally aligned - the same rules every USDT record follows - and
+// mirrored by gpuprobe.cubinHeader, whose decoder pins the same offsets from
+// the other side.
+//
+// `crc` is cuptiGetCubinCrc() over exactly the `size` bytes in the memfd. The
+// consumer does not recompute it: CUPTI's polynomial is not published and the
+// agent has no CUDA toolkit. It is the key gpu_pc_sample_batch_v1 joins on,
+// so what matters is that the same number reaches both ends.
+struct CubinOfferHeader {
+    uint32_t magic;
+    uint16_t version;
+    uint16_t flags;  // reserved; must be 0, and a non-zero one is refused
+    uint64_t size;
+    uint64_t crc;
+};
+
+// 'C' 'U' 'B' '1' read little-endian, i.e. the four bytes in that order.
+constexpr uint32_t kCubinOfferMagic =
+    (uint32_t)'C' | ((uint32_t)'U' << 8) | ((uint32_t)'B' << 16) |
+    ((uint32_t)'1' << 24);
+constexpr uint16_t kCubinOfferVersion = 1;
+
+static_assert(sizeof(CubinOfferHeader) == 24, "the offer header is 24 bytes");
+static_assert(offsetof(CubinOfferHeader, magic) == 0, "magic at 0");
+static_assert(offsetof(CubinOfferHeader, version) == 4, "version at 4");
+static_assert(offsetof(CubinOfferHeader, flags) == 6, "flags at 6");
+static_assert(offsetof(CubinOfferHeader, size) == 8, "size at 8");
+static_assert(offsetof(CubinOfferHeader, crc) == 16, "crc at 16");
+
+// The reply, one byte, spelled the same way the enrolment reply is.
+constexpr char kCubinReplyOK = 'K';
+constexpr char kCubinReplyRefused = 'X';
+
+// Builds the offer name for the mapping that contains `addr`, reading
+// `maps_path` in the /proc/<pid>/maps format. Implemented on top of
+// enroll_name_from_maps so there is ONE parser and ONE dev:inode derivation
+// for both channels: they must always agree about which shim image they mean.
+bool cubin_name_from_maps(const char *maps_path, unsigned long addr, char *out,
+                          size_t outsz);
+
+// The offer name this image derives for itself, without connecting.
+bool cubin_self_name(char *out, size_t outsz);
+
+// Copies `len` bytes into a fresh memfd and applies every required seal.
+// Returns the descriptor, or -1. The caller closes it.
+//
+// One place applies the seals, so "which seals" is a fact about this function
+// rather than a convention spread over its callers.
+int cubin_seal_bytes(const void *bytes, size_t len);
+
+// Offers an already-sealed descriptor. Does NOT close `fd`.
+//
+// `timeout_ms` is ONE budget for the whole offer - connect, send and reply
+// together - against a CLOCK_MONOTONIC deadline taken on entry, for the same
+// two measured reasons enroll.cc spells out: a per-syscall timeout re-armed
+// on EINTR never expires, and one timeout per phase is two budgets.
+CubinOfferResult cubin_offer_fd(const char *name, int fd, uint64_t size,
+                                uint64_t crc, unsigned timeout_ms);
+
+// Seals `bytes` and offers them to `name`.
+CubinOfferResult cubin_offer(const char *name, const void *bytes, size_t len,
+                             uint64_t crc, unsigned timeout_ms);
+
+// The whole offer for the image this function is linked into: derive the name
+// from our own mapping, seal, connect, send, wait.
+//
+// Call it from the DRAIN THREAD. Never from a CUPTI callback.
+CubinOfferResult cubin_offer_to_consumer(const void *bytes, size_t len,
+                                         uint64_t crc, unsigned timeout_ms);
+
+// The offer budget, from PERFAGENT_GPU_CUBIN_TIMEOUT_MS, or `dflt` when unset
+// or unparseable. An explicit 0 disables offers outright.
+unsigned cubin_timeout_ms(unsigned dflt);
+
+// The two producer-side counters from the plan's table.
+//
+//   cubins_offered      modules this shim tried to hand over
+//   cubins_send_failed  refused, timed out, or short-written
+//
+// Both are monotonic and both are read by the adapter's stats dump. A module
+// that is offered and not accepted is a module whose PC samples will read
+// "no-module", so the difference between these two is exactly the size of
+// what this process could not explain.
+uint64_t cubins_offered();
+uint64_t cubins_send_failed();
+
+}  // namespace perfagent
+
+#endif

--- a/shim/core/cubin_test.cc
+++ b/shim/core/cubin_test.cc
@@ -1,0 +1,322 @@
+// The producer half of the cubin transport, without a consumer: a hand-rolled
+// abstract-socket receiver stands in for gpuprobe's listener.
+//
+// What this proves that the Go tests cannot: that the bytes THIS end puts on
+// the wire are the 24 bytes the format says, in the order it says, and that
+// the descriptor it hands over really carries all four seals. The Go tests
+// prove the other direction against a Go producer; only a test that reads the
+// C++ producer's own sendmsg can catch a struct-layout or endianness drift
+// between the two halves.
+#include "cubin.h"
+
+#include "enroll.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#ifndef F_GET_SEALS
+#define F_GET_SEALS 1034
+#endif
+#ifndef F_SEAL_SEAL
+#define F_SEAL_SEAL 0x0001
+#endif
+#ifndef F_SEAL_SHRINK
+#define F_SEAL_SHRINK 0x0002
+#endif
+#ifndef F_SEAL_GROW
+#define F_SEAL_GROW 0x0004
+#endif
+#ifndef F_SEAL_WRITE
+#define F_SEAL_WRITE 0x0008
+#endif
+
+using perfagent::CubinOfferHeader;
+using perfagent::CubinOfferResult;
+using perfagent::cubin_name_from_maps;
+using perfagent::cubin_offer;
+using perfagent::cubin_offer_result_name;
+using perfagent::cubin_seal_bytes;
+using perfagent::cubin_timeout_ms;
+using perfagent::cubins_offered;
+using perfagent::cubins_send_failed;
+using perfagent::kCubinOfferAccepted;
+using perfagent::kCubinOfferDisabled;
+using perfagent::kCubinOfferMagic;
+using perfagent::kCubinOfferNoListener;
+using perfagent::kCubinOfferRefused;
+using perfagent::kCubinOfferVersion;
+using perfagent::kCubinReplyOK;
+using perfagent::kCubinReplyRefused;
+
+namespace {
+
+int bind_abstract(const char *name) {
+    const int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    assert(fd >= 0);
+    struct sockaddr_un sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sun_family = AF_UNIX;
+    const size_t nlen = strlen(name);
+    memcpy(sa.sun_path + 1, name, nlen);
+    const socklen_t salen =
+        (socklen_t)(offsetof(struct sockaddr_un, sun_path) + 1 + nlen);
+    assert(bind(fd, (struct sockaddr *)&sa, salen) == 0);
+    assert(listen(fd, 8) == 0);
+    return fd;
+}
+
+// What one accepted offer looked like from the receiving side.
+struct received {
+    bool got = false;
+    unsigned char raw[64] = {0};
+    ssize_t raw_len = 0;
+    int fd = -1;
+    int seals = 0;
+    std::string body;
+};
+
+// Accepts one offer, records exactly what arrived, and answers with `reply`.
+std::thread receive_once(int lfd, received *out, char reply) {
+    return std::thread([lfd, out, reply] {
+        const int cfd = accept(lfd, nullptr, nullptr);
+        if (cfd < 0) return;
+        struct iovec iov;
+        iov.iov_base = out->raw;
+        iov.iov_len = sizeof(out->raw);
+        union {
+            char buf[CMSG_SPACE(sizeof(int) * 4)];
+            struct cmsghdr align;
+        } cmsg;
+        memset(&cmsg, 0, sizeof(cmsg));
+        struct msghdr msg;
+        memset(&msg, 0, sizeof(msg));
+        msg.msg_iov = &iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = cmsg.buf;
+        msg.msg_controllen = sizeof(cmsg.buf);
+
+        out->raw_len = recvmsg(cfd, &msg, 0);
+        for (struct cmsghdr *c = CMSG_FIRSTHDR(&msg); c; c = CMSG_NXTHDR(&msg, c)) {
+            if (c->cmsg_level != SOL_SOCKET || c->cmsg_type != SCM_RIGHTS) continue;
+            memcpy(&out->fd, CMSG_DATA(c), sizeof(int));
+        }
+        if (out->fd >= 0) {
+            out->seals = fcntl(out->fd, F_GET_SEALS, 0);
+            char buf[4096];
+            ssize_t n = 0;
+            off_t off = 0;
+            while ((n = pread(out->fd, buf, sizeof(buf), off)) > 0) {
+                out->body.append(buf, (size_t)n);
+                off += n;
+            }
+        }
+        out->got = out->raw_len > 0;
+        const ssize_t w = write(cfd, &reply, 1);
+        (void)w;
+        close(cfd);
+    });
+}
+
+uint32_t le32(const unsigned char *p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) |
+           ((uint32_t)p[3] << 24);
+}
+uint16_t le16(const unsigned char *p) {
+    return (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+}
+uint64_t le64(const unsigned char *p) {
+    uint64_t v = 0;
+    for (int i = 7; i >= 0; i--) v = (v << 8) | p[i];
+    return v;
+}
+
+// The seals are the whole reason an offer is safe to map, so they are checked
+// here on the descriptor that actually crossed the socket rather than on the
+// one the producer still holds.
+void test_seals_are_applied_and_survive_the_socket() {
+    const std::string body(5 * 1024, 'z');
+    const char *name = "perfagent-cubin-test.seals";
+    const int lfd = bind_abstract(name);
+    received got;
+    std::thread t = receive_once(lfd, &got, kCubinReplyOK);
+
+    const CubinOfferResult r = cubin_offer(name, body.data(), body.size(), 0xC0FFEEULL, 2000);
+    t.join();
+    close(lfd);
+    if (got.fd >= 0) close(got.fd);
+
+    assert(r == kCubinOfferAccepted);
+    assert(got.got);
+    assert(got.fd >= 0 && "the descriptor never crossed: SCM_RIGHTS did not go out");
+    assert(got.seals >= 0 && "F_GET_SEALS failed: this is not a sealable memfd");
+    assert((got.seals & F_SEAL_SEAL) && "F_SEAL_SEAL missing: the others can be removed again");
+    assert((got.seals & F_SEAL_SHRINK) &&
+           "F_SEAL_SHRINK missing: a peer could ftruncate under the consumer's mmap and SIGBUS it");
+    assert((got.seals & F_SEAL_GROW) && "F_SEAL_GROW missing: the validated size is not the mapped size");
+    assert((got.seals & F_SEAL_WRITE) && "F_SEAL_WRITE missing: the ELF can mutate under the parser");
+    assert(got.body == body && "the memfd's contents are not the bytes offered");
+}
+
+// The 24 bytes on the wire, read as bytes rather than as a struct: a struct
+// cast would agree with itself no matter what the layout was.
+void test_the_header_is_the_documented_24_bytes() {
+    const std::string body = "cubin";
+    const char *name = "perfagent-cubin-test.header";
+    const int lfd = bind_abstract(name);
+    received got;
+    std::thread t = receive_once(lfd, &got, kCubinReplyOK);
+
+    const CubinOfferResult r =
+        cubin_offer(name, body.data(), body.size(), 0x0123456789ABCDEFULL, 2000);
+    t.join();
+    close(lfd);
+    if (got.fd >= 0) close(got.fd);
+
+    assert(r == kCubinOfferAccepted);
+    assert(got.raw_len == (ssize_t)sizeof(CubinOfferHeader));
+    assert(le32(got.raw + 0) == kCubinOfferMagic);
+    assert(got.raw[0] == 'C' && got.raw[1] == 'U' && got.raw[2] == 'B' && got.raw[3] == '1');
+    assert(le16(got.raw + 4) == kCubinOfferVersion);
+    assert(le16(got.raw + 6) == 0 && "flags are reserved and must go out as zero");
+    assert(le64(got.raw + 8) == body.size());
+    assert(le64(got.raw + 16) == 0x0123456789ABCDEFULL);
+}
+
+// A refusal is not a crash and not a retry: the module simply goes
+// unresolvable, and the counter says so.
+void test_a_refusal_is_counted_as_a_send_failure() {
+    const uint64_t before_offered = cubins_offered();
+    const uint64_t before_failed = cubins_send_failed();
+
+    const std::string body = "refused";
+    const char *name = "perfagent-cubin-test.refused";
+    const int lfd = bind_abstract(name);
+    received got;
+    std::thread t = receive_once(lfd, &got, kCubinReplyRefused);
+
+    const CubinOfferResult r = cubin_offer(name, body.data(), body.size(), 7, 2000);
+    t.join();
+    close(lfd);
+    if (got.fd >= 0) close(got.fd);
+
+    assert(r == kCubinOfferRefused);
+    assert(cubins_offered() == before_offered + 1);
+    assert(cubins_send_failed() == before_failed + 1);
+}
+
+// Nobody listening is the ordinary case in an unprofiled process, and it must
+// cost nothing and count nothing as a failure: there was nothing to send to.
+void test_no_listener_is_not_a_send_failure() {
+    const uint64_t before_failed = cubins_send_failed();
+    const std::string body = "x";
+    const CubinOfferResult r =
+        cubin_offer("perfagent-cubin-test.nobody-is-here", body.data(), body.size(), 1, 500);
+    assert(r == kCubinOfferNoListener);
+    assert(cubins_send_failed() == before_failed &&
+           "an unprofiled process must not accumulate send failures");
+}
+
+// A timeout of 0 turns the channel off outright, and must do so before a
+// memfd is created or an offer is counted.
+void test_zero_timeout_disables_offers_entirely() {
+    const uint64_t before_offered = cubins_offered();
+    const std::string body = "x";
+    assert(cubin_offer("perfagent-cubin-test.disabled", body.data(), body.size(), 1, 0) ==
+           kCubinOfferDisabled);
+    assert(cubins_offered() == before_offered);
+}
+
+// The two channels must never disagree about WHICH shim image they mean, so
+// the cubin name is derived through the enrolment name's own parser. This
+// pins that: same dev:inode tail, different prefix.
+void test_the_two_channel_names_share_one_derivation() {
+    char path[] = "/tmp/perfagent_cubin_mapsXXXXXX";
+    const int fd = mkstemp(path);
+    assert(fd >= 0);
+    const char *body =
+        "55e0d0a00000-55e0d0a01000 r--p 00000000 fd:01 100 /bin/thing\n"
+        "7fc9a0a00000-7fc9a0a21000 r-xp 00001000 08:02 4242 /lib/libshim.so\n";
+    const ssize_t n = write(fd, body, strlen(body));
+    assert(n == (ssize_t)strlen(body));
+    close(fd);
+
+    char enroll_name[128] = {0};
+    char cubin_name[128] = {0};
+    assert(perfagent::enroll_name_from_maps(path, 0x7fc9a0a00100UL, enroll_name,
+                                            sizeof(enroll_name)));
+    assert(cubin_name_from_maps(path, 0x7fc9a0a00100UL, cubin_name, sizeof(cubin_name)));
+    unlink(path);
+
+    assert(strcmp(enroll_name, "perfagent-gpu-enroll.v1.8.2.4242") == 0);
+    assert(strcmp(cubin_name, "perfagent-gpu-cubin.v1.8.2.4242") == 0);
+
+    // And the tails are literally the same characters, not merely equal
+    // today: that is what "one derivation" means.
+    const char *etail = strrchr(enroll_name, 'v');
+    const char *ctail = strrchr(cubin_name, 'v');
+    assert(etail && ctail && strcmp(etail, ctail) == 0);
+
+    // An anonymous mapping has no inode a uprobe could attach to, so it has
+    // no name on either channel.
+    char none[128] = {0};
+    assert(!cubin_name_from_maps(path, 0x1UL, none, sizeof(none)));
+    assert(none[0] == '\0');
+}
+
+void test_seal_bytes_refuses_nothing_to_seal() {
+    assert(cubin_seal_bytes(nullptr, 0) < 0);
+    const char b = 'x';
+    assert(cubin_seal_bytes(&b, 0) < 0);
+    const int fd = cubin_seal_bytes(&b, 1);
+    assert(fd >= 0);
+    const int seals = fcntl(fd, F_GET_SEALS, 0);
+    assert((seals & (F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE)) ==
+           (F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE));
+    close(fd);
+}
+
+void test_timeout_env_parsing() {
+    unsetenv("PERFAGENT_GPU_CUBIN_TIMEOUT_MS");
+    assert(cubin_timeout_ms(1500) == 1500);
+    setenv("PERFAGENT_GPU_CUBIN_TIMEOUT_MS", "250", 1);
+    assert(cubin_timeout_ms(1500) == 250);
+    // An explicit 0 is a choice, not an absent value.
+    setenv("PERFAGENT_GPU_CUBIN_TIMEOUT_MS", "0", 1);
+    assert(cubin_timeout_ms(1500) == 0);
+    setenv("PERFAGENT_GPU_CUBIN_TIMEOUT_MS", "not-a-number", 1);
+    assert(cubin_timeout_ms(1500) == 1500);
+    unsetenv("PERFAGENT_GPU_CUBIN_TIMEOUT_MS");
+}
+
+void test_result_names_are_never_null() {
+    for (int i = 0; i <= (int)perfagent::kCubinOfferError; i++) {
+        const char *n = cubin_offer_result_name((CubinOfferResult)i);
+        assert(n && *n);
+    }
+}
+
+}  // namespace
+
+int main() {
+    test_the_two_channel_names_share_one_derivation();
+    test_seal_bytes_refuses_nothing_to_seal();
+    test_seals_are_applied_and_survive_the_socket();
+    test_the_header_is_the_documented_24_bytes();
+    test_a_refusal_is_counted_as_a_send_failure();
+    test_no_listener_is_not_a_send_failure();
+    test_zero_timeout_disables_offers_entirely();
+    test_timeout_env_parsing();
+    test_result_names_are_never_null();
+    printf("cubin_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
**Task 3 of [the GPU PC sampling plan](docs/superpowers/plans/2026-08-25-gpu-pc-sampling.md)** — the task the plan calls riskiest, since everything Tier B does sits behind it.

### Why not the enrollment socket

The first draft of the plan carried cubins there. Review found that unimplementable, and the reason is issue #49 returning by another route: `enroll.h` states the protocol as "the producer sends nothing" and `handle()` implements exactly that — creds → admit → uid/pid → `procMapsHaveInode` → `reg.enroll` → one status byte, **never reading**. A cubin offer must send a header, so a shared socket forces a read to discriminate, and on a genuine enrollment connection that read blocks until the producer's 2 s budget expires: every rendezvous becomes a 2 s stall ending in `kEnrollError`.

Three more on the same socket: `serve()` is serial **at `Accept`**, so offers queue ahead of a producer already in the backlog; admission is charged per connection at 32/s, so a module-heavy workload refuses genuine enrollments and silently restores the ~38% stack loss #49 measured; and it would put a `connect()` plus a 2 MB write on the application's `cuModuleLoad` path.

### What landed

A second channel, structurally separate. **`gpuprobe/enroll.go` and `shim/core/enroll.{h,cc}` are byte-for-byte unchanged** — reuse is by *calling* `enrollShimIdentity` (inheriting the btrfs `stat`-vs-`maps` fix), `enrollPeerCreds`, `procMapsHaveInode` and `enrollRequiredUID`. On the C++ side `cubin_name_from_maps` calls `enroll_name_from_maps` and re-prefixes, so **one** maps parser and **one** dev:inode derivation feed both channels and cannot drift.

Wire: `@perfagent-gpu-cubin.v1.<maj>.<min>.<ino>`, one `sendmsg` carrying a 24-byte little-endian header (`magic 'CUB1' | version | flags | size | crc`) plus one descriptor; reply `'K'`/`'X'`. Pinned from both sides — `static_assert`s in C++, byte-level assertions in both suites.

### Seals

All four (`F_SEAL_SEAL|SHRINK|GROW|WRITE`) verified with `F_GET_SEALS` **before `fstat` and before `mmap`**, with no fallback branch in existence. Without `F_SEAL_SHRINK` a peer can `ftruncate` under our `mmap` and SIGBUS the agent; without `F_SEAL_WRITE` the ELF mutates mid-parse.

Tested with each seal missing in turn, plus a pipe (`EINVAL`) and — the sneaky case — an **unsealed tmpfs file**, since tmpfs is sealable and answers `F_SEAL_SEAL` alone.

### Counters

All nine implemented and assertable, each asserted at **zero** on healthy runs via `assertNoCubinRejections`. Two judgement calls, both flagged: a tenth counter `CubinsDuplicate`, because the plan requires the duplicate-CRC no-op be counted and none of the nine could hold it without lying; and the total-bytes ceiling counted in `CubinsRejectedTooLarge` with the reason string distinguishing it.

An oversized cubin is rejected **whole**, never truncated — a truncated cubin parses into a *wrong* line table, the one failure worse than no line table.

### The isolation test, both orders

AHEAD is built by wedging a genuine offer inside the store so the cubin `Accept` loop is occupied and 512 offers queue in its backlog *before* the enrolment dials — the direction a shared socket fails:

```
AHEAD:  cubin offered=513 received=130 throttled=383 | enrol requests=1 confirmed=1 throttled=0
BEHIND: cubin offered=512 received=129 throttled=383 | enrol requests=2 confirmed=2 throttled=0
```

### The no-read regression, asserted structurally

Twice: behaviourally (a producer that writes nothing is answered promptly) **and** by walking the `go/ast` of `enrollListener.handle` and failing on any read call. A behavioural test alone would pass for a handler that reads with a short deadline, so it would not stop someone adding a discriminating read later.

Beyond the brief: a cross-language wire test that builds the real C++ producer and runs it against the real Go listener on **both filesystems** — btrfs and tmpfs — with the 5 KB fixture generated independently on each side.

### Cannot verify — and one is load-bearing

`CapEff: 0`, no GPU. Everything here moves a synthetic fixture, so a real `MODULE_LOADED` cubin surviving byte-identical is unproven.

More important: **that `cuptiGetCubinCrc()` over the received bytes equals the `cubinCrc` the PC records carry.** The agent cannot recompute it and trusts the header as the join key. If those disagree on hardware, every Tier B sample resolves `no-module` **with all counters green** — which is this project's signature failure mode. It is the first thing the GPU run must check.

Task 5 inherits the "copy in the callback, offer on the drain thread" rule in writing — stated in `cubin.h` rather than left to recollection.