### PR TITLE
gpu: ModuleStore, the bounded CRC-keyed store behind gpu_src_status

### DIFF
--- a/.superpowers/sdd/task-4-modulestore-report.md
+++ b/.superpowers/sdd/task-4-modulestore-report.md
@@ -1,0 +1,365 @@
+# Task 4 — `gpu.ModuleStore`, the bounded CRC-keyed store
+
+Branch `feat/gpu-module-store`. One commit. Plan:
+`docs/superpowers/plans/2026-08-25-gpu-pc-sampling.md`, Task 4. Predecessor:
+`internal/cubin` (Task 1, merged) and `.superpowers/sdd/task-1-cubin-report.md`.
+
+Two files, both new: `gpu/modulestore.go` and `gpu/modulestore_test.go`. Nothing
+else in the repository was touched — `Timeline`, `LaunchCache`, the join and the
+projection are untouched, and nothing consumes the store yet.
+
+**Cannot verify.** The plan states of this task: *"Must be measured on the RTX
+3090 afterwards: nothing."* That held — but three things are premises rather than
+findings and must be read as untested:
+
+- **`functionIndex` is assumed to be the cubin's `.symtab` index.** The store
+  keys its `functionIndex → name` table on `cubin.Function.SymIndex`, which is
+  the design's finding-2 premise and is measured by Task 6, not here. Task 1
+  exposed `SymIndex` without asserting it and this task consumes it the same
+  way: the tests read the index out of the fixture rather than hard-coding one,
+  so they assert the store uses it *consistently*, never that CUPTI agrees. If
+  Task 6 measures otherwise, the pre-approved fallback (`gpu_pc_sample_batch_v2`
+  with `kernel_id`) changes one map in `indexFunctions` and the `Resolve`
+  lookup, not the status logic or any counter.
+- **Nothing here has seen a real cubin from `MODULE_LOADED`.** Every module the
+  store has ever held is one of Task 1's four `sm_86` / CUDA 13.3 fixtures, or a
+  deliberate corruption of one.
+- **This machine has `CapEff: 0` and no GPU.** No BPF, no CUPTI, no shim was run.
+
+---
+
+## 1. The API as built
+
+```go
+type ModuleStore struct{ /* unexported */ }
+
+func NewModuleStore(cfg ModuleStoreConfig) *ModuleStore
+func (s *ModuleStore) Put(crc uint64, b []byte) error
+func (s *ModuleStore) Resolve(crc uint64, functionIndex uint32, pcOffset uint64) Resolution
+func (s *ModuleStore) Len() int
+func (s *ModuleStore) Stats() ModuleStoreStats
+
+type ModuleStoreConfig struct {
+    Capacity int   // modules; 0 -> 512
+    MaxBytes int64 // total stored cubin bytes; 0 -> 64 MiB
+}
+
+type Resolution struct{ /* unexported */ }
+func (r Resolution) Status() SrcStatus
+func (r Resolution) Source() (function, file string, line uint32, ok bool)
+
+type SrcStatus uint8
+const (SrcResolved; SrcNoLineInfo; SrcNoModule; SrcUnmapped) // plus an unexported zero
+func SrcStatuses() []SrcStatus
+func (s SrcStatus) String() string
+func (s SrcStatus) MarshalJSON() ([]byte, error)
+```
+
+`Put` and `Resolve` are exactly the two entry points the plan specifies, with
+the specified signatures. `Resolution` carries `{Status, Function, File, Line}`
+as specified — through two methods rather than four fields, for the reason in
+§2.
+
+Two deviations from a literal reading, both deliberate:
+
+**`Put` does not retain `b`.** It copies. This is not defensiveness about
+mutation: Task 3 hands the store an `mmap` of a sealed memfd and drops the
+mapping once the offer is handled, which is precisely why Task 1 wrote
+`TestParseDoesNotRetainInput`. A store that retained the caller's slice would
+put that use-after-unmap hazard straight back one layer up. The copy is what
+`MaxBytes` bounds. `TestPutDoesNotRetainCallerBytes` scribbles `0xAA` over the
+caller's buffer after `Put` and resolves correctly afterwards.
+
+**`Put`'s error is diagnostic, not a rejection.** An unparseable cubin is
+*stored* (so a re-offer is not re-parsed), counted in `ModulesUnparseable`, and
+resolves as `no-module` — and the parse error is returned so the caller can log
+*why*. That is documented on `Put` with an explicit warning that a non-nil error
+does not mean "retry"; the counters, not the error, are the record. There is
+consequently no special case for empty or nil bytes: `cubin.Parse` rejects them
+like any other non-ELF, so there is exactly one path and no uncounted refusal.
+
+---
+
+## 2. How the four-valued status is made structurally unavoidable
+
+The plan requires that the store be the single place `gpu_src_status` is
+decided, "structurally true, not merely documented". Four mechanisms, each
+closing a different hole:
+
+**(a) `Resolution` has no exported fields and no exported constructor.** Its
+four fields — `status`, `function`, `file`, `line` — are unexported and the type
+lives in `package gpu`. No code outside this package can build a `Resolution`
+carrying a status the store did not choose, or attach a file and line to a
+status that has none. This is the load-bearing one: everything downstream (Task
+9's labels) reads a `Resolution`, and a `Resolution` can only come from
+`Resolve`.
+
+**(b) The source location is reachable only through `Source`, which returns
+`ok` in the same expression.** There are deliberately no `File()` / `Line()` /
+`Function()` getters. A caller who wants the location must take the `ok`
+alongside it, so emitting `gpu_src_func` under a `no-lineinfo` status requires
+*ignoring a returned bool*, not merely forgetting a check. `Source` returns
+`("", "", 0, false)` for every status but `SrcResolved`, so there is no partial
+location to leak even if someone does ignore it.
+
+**(c) Four unexported constructors, one per status, and three of them take no
+arguments.** `resolvedAt(fn, file, line)`, `noModule()`, `noLineInfo()`,
+`unmapped()`. The three non-resolved ones *cannot* carry a location because
+they have no parameters — the type signature does the work, not a convention.
+`Resolve` has exactly four return points and each calls exactly one constructor
+and increments exactly one counter, adjacent, on the same two lines.
+
+**(d) The zero value is not one of the four.** `srcStatusInvalid` is the
+unexported `iota` zero, so the four real values start at 1. A struct that was
+never given a status therefore holds a status that is not a status, and it says
+so: `String()` returns `"unset-src-status"` for the zero and
+`"invalid-src-status-N"` for a fabricated one (two different causes, named
+apart), and `MarshalJSON` **errors** on both, matching `ClockDomain` and
+`GPUCapability` in this package. So a status nobody decided cannot reach a
+serialized profile at all — it fails at the boundary rather than shipping a
+string a consumer would read as meaningful. `Resolve` never returns it.
+
+`SrcStatuses()` returns the four in stable order so a downstream switch can be
+tested for exhaustiveness against the enum itself rather than a hand-copied
+list. The four strings — `resolved`, `no-lineinfo`, `no-module`, `unmapped` —
+are pinned by `TestSrcStatusesIsExhaustiveAndStable`; they are the label values,
+not cosmetics, and rewording one would silently change the profile.
+
+What is *not* claimed: `SrcStatus` is a `uint8`, so a caller can still write
+`gpu.SrcStatus(99)` in their own variable. They cannot get it out of a
+`Resolution`, cannot get it into one, and cannot serialize it. A struct-wrapped
+enum would have closed even that, at the cost of turning the constants into
+mutable package-level `var`s — a strictly worse hole. The chosen shape puts the
+guarantee where the data actually flows.
+
+---
+
+## 3. The damaged-table decision, and why it gets its own counter
+
+Task 1 found a third line-info state its two-valued split did not cover and
+recommended: *"map the damaged-table case to `no-module`, not `no-lineinfo`."*
+**Followed exactly.** `Resolve`'s decision order:
+
+| condition | status | counter |
+| --- | --- | --- |
+| CRC not held (never arrived, or evicted) | `no-module` | `ResolveNoModule` |
+| bytes did not parse (`cubin.Parse` failed) | `no-module` | `ResolveNoModule` |
+| `.debug_line` present but damaged (`LineInfoErr() != nil`) | `no-module` | `ResolveNoModule` |
+| no `.debug_line` at all | `no-lineinfo` | `ResolveNoLineInfo` |
+| `functionIndex` not in the module's symbol table | `unmapped` | `ResolveUnmapped` |
+| line table does not cover this `pcOffset` | `unmapped` | `ResolveUnmapped` |
+| otherwise | `resolved` | `ResolveResolved` |
+
+The reasoning Task 1 gave is the reasoning implemented: `no-lineinfo` tells the
+operator to add a build flag they already passed, which is an active lie about
+the build. `no-module` says "we hold nothing usable", which is true.
+
+A fourth row deserves naming because the plan's table does not cover it: **a
+module that has a line table, but whose particular function carries no sequence
+in it**, answers `unmapped`, not `no-lineinfo` — by the same rule. The module
+*was* built with `-lineinfo`; saying otherwise would misdirect the reader
+identically.
+
+### The counter: separate, not folded into `ModulesUnparseable`
+
+The brief invited either "`ModulesUnparseable` covers this case too" or a
+reason a separate counter is better. **A separate counter — `ModulesDamagedLineInfo`
+— is better, and here is why.**
+
+The two conditions produce the same *status* but point at different *causes*:
+
+- `ModulesUnparseable` means the bytes did not survive transport, or are not a
+  cubin at all. The operator inspects the Task 3 channel.
+- `ModulesDamagedLineInfo` means the ELF is fine and **our reader** refused the
+  DWARF inside it. Task 1's `relocSequences` refuses the whole table on any
+  layout it does not recognize — the exact shape a future toolkit emitting
+  `.debug_line` differently would take. The operator inspects the toolkit and
+  the reader, not the channel.
+
+Folded together, a toolkit change would climb `ModulesUnparseable` and send an
+operator to audit a transport that is working perfectly. That is this project's
+recurring defect class — a counter that reads the wrong colour when things are
+worst — arriving by a new route. The plan's own rationale for keeping
+`ModulesUnparseable` and `ModulesWithoutLineInfo` apart ("what makes a transport
+bug distinguishable from a build-flag choice") is the same argument one level
+down, so splitting here is consistent with the plan rather than a departure from
+it.
+
+Both counters are asserted non-interchangeably:
+`TestDamagedLineTableResolvesAsNoModuleNotNoLineInfo` requires
+`ModulesDamagedLineInfo == 1` *and* `ModulesUnparseable == 0` *and*
+`ModulesWithoutLineInfo == 0` on a module whose ELF parses and whose DWARF does
+not; `TestUnparseableIsNotWithoutLineInfo` requires the mirror.
+
+---
+
+## 4. Counters, and the two sum identities
+
+All eight counters the plan names are present under exactly those names.
+`ModulesEvicted` gained a two-way breakdown and there are two additions
+(`ModulesWithLineInfo`, `ModulesDamagedLineInfo`), both so that the module side
+*reconciles* rather than merely reports.
+
+```
+Live, LiveBytes                                   gauges of what is held now
+
+ModulesStored                                     distinct modules ever admitted
+ModulesEvicted = ModulesEvictedCapacity
+               + ModulesEvictedBytes              identity, tested
+
+ModulesStored = ModulesWithLineInfo
+              + ModulesWithoutLineInfo
+              + ModulesDamagedLineInfo
+              + ModulesUnparseable                identity, tested
+
+Resolve calls = ResolveResolved + ResolveNoModule
+              + ResolveNoLineInfo
+              + ResolveUnmapped                   THE identity, tested
+```
+
+The plan's identity — "the four `Resolve*` counters must sum to every `Resolve`
+call" — is tested by wrapping the store in a `counting` type in the test file
+that increments a local call counter on every `Resolve` and comparing it against
+`Stats().ResolveTotal()`. It is asserted at the end of five separate tests,
+including a 384-call mixed workload that reaches all four statuses
+(`TestModuleStoreResolveCountersSumToEveryCall`) and the concurrent test.
+
+The classification counters are cumulative, not gauges — an evicted module's
+classification is not un-counted — which is documented on the type, because
+`ModulesStored` being the denominator rather than `Live` is exactly the kind of
+thing that gets misread.
+
+---
+
+## 5. LRU behaviour and bounds
+
+**It is a real LRU: recency is refreshed by `Resolve`, not only by `Put`.** A
+module under active PC sampling must survive a burst of unrelated module loads,
+which is precisely what an insertion-ordered FIFO would fail to do — its samples
+would silently start answering `no-module` while the store still had room for
+it.
+
+**`orderedFIFO` was deliberately not reused**, despite being the package's
+shared bounded-FIFO mechanism. It reclaims superseded positions only while
+something is evicting, so touching an entry on every `Resolve` — a per-PC-sample
+operation — would grow its `order` slice without bound whenever the store sits
+*under* its capacity. That is the opposite of "bounded means bounded". A
+`container/list` LRU has no such garbage: a touch is `MoveToFront`, O(1), zero
+allocation. `Resolve` therefore takes the write lock; PC-sample decoding is
+batched, so contention is per batch, not per sample.
+
+**Two bounds, because one is not a bound.** `Capacity` caps distinct modules;
+`MaxBytes` caps total held bytes. A count bound alone is not a memory bound —
+cubins run from a few KB to hundreds of KB, so 512 modules is anywhere from a
+few MB to a hundred — and a byte bound alone misses map and list overhead under
+a flood of tiny modules. Capacity evictions and byte evictions are counted
+separately and sum to `ModulesEvicted`.
+
+`MaxBytes` is **absolute**: a single module larger than the whole budget is
+stored, then evicted along with everything else, leaving the store empty rather
+than one entry over the limit. Its `Resolve`s then answer `no-module`, which is
+true — it is not held. `TestModuleStoreOversizedModuleLeavesTheStoreEmpty` pins
+that.
+
+**There is no memoized resolution anywhere in the type.** Every answer is
+derived from the stored bytes on every call. That is what makes the
+after-eviction guarantee absolute rather than probabilistic.
+
+---
+
+## 6. Tests
+
+`go test ./gpu/ -run ModuleStore -count=1` — 16 tests, all pass. Table-driven
+over Task 1's fixtures, read from `../internal/cubin/testdata/` rather than
+copied into `gpu/testdata/`: two copies of a binary fixture drift, and the point
+is that this store answers correctly about the *same bytes* Task 1 asserts its
+own claims against.
+
+- `TestModuleStoreAllFourStatusesAreReachable` — the core table. Seven cases
+  producing all four statuses, each asserted against `SrcStatuses()` so a
+  status no case reaches fails the test; exact per-counter values; the sum
+  identity; and, for every non-resolved case, that `Source()` returns `false`
+  with all three data returns zero.
+- `TestModuleStoreResolveCountersSumToEveryCall` — 384 calls across a
+  `-lineinfo` module, a no-`-lineinfo` module, a truncated module and an absent
+  CRC, with every status positive and the identity holding.
+- `TestSrcStatusZeroValueIsNotAStatus`, `TestSrcStatusesIsExhaustiveAndStable` —
+  §2(d): the zero is not in `SrcStatuses()`, names itself apart from a
+  fabricated value, and neither serializes; the four wire strings are pinned;
+  `SrcStatuses()` returns a copy.
+- `TestDamagedLineTableResolvesAsNoModuleNotNoLineInfo`,
+  `TestUnparseableIsNotWithoutLineInfo` — §3, both directions.
+- `TestModuleStoreResolvesExactSourceLines` — the exact `(pcOffset → line)`
+  table for `addOne`, all eight row boundaries plus four interior PCs plus
+  three past `end_sequence`. Task 1 notes lines 10, 9, 10 at `0xa0/0xb0/0xc0`:
+  the table is not monotonic, so a merely plausible-looking answer does not
+  pass.
+- `TestModuleStoreBindsFunctionIndexToTheRightKernel` — the two-kernel fixture,
+  whose kernels occupy the identical PC range with disjoint source-line ranges.
+  A store that swapped the two indices would still answer `resolved`, with
+  confidently wrong lines.
+- `TestModuleStoreEvictionIsExactUnderPressure` — capacity 3, 50 puts,
+  `ModulesEvicted == 47` exactly, breakdown exact, bound checked at every step.
+- `TestModuleStoreLRUKeepsWhatIsBeingResolved` — a `Resolve` saves a module a
+  `Put` would otherwise have evicted; a re-offer counts as use too.
+- `TestResolveAfterEvictionIsNoModuleNotStale` — the plan's explicit test.
+  Resolve at `0x10` → line 6; evict; then every offset that resolved before
+  answers `no-module` at the same coordinates, three times over. It also
+  asserts that the `Resolution` *value* taken before eviction still reads as it
+  did — that is not staleness in the store, and the assertion exists so the two
+  are not confused.
+- `TestModuleStoreByteBoundEvicts`, `TestModuleStoreOversizedModuleLeavesTheStoreEmpty`,
+  `TestModuleStoreDefaultsAreApplied` — §5.
+- `TestPutOfAKnownCRCIsANoOp`, `TestPutDoesNotRetainCallerBytes` — §1.
+- `TestModuleStoreConcurrentPutAndResolve` — 8 goroutines × 200 mixed
+  operations under `-race`, asserting the resolve identity, the classification
+  identity, the eviction identity, and `ModulesStored - Live == ModulesEvicted`.
+
+**Mutation-checked.** Four deliberate defects were introduced and each was
+caught before being reverted:
+
+| defect | caught by |
+| --- | --- |
+| damaged table mapped to `no-lineinfo` | `AllFourStatusesAreReachable`, `DamagedLineTable...` |
+| `Resolve` does not refresh LRU recency | `LRUKeepsWhatIsBeingResolved` |
+| eviction removes from the LRU list but not the map (the classic stale-answer bug) | `ResolveAfterEvictionIsNoModuleNotStale` + 4 others |
+| the `unmapped` return forgets its counter | both sum-identity tests |
+
+A test that cannot fail is not a test.
+
+---
+
+## 7. Scope
+
+Additive only. `Timeline`, `LaunchCache`, `orderedFIFO`, the join and
+`projection.go` are unchanged; `git diff --stat` against `origin/main` shows two
+new files and nothing else. Nothing consumes the store — Task 7 decodes and Task
+8b joins, and wiring it in here was explicitly out of scope.
+
+**One gap flagged for Task 8b.** `Resolution` carries a function name *only*
+when the status is `resolved`, following the design's representation table
+literally (`gpu_src_func` is absent for all three non-resolved statuses). But
+Tier B's attribution chain — `cubin_crc → module → function → symbol`, reaching
+the kernel name for the `[gpu:kernel:<name>]` frame — needs a name even when the
+source line is unavailable, e.g. from a module built without `-lineinfo`. The
+store holds that name (`moduleEntry.byIndex` is populated for every parseable
+module, with or without line info) but does not currently expose it. Task 8b
+will need a small `FunctionName(crc, functionIndex) (string, bool)` accessor. It
+is deliberately not added here: the plan says nothing consumes the store yet,
+and an accessor with no caller is an accessor with no test.
+
+---
+
+## 8. Verification run
+
+```
+go build ./...                          ok
+go vet ./...                            ok
+go test ./gpu/ ./internal/... -count=1  ok
+go test ./gpu/ -race -count=4           ok  (19.3s)
+go test ./... -count=1                  ok  (whole repo, no regressions)
+golangci-lint run --timeout=5m          0 issues
+```
+
+Not run, and not runnable here: anything needing capabilities or a GPU. Per the
+plan, this task needed neither.

--- a/gpu/modulestore.go
+++ b/gpu/modulestore.go
@@ -1,0 +1,606 @@
+package gpu
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	"github.com/dpsoft/perf-agent/internal/cubin"
+)
+
+// SrcStatus is the four-valued gpu_src_status from the PC-sampling design:
+// why a PC sample does, or does not, have a source location.
+//
+// The four values are mutually exclusive and exhaustive, and ModuleStore is the
+// only place any of them is decided. They exist because an ABSENT source label
+// reads as "not sampled", while an explicit status reads as "sampled,
+// unresolvable" - different facts, needing different actions from the reader:
+//
+//	resolved     the module's line table covers this PC
+//	no-lineinfo  the module is in hand and was built WITHOUT -lineinfo
+//	no-module    no usable module bytes exist for this CRC
+//	unmapped     the module has a line table, but nothing covers this PC
+//
+// no-lineinfo is a property of the MODULE and unmapped is a property of the PC.
+// Keeping them apart is the difference between "recompile with -lineinfo" and
+// "the compiler emitted no line for this instruction", which are different
+// actions. A line is never synthesized: no nearest-line search, no fall back to
+// the function's first line.
+//
+// The zero value is deliberately NOT one of the four. It is invalid, it names
+// itself as invalid in String, and it refuses to marshal, so a status that was
+// never decided by this store cannot be mistaken for one that was. Resolve
+// never returns it.
+type SrcStatus uint8
+
+const (
+	// srcStatusInvalid is the zero value: not a status. It is unexported so
+	// that the only SrcStatus values a caller can name are the four real
+	// ones, and it is checked for rather than defaulted to.
+	srcStatusInvalid SrcStatus = iota
+
+	// SrcResolved means the module's line table covers this pcOffset. It is
+	// the only status under which a Resolution carries a function, file and
+	// line.
+	SrcResolved
+
+	// SrcNoLineInfo means the module is in hand, parsed, and has no
+	// .debug_line at all - it was built without -lineinfo. The fix is a
+	// build flag.
+	SrcNoLineInfo
+
+	// SrcNoModule means no usable module bytes exist for this CRC: none ever
+	// arrived, they were evicted, they failed to parse, or the line table
+	// they carry is damaged. In every one of those cases the actionable fact
+	// for the reader is identical - there is nothing here to resolve against
+	// - and reporting any of them as SrcNoLineInfo would send the reader
+	// after a compiler flag that would not help. See ModuleStore.Resolve.
+	SrcNoModule
+
+	// SrcUnmapped means the module has a usable line table but nothing in it
+	// covers this (functionIndex, pcOffset). A property of the PC, not of
+	// the build.
+	SrcUnmapped
+)
+
+// srcStatusToName is the wire spelling of each status. These strings are the
+// gpu_src_status label values exactly as the design fixes them; they are not
+// cosmetic and must not be reworded.
+var srcStatusToName = map[SrcStatus]string{
+	SrcResolved:   "resolved",
+	SrcNoLineInfo: "no-lineinfo",
+	SrcNoModule:   "no-module",
+	SrcUnmapped:   "unmapped",
+}
+
+// srcStatuses lists the four in stable order. Ordered so a consumer rendering
+// a breakdown gets the same order every time, and so an exhaustiveness test has
+// something to enumerate.
+var srcStatuses = []SrcStatus{SrcResolved, SrcNoLineInfo, SrcNoModule, SrcUnmapped}
+
+// SrcStatuses returns the four gpu_src_status values in stable order.
+//
+// It exists so that a consumer switching on a status can be tested for
+// exhaustiveness against the enum itself rather than against a hand-copied
+// list that a fifth value would silently escape.
+func SrcStatuses() []SrcStatus {
+	out := make([]SrcStatus, len(srcStatuses))
+	copy(out, srcStatuses)
+	return out
+}
+
+func (s SrcStatus) String() string {
+	if name, ok := srcStatusToName[s]; ok {
+		return name
+	}
+	if s == srcStatusInvalid {
+		// The zero value: a status nobody decided. Named apart from a
+		// fabricated one because the causes differ - this one is a struct
+		// that was never given an answer, which is the "silent default" the
+		// enum is shaped to prevent.
+		return "unset-src-status"
+	}
+	return fmt.Sprintf("invalid-src-status-%d", uint8(s))
+}
+
+// MarshalJSON refuses any value that is not one of the four, matching
+// ClockDomain and GPUCapability in this package: a status nobody decided must
+// fail loudly at the serialization boundary rather than ship as a string a
+// consumer would read as meaningful.
+func (s SrcStatus) MarshalJSON() ([]byte, error) {
+	name, ok := srcStatusToName[s]
+	if !ok {
+		return nil, fmt.Errorf("invalid gpu_src_status %d", uint8(s))
+	}
+	return []byte(`"` + name + `"`), nil
+}
+
+// Resolution is ModuleStore.Resolve's answer: the four-valued status, and - only
+// when that status is SrcResolved - the source location.
+//
+// Every field is unexported and there is no exported constructor, so a
+// Resolution can only come from ModuleStore.Resolve. That is what makes "the
+// store is the single place gpu_src_status is decided" structurally true rather
+// than a comment: no caller can build one carrying a status the store did not
+// choose, and no caller can attach a file, line or function to a status that
+// does not have one.
+//
+// The source location is reachable only through Source, which returns ok
+// together with the data. There are deliberately no separate File/Line/Function
+// getters: a caller who wants the location has to take the ok in the same
+// expression, so emitting gpu_src_func under a no-lineinfo status requires
+// ignoring a returned bool rather than merely forgetting a check.
+//
+// The zero Resolution is not a valid answer - its Status is srcStatusInvalid -
+// and Resolve never returns one.
+type Resolution struct {
+	status   SrcStatus
+	function string
+	file     string
+	line     uint32
+}
+
+// Status returns the four-valued gpu_src_status. It is always one of the four
+// for any Resolution that came from Resolve.
+func (r Resolution) Status() SrcStatus { return r.status }
+
+// Source returns the source location, and ok reporting whether there is one.
+//
+// ok is true exactly when Status is SrcResolved. When it is false the other
+// three returns are zero: the store never hands out a partial location, because
+// a location paired with a non-resolved status is precisely the mislabeling the
+// four-valued status exists to prevent.
+func (r Resolution) Source() (function, file string, line uint32, ok bool) {
+	if r.status != SrcResolved {
+		return "", "", 0, false
+	}
+	return r.function, r.file, r.line, true
+}
+
+// The four constructors below are the ONLY places a Resolution is built, and
+// each one is the sole producer of its status. Three of the four cannot carry a
+// location because they take no arguments; that is the type doing the work.
+
+func resolvedAt(function, file string, line uint32) Resolution {
+	return Resolution{status: SrcResolved, function: function, file: file, line: line}
+}
+
+func noModule() Resolution   { return Resolution{status: SrcNoModule} }
+func noLineInfo() Resolution { return Resolution{status: SrcNoLineInfo} }
+func unmapped() Resolution   { return Resolution{status: SrcUnmapped} }
+
+// ModuleStoreStats reports what the store holds, how it classified what it was
+// given, and what it lost. Every eviction path is counted, and the classifying
+// counters partition ModulesStored exactly, so a caller can reconcile rather
+// than trust.
+//
+// The Modules* classification counters are CUMULATIVE over everything ever
+// stored, not gauges of what is live: an evicted module's classification is not
+// un-counted. Live and LiveBytes are the gauges.
+type ModuleStoreStats struct {
+	// Live and LiveBytes are gauges of what the store currently holds.
+	Live      int   `json:"live"`
+	LiveBytes int64 `json:"live_bytes"`
+
+	// ModulesStored counts every Put that inserted a new CRC. A repeated Put
+	// for a CRC already held is a no-op that refreshes recency and is not
+	// counted here, so ModulesStored is the number of distinct modules the
+	// store has ever admitted.
+	ModulesStored uint64 `json:"modules_stored,omitempty"`
+
+	// ModulesEvicted counts modules dropped to stay inside the bounds. It is
+	// the total; ModulesEvictedCapacity and ModulesEvictedBytes are its
+	// mutually exclusive breakdown and always sum to it.
+	//
+	// An eviction is a real loss of resolution: every subsequent Resolve for
+	// that CRC answers SrcNoModule. That is the honest answer and it is the
+	// one the store gives - there is no memo of a previous resolution that
+	// could outlive the bytes it was derived from.
+	ModulesEvicted         uint64 `json:"modules_evicted,omitempty"`
+	ModulesEvictedCapacity uint64 `json:"modules_evicted_capacity,omitempty"`
+	ModulesEvictedBytes    uint64 `json:"modules_evicted_bytes,omitempty"`
+
+	// The four classification counters below partition ModulesStored: every
+	// stored module is classified exactly once, at Put, and
+	//
+	//	ModulesWithLineInfo + ModulesWithoutLineInfo +
+	//	ModulesDamagedLineInfo + ModulesUnparseable == ModulesStored
+	//
+	// is an invariant the tests assert. The partition is deliberately the
+	// same shape as the Resolve* partition below, which is what lets a
+	// reader reconcile "what we hold" against "what we could answer".
+
+	// ModulesWithLineInfo counts modules that parsed and carry a usable line
+	// table. These are the only modules that can produce SrcResolved.
+	ModulesWithLineInfo uint64 `json:"modules_with_line_info,omitempty"`
+
+	// ModulesWithoutLineInfo counts modules that parsed but have no
+	// .debug_line at all - built without -lineinfo. This is a BUILD-FLAG
+	// fact about an otherwise healthy pipeline, and it is why this counter
+	// is kept apart from ModulesUnparseable: one says "add -lineinfo", the
+	// other says "the bytes are wrong".
+	ModulesWithoutLineInfo uint64 `json:"modules_without_line_info,omitempty"`
+
+	// ModulesDamagedLineInfo counts modules that parsed as ELF and DO carry
+	// a .debug_line, but whose line table could not be read
+	// (cubin.LineInfoErr). They resolve as SrcNoModule, alongside
+	// ModulesUnparseable, because we hold bytes we cannot use for source.
+	//
+	// It is a separate counter from ModulesUnparseable on purpose. The two
+	// point at different causes: unparseable means the bytes did not survive
+	// transport or are not a cubin at all, while a damaged table means the
+	// ELF is fine and OUR READER refused the DWARF in it - the shape a
+	// future toolkit emitting a line table this reader does not understand
+	// would take. Folded together, that case would read as a transport bug
+	// and send the operator to inspect a channel that is working perfectly.
+	// This project's recurring defect is a counter that points the wrong
+	// way; one number covering both would be exactly that.
+	ModulesDamagedLineInfo uint64 `json:"modules_damaged_line_info,omitempty"`
+
+	// ModulesUnparseable counts modules whose bytes cubin.Parse rejected
+	// outright: not an ELF, not a CUDA ELF, truncated, no symbol table. They
+	// are STORED (so an offer for the same CRC is not re-parsed) and they
+	// resolve as SrcNoModule, because holding bytes we cannot use is the
+	// same actionable fact for the reader as holding nothing.
+	ModulesUnparseable uint64 `json:"modules_unparseable,omitempty"`
+
+	// The four counters below partition every call to Resolve exactly:
+	//
+	//	ResolveResolved + ResolveNoModule +
+	//	ResolveNoLineInfo + ResolveUnmapped == calls to Resolve
+	//
+	// That identity is the reason Resolve has exactly four return points and
+	// increments exactly one counter at each. It is asserted by the tests.
+	ResolveResolved   uint64 `json:"resolve_resolved,omitempty"`
+	ResolveNoModule   uint64 `json:"resolve_no_module,omitempty"`
+	ResolveNoLineInfo uint64 `json:"resolve_no_line_info,omitempty"`
+	ResolveUnmapped   uint64 `json:"resolve_unmapped,omitempty"`
+}
+
+// ResolveTotal returns the number of Resolve calls the four Resolve* counters
+// account for. The identity it exists to make checkable is that this equals the
+// number of times Resolve was actually called.
+func (s ModuleStoreStats) ResolveTotal() uint64 {
+	return s.ResolveResolved + s.ResolveNoModule + s.ResolveNoLineInfo + s.ResolveUnmapped
+}
+
+// ModulesClassified returns the number of stored modules the four
+// classification counters account for, which must equal ModulesStored.
+func (s ModuleStoreStats) ModulesClassified() uint64 {
+	return s.ModulesWithLineInfo + s.ModulesWithoutLineInfo +
+		s.ModulesDamagedLineInfo + s.ModulesUnparseable
+}
+
+// ModuleStoreConfig bounds the store two ways, because one way is not a bound.
+//
+// A count bound alone is not a memory bound: cubins run from a few KB to
+// hundreds of KB, so a capacity that is safe for small modules is a hundredfold
+// overshoot for large ones. A byte bound alone is not a bound either, since a
+// flood of tiny modules costs map and list overhead the byte count does not
+// see. Both are enforced, and evictions under each are counted separately.
+type ModuleStoreConfig struct {
+	// Capacity is the maximum number of modules held. Zero means
+	// defaultModuleStoreCapacity.
+	Capacity int
+
+	// MaxBytes is the maximum total of stored cubin bytes. Zero means
+	// defaultModuleStoreMaxBytes.
+	//
+	// The bound is absolute: a single module larger than MaxBytes is stored,
+	// then immediately evicted along with everything else, leaving the store
+	// empty rather than one entry over the limit. Its Resolves then answer
+	// SrcNoModule, which is true - we are not holding it.
+	MaxBytes int64
+}
+
+const (
+	// defaultModuleStoreCapacity bounds distinct modules. A process loading
+	// more than this many distinct cubins is the JIT/template-explosion case
+	// the design names; the LRU plus ModulesEvicted is the answer to it.
+	defaultModuleStoreCapacity = 512
+
+	// defaultModuleStoreMaxBytes bounds total held cubin bytes. Sized for a
+	// per-pod agent: large enough for a few hundred ordinary cubins, small
+	// enough that a pathological producer cannot turn the store into the
+	// agent's dominant allocation.
+	defaultModuleStoreMaxBytes = 64 << 20 // 64 MiB
+)
+
+// moduleEntry is one stored module: the bytes as offered, what parsing them
+// produced, and the functionIndex -> name table Resolve needs.
+type moduleEntry struct {
+	crc   uint64
+	bytes []byte
+
+	// parsed is nil exactly when parseErr is non-nil.
+	parsed   *cubin.Cubin
+	parseErr error
+
+	// byIndex maps a PC record's functionIndex to a device function name.
+	//
+	// It is built from cubin.Function.SymIndex, which is the function's index
+	// in the module's .symtab. CUPTI documents CUpti_PCSamplingPCData's
+	// functionIndex as "the function's unique symbol index in the module";
+	// whether that is the .symtab index cannot be determined without
+	// hardware, so this mapping is the design's PREMISE, not a measured
+	// fact. It is measured on the RTX 3090 by the task that enables PC
+	// sampling, and the design pre-approves a wire-format fallback (a v2 PC
+	// record carrying kernel_id) if it turns out to be something else. An
+	// index that misses this table answers SrcUnmapped - never a guess at a
+	// neighbouring function.
+	byIndex map[uint32]string
+
+	// elem is this entry's position in the LRU list, so a touch is O(1).
+	elem *list.Element
+}
+
+// ModuleStore maps a cubin CRC to the module's parsed line table, bounded and
+// LRU, and is the single place the four-valued gpu_src_status is decided.
+//
+// It sits beside Timeline rather than inside it. Timeline's EmitModule records
+// THAT a module loaded (its CRC, size and load time, in a bounded ring); this
+// store holds what a module IS. The two are deliberately separate: the ring is
+// a timeline of events and evicting from it loses history, while this store is
+// a cache of content and evicting from it loses resolution - different losses,
+// different bounds, different counters.
+//
+// # Why the LRU is a real LRU
+//
+// Recency is refreshed by Resolve, not only by Put. A module being actively
+// sampled must not be evicted by a burst of unrelated module loads, which is
+// exactly what an insertion-ordered FIFO would do. That is also why this does
+// not reuse orderedFIFO: orderedFIFO reclaims superseded positions only while
+// something is evicting, so touching an entry on every Resolve - a per-PC-sample
+// operation - would grow its order slice without bound whenever the store sits
+// under its capacity. A container/list LRU has no such garbage.
+//
+// # No memoized resolutions
+//
+// There is no cache of past Resolve answers anywhere in this type. A resolution
+// is derived from the bytes on every call, so when a module is evicted its
+// resolutions become SrcNoModule immediately and completely. A memo would be a
+// stale answer that outlived its evidence, which is worse than no answer.
+//
+// Safe for concurrent use. Resolve takes the write lock because it refreshes
+// recency; PC-sample decoding is batched, so the contention is per batch rather
+// than per sample.
+type ModuleStore struct {
+	mu    sync.Mutex
+	cfg   ModuleStoreConfig
+	byCRC map[uint64]*moduleEntry
+
+	// lru holds *moduleEntry, most recently used at the front.
+	lru       *list.List
+	liveBytes int64
+	stats     ModuleStoreStats
+}
+
+// NewModuleStore constructs a bounded, LRU module store.
+func NewModuleStore(cfg ModuleStoreConfig) *ModuleStore {
+	if cfg.Capacity <= 0 {
+		cfg.Capacity = defaultModuleStoreCapacity
+	}
+	if cfg.MaxBytes <= 0 {
+		cfg.MaxBytes = defaultModuleStoreMaxBytes
+	}
+	return &ModuleStore{
+		cfg:   cfg,
+		byCRC: make(map[uint64]*moduleEntry),
+		lru:   list.New(),
+	}
+}
+
+// Put stores a module's bytes under its CRC, parses them once, and builds the
+// functionIndex -> name table Resolve uses.
+//
+// A CRC already held is a no-op: the bytes are not re-parsed and ModulesStored
+// does not move. It still refreshes recency, because a producer re-offering a
+// module is evidence that module is in use. Since cubin_crc is content
+// addressed, a repeated CRC is by definition the same bytes, so there is
+// nothing to update.
+//
+// The returned error reports that the bytes could not be parsed. It is
+// DIAGNOSTIC, not a rejection: the entry is stored anyway and counted in
+// ModulesUnparseable, so that a re-offer of the same bad module is not
+// re-parsed, and its Resolves answer SrcNoModule. A caller must not read a
+// non-nil error as "try again"; the counters, not the error, are the record.
+//
+// b is NOT retained; the store keeps its own copy. That is not defensiveness
+// about mutation, it is the transport's contract: cubin bytes arrive as a
+// sealed memfd the agent mmaps, and the mapping is dropped once the offer is
+// handled. cubin.Parse is written not to retain its input for exactly that
+// reason, and a store that retained it would quietly reintroduce the
+// use-after-unmap the transport was designed to avoid. The copy is what
+// ModuleStoreConfig.MaxBytes bounds.
+func (s *ModuleStore) Put(crc uint64, b []byte) error {
+	// A CRC already held costs no parse and no copy. cubin_crc is content
+	// addressed, so a repeated CRC is the same bytes and there is nothing to
+	// update beyond recency.
+	s.mu.Lock()
+	if e, ok := s.byCRC[crc]; ok {
+		s.lru.MoveToFront(e.elem)
+		err := e.parseErr
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
+
+	// Parsing is pure and can be slow on a large cubin, so it happens outside
+	// the lock rather than under it.
+	parsed, parseErr := cubin.Parse(b)
+	owned := make([]byte, len(b))
+	copy(owned, b)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Re-check: a concurrent Put for the same CRC may have landed while this
+	// one was parsing. First writer wins; the loser is a no-op, exactly as a
+	// re-offer is.
+	if e, ok := s.byCRC[crc]; ok {
+		s.lru.MoveToFront(e.elem)
+		return e.parseErr
+	}
+
+	e := &moduleEntry{crc: crc, bytes: owned, parsed: parsed, parseErr: parseErr}
+	switch {
+	case parseErr != nil:
+		s.stats.ModulesUnparseable++
+	case parsed.LineInfoErr() != nil:
+		s.stats.ModulesDamagedLineInfo++
+	case !parsed.HasLineInfo():
+		s.stats.ModulesWithoutLineInfo++
+	default:
+		s.stats.ModulesWithLineInfo++
+	}
+	if parsed != nil {
+		e.byIndex = indexFunctions(parsed)
+	}
+
+	e.elem = s.lru.PushFront(e)
+	s.byCRC[crc] = e
+	s.liveBytes += int64(len(owned))
+	s.stats.ModulesStored++
+	s.evictLocked()
+	return parseErr
+}
+
+// indexFunctions builds the functionIndex -> name table from a parsed cubin.
+// See moduleEntry.byIndex for why .symtab index is the key and why that is a
+// premise rather than a measurement.
+func indexFunctions(c *cubin.Cubin) map[uint32]string {
+	fns := c.Functions()
+	m := make(map[uint32]string, len(fns))
+	for _, fn := range fns {
+		// A negative or out-of-range symbol index cannot be a functionIndex
+		// on the wire, which is a uint32. Skipping is right: the name is
+		// simply not addressable, and Resolve answers SrcUnmapped rather
+		// than picking a neighbour.
+		if fn.SymIndex < 0 || int64(fn.SymIndex) > int64(^uint32(0)) {
+			continue
+		}
+		m[uint32(fn.SymIndex)] = fn.Name //nolint:gosec // range-checked immediately above.
+	}
+	return m
+}
+
+// Resolve turns a PC sample's (cubin CRC, function index, PC offset) into a
+// source location, or into the reason there is not one.
+//
+// It has exactly four return points, one per gpu_src_status, and each
+// increments exactly one Resolve* counter, so the four counters sum to the
+// number of calls. The decision order is:
+//
+//	CRC not held                  -> no-module   (never arrived, or evicted)
+//	bytes did not parse           -> no-module   (we hold bytes we cannot use)
+//	.debug_line present, damaged  -> no-module   (same: bytes we cannot use)
+//	no .debug_line at all         -> no-lineinfo (a build-flag fact)
+//	functionIndex unknown         -> unmapped
+//	line table does not cover PC  -> unmapped
+//	otherwise                     -> resolved
+//
+// The third case is the one worth spelling out. A present-but-damaged line
+// table is NOT reported as no-lineinfo, because no-lineinfo tells the operator
+// to add a compiler flag they already passed - an active lie about the build.
+// It is no-module for the same reason an unparseable cubin is: we hold bytes we
+// cannot use, and for the reader that is the same actionable fact as holding
+// nothing. ModulesDamagedLineInfo is what keeps the two causes distinguishable
+// even though the answer they produce is identical.
+//
+// A module whose CRC is held but whose particular function carries no line-table
+// sequence, in a module that does have a table, answers unmapped rather than
+// no-lineinfo - by the same rule: the module was built with -lineinfo, so
+// telling the reader otherwise would be wrong.
+func (s *ModuleStore) Resolve(crc uint64, functionIndex uint32, pcOffset uint64) Resolution {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.byCRC[crc]
+	if !ok {
+		s.stats.ResolveNoModule++
+		return noModule()
+	}
+	s.lru.MoveToFront(e.elem)
+
+	if e.parseErr != nil || e.parsed.LineInfoErr() != nil {
+		s.stats.ResolveNoModule++
+		return noModule()
+	}
+	if !e.parsed.HasLineInfo() {
+		s.stats.ResolveNoLineInfo++
+		return noLineInfo()
+	}
+	fn, ok := e.byIndex[functionIndex]
+	if !ok {
+		s.stats.ResolveUnmapped++
+		return unmapped()
+	}
+	file, line, ok := e.parsed.Resolve(fn, pcOffset)
+	if !ok {
+		s.stats.ResolveUnmapped++
+		return unmapped()
+	}
+	s.stats.ResolveResolved++
+	return resolvedAt(fn, file, line)
+}
+
+// Len reports how many modules are currently held.
+func (s *ModuleStore) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.byCRC)
+}
+
+// Stats returns the counters and the two gauges.
+func (s *ModuleStore) Stats() ModuleStoreStats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.stats
+	out.Live = len(s.byCRC)
+	out.LiveBytes = s.liveBytes
+	return out
+}
+
+// evictLocked drops least-recently-used modules until both bounds hold. The
+// caller must hold s.mu.
+//
+// Capacity is enforced first and byte pressure second, and each is counted
+// under its own reason so that "the store is too small" and "the modules are
+// too big" are separable. The byte loop can empty the store entirely, which is
+// the correct behaviour for a single module larger than MaxBytes: the bound is
+// absolute, and a Resolve that then answers no-module is telling the truth.
+func (s *ModuleStore) evictLocked() {
+	for len(s.byCRC) > s.cfg.Capacity {
+		if !s.evictOldestLocked() {
+			return
+		}
+		s.stats.ModulesEvictedCapacity++
+	}
+	for s.liveBytes > s.cfg.MaxBytes {
+		if !s.evictOldestLocked() {
+			return
+		}
+		s.stats.ModulesEvictedBytes++
+	}
+}
+
+// evictOldestLocked removes the least recently used module, returning false if
+// there is nothing left to remove. The caller must hold s.mu.
+func (s *ModuleStore) evictOldestLocked() bool {
+	back := s.lru.Back()
+	if back == nil {
+		return false
+	}
+	e, ok := back.Value.(*moduleEntry)
+	if !ok {
+		// Unreachable: the list holds nothing else. Refusing to proceed is
+		// better than a panic on a profiling path.
+		s.lru.Remove(back)
+		return false
+	}
+	s.lru.Remove(back)
+	delete(s.byCRC, e.crc)
+	s.liveBytes -= int64(len(e.bytes))
+	s.stats.ModulesEvicted++
+	return true
+}

--- a/gpu/modulestore_test.go
+++ b/gpu/modulestore_test.go
@@ -1,0 +1,695 @@
+package gpu
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dpsoft/perf-agent/internal/cubin"
+)
+
+// The fixtures live with the package that produced them (internal/cubin), not
+// duplicated here. Two copies of a binary fixture drift, and the point of these
+// tests is that the store answers correctly about the SAME bytes that package
+// asserts its own claims against.
+func fixturePath(name string) string {
+	return filepath.Join("..", "internal", "cubin", "testdata", name)
+}
+
+func fixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(fixturePath(name))
+	require.NoError(t, err, "fixture %s", name)
+	require.NotEmpty(t, b)
+	return b
+}
+
+// symIndexOf returns the .symtab index the store keys its functionIndex table
+// on, read from the fixture rather than hard-coded. Whether CUPTI's
+// functionIndex IS this index is the design's premise and is measured on
+// hardware elsewhere; these tests assert only that the store uses it
+// consistently.
+func symIndexOf(t *testing.T, b []byte, fn string) uint32 {
+	t.Helper()
+	c, err := cubin.Parse(b)
+	require.NoError(t, err)
+	for _, f := range c.Functions() {
+		if f.Name == fn {
+			require.GreaterOrEqual(t, f.SymIndex, 0)
+			require.LessOrEqual(t, int64(f.SymIndex), int64(math.MaxUint32))
+			return uint32(f.SymIndex)
+		}
+	}
+	t.Fatalf("fixture has no function %q", fn)
+	return 0
+}
+
+// damagedLineInfo returns single_lineinfo.cubin with the DW_LNE_set_address
+// opcode that .rel.debug_line points at corrupted, which is the third
+// line-info state: .debug_line present, table unusable. It is built the same
+// way internal/cubin builds it for its own test of that state.
+func damagedLineInfo(t *testing.T) []byte {
+	t.Helper()
+	b := fixture(t, "single_lineinfo.cubin")
+
+	f, err := elf.NewFile(bytes.NewReader(b))
+	require.NoError(t, err)
+	lineSec := f.Section(".debug_line")
+	require.NotNil(t, lineSec)
+	rel, err := f.Section(".rel.debug_line").Data()
+	require.NoError(t, err)
+	require.NotEmpty(t, rel)
+	require.NoError(t, f.Close())
+
+	opcodeAt := lineSec.Offset + binary.LittleEndian.Uint64(rel[0:]) - 1
+	require.Less(t, opcodeAt, uint64(len(b)))
+
+	damaged := append([]byte(nil), b...)
+	require.Equal(t, byte(0x02), damaged[opcodeAt], "expected DW_LNE_set_address here")
+	damaged[opcodeAt] = 0x03
+
+	// Confirm the fixture really is in the third state before any store test
+	// leans on it, so a toolkit change turns into a failure here rather than a
+	// silently weaker test elsewhere.
+	c, err := cubin.Parse(damaged)
+	require.NoError(t, err)
+	require.True(t, c.HasLineInfo())
+	require.Error(t, c.LineInfoErr())
+	return damaged
+}
+
+// counting wraps a store so a test can assert the Resolve* counters against the
+// number of calls actually made, which is the identity the design requires.
+type counting struct {
+	*ModuleStore
+	calls uint64
+}
+
+func (c *counting) Resolve(crc uint64, fnIdx uint32, pc uint64) Resolution {
+	c.calls++
+	return c.ModuleStore.Resolve(crc, fnIdx, pc)
+}
+
+// requireSumIdentity asserts the two partitions the design fixes: the four
+// Resolve* counters account for exactly the calls made, and the four
+// classification counters account for exactly the modules stored.
+func requireSumIdentity(t *testing.T, c *counting) {
+	t.Helper()
+	s := c.Stats()
+	require.Equal(t, c.calls, s.ResolveTotal(),
+		"the four Resolve* counters must sum to every Resolve call: %+v", s)
+	require.Equal(t, s.ModulesStored, s.ModulesClassified(),
+		"the four classification counters must partition ModulesStored: %+v", s)
+	require.Equal(t, s.ModulesEvicted, s.ModulesEvictedCapacity+s.ModulesEvictedBytes,
+		"the eviction breakdown must sum to ModulesEvicted: %+v", s)
+}
+
+// ---------------------------------------------------------------------------
+// The four-valued status
+// ---------------------------------------------------------------------------
+
+// TestModuleStoreAllFourStatusesAreReachable is the core table: every value of
+// gpu_src_status is produced by a real fixture through the real store, and each
+// increments its own counter. A status that no test can reach is a status the
+// profile could carry without anyone ever having seen it.
+func TestModuleStoreAllFourStatusesAreReachable(t *testing.T) {
+	withInfo := fixture(t, "single_lineinfo.cubin")
+	noInfo := fixture(t, "single_nolineinfo.cubin")
+	damaged := damagedLineInfo(t)
+
+	const (
+		crcWithInfo    = 0x1111
+		crcNoInfo      = 0x2222
+		crcDamaged     = 0x3333
+		crcUnparseable = 0x4444
+		crcAbsent      = 0x5555
+	)
+
+	st := &counting{ModuleStore: NewModuleStore(ModuleStoreConfig{Capacity: 16})}
+	require.NoError(t, st.Put(crcWithInfo, withInfo))
+	require.NoError(t, st.Put(crcNoInfo, noInfo))
+	require.NoError(t, st.Put(crcDamaged, damaged), "a damaged line table is not a parse failure")
+	require.Error(t, st.Put(crcUnparseable, []byte("not an ELF at all")))
+
+	idx := symIndexOf(t, withInfo, "addOne")
+	noInfoIdx := symIndexOf(t, noInfo, "addOne")
+
+	tests := []struct {
+		name     string
+		crc      uint64
+		fnIdx    uint32
+		pc       uint64
+		want     SrcStatus
+		wantFile string
+		wantLine uint32
+	}{
+		{
+			name: "covered pc in a -lineinfo module", crc: crcWithInfo, fnIdx: idx, pc: 0x10,
+			want: SrcResolved, wantFile: "single.cu", wantLine: 6,
+		},
+		{
+			name: "module built without -lineinfo", crc: crcNoInfo, fnIdx: noInfoIdx, pc: 0x10,
+			want: SrcNoLineInfo,
+		},
+		{
+			name: "crc never offered", crc: crcAbsent, fnIdx: idx, pc: 0x10,
+			want: SrcNoModule,
+		},
+		{
+			name: "bytes we hold but cannot parse", crc: crcUnparseable, fnIdx: idx, pc: 0x10,
+			want: SrcNoModule,
+		},
+		{
+			name: "line table present but damaged", crc: crcDamaged, fnIdx: idx, pc: 0x10,
+			want: SrcNoModule,
+		},
+		{
+			name: "pc past the end of the function", crc: crcWithInfo, fnIdx: idx, pc: 0x180,
+			want: SrcUnmapped,
+		},
+		{
+			name: "function index this module does not have", crc: crcWithInfo, fnIdx: idx + 1000, pc: 0x10,
+			want: SrcUnmapped,
+		},
+	}
+
+	seen := make(map[SrcStatus]bool)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := st.Resolve(tc.crc, tc.fnIdx, tc.pc)
+			require.Equal(t, tc.want, r.Status(), "status for %s", tc.name)
+
+			fn, file, line, ok := r.Source()
+			if tc.want != SrcResolved {
+				assert.False(t, ok, "only a resolved status may carry a source location")
+				assert.Empty(t, fn)
+				assert.Empty(t, file)
+				assert.Zero(t, line)
+				return
+			}
+			require.True(t, ok)
+			assert.Equal(t, "addOne", fn)
+			assert.Equal(t, tc.wantFile, filepath.Base(file))
+			assert.Equal(t, tc.wantLine, line)
+		})
+		seen[tc.want] = true
+	}
+
+	for _, s := range SrcStatuses() {
+		assert.True(t, seen[s], "status %s is not reachable from this table", s)
+	}
+
+	got := st.Stats()
+	assert.Equal(t, uint64(1), got.ResolveResolved)
+	assert.Equal(t, uint64(1), got.ResolveNoLineInfo)
+	assert.Equal(t, uint64(3), got.ResolveNoModule)
+	assert.Equal(t, uint64(2), got.ResolveUnmapped)
+	requireSumIdentity(t, st)
+}
+
+// TestModuleStoreResolveCountersSumToEveryCall drives a mixed, repetitive
+// workload across every status and asserts the identity holds for all of it -
+// the design states it as a test, not as a property.
+func TestModuleStoreResolveCountersSumToEveryCall(t *testing.T) {
+	withInfo := fixture(t, "single_lineinfo.cubin")
+	noInfo := fixture(t, "single_nolineinfo.cubin")
+
+	st := &counting{ModuleStore: NewModuleStore(ModuleStoreConfig{Capacity: 4})}
+	require.NoError(t, st.Put(1, withInfo))
+	require.NoError(t, st.Put(2, noInfo))
+	require.Error(t, st.Put(3, withInfo[:64]))
+
+	idx := symIndexOf(t, withInfo, "addOne")
+	for pc := uint64(0); pc < 0x200; pc += 0x10 {
+		for crc := uint64(1); crc <= 4; crc++ {
+			st.Resolve(crc, idx, pc)
+			st.Resolve(crc, idx+7, pc)
+		}
+	}
+
+	s := st.Stats()
+	require.Positive(t, s.ResolveResolved)
+	require.Positive(t, s.ResolveNoModule)
+	require.Positive(t, s.ResolveNoLineInfo)
+	require.Positive(t, s.ResolveUnmapped)
+	requireSumIdentity(t, st)
+}
+
+// TestSrcStatusZeroValueIsNotAStatus pins the "no silent default" half of the
+// design's requirement. The zero value cannot be one of the four, because a
+// caller who forgot to set a status would otherwise ship whichever of the four
+// happened to be zero, and it would be unreadable as a mistake.
+func TestSrcStatusZeroValueIsNotAStatus(t *testing.T) {
+	var zero SrcStatus
+	assert.NotContains(t, SrcStatuses(), zero)
+	assert.Equal(t, srcStatusInvalid, zero)
+	assert.Equal(t, "unset-src-status", zero.String(), "an undecided status names itself as one")
+	assert.Equal(t, "invalid-src-status-200", SrcStatus(200).String(), "a fabricated one names itself apart")
+
+	_, err := json.Marshal(zero)
+	assert.Error(t, err, "a status nobody decided must not serialize")
+
+	_, err = json.Marshal(SrcStatus(200))
+	assert.Error(t, err, "a fabricated status must not serialize")
+
+	var r Resolution
+	assert.Equal(t, zero, r.Status())
+	_, _, _, ok := r.Source()
+	assert.False(t, ok, "the zero Resolution has no source")
+}
+
+// TestSrcStatusesIsExhaustiveAndStable asserts SrcStatuses covers exactly the
+// four wire values and that each spells itself the way the design fixes it.
+// These strings are the gpu_src_status label values; rewording one silently
+// changes the profile.
+func TestSrcStatusesIsExhaustiveAndStable(t *testing.T) {
+	all := SrcStatuses()
+	require.Len(t, all, 4)
+	assert.Equal(t, []SrcStatus{SrcResolved, SrcNoLineInfo, SrcNoModule, SrcUnmapped}, all)
+
+	want := map[SrcStatus]string{
+		SrcResolved:   "resolved",
+		SrcNoLineInfo: "no-lineinfo",
+		SrcNoModule:   "no-module",
+		SrcUnmapped:   "unmapped",
+	}
+	for _, s := range all {
+		assert.Equal(t, want[s], s.String())
+		b, err := json.Marshal(s)
+		require.NoError(t, err)
+		assert.JSONEq(t, `"`+want[s]+`"`, string(b))
+	}
+
+	// Mutating the returned slice must not reach the package's own list.
+	all[0] = SrcUnmapped
+	assert.Equal(t, SrcResolved, SrcStatuses()[0])
+}
+
+// ---------------------------------------------------------------------------
+// The damaged-table decision, and the counters that keep causes apart
+// ---------------------------------------------------------------------------
+
+// TestDamagedLineTableResolvesAsNoModuleNotNoLineInfo is the decision
+// internal/cubin recommended and this store implements. A present-but-damaged
+// .debug_line reported as no-lineinfo would tell the operator to add a build
+// flag they already passed. It resolves as no-module - we hold bytes we cannot
+// use - while its own counter keeps the cause visible.
+func TestDamagedLineTableResolvesAsNoModuleNotNoLineInfo(t *testing.T) {
+	damaged := damagedLineInfo(t)
+	idx := symIndexOf(t, damaged, "addOne")
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 4})
+	require.NoError(t, st.Put(9, damaged), "the ELF is fine; only its line table is not")
+
+	for pc := uint64(0); pc < 0x180; pc += 0x10 {
+		r := st.Resolve(9, idx, pc)
+		require.Equal(t, SrcNoModule, r.Status(), "pcOffset %#x", pc)
+		require.NotEqual(t, SrcNoLineInfo, r.Status(),
+			"a damaged table must never be reported as a missing build flag")
+	}
+
+	s := st.Stats()
+	assert.Equal(t, uint64(1), s.ModulesDamagedLineInfo)
+	assert.Equal(t, uint64(0), s.ModulesUnparseable, "the bytes parsed; only the DWARF did not")
+	assert.Equal(t, uint64(0), s.ModulesWithoutLineInfo, "it HAS .debug_line")
+	assert.Equal(t, uint64(0), s.ModulesWithLineInfo)
+	assert.Equal(t, s.ModulesStored, s.ModulesClassified())
+}
+
+// TestUnparseableIsNotWithoutLineInfo is the distinction the design flags: one
+// counter means "the bytes are wrong", the other means "the build flags are".
+// They answer the reader with the same status but they are not the same fact,
+// and a single counter covering both would make a transport bug look like a
+// compiler option.
+func TestUnparseableIsNotWithoutLineInfo(t *testing.T) {
+	noInfo := fixture(t, "single_nolineinfo.cubin")
+	withInfo := fixture(t, "single_lineinfo.cubin")
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 8})
+	require.NoError(t, st.Put(1, noInfo))
+	require.Error(t, st.Put(2, []byte("junk")))
+	require.Error(t, st.Put(3, withInfo[:len(withInfo)/2]), "a truncated cubin is unparseable")
+	require.Error(t, st.Put(4, nil))
+
+	s := st.Stats()
+	assert.Equal(t, uint64(1), s.ModulesWithoutLineInfo)
+	assert.Equal(t, uint64(3), s.ModulesUnparseable)
+	assert.Equal(t, uint64(0), s.ModulesDamagedLineInfo)
+	assert.Equal(t, uint64(4), s.ModulesStored, "unparseable modules are stored, not dropped")
+	assert.Equal(t, s.ModulesStored, s.ModulesClassified())
+
+	// Both resolve as no-module; the counters are the only thing separating
+	// the two causes, which is exactly why they are separate.
+	assert.Equal(t, SrcNoModule, st.Resolve(2, 0, 0).Status())
+	assert.Equal(t, SrcNoLineInfo, st.Resolve(1, symIndexOf(t, noInfo, "addOne"), 0).Status())
+}
+
+// ---------------------------------------------------------------------------
+// Source resolution against the fixtures
+// ---------------------------------------------------------------------------
+
+// TestModuleStoreResolvesExactSourceLines pins the store's answers against the
+// line table internal/cubin asserts from the same bytes. Note lines 10, 9, 10
+// at 0xa0/0xb0/0xc0: the table is not monotonic in line number, so an answer
+// that merely looked plausible would not pass.
+func TestModuleStoreResolvesExactSourceLines(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 4})
+	require.NoError(t, st.Put(1, b))
+
+	want := []struct {
+		pc   uint64
+		line uint32
+	}{
+		{0x00, 5}, {0x10, 6}, {0x40, 7}, {0x60, 8},
+		{0xa0, 10}, {0xb0, 9}, {0xc0, 10}, {0xd0, 12},
+		{0x30, 6}, {0x50, 7}, {0x9f, 8}, {0x17f, 12},
+	}
+	for _, w := range want {
+		r := st.Resolve(1, idx, w.pc)
+		require.Equal(t, SrcResolved, r.Status(), "pcOffset %#x", w.pc)
+		fn, file, line, ok := r.Source()
+		require.True(t, ok)
+		assert.Equal(t, "addOne", fn)
+		assert.Equal(t, "single.cu", filepath.Base(file))
+		assert.Equal(t, w.line, line, "pcOffset %#x", w.pc)
+	}
+
+	// The end_sequence sits at the function's size; nothing beyond resolves,
+	// and no line is ever synthesized for it.
+	for _, pc := range []uint64{0x180, 0x190, 1 << 40} {
+		r := st.Resolve(1, idx, pc)
+		assert.Equal(t, SrcUnmapped, r.Status(), "pcOffset %#x", pc)
+	}
+}
+
+// TestModuleStoreBindsFunctionIndexToTheRightKernel uses the two-kernel fixture,
+// whose kernels occupy the identical PC range and whose source-line ranges are
+// disjoint. A store that mixed the two indices up would still answer
+// "resolved", with confidently wrong lines - the failure mode the whole design
+// exists to prevent.
+func TestModuleStoreBindsFunctionIndexToTheRightKernel(t *testing.T) {
+	b := fixture(t, "two_kernels_lineinfo.cubin")
+	scaleIdx := symIndexOf(t, b, "scale")
+	offsetIdx := symIndexOf(t, b, "offset")
+	require.NotEqual(t, scaleIdx, offsetIdx)
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 4})
+	require.NoError(t, st.Put(1, b))
+
+	var scaleHits, offsetHits int
+	for pc := uint64(0); pc < 0x180; pc += 0x10 {
+		if r := st.Resolve(1, scaleIdx, pc); r.Status() == SrcResolved {
+			fn, _, line, ok := r.Source()
+			require.True(t, ok)
+			assert.Equal(t, "scale", fn)
+			assert.Less(t, line, uint32(13), "scale's lines are all below offset's")
+			scaleHits++
+		}
+		if r := st.Resolve(1, offsetIdx, pc); r.Status() == SrcResolved {
+			fn, _, line, ok := r.Source()
+			require.True(t, ok)
+			assert.Equal(t, "offset", fn)
+			assert.Greater(t, line, uint32(11), "offset's lines are all above scale's")
+			offsetHits++
+		}
+	}
+	assert.Positive(t, scaleHits)
+	assert.Positive(t, offsetHits)
+}
+
+// ---------------------------------------------------------------------------
+// Bounds
+// ---------------------------------------------------------------------------
+
+// TestModuleStoreEvictionIsExactUnderPressure asserts ModulesEvicted is exact,
+// not approximate, and that its breakdown reconciles. A bound whose counter is
+// only roughly right is the kind of green-when-worst reading this project keeps
+// finding.
+func TestModuleStoreEvictionIsExactUnderPressure(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+
+	const capacity, puts = 3, 50
+	st := &counting{ModuleStore: NewModuleStore(ModuleStoreConfig{Capacity: capacity})}
+	for i := range uint64(puts) {
+		require.NoError(t, st.Put(i, b))
+		require.LessOrEqual(t, st.Len(), capacity, "the bound must hold at every step")
+	}
+
+	s := st.Stats()
+	assert.Equal(t, capacity, s.Live)
+	assert.Equal(t, uint64(puts), s.ModulesStored)
+	assert.Equal(t, uint64(puts-capacity), s.ModulesEvicted)
+	assert.Equal(t, uint64(puts-capacity), s.ModulesEvictedCapacity)
+	assert.Equal(t, uint64(0), s.ModulesEvictedBytes)
+	assert.Equal(t, int64(capacity*len(b)), s.LiveBytes)
+	requireSumIdentity(t, st)
+}
+
+// TestModuleStoreLRUKeepsWhatIsBeingResolved is why this is an LRU and not an
+// insertion-ordered FIFO. A module under active PC sampling must survive a
+// burst of unrelated module loads; under a FIFO it would not, and its samples
+// would silently become no-module while the store still had room for it.
+func TestModuleStoreLRUKeepsWhatIsBeingResolved(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 2})
+	require.NoError(t, st.Put(1, b))
+	require.NoError(t, st.Put(2, b))
+
+	// Touch 1 by resolving against it, making 2 the least recently used.
+	require.Equal(t, SrcResolved, st.Resolve(1, idx, 0x10).Status())
+
+	require.NoError(t, st.Put(3, b))
+	assert.Equal(t, SrcResolved, st.Resolve(1, idx, 0x10).Status(),
+		"the module being resolved against must survive")
+	assert.Equal(t, SrcNoModule, st.Resolve(2, idx, 0x10).Status(),
+		"the untouched module is the one that goes")
+	assert.Equal(t, SrcResolved, st.Resolve(3, idx, 0x10).Status())
+
+	// A re-offer counts as use too: a producer re-announcing a module is
+	// evidence it is live.
+	require.NoError(t, st.Put(1, b))
+	require.NoError(t, st.Put(4, b))
+	assert.Equal(t, SrcResolved, st.Resolve(1, idx, 0x10).Status())
+	assert.Equal(t, SrcNoModule, st.Resolve(3, idx, 0x10).Status())
+}
+
+// TestResolveAfterEvictionIsNoModuleNotStale is the explicit test the design
+// calls for. Nothing in the store memoizes a resolution, so an evicted module's
+// answers revert to no-module immediately and completely: a stale source
+// location is indistinguishable from a measured one once it reaches a label.
+func TestResolveAfterEvictionIsNoModuleNotStale(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	st := &counting{ModuleStore: NewModuleStore(ModuleStoreConfig{Capacity: 1})}
+	require.NoError(t, st.Put(1, b))
+
+	before := st.Resolve(1, idx, 0x10)
+	require.Equal(t, SrcResolved, before.Status())
+	_, _, line, ok := before.Source()
+	require.True(t, ok)
+	require.Equal(t, uint32(6), line)
+
+	require.NoError(t, st.Put(2, b))
+	require.Equal(t, uint64(1), st.Stats().ModulesEvicted)
+
+	// Every offset that resolved before must now answer no-module, at the
+	// exact same coordinates. Repeatedly: a cache that answered correctly once
+	// and staled later would pass a single check.
+	for range 3 {
+		for pc := uint64(0); pc < 0x180; pc += 0x10 {
+			after := st.Resolve(1, idx, pc)
+			require.Equal(t, SrcNoModule, after.Status(), "pcOffset %#x", pc)
+			fn, file, ln, ok := after.Source()
+			require.False(t, ok)
+			require.Empty(t, fn)
+			require.Empty(t, file)
+			require.Zero(t, ln)
+		}
+	}
+
+	// The Resolution taken before the eviction is a value, so it still reads
+	// as it did. That is not staleness in the store - nothing the store
+	// answers now depends on it - and the point of this assertion is that the
+	// two are different things.
+	assert.Equal(t, SrcResolved, before.Status())
+	requireSumIdentity(t, st)
+}
+
+// TestModuleStoreByteBoundEvicts asserts the second bound is real. A count
+// bound alone is not a memory bound, and a store whose only limit is "512
+// modules" can hold hundreds of megabytes without any counter noticing.
+func TestModuleStoreByteBoundEvicts(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+
+	st := &counting{ModuleStore: NewModuleStore(ModuleStoreConfig{
+		Capacity: 1000,
+		MaxBytes: int64(2 * len(b)),
+	})}
+	for i := range uint64(10) {
+		require.NoError(t, st.Put(i, b))
+		require.LessOrEqual(t, st.Stats().LiveBytes, int64(2*len(b)))
+	}
+
+	s := st.Stats()
+	assert.Equal(t, 2, s.Live)
+	assert.Equal(t, uint64(8), s.ModulesEvicted)
+	assert.Equal(t, uint64(8), s.ModulesEvictedBytes)
+	assert.Equal(t, uint64(0), s.ModulesEvictedCapacity)
+	requireSumIdentity(t, st)
+}
+
+// TestModuleStoreOversizedModuleLeavesTheStoreEmpty pins the absolute reading
+// of MaxBytes. A single module larger than the whole budget is not kept "just
+// this once": it is evicted like anything else, the store ends empty, and its
+// Resolves say no-module - which is true, because it is not held.
+func TestModuleStoreOversizedModuleLeavesTheStoreEmpty(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 10, MaxBytes: int64(len(b) / 2)})
+	require.NoError(t, st.Put(1, b))
+
+	s := st.Stats()
+	assert.Equal(t, 0, s.Live)
+	assert.Equal(t, int64(0), s.LiveBytes)
+	assert.Equal(t, uint64(1), s.ModulesStored)
+	assert.Equal(t, uint64(1), s.ModulesEvicted)
+	assert.Equal(t, uint64(1), s.ModulesEvictedBytes)
+	assert.Equal(t, SrcNoModule, st.Resolve(1, idx, 0x10).Status())
+}
+
+// TestModuleStoreDefaultsAreApplied keeps a zero config from meaning
+// "unbounded", which is how a bound becomes a bound only for callers who
+// remembered to ask for one.
+func TestModuleStoreDefaultsAreApplied(t *testing.T) {
+	st := NewModuleStore(ModuleStoreConfig{})
+	assert.Equal(t, defaultModuleStoreCapacity, st.cfg.Capacity)
+	assert.Equal(t, int64(defaultModuleStoreMaxBytes), st.cfg.MaxBytes)
+
+	neg := NewModuleStore(ModuleStoreConfig{Capacity: -1, MaxBytes: -1})
+	assert.Equal(t, defaultModuleStoreCapacity, neg.cfg.Capacity)
+	assert.Equal(t, int64(defaultModuleStoreMaxBytes), neg.cfg.MaxBytes)
+}
+
+// ---------------------------------------------------------------------------
+// Put's contract
+// ---------------------------------------------------------------------------
+
+// TestPutOfAKnownCRCIsANoOp asserts a re-offer costs nothing and changes
+// nothing. cubin_crc is content addressed, so a repeated CRC is the same bytes
+// by definition.
+func TestPutOfAKnownCRCIsANoOp(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 4})
+	require.NoError(t, st.Put(1, b))
+	for range 5 {
+		require.NoError(t, st.Put(1, b))
+	}
+
+	s := st.Stats()
+	assert.Equal(t, uint64(1), s.ModulesStored)
+	assert.Equal(t, uint64(1), s.ModulesWithLineInfo)
+	assert.Equal(t, int64(len(b)), s.LiveBytes, "a re-offer must not double-count bytes")
+	assert.Equal(t, uint64(0), s.ModulesEvicted)
+
+	// A re-offer of an unparseable module returns the same diagnostic error
+	// without re-parsing.
+	require.Error(t, st.Put(2, []byte("junk")))
+	require.Error(t, st.Put(2, []byte("junk")))
+	assert.Equal(t, uint64(1), st.Stats().ModulesUnparseable)
+}
+
+// TestPutDoesNotRetainCallerBytes is not defensiveness about mutation: the
+// transport hands the store an mmap of a sealed memfd and drops the mapping
+// once the offer is handled. internal/cubin.Parse is written not to retain its
+// input for that reason, and a store that retained it would put the hazard
+// straight back.
+func TestPutDoesNotRetainCallerBytes(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	caller := append([]byte(nil), b...)
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 4})
+	require.NoError(t, st.Put(1, caller))
+
+	// Scribble over the caller's buffer, standing in for an unmap.
+	for i := range caller {
+		caller[i] = 0xAA
+	}
+
+	r := st.Resolve(1, idx, 0x10)
+	require.Equal(t, SrcResolved, r.Status())
+	_, file, line, ok := r.Source()
+	require.True(t, ok)
+	assert.Equal(t, "single.cu", filepath.Base(file))
+	assert.Equal(t, uint32(6), line)
+	assert.Equal(t, int64(len(b)), st.Stats().LiveBytes)
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+// TestModuleStoreConcurrentPutAndResolve exercises the store under -race. Both
+// Put and Resolve mutate (Resolve refreshes LRU recency), so both take the
+// write lock, and the identities must survive concurrent use.
+func TestModuleStoreConcurrentPutAndResolve(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	noInfo := fixture(t, "single_nolineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 8})
+
+	const workers, iters = 8, 200
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var calls uint64
+
+	for w := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			local := uint64(0)
+			for i := range uint64(iters) {
+				crc := (uint64(w)*iters + i) % 20
+				switch i % 3 {
+				case 0:
+					_ = st.Put(crc, b)
+				case 1:
+					_ = st.Put(crc, noInfo)
+				default:
+					st.Resolve(crc, idx, (i%0x18)*0x10)
+					local++
+				}
+			}
+			mu.Lock()
+			calls += local
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	s := st.Stats()
+	assert.LessOrEqual(t, s.Live, 8)
+	assert.Equal(t, calls, s.ResolveTotal())
+	assert.Equal(t, s.ModulesStored, s.ModulesClassified())
+	assert.Equal(t, s.ModulesEvicted, s.ModulesEvictedCapacity+s.ModulesEvictedBytes)
+	assert.Equal(t, s.ModulesStored-uint64(s.Live), s.ModulesEvicted,
+		"every stored module is either live or evicted")
+}


### PR DESCRIPTION
**Task 4 of [the GPU PC sampling plan](docs/superpowers/plans/2026-08-25-gpu-pc-sampling.md).** Additive — `Timeline`, `LaunchCache`, `orderedFIFO`, the join and `projection.go` are untouched, and nothing consumes the store yet.

Maps `cubin_crc → (bytes, *cubin.Cubin, functionIndex→name)`, bounded and LRU. `Put(crc, bytes) error` and `Resolve(crc, functionIndex, pcOffset) Resolution`.

### The four-valued status is structurally unavoidable, by four mechanisms

The plan requires the store be *the single place* `gpu_src_status` is decided, so no caller can invent a fifth answer or a silent default. Rather than document that:

- `Resolution` has no exported fields and no exported constructor — nothing outside `gpu` can build one.
- The location is reachable only via `Source() (fn, file string, line uint32, ok bool)`. There are deliberately **no** `File()`/`Line()`/`Function()` getters, so mislabeling requires ignoring a returned bool rather than forgetting a check.
- Three of the four unexported constructors take no arguments and therefore *cannot* carry a location.
- The zero value is `srcStatusInvalid`, which prints as `unset-src-status` and **errors in `MarshalJSON`** (matching `ClockDomain`/`GPUCapability`), so an undecided status cannot reach a serialized profile.

### Damaged line table: , but its own counter

Task 1's recommendation followed exactly — `LineInfoErr() != nil` resolves as `no-module`, because a damaged table reported as `no-lineinfo` tells the operator to add a build flag they already passed.

It is **not** folded into `ModulesUnparseable`; it gets `ModulesDamagedLineInfo`. Unparseable means the bytes did not survive transport; damaged means the ELF is fine and *our reader* refused the DWARF — the shape a future toolkit change would take. Folded together, that toolkit change would climb `ModulesUnparseable` and send an operator to audit a channel that is working, which is the same wrong-colour-counter failure the plan's own unparseable/without-lineinfo split exists to prevent, one level down. Both directions are asserted non-interchangeably.

### Deviations, each with a reason

- **`Put` copies rather than retains `b`.** Task 3 hands over an `mmap` it then unmaps — the exact hazard Task 1's `TestParseDoesNotRetainInput` was written for.
- **`Put`'s error is diagnostic, not a rejection.** The entry is stored and counted so a re-offer is not re-parsed; documented explicitly so nobody reads it as "retry".
- **`MaxBytes` alongside `Capacity`.** 512 modules is anywhere from a few MB to a hundred.
- **`orderedFIFO` deliberately not reused.** It reclaims superseded positions only while evicting, so per-`Resolve` touching would grow its order slice without bound while the store sits under capacity.

### Identities, tested

`ResolveResolved + ResolveNoModule + ResolveNoLineInfo + ResolveUnmapped == calls` — asserted in five tests through a counting wrapper, including a 384-call mixed workload and the concurrent test. Also `ModulesStored == the four classification counters`, `ModulesEvicted == capacity + bytes evictions`, and `ModulesStored - Live == ModulesEvicted` under concurrency.

**Mutation-checked** with four deliberate defects, each caught then reverted: damaged→`no-lineinfo`; `Resolve` not refreshing LRU; eviction removing from the list but not the map (the stale-answer bug the plan names explicitly); and an `unmapped` return missing its counter.

### Flagged for Task 8b

`Resolution` carries a function name only when `resolved`, per the representation table. Tier B's kernel-name frame needs one even for a module built without `-lineinfo`. The store holds it — `byIndex` is populated for every parseable module — but does not expose it; Task 8b will want `FunctionName(crc, functionIndex) (string, bool)`. Not added here: an accessor with no caller is an accessor with no test.

### Cannot verify

`CapEff: 0`, no GPU — and the plan states this task needs neither. Three premises remain untested: that CUPTI's `functionIndex` is the `.symtab` index (the store keys on `cubin.Function.SymIndex`, and the tests read it from the fixture rather than hard-coding, so they assert consistency and never that CUPTI agrees — Task 6 measures it, and the pre-approved v2 fallback would change one map, not the status logic); no real `MODULE_LOADED` cubin has been seen; and every module tested is one of Task 1's four sm_86 / CUDA 13.3 fixtures or a deliberate corruption of one.