### PR TITLE
gpu: the adapter copies a cubin in the callback and offers it from the drain thread

### DIFF
--- a/.superpowers/sdd/task-5-adapter-cubins-report.md
+++ b/.superpowers/sdd/task-5-adapter-cubins-report.md
@@ -1,0 +1,328 @@
+# Task 5 — The adapter captures cubins
+
+Branch `feat/adapter-captures-cubins`, one commit, rebased onto `origin/main`
+(which now carries Task 1's `internal/cubin` and Task 2's ABI additions) with
+Task 3's transport commit beneath it. Verified offline: `CapEff: 0`, no GPU.
+Everything Task 5 can prove without hardware is proven; the three things the
+plan defers to the RTX 3090 are stated as outstanding at the end, and a fourth
+that this implementation introduces is stated with them.
+
+## What was built
+
+| file | what |
+| --- | --- |
+| `shim/core/cubinqueue.h` | `CubinView` — the non-owning view whose pointer cannot escape — and `CubinQueue`, the bounded copy-now/send-later queue |
+| `shim/core/cubinqueue.cc` | the copy, the CRC-over-the-copy, the intern, the bounded push, the lock-free-of-the-offer drain |
+| `shim/core/cubinqueue_test.cc` | 13 runtime assertions, including the one that fails if the copy is deferred |
+| `shim/core/cubin_defer_test.cc` | the compile-time assertion: five deferrals that must not compile, plus a control that must |
+| `shim/nvidia/cupti_adapter.cc` | `CUPTI_CBID_RESOURCE_MODULE_LOADED` is read; `cuptiGetCubinCrc()`; `gpu_module_load_v1`; the drain-tick offer; nine counters in the stats dump |
+| `shim/stub/stub.cc` | the fake module-load path: `PERFAGENT_STUB_CUBINS`, the same `CubinQueue`, the same probe, the real cubin channel |
+| `gpuprobe/cubin_test.go` | four Go tests driving the stub's module path over the real Task 3 listener |
+| `shim/Makefile` | `core/cubinqueue.cc` into `CORE_SRC`; `cubinqueue_test` into `test` and `test-tsan`; the new `check-cubin-defer` target, which `test` depends on |
+
+**Task 3's transport and the enrolment path are unchanged in substance.**
+`shim/core/cubin.{h,cc}`, `gpuprobe/cubin.go`, `gpuprobe/enroll.go` and
+`shim/core/enroll.{h,cc}` have no production edits. What Task 5 uses, it uses by
+calling: `cubin_offer_to_consumer`, `cubin_timeout_ms`, `cubin_self_name`,
+`cubins_offered()`, `cubins_send_failed()`. `CubinOfferFn` is deliberately
+signature-compatible with `cubin_offer_to_consumer`, so the production wiring is
+a name and the tests are a substitute.
+
+One change to a Task 3 **test helper** is flagged in its own section below.
+
+## The capture path
+
+`cubin.h` states the rule as a contract — *"Nothing in this header may be called
+from a CUPTI callback. The MODULE_LOADED callback's job is the memcpy … the
+offer belongs to the drain thread"* — and this task implements exactly that
+split.
+
+**In the callback** (`on_module_loaded`, on the application's `cuModuleLoad`
+thread):
+
+1. reject a descriptor with no bytes → `g_module_no_bytes`
+2. gate: is a consumer believed present → `g_module_unattached`
+3. reject a cubin over the per-cubin ceiling **before the memcpy** → `cubin_too_large`
+4. `malloc` + **`memcpy`** — the copy, with nothing deferred ahead of it
+5. `cuptiGetCubinCrc()` **over the copy** → zero means "could not" → `cubin_crc_failed`
+6. intern by CRC; a re-load is skipped → `module_reload_skipped`
+7. **fire `gpu_module_load_v1`**, `bytes_ptr` = the copy
+8. push to the bounded queue, or drop the *offer* → `cubin_queue_full`
+
+**On the drain thread** (the 100 ms `on_tick` the adapter already owns, plus one
+bounded pass in the `atexit` handler): pop, `cubin_offer_to_consumer`, free.
+`drain()` never holds the queue mutex across an offer — doing so would hand the
+offer's whole 2 s timeout to the application's next module load, which is the
+cost the split exists to avoid. `test_a_slow_offer_does_not_block_a_capture`
+asserts a capture completes while an offer is wedged, and TSan proves the
+absence of the race rather than the counters agreeing by luck.
+
+**Step 7's position is load-bearing, not stylistic.** The record is emitted
+*after* the CRC and *before* the push, which is the only instant at which the
+copy is owned by nobody else: after the push the drain thread may offer and free
+it, and `bytes_ptr` would name freed memory. `bytes_ptr` stays in the ABI and
+stays accurate; it is still not a transport, because reading it from the agent
+needs `CAP_SYS_PTRACE`.
+
+**Why the gate is not the probe semaphore alone.** `capture_enabled()` is
+`g_consumer_enrolled || gpu_module_load_v1_enabled()`. Issue #49 measured that
+the semaphore reads **zero** at `InitializeInjection` on the RTX 3090 across
+three runs while four thousand probes fired later in the same process — it
+answers "has the kernel told this process yet", not "is a consumer attached".
+CUDA's lazy loading can put the first `MODULE_LOADED` very close to that moment,
+and a module missed there is missed *permanently*: there is no "copy it later".
+So the gate is the one #49's second fix settled on — the rendezvous `connect()`
+succeeded — with the semaphore as a second chance. An unprofiled process reads
+false on both and copies nothing.
+
+## The compile error that proves the deferral is impossible
+
+`CubinView` has no copy constructor, no move constructor, no assignment, no
+default constructor, a deleted `operator new`, and **no accessor for its
+pointer at all**. `copy_to(dst, cap)` is the only member that can reach
+`bytes_`, and it writes into a buffer the caller already owns. The consequence
+is that the vendor's pointer has exactly one consumer — the memcpy — and cannot
+reach any structure that outlives the callback.
+
+`make -C shim check-cubin-defer` runs as a prerequisite of `make -C shim test`.
+It compiles `core/cubin_defer_test.cc` six times and fails the build if any of
+the five violations compiles, or if the control does not:
+
+```
+check-cubin-defer: OK - the compliant capture compiles, all 5 deferrals do not
+```
+
+The five, with the errors GCC 16 actually produced:
+
+| mode | the deferral attempted | `c++ -std=c++17 -Wall -Werror -I core -fsyntax-only` |
+| --- | --- | --- |
+| 1 | store the view in a struct that outlives the callback | `error: use of deleted function ‘perfagent::CubinView::CubinView(const perfagent::CubinView&)’` |
+| 2 | heap-allocate the view and keep the address | `error: use of deleted function ‘static void* perfagent::CubinView::operator new(size_t)’` |
+| 3 | move the view into a `std::vector` | `error: use of deleted function ‘perfagent::CubinView::CubinView(perfagent::CubinView&&)’` |
+| 4 | read the borrowed pointer straight out | `error: ‘const class perfagent::CubinView’ has no member named ‘bytes’; did you mean ‘const void* perfagent::CubinView::bytes_’? (not accessible from this context)` |
+| 5 | keep a long-lived view slot and re-point it | `error: use of deleted function ‘perfagent::CubinView& perfagent::CubinView::operator=(perfagent::CubinView&&)’` |
+
+**Mode 0 is the control and it must compile.** Without it the whole check would
+pass just as happily on a file broken for an unrelated reason — a typo, a
+renamed header — and would be proving nothing at all, which is the exact shape
+of the eleven counters this project has shipped reading green at the worst
+possible moment. The Makefile prints a distinct diagnostic for a failing control
+and for each compiling violation, naming spec §6.3 finding 2 as the reason.
+
+The runtime companion is `test_the_copy_is_taken_inside_the_callback`: it
+captures 4,096 bytes, then **overwrites the source buffer** exactly as CUPTI's
+does after `cuModuleUnload`, then drains — and asserts the offered bytes are the
+original. A deferred copy passes every other assertion in that file and fails
+this one.
+
+## The stub's fake module-load path
+
+`PERFAGENT_STUB_CUBINS` is a `:`-separated list of paths, in the shape `PATH`
+itself uses. For each, the stub reads the file, builds a `CubinView` over it,
+and runs it through **the same `perfagent::CubinQueue` the CUPTI adapter runs**
+— same capture, same crc-over-the-copy, same `gpu_module_load_v1` fired from
+inside `capture()`, same offer on the drain thread. Modules are captured before
+the launch loop, as they are in a CUDA process, and the stub waits (bounded at
+5 s) for the queue to empty so a gate can assert on a module the consumer
+provably already holds.
+
+The fixtures are Task 1's, reused rather than reinvented, so the same bytes are
+exercised by the reader's tests, the module store's, and the transport's:
+
+```
+$ PERFAGENT_STUB_CUBINS=…/single_lineinfo.cubin:…/single_nolineinfo.cubin \
+    shim/perfagent-gpu-stub 0 0 8 0
+stub: module id=1 path=…/single_lineinfo.cubin size=4840 crc=0x9d57accad01046eb captured=yes
+stub: module id=2 path=…/single_nolineinfo.cubin size=3240 crc=0x4db8f7580a182c2e captured=yes
+stub: cubins requested=2 captured=2 reload_skipped=0 queue_full=0 too_large=0 crc_failed=0
+      alloc_failed=0 sent=0 send_failed=2 pending=0 offered=2 transport_send_failed=0
+      timeout_ms=2000 cubin_addr=@perfagent-gpu-cubin.v1.0.34.2089417
+```
+
+(`send_failed=2` above is a run with no listener bound — the honest reading of
+"a consumer will not have these bytes". With the Go listener up it is 0 and
+`sent=2`.)
+
+**The CRC is a documented stand-in and is not `cuptiGetCubinCrc()`.** CUPTI's
+polynomial is unpublished and there is no CUDA toolkit on the consumer's path.
+What the join actually requires is that one number names one set of bytes and
+that the *same* number reaches both ends; the stub declares FNV-1a, spelled once
+in `stub.cc` and independently a second time in Go (`stubCubinCRC`), so "the key
+the consumer stored is the key the producer meant" is an assertion rather than a
+read-back.
+
+**What this now drives end to end with no GPU:**
+
+- **Task 3** — the real sealed-memfd offer over the real abstract socket, from a
+  real producer binary, with the address derived independently at both ends;
+- **Task 4** — a real `-lineinfo` cubin and a real no-lineinfo cubin arrive at
+  the store, which is what makes more than one `gpu_src_status` value reachable
+  from one producer run;
+- **Task 7** — `gpu_module_load_v1` on the wire from a producer, so `kindModule`
+  has something to decode;
+- **Task 9** — a module whose line table resolves, reached from a producer
+  rather than from a hand-built fixture.
+
+Four Go tests, all passing without capabilities:
+
+```
+--- PASS: TestTheStubsFakeModuleLoadDeliversACheckedInCubin
+--- PASS: TestTheStubDeliversSeveralModulesInOneRun
+--- PASS: TestTheStubDoesNotReofferAReloadedModule
+--- PASS: TestAStubRunWithNoModulesTouchesTheCubinChannelAtAll
+```
+
+The last one is the zero-direction assertion: a run that asked for no modules
+must read zero on every producer counter *and* leave `mapped`, `received` and
+`bytes` at zero on the consumer.
+
+## The counters
+
+The plan names four. Four are not enough, because three further paths drop a
+module and one path drops it before the queue exists — and a drop with no
+counter is the failure this project has shipped eleven times. All nine are
+printed by the adapter's `report()` and by the stub's summary line.
+
+| counter | where | drops what | healthy run |
+| --- | --- | --- | --- |
+| **`g_modules_captured`** | `CubinQueue` | — (the success count) | = distinct modules |
+| **`g_module_reload_skipped`** | `CubinQueue` | a re-offer of a CRC already sent | 0 (non-zero is normal under lazy loading) |
+| **`g_cubin_queue_full`** | `CubinQueue` | the OFFER, past `max_entries` or `max_queued_bytes` | **0** |
+| **`g_cubin_send_failed`** | `CubinQueue` | an offer that did not end `accepted` | **0** |
+| `g_cubin_too_large` | `CubinQueue` | a cubin over the per-cubin ceiling, **before the memcpy** | **0** |
+| `g_cubin_crc_failed` | `CubinQueue` | a cubin whose CRC came back zero | **0** |
+| `g_cubin_alloc_failed` | `CubinQueue` | the copy itself could not be allocated | **0** |
+| `g_module_unattached` | adapter | a `MODULE_LOADED` declined because no consumer was believed present | **0** while attached |
+| `g_module_no_bytes` | adapter | a `MODULE_LOADED` whose descriptor carried no cubin | **0** |
+
+Plus `cubins_sent` (accepted offers) and `cubin_queue_depth`, and Task 3's own
+`cubins_offered` / `cubins_send_failed` reprinted beside them.
+
+`g_cubin_send_failed` is deliberately **broader** than Task 3's
+`cubins_send_failed()`: that one excludes "nobody was listening", because an
+unprofiled process must not accumulate failures. The queue only ever holds bytes
+when a consumer was believed present, so here a no-listener result *is* a module
+the consumer will not have, and it is counted.
+
+`test_a_healthy_run_reads_zero_on_every_drop_counter` asserts all seven queue
+counters at zero on a clean run, and each of them at an exact non-zero value in
+its own case. A counter that cannot go non-zero in a test is not a counter.
+
+Two deliberate readings, on the record rather than buried:
+
+- **The queued-bytes ceiling counts as `cubin_queue_full`, not as a tenth
+  counter.** A queue full by bytes and a queue full by entries are the same
+  drop with the same consequence and the same operator action; both are tested
+  separately.
+- **A queue-full drop does not intern the CRC.** A later re-load of that module
+  gets another chance at a queue that may since have drained. Interning it would
+  make one moment of backpressure permanent for that module.
+
+## The one change outside this task
+
+`gpuprobe/cubin_test.go`'s `offerCubinFDs` helper now tolerates `EPIPE` /
+`ECONNRESET` on its `WriteMsgUnix` instead of `require.NoError`-ing on it.
+
+This is **pre-existing and not caused by anything here**:
+
+```
+$ git worktree add --detach /tmp/pa-base origin/feat/cubin-transport
+$ cd /tmp/pa-base && go test ./gpuprobe/ -run TestAPerPIDConsumerRefusesCubinsFromEveryOtherPID -count=20
+--- FAIL: TestAPerPIDConsumerRefusesCubinsFromEveryOtherPID
+    Error: Received unexpected error: write unix @: sendmsg: broken pipe
+FAIL
+```
+
+The listener decides unauthorized and throttled offers **from the peer's
+credentials alone, without ever reading** — which is Task 3's design and is
+correct — so it can reply `'X'` and close before the test's write lands. The
+status byte is still queued on the test's end and the read below returns it, so
+failing on the write makes every reject-before-read case a coin toss on how the
+two ends interleave. On this machine (6.19.10) it loses reproducibly. The
+transport is untouched; only the test's write-error handling changed, and the
+assertion on the `'X'` reply is unchanged. Flagged here so Task 3's owner sees
+it rather than discovering it as a conflict.
+
+## Verification run
+
+```
+make -C shim                        exit 0
+make -C shim test                   exit 0   (check-cubin-defer OK, cubinqueue_test OK)
+make -C shim test-tsan              exit 0   (cubinqueue_test under ThreadSanitizer)
+make -C shim check-fpless           exit 0
+make -C shim nvidia                 exit 0   (CUDA 13.3; the adapter's compile check)
+go build ./... && go vet ./...      clean
+go test ./gpuprobe/ ./gpu/ ./internal/... -count=1
+                                    ok gpuprobe 4.4s, gpu 3.7s, 9 internal pkgs
+go test ./gpuprobe/ -race -count=4  ok 18.2s
+~/go/bin/golangci-lint run          0 issues
+```
+
+`readelf -n libperfagent-gpu-nvidia.so` and `libperfagent-gpu-fpless.so` both
+carry the `gpu_module_load_v1` note, so the probe the consumer's cookie expects
+exists in both producers.
+
+`shim/core/cubinqueue_test.cc`, all green:
+
+```
+  copy-in-the-callback: 4096 bytes survive the vendor overwriting its buffer
+  gpu_module_load_v1 fires inside capture, over the owned copy
+  the CRC is computed over the copy, not over the borrowed buffer
+  a zero CRC is refused and counted: crc_failed=1
+  a re-load of one CRC offers once: captured=1 reload_skipped=1
+  a full queue drops 3 offers, counts them, and never blocks
+  the queued-bytes ceiling is the same drop with the same counter
+  a cubin over the per-cubin ceiling is refused before the memcpy
+  a refused offer counts send_failed=1 and is not retried
+  drain empties the queue, is bounded, and passes the timeout through
+  a capture completes while a slow offer is in flight (no lock held across it)
+  healthy run: captured=4 sent=4 and every drop counter at zero
+  destroying a non-empty queue releases its copies
+cubinqueue_test: OK
+```
+
+The existing gate is unaffected: it runs the stub **without**
+`PERFAGENT_STUB_CUBINS`, so no module record fires and its
+`assert.Zero(t, stats.Undecoded)` still holds. Task 7 decodes `kindModule`
+before the gate starts emitting them.
+
+## Cannot verify — outstanding on the RTX 3090
+
+The implementer has `CapEff: 0` and no GPU. The plan defers three things from
+this task to hardware; a fourth is introduced by this implementation's gating
+choice and belongs on the same list.
+
+1. **That `MODULE_LOADED` fires at all for the test workload, and how often.**
+   Nothing here has seen a real CUPTI resource callback. CUDA's lazy module
+   loading may put the first one much later than expected — possibly after the
+   first launch — and `g_resource_events[6]` beside `g_modules_captured` is what
+   answers it on the first run.
+
+2. **That a `cuModuleUnload` after capture leaves our copy's recomputed CRC
+   unchanged** — the direct test of §6.3 finding 2. The offline test simulates
+   the hazard by overwriting the source buffer; only hardware shows that CUPTI's
+   buffer really does change under us and that the copy really is taken early
+   enough to miss it.
+
+3. **That `cuptiGetCubinCrc()` over the copy matches the PC records'
+   `cubinCrc`.** This is the most consequential unknown in the phase and it is
+   load-bearing beyond this task. Task 3's report already notes that the agent
+   **cannot recompute the CRC** — no CUDA toolkit — and therefore trusts the
+   offer header's value as the join key. If the two numbers disagree on
+   hardware, **every Tier B PC sample resolves `no-module` with every counter on
+   both sides reading green.** There is no offline experiment that can move this
+   one; it must be the first thing the first GPU run prints.
+
+4. **That `capture_enabled()` reads true by the time the first `MODULE_LOADED`
+   arrives.** This is new with Task 5. The gate is `enroll == confirmed ||
+   semaphore != 0`, chosen precisely because issue #49 measured the semaphore
+   reading zero at `InitializeInjection`. If the rendezvous is *also* not
+   confirmed at that moment in some configuration, the first module is declined
+   and — because there is no "copy it later" — permanently unresolvable.
+   `g_module_unattached` is the counter that makes it visible; it must read
+   zero on a profiled run, and a non-zero value there is the signal to widen
+   the gate rather than to widen the tolerance.
+
+Also untested here, by design: the CUPTI adapter has **only** a compile check
+and the escape-analysis assertion, exactly as the plan says it can. No `CUpti_`
+code path in this commit has ever executed.

--- a/gpuprobe/cubin_test.go
+++ b/gpuprobe/cubin_test.go
@@ -2,6 +2,7 @@ package gpuprobe
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -98,8 +99,20 @@ func offerCubinFDs(t *testing.T, addr string, hdr []byte, fds []int) byte {
 	if len(fds) > 0 {
 		rights = unix.UnixRights(fds...)
 	}
-	_, _, err = uc.WriteMsgUnix(hdr, rights, nil)
-	require.NoError(t, err)
+	// EPIPE / ECONNRESET here is not a failure: the listener decides
+	// unauthorized and throttled offers from the peer's credentials alone,
+	// without ever reading, so it can have replied 'X' and closed before this
+	// write lands. The status byte it wrote is still queued on this end and
+	// the read below returns it. Failing on the write instead makes every
+	// reject-before-read test a coin toss on how the two ends interleave -
+	// reproducibly lost on 6.19, and the reason this is not a require.
+	//
+	// (Task 5 note: pre-existing. TestAPerPIDConsumerRefusesCubinsFromEveryOtherPID
+	// fails identically on origin/feat/cubin-transport unmodified.)
+	if _, _, werr := uc.WriteMsgUnix(hdr, rights, nil); werr != nil {
+		require.True(t, errors.Is(werr, unix.EPIPE) || errors.Is(werr, unix.ECONNRESET),
+			"unexpected write error: %v", werr)
+	}
 	var b [1]byte
 	n, err := uc.Read(b[:])
 	if err != nil || n != 1 {
@@ -1145,3 +1158,197 @@ int main() {
     return 0;
 }
 `
+
+// ---------------------------------------------------------------------------
+// Task 5: the stub's fake module-load path, end to end over the real channel.
+//
+// This is the assertion that makes Task 5 verifiable without a GPU. The stub
+// runs the SAME perfagent::CubinQueue the CUPTI adapter runs - same
+// CubinView, same copy-inside-the-callback, same crc-over-the-copy, same
+// offer-on-the-drain-thread - over a checked-in cubin from
+// internal/cubin/testdata. Reusing that fixture rather than inventing bytes
+// is what makes "the reader parses what the transport delivers" one set of
+// bytes instead of two that agree by assumption.
+//
+// What it cannot prove is anything about CUPTI: that MODULE_LOADED fires at
+// all, that cuptiGetCubinCrc() over our copy matches the PC records' cubinCrc,
+// or that a cuModuleUnload leaves our copy intact. Those are on the RTX 3090.
+
+// stubCubinFixture reads one of Task 1's checked-in cubins.
+func stubCubinFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	p := filepath.Join("..", "internal", "cubin", "testdata", name)
+	b, err := os.ReadFile(p)
+	require.NoError(t, err, "the Task 1 fixture must be checked in")
+	require.NotEmpty(t, b)
+	return b
+}
+
+// stubCubinCRC is an independent Go spelling of stub.cc's stub_cubin_crc.
+// Two spellings, so "the key the consumer stored is the key the producer
+// meant" is an assertion rather than a read-back.
+//
+// It stands in for cuptiGetCubinCrc(), which needs a CUDA toolkit this side
+// does not have. What the join requires is that one number names one set of
+// bytes and that the same number reaches both ends; a content hash satisfies
+// that exactly as CUPTI's unpublished polynomial does.
+func stubCubinCRC(b []byte) uint64 {
+	h := uint64(1469598103934665603)
+	for _, c := range b {
+		h ^= uint64(c)
+		h *= 1099511628211
+	}
+	if h == 0 {
+		return 1
+	}
+	return h
+}
+
+// buildStub builds shim/perfagent-gpu-stub and hands back a copy with an
+// inode of its own. The inode is the point: the cubin address embeds it, so a
+// private copy is what stops a concurrent stub run - a second developer, a CI
+// job - offering into this test's listener.
+func buildStub(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("make"); err != nil {
+		t.Skip("make unavailable")
+	}
+	shim, err := filepath.Abs(filepath.Join("..", "shim"))
+	require.NoError(t, err)
+	if _, serr := os.Stat(filepath.Join(shim, "stub", "stub.cc")); serr != nil {
+		t.Skipf("shim/stub not present: %v", serr)
+	}
+	out, err := exec.Command("make", "-C", shim, "perfagent-gpu-stub").CombinedOutput()
+	require.NoError(t, err, "build perfagent-gpu-stub: %s", out)
+
+	src := filepath.Join(shim, "perfagent-gpu-stub")
+	data, err := os.ReadFile(src)
+	require.NoError(t, err)
+	dst := filepath.Join(repoTempDir(t), "perfagent-gpu-stub")
+	require.NoError(t, os.WriteFile(dst, data, 0o700))
+	return dst
+}
+
+// runStubWithCubins runs the stub with no launches at all, so the only thing
+// it does is the fake module load. Returns its stderr.
+func runStubWithCubins(t *testing.T, stub string, paths ...string) string {
+	t.Helper()
+	cmd := exec.Command(stub, "0", "0", "8", "0")
+	cmd.Env = append(os.Environ(), "PERFAGENT_STUB_CUBINS="+strings.Join(paths, ":"))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Run(), "stub failed: %s", stderr.String())
+	return stderr.String()
+}
+
+func TestTheStubsFakeModuleLoadDeliversACheckedInCubin(t *testing.T) {
+	stub := buildStub(t)
+	fixture := stubCubinFixture(t, "single_lineinfo.cubin")
+	want := stubCubinCRC(fixture)
+
+	sink := newRecordingCubinSink()
+	l := testCubinListener(t, Config{ShimPath: stub}, sink)
+
+	path, err := filepath.Abs(filepath.Join("..", "internal", "cubin", "testdata", "single_lineinfo.cubin"))
+	require.NoError(t, err)
+	out := runStubWithCubins(t, stub, path)
+
+	// The address first: when the two ends derive different names every
+	// counter on both sides reads zero and nothing else in this test says why.
+	assert.Contains(t, out, "cubin_addr=@"+strings.TrimPrefix(l.address(), "@"),
+		"the stub derived a different cubin address than the listener bound")
+
+	stored, ok := sink.get(want)
+	require.True(t, ok, "nothing stored under the CRC the stub declared. stub said: %s", out)
+	assert.True(t, bytes.Equal(fixture, stored),
+		"the bytes the stub offered are not the fixture's bytes")
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.received)
+	assert.Equal(t, uint64(len(fixture)), st.bytes)
+	assertNoCubinRejections(t, st)
+
+	// The producer's own accounting, which no consumer-side counter can see:
+	// a module dropped before it ever reached the wire is upstream of
+	// everything above.
+	assert.Contains(t, out, "captured=1 reload_skipped=0 queue_full=0 too_large=0 "+
+		"crc_failed=0 alloc_failed=0 sent=1 send_failed=0 pending=0")
+}
+
+func TestTheStubDeliversSeveralModulesInOneRun(t *testing.T) {
+	stub := buildStub(t)
+	sink := newRecordingCubinSink()
+	l := testCubinListener(t, Config{ShimPath: stub}, sink)
+
+	names := []string{"single_lineinfo.cubin", "single_nolineinfo.cubin", "two_kernels_lineinfo.cubin"}
+	var paths []string
+	total := 0
+	for _, n := range names {
+		p, err := filepath.Abs(filepath.Join("..", "internal", "cubin", "testdata", n))
+		require.NoError(t, err)
+		paths = append(paths, p)
+		total += len(stubCubinFixture(t, n))
+	}
+	out := runStubWithCubins(t, stub, paths...)
+
+	// A -lineinfo cubin and a no-lineinfo one in one run is what lets the
+	// gate reach more than one gpu_src_status value from a single producer.
+	for _, n := range names {
+		fixture := stubCubinFixture(t, n)
+		stored, ok := sink.get(stubCubinCRC(fixture))
+		require.True(t, ok, "%s did not arrive. stub said: %s", n, out)
+		assert.True(t, bytes.Equal(fixture, stored), "%s arrived with different bytes", n)
+	}
+	st := l.snapshot()
+	assert.Equal(t, uint64(3), st.received)
+	assert.Equal(t, uint64(total), st.bytes)
+	assertNoCubinRejections(t, st)
+}
+
+// The adapter-side intern: CUDA's lazy loading re-loads modules, and a
+// re-load of the same CRC must not re-offer. Counted on the producer, since
+// the consumer would only ever see it as a duplicate.
+func TestTheStubDoesNotReofferAReloadedModule(t *testing.T) {
+	stub := buildStub(t)
+	fixture := stubCubinFixture(t, "unrolled_lineinfo.cubin")
+
+	sink := newRecordingCubinSink()
+	l := testCubinListener(t, Config{ShimPath: stub}, sink)
+
+	path, err := filepath.Abs(filepath.Join("..", "internal", "cubin", "testdata", "unrolled_lineinfo.cubin"))
+	require.NoError(t, err)
+	out := runStubWithCubins(t, stub, path, path, path)
+
+	assert.Contains(t, out, "captured=1 reload_skipped=2")
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.received)
+	assert.Equal(t, uint64(len(fixture)), st.bytes)
+	// A re-offer would have shown up here rather than as a rejection, so the
+	// duplicate counter is checked at zero too: the producer suppressed it,
+	// the consumer never had to.
+	assert.Zero(t, st.duplicate, "the consumer had to absorb a re-offer the producer should have suppressed")
+	assertNoCubinRejections(t, st)
+}
+
+// The boring run must read zero everywhere. Eleven defects on this project
+// were counters reading green exactly when things were worst, so the
+// direction that matters is asserted in both.
+func TestAStubRunWithNoModulesTouchesTheCubinChannelAtAll(t *testing.T) {
+	stub := buildStub(t)
+	sink := newRecordingCubinSink()
+	l := testCubinListener(t, Config{ShimPath: stub}, sink)
+
+	cmd := exec.Command(stub, "0", "0", "8", "0")
+	cmd.Env = append(os.Environ(), "PERFAGENT_STUB_CUBINS=")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Run(), "stub failed: %s", stderr.String())
+
+	assert.Contains(t, stderr.String(), "cubins requested=0 captured=0 reload_skipped=0 "+
+		"queue_full=0 too_large=0 crc_failed=0 alloc_failed=0 sent=0 send_failed=0 pending=0")
+	st := l.snapshot()
+	assert.Zero(t, st.received)
+	assert.Zero(t, st.bytes)
+	assert.Zero(t, st.mapped)
+	assertNoCubinRejections(t, st)
+}

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -21,10 +21,10 @@ NVCC ?= $(CUDA_HOME)/bin/nvcc
 # sm_86 is the RTX 3090 this adapter was proven on.
 CUDA_ARCH ?= sm_86
 
-CORE_SRC := core/batch.cc core/clock.cc core/cubin.cc core/drain.cc core/enroll.cc core/sampler.cc
+CORE_SRC := core/batch.cc core/clock.cc core/cubin.cc core/cubinqueue.cc core/drain.cc core/enroll.cc core/sampler.cc
 CORE_OBJ := $(CORE_SRC:.cc=.o)
 
-.PHONY: all test test-tsan nvidia nvidia-workload clean
+.PHONY: all test test-tsan check-cubin-defer nvidia nvidia-workload clean
 all: libperfagent-gpu-core.a
 
 libperfagent-gpu-core.a: $(CORE_OBJ)
@@ -177,6 +177,42 @@ nvidia/testdata/cuda_workload: nvidia/testdata/cuda_workload.cu
 	$(NVCC) -O2 -g -lineinfo -arch=$(CUDA_ARCH) \
 		-Xcompiler -fno-omit-frame-pointer -Xcompiler -rdynamic -o $@ $<
 
+# Task 5's structural assertion, run as a BUILD step rather than asserted in a
+# comment: the copy of a cubin must happen inside the vendor callback, so no
+# deferral may sit between callback entry and the memcpy. core/cubinqueue.h
+# enforces that by shape - CubinView has no copy, no move, no assignment, no
+# operator new and NO ACCESSOR FOR ITS POINTER - and this target is the proof
+# that the enforcement works, by trying to violate it five ways and requiring
+# every one to be rejected by the compiler.
+#
+# Mode 0 is the control and it MUST compile. Without it the whole check would
+# pass just as happily on a file that fails to build for an unrelated reason -
+# a typo, a renamed header - and would then be proving nothing, which is the
+# exact shape of the eleven counters this project has shipped reading green at
+# the worst possible moment.
+#
+# 2>/dev/null on the negative arms: the compiler errors ARE the pass, and
+# printing five screens of them would bury the one line that matters.
+.PHONY: check-cubin-defer
+check-cubin-defer: core/cubin_defer_test.cc core/cubinqueue.h
+	@$(CXX) -std=c++17 -Wall -Werror -I core -fsyntax-only \
+		-DPERFAGENT_CUBIN_DEFER=0 core/cubin_defer_test.cc || { \
+	  echo "check-cubin-defer: the COMPLIANT capture does not compile; this check would"; \
+	  echo "                   otherwise pass for the wrong reason. Fix core/cubinqueue.h."; \
+	  exit 1; }
+	@rc=0; for m in 1 2 3 4 5; do \
+	  if $(CXX) -std=c++17 -Wall -Werror -I core -fsyntax-only \
+		-DPERFAGENT_CUBIN_DEFER=$$m core/cubin_defer_test.cc 2>/dev/null; then \
+	    echo "check-cubin-defer: deferral mode $$m COMPILED. The vendor's pointer can escape"; \
+	    echo "                   the callback, so the copy can be deferred past the buffer's"; \
+	    echo "                   lifetime and a late reader gets silently WRONG bytes (spec"; \
+	    echo "                   6.3 finding 2). See core/cubin_defer_test.cc mode $$m."; \
+	    rc=1; \
+	  fi; \
+	done; \
+	[ $$rc -eq 0 ] && echo "check-cubin-defer: OK - the compliant capture compiles, all 5 deferrals do not"; \
+	exit $$rc
+
 # core/probe_args_test.cc and stub/probe_order_test.cc are the two tests here
 # built with -O2, and that is not a detail. probe_args_test checks that the
 # record a probe points at has actually been written to memory when the probe
@@ -192,12 +228,13 @@ nvidia/testdata/cuda_workload: nvidia/testdata/cuda_workload.cu
 # _Static_asserts are the test. Compiling it only as C++ leaves the C11 spelling
 # unguarded -- which is how the header's validity broke earlier in this branch,
 # when a C++ translation unit included it for the first time.
-test: core/batch_test.cc core/clock_test.cc core/cubin_test.cc core/drain_test.cc core/enroll_test.cc core/usdt_abi_test.c core/sampler_test.cc core/probe_args_test.cc stub/probe_order_test.cc stub/stub.cc $(CORE_SRC)
+test: check-cubin-defer core/batch_test.cc core/clock_test.cc core/cubin_test.cc core/cubinqueue_test.cc core/drain_test.cc core/enroll_test.cc core/usdt_abi_test.c core/sampler_test.cc core/probe_args_test.cc stub/probe_order_test.cc stub/stub.cc $(CORE_SRC)
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/batch_test core/batch_test.cc core/batch.cc && /tmp/batch_test
 	$(CXX) -std=c++17 -I core -o /tmp/clock_test core/clock_test.cc core/clock.cc && /tmp/clock_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/drain_test core/drain_test.cc core/drain.cc && /tmp/drain_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/enroll_test core/enroll_test.cc core/enroll.cc && /tmp/enroll_test
 	$(CXX) -std=c++17 -Wall -Werror -pthread -I core -o /tmp/cubin_test core/cubin_test.cc core/cubin.cc core/enroll.cc && /tmp/cubin_test
+	$(CXX) -std=c++17 -Wall -Werror -pthread -I core -o /tmp/cubinqueue_test core/cubinqueue_test.cc core/cubinqueue.cc && /tmp/cubinqueue_test
 	$(CC) -std=c11 -Wall -Werror -I core -o /tmp/usdt_abi_test core/usdt_abi_test.c && /tmp/usdt_abi_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/sampler_test core/sampler_test.cc core/sampler.cc && /tmp/sampler_test
 	$(CXX) -std=c++17 -O2 -Wall -Werror -I core -o /tmp/probe_args_test core/probe_args_test.cc && /tmp/probe_args_test
@@ -209,11 +246,19 @@ test: core/batch_test.cc core/clock_test.cc core/cubin_test.cc core/drain_test.c
 # which passes on most runs even with Batch's mutex deleted -- only the
 # sanitizer actually proves the absence of the race. sampler_test.cc's
 # concurrent case is the same shape, for Sampler's atomics.
-test-tsan: core/batch_test.cc core/batch.cc core/batch.h core/sampler_test.cc core/sampler.cc core/sampler.h
+#
+# cubinqueue_test.cc belongs here for a third reason: its capture path runs on
+# the APPLICATION's thread while drain() runs on the profiler's, and the whole
+# design turns on drain() not holding the mutex across an offer. A test that
+# only checks the counters passes with the lock held the wrong way round; only
+# TSan sees the unsynchronized access if one is ever introduced.
+test-tsan: core/batch_test.cc core/batch.cc core/batch.h core/sampler_test.cc core/sampler.cc core/sampler.h core/cubinqueue_test.cc core/cubinqueue.cc core/cubinqueue.h
 	$(TSAN_CXX) -std=c++17 -g -O1 -fsanitize=thread -pthread -I core \
 		-o /tmp/batch_test_tsan core/batch_test.cc core/batch.cc && /tmp/batch_test_tsan
 	$(TSAN_CXX) -std=c++17 -g -O1 -fsanitize=thread -pthread -I core \
 		-o /tmp/sampler_test_tsan core/sampler_test.cc core/sampler.cc && /tmp/sampler_test_tsan
+	$(TSAN_CXX) -std=c++17 -g -O1 -fsanitize=thread -pthread -I core \
+		-o /tmp/cubinqueue_test_tsan core/cubinqueue_test.cc core/cubinqueue.cc && /tmp/cubinqueue_test_tsan
 
 clean:
 	rm -f $(CORE_OBJ) libperfagent-gpu-core.a perfagent-gpu-stub libperfagent-gpu-stub.so \

--- a/shim/core/cubin_defer_test.cc
+++ b/shim/core/cubin_defer_test.cc
@@ -1,0 +1,105 @@
+// A compile-time test with no runtime: it passes by FAILING to compile.
+//
+// The plan's structural assertion for Task 5 is that "no deferral may sit
+// between callback entry and the memcpy", enforced by the type system rather
+// than by a comment. A guarantee nobody has tried to violate is a claim, so
+// this file tries, five ways, and shim/Makefile's `test` target fails the
+// build if any of them succeeds.
+//
+// Build it with -DPERFAGENT_CUBIN_DEFER=<n>:
+//
+//   0  the COMPLIANT capture. Must compile. Without this control the check
+//      would pass just as happily on a file that fails to compile for some
+//      unrelated reason - a typo, a missing include, a renamed header - and
+//      would then be proving nothing at all.
+//   1  store the view in a struct that outlives the callback
+//   2  heap-allocate the view and keep the address
+//   3  move the view into a container
+//   4  read the borrowed pointer straight out of the view
+//   5  assign one view over another
+//
+// Each of 1-5 is a real thing an implementer would reach for while "just
+// deferring the copy to the drain thread"; each is a compile error, and the
+// Makefile prints which.
+#include "cubinqueue.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <utility>
+#include <vector>
+
+#ifndef PERFAGENT_CUBIN_DEFER
+#define PERFAGENT_CUBIN_DEFER 0
+#endif
+
+namespace {
+
+uint64_t fake_crc(const void *bytes, size_t len) {
+    (void)bytes;
+    return len ? 0x1234u : 0u;
+}
+
+void fake_captured(void *, uint64_t, const void *, size_t) {}
+
+}  // namespace
+
+#if PERFAGENT_CUBIN_DEFER == 0
+
+// The compliant shape: the view is created at the callback, handed to
+// capture, and dies there. The copy is taken before the function returns.
+bool compliant(perfagent::CubinQueue &q, const void *vendor_bytes, size_t len) {
+    const perfagent::CubinView view(vendor_bytes, len);
+    return q.capture(view, fake_crc, fake_captured, nullptr);
+}
+
+#elif PERFAGENT_CUBIN_DEFER == 1
+
+// "I'll stash it and copy on the drain thread." The view has no copy
+// constructor and no default constructor, so it cannot be a member that is
+// filled in later.
+struct Deferred {
+    perfagent::CubinView view;
+};
+
+Deferred defer_by_storing(const void *vendor_bytes, size_t len) {
+    const perfagent::CubinView view(vendor_bytes, len);
+    return Deferred{view};
+}
+
+#elif PERFAGENT_CUBIN_DEFER == 2
+
+// "I'll put it on the heap and keep the pointer." operator new is deleted.
+perfagent::CubinView *defer_by_heap(const void *vendor_bytes, size_t len) {
+    return new perfagent::CubinView(vendor_bytes, len);
+}
+
+#elif PERFAGENT_CUBIN_DEFER == 3
+
+// "I'll move it into the queue." No move constructor either, so a container
+// cannot hold one.
+void defer_by_moving(std::vector<perfagent::CubinView> &sink, const void *vendor_bytes,
+                     size_t len) {
+    perfagent::CubinView view(vendor_bytes, len);
+    sink.push_back(std::move(view));
+}
+
+#elif PERFAGENT_CUBIN_DEFER == 4
+
+// The direct route: take the pointer out and keep THAT. There is no accessor
+// for it - copy_to() is the only member that can reach bytes_ - so this does
+// not compile no matter how the caller then stores the result.
+const void *defer_by_stealing_the_pointer(const perfagent::CubinView &view) {
+    return view.bytes();
+}
+
+#elif PERFAGENT_CUBIN_DEFER == 5
+
+// "I'll keep one around and re-point it at each new buffer." Assignment is
+// deleted, so a long-lived view slot does not exist.
+void defer_by_reassigning(perfagent::CubinView &slot, const void *vendor_bytes, size_t len) {
+    slot = perfagent::CubinView(vendor_bytes, len);
+}
+
+#else
+#error "PERFAGENT_CUBIN_DEFER must be 0..5"
+#endif

--- a/shim/core/cubinqueue.cc
+++ b/shim/core/cubinqueue.cc
@@ -1,0 +1,155 @@
+#include "cubinqueue.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace perfagent {
+
+bool CubinView::copy_to(void *dst, size_t cap) const noexcept {
+    if (bytes_ == nullptr || len_ == 0 || dst == nullptr || cap < len_) return false;
+    memcpy(dst, bytes_, len_);
+    return true;
+}
+
+CubinQueue::CubinQueue(const CubinQueueLimits &limits) : limits_(limits) {}
+
+CubinQueue::~CubinQueue() {
+    std::lock_guard<std::mutex> g(mu_);
+    for (Entry &e : q_) free(e.bytes);
+    q_.clear();
+    queued_bytes_ = 0;
+}
+
+bool CubinQueue::capture(const CubinView &view, CubinCrcFn crc, CubinCapturedFn on_captured,
+                         void *ctx) {
+    // Everything before the memcpy is a decision NOT to copy - a bound, or a
+    // missing input. Nothing here defers the copy, and nothing here may: see
+    // cubinqueue.h and core/cubin_defer_test.cc.
+    if (view.empty() || crc == nullptr) return false;
+    const size_t len = view.size();
+    if (len > limits_.max_cubin_bytes) {
+        // Refused whole, never truncated. A truncated cubin parses into a
+        // WRONG line table, which is the one failure worse than no line
+        // table, and the consumer would have refused it for its size anyway.
+        too_large_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    void *copy = malloc(len);
+    if (copy == nullptr) {
+        alloc_failed_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+    // THE COPY. The vendor's buffer is valid here and provably nowhere else.
+    if (!view.copy_to(copy, len)) {
+        free(copy);
+        alloc_failed_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    // Over the copy, never over the view: a CRC and the bytes it names must
+    // come from one read of one buffer.
+    const uint64_t key = crc(copy, len);
+    if (key == 0) {
+        // Zero is the ABI's "no module". Sending it would produce a module
+        // record that joins to nothing, with every other counter green.
+        free(copy);
+        crc_failed_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    // One lock from the intern check to the push, so two threads loading the
+    // same module cannot both decide they are the first and fire two records
+    // for one CRC. on_captured runs inside it and is documented as forbidden
+    // from re-entering the queue; it is a probe fire, which is a nop when no
+    // consumer is attached and a ~1-2us uprobe trap when one is.
+    std::unique_lock<std::mutex> g(mu_);
+
+    if (interned_.count(key) != 0) {
+        g.unlock();
+        free(copy);
+        reload_skipped_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    // Fired here, before the push, because this is the last moment the copy
+    // is owned by nobody else: after the push the drain thread may free it,
+    // and gpu_module_load_v1.bytes_ptr would then name freed memory. The
+    // record stays accurate exactly because it is emitted here.
+    if (on_captured != nullptr) on_captured(ctx, key, copy, len);
+
+    if (q_.size() >= limits_.max_entries || queued_bytes_ + len > limits_.max_queued_bytes) {
+        // The OFFER is dropped; the copy has already served its purpose of
+        // being taken in time. The module goes unresolvable rather than the
+        // application going slow, and this counter is the size of that.
+        //
+        // Deliberately NOT interned: a later re-load of the same module gets
+        // another chance at a queue that may since have drained.
+        g.unlock();
+        free(copy);
+        queue_full_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    // Interning is bounded like everything else. Past the bound we stop
+    // remembering rather than stop capturing: the consequence of forgetting
+    // is a duplicate offer, which the consumer answers with a counted no-op
+    // (CubinsDuplicate), and the consequence of not capturing is a module
+    // nothing can resolve. The cheaper mistake is the one we make.
+    if (interned_.size() < limits_.max_interned) interned_.insert(key);
+
+    Entry e;
+    e.crc = key;
+    e.bytes = copy;
+    e.len = len;
+    q_.push_back(e);
+    queued_bytes_ += len;
+    g.unlock();
+
+    captured_.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+size_t CubinQueue::drain(CubinOfferFn offer, unsigned timeout_ms) {
+    if (offer == nullptr) return 0;
+    size_t budget;
+    {
+        std::lock_guard<std::mutex> g(mu_);
+        budget = q_.size();
+    }
+    size_t done = 0;
+    for (; done < budget; done++) {
+        Entry e;
+        {
+            std::lock_guard<std::mutex> g(mu_);
+            if (q_.empty()) break;
+            e = q_.front();
+            q_.pop_front();
+            queued_bytes_ -= e.len;
+        }
+        // The mutex is NOT held here. An offer can block for its whole
+        // timeout, and holding the lock across it would hand that timeout to
+        // the application's next module load - which is the exact cost this
+        // whole split exists to avoid.
+        const CubinOfferResult r = offer(e.bytes, e.len, e.crc, timeout_ms);
+        free(e.bytes);
+        if (r == kCubinOfferAccepted) {
+            sent_.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            // Broader than cubin.cc's cubins_send_failed(), on purpose: that
+            // counter excludes "nobody was listening", because an unprofiled
+            // process must not accumulate failures. Here the queue only ever
+            // holds bytes when a consumer was believed present, so a
+            // no-listener result IS a module the consumer will not have.
+            send_failed_.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    return done;
+}
+
+size_t CubinQueue::depth() const {
+    std::lock_guard<std::mutex> g(mu_);
+    return q_.size();
+}
+
+}  // namespace perfagent

--- a/shim/core/cubinqueue.h
+++ b/shim/core/cubinqueue.h
@@ -1,0 +1,191 @@
+// The two halves of a cubin capture, split by their deadlines rather than by
+// taste, and held apart by the type system rather than by a comment.
+//
+// # Two deadlines, and why collapsing them costs the application
+//
+// The vendor hands the bytes to a callback that runs on the APPLICATION's
+// thread, inside cuModuleLoad. Spec §6.3 finding 2 measured what happens to
+// that buffer afterwards: following cuModuleUnload it is still mapped and
+// still readable, and its CONTENTS HAVE CHANGED. A late reader therefore gets
+// silently wrong bytes rather than a fault - the worst available failure,
+// because a wrong cubin parses into a wrong line table and every source line
+// derived from it is confidently incorrect. CUDA's lazy loading puts loads
+// and unloads at arbitrary points in a long-running process, so there is no
+// safe definition of "copy later".
+//
+//   The COPY is deadline-bound by the vendor's buffer lifetime.
+//   The SEND is deadline-bound by nothing at all.
+//
+// So the copy happens in the callback and the offer does not. A connect()
+// plus an up-to-8 MiB handover on cuModuleLoad would stall the application
+// for the profiler's benefit. Capture is a bounded malloc, a memcpy and a
+// mutexed push; the offer runs on the drain thread, which nothing is waiting
+// on. A full queue drops the OFFER and never the copy-in-time decision, so
+// the failure mode is a module that reads gpu_src_status "no-module" rather
+// than an application that got slower - and cubin_queue_full() is exactly the
+// size of that trade.
+//
+// # Why CubinView is shaped the way it is
+//
+// "No deferral may sit between callback entry and the memcpy" is a structural
+// assertion here, not a comment that a later edit can quietly falsify.
+// CubinView is a non-owning view of the vendor's buffer with:
+//
+//   - no copy constructor, no move constructor, no assignment: it cannot be
+//     stored in a queue node, a std::vector, a struct field or a lambda
+//     capture-by-value;
+//   - deleted operator new: it cannot be heap-allocated and the address kept;
+//   - NO ACCESSOR FOR THE POINTER AT ALL. copy_to() is the only member that
+//     touches it, and copy_to writes into a buffer the caller already owns.
+//
+// The consequence is that the borrowed pointer has exactly one consumer -
+// the copy - and cannot reach any data structure that outlives the callback.
+// Deferring the copy does not compile. core/cubin_defer_test.cc spells five
+// ways to try it and shim/Makefile's `test` target fails the build if any of
+// them compiles, plus a compliant control that must.
+//
+// The CRC runs over the COPY, never over the view, for the same reason: the
+// crc function is handed the owned bytes, so a CRC and the bytes it names can
+// never come from two different reads of a buffer that changed in between.
+#ifndef PERFAGENT_CUBINQUEUE_H
+#define PERFAGENT_CUBINQUEUE_H
+
+#include "cubin.h"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <unordered_set>
+
+namespace perfagent {
+
+// A non-owning view of the vendor's buffer, valid only for the duration of
+// the callback that was handed it. See the header comment: it exists to make
+// the pointer unable to escape, so read what it forbids before adding to it.
+class CubinView {
+public:
+    CubinView(const void *bytes, size_t len) noexcept : bytes_(bytes), len_(len) {}
+
+    // Every way of keeping one is deleted. These are the assertion.
+    CubinView() = delete;
+    CubinView(const CubinView &) = delete;
+    CubinView &operator=(const CubinView &) = delete;
+    CubinView(CubinView &&) = delete;
+    CubinView &operator=(CubinView &&) = delete;
+    static void *operator new(size_t) = delete;
+    static void *operator new[](size_t) = delete;
+
+    size_t size() const noexcept { return len_; }
+    bool empty() const noexcept { return bytes_ == nullptr || len_ == 0; }
+
+    // The ONLY consumer of the borrowed pointer, and deliberately the only
+    // member that can reach it. Copies exactly size() bytes into dst, or
+    // returns false without writing anything when dst is too small.
+    bool copy_to(void *dst, size_t cap) const noexcept;
+
+private:
+    // No accessor. Adding one re-opens the escape route the whole type
+    // exists to close, and core/cubin_defer_test.cc mode 4 is the test that
+    // would then start passing when it must not.
+    const void *bytes_;
+    size_t len_;
+};
+
+// Computes the join key over the OWNED COPY. On the vendor side this wraps
+// cuptiGetCubinCrc(); the stub substitutes a documented stand-in. Returning
+// zero means "could not", and is counted rather than sent - a zero CRC joins
+// to nothing and would be an unresolvable module with every counter green.
+typedef uint64_t (*CubinCrcFn)(const void *bytes, size_t len);
+
+// Called once per captured module, on the callback's thread, while the copy
+// is owned by nobody else. This is where gpu_module_load_v1 is fired, and it
+// is the only moment at which the record's bytes_ptr provably points at live
+// adapter-owned bytes. It must not call back into the queue.
+typedef void (*CubinCapturedFn)(void *ctx, uint64_t crc, const void *bytes, size_t len);
+
+// The send. Signature-compatible with cubin_offer_to_consumer by design, so
+// the production wiring is a name and the tests are a substitute.
+typedef CubinOfferResult (*CubinOfferFn)(const void *bytes, size_t len, uint64_t crc,
+                                         unsigned timeout_ms);
+
+// All four bounds are on the APPLICATION's side of the trade. Defaults are
+// sized for the observed shape of a CUDA process - tens of modules, a few
+// hundred KB each - with a per-cubin ceiling matching the consumer's own
+// Config.CubinMaxBytes default so a cubin this end copies is not one the
+// other end was always going to refuse.
+struct CubinQueueLimits {
+    size_t max_entries = 32;                     // queued offers
+    size_t max_queued_bytes = 64u * 1024 * 1024; // their total
+    size_t max_cubin_bytes = 8u * 1024 * 1024;   // one module, the memcpy bound
+    size_t max_interned = 4096;                  // distinct CRCs remembered
+};
+
+// Bounded, mutex-guarded, and drained by somebody else's thread.
+class CubinQueue {
+public:
+    explicit CubinQueue(const CubinQueueLimits &limits = CubinQueueLimits());
+    ~CubinQueue();
+
+    CubinQueue(const CubinQueue &) = delete;
+    CubinQueue &operator=(const CubinQueue &) = delete;
+
+    // The callback half. Copies view NOW, computes the CRC over the copy,
+    // calls on_captured while the copy is still exclusively ours, and pushes.
+    // Returns true only when the copy was made AND enqueued for offer.
+    //
+    // Every early return has a counter; none is silent.
+    bool capture(const CubinView &view, CubinCrcFn crc, CubinCapturedFn on_captured,
+                 void *ctx);
+
+    // The drain-thread half. Offers at most the entries present on entry, so
+    // a producer that keeps capturing cannot pin this thread here, and never
+    // holds the mutex across an offer - doing so would put the offer's whole
+    // timeout back onto the application's next capture.
+    size_t drain(CubinOfferFn offer, unsigned timeout_ms);
+
+    // The plan's four, plus the three drop paths the plan's four do not
+    // cover. A drop with no counter is the failure mode this project has
+    // shipped eleven times.
+    uint64_t modules_captured() const { return captured_.load(std::memory_order_relaxed); }
+    uint64_t module_reload_skipped() const { return reload_skipped_.load(std::memory_order_relaxed); }
+    uint64_t cubin_queue_full() const { return queue_full_.load(std::memory_order_relaxed); }
+    uint64_t cubin_send_failed() const { return send_failed_.load(std::memory_order_relaxed); }
+    uint64_t cubin_too_large() const { return too_large_.load(std::memory_order_relaxed); }
+    uint64_t cubin_crc_failed() const { return crc_failed_.load(std::memory_order_relaxed); }
+    uint64_t cubin_alloc_failed() const { return alloc_failed_.load(std::memory_order_relaxed); }
+    uint64_t cubins_sent() const { return sent_.load(std::memory_order_relaxed); }
+
+    // Queued-but-not-yet-offered. A producer waiting for its offers to land
+    // polls this; an operator reads it as the size of what a hard exit would
+    // take with it.
+    size_t depth() const;
+
+private:
+    struct Entry {
+        uint64_t crc;
+        void *bytes;
+        size_t len;
+    };
+
+    const CubinQueueLimits limits_;
+
+    mutable std::mutex mu_;
+    std::deque<Entry> q_;
+    size_t queued_bytes_ = 0;
+    std::unordered_set<uint64_t> interned_;
+
+    std::atomic<uint64_t> captured_{0};
+    std::atomic<uint64_t> reload_skipped_{0};
+    std::atomic<uint64_t> queue_full_{0};
+    std::atomic<uint64_t> send_failed_{0};
+    std::atomic<uint64_t> too_large_{0};
+    std::atomic<uint64_t> crc_failed_{0};
+    std::atomic<uint64_t> alloc_failed_{0};
+    std::atomic<uint64_t> sent_{0};
+};
+
+}  // namespace perfagent
+
+#endif

--- a/shim/core/cubinqueue_test.cc
+++ b/shim/core/cubinqueue_test.cc
@@ -1,0 +1,418 @@
+// The runtime half of Task 5's assertions. The compile-time half is
+// core/cubin_defer_test.cc, which passes by not compiling.
+//
+// What this proves without a GPU: that the copy is taken inside capture()
+// and is a real copy (mutating the source afterwards does not change what is
+// offered); that the CRC is computed over the copy; that gpu_module_load_v1's
+// moment is inside capture() while the bytes are exclusively ours; that a
+// re-load of the same CRC is skipped and counted; that every bound drops the
+// OFFER and counts it rather than dropping the copy or blocking; and that
+// drain() does not hold the mutex across an offer, which is the property that
+// keeps an offer's timeout off the application's next module load.
+#include "cubinqueue.h"
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+using perfagent::CubinOfferResult;
+using perfagent::CubinQueue;
+using perfagent::CubinQueueLimits;
+using perfagent::CubinView;
+using perfagent::kCubinOfferAccepted;
+using perfagent::kCubinOfferRefused;
+
+namespace {
+
+// ------------------------------------------------------------- a fake wire
+
+struct Offered {
+    uint64_t crc;
+    std::string bytes;
+    unsigned timeout_ms;
+};
+
+std::vector<Offered> g_offers;
+CubinOfferResult g_offer_result = kCubinOfferAccepted;
+
+CubinOfferResult record_offer(const void *bytes, size_t len, uint64_t crc,
+                              unsigned timeout_ms) {
+    Offered o;
+    o.crc = crc;
+    o.bytes.assign((const char *)bytes, len);
+    o.timeout_ms = timeout_ms;
+    g_offers.push_back(o);
+    return g_offer_result;
+}
+
+void reset_offers() {
+    g_offers.clear();
+    g_offer_result = kCubinOfferAccepted;
+}
+
+// A CRC that depends on every byte, so "the CRC was taken over the copy" is
+// distinguishable from "the CRC was taken over the vendor's buffer later".
+uint64_t fnv1a(const void *bytes, size_t len) {
+    const unsigned char *p = (const unsigned char *)bytes;
+    uint64_t h = 1469598103934665603ULL;
+    for (size_t i = 0; i < len; i++) {
+        h ^= p[i];
+        h *= 1099511628211ULL;
+    }
+    return h ? h : 1;
+}
+
+// ------------------------------------------------- what on_captured records
+
+struct Captured {
+    uint64_t crc;
+    std::string bytes;
+    size_t len;
+    int calls;
+};
+
+Captured g_captured;
+
+void record_capture(void *ctx, uint64_t crc, const void *bytes, size_t len) {
+    (void)ctx;
+    g_captured.crc = crc;
+    g_captured.bytes.assign((const char *)bytes, len);
+    g_captured.len = len;
+    g_captured.calls++;
+}
+
+void reset_captured() { g_captured = Captured{0, std::string(), 0, 0}; }
+
+std::string body(size_t n, char seed) {
+    std::string s(n, '\0');
+    for (size_t i = 0; i < n; i++) s[i] = (char)(unsigned char)(i * 31 + (unsigned char)seed);
+    return s;
+}
+
+// --------------------------------------------------------------- the tests
+
+// The whole point of Task 5: after capture() returns, the vendor may do
+// whatever it likes to its buffer - §6.3 finding 2 measured that it CHANGES
+// after cuModuleUnload while staying mapped and readable - and what we offer
+// is unaffected. If the copy were deferred to the drain thread this test
+// would offer the mutated bytes and pass every other assertion in this file.
+void test_the_copy_is_taken_inside_the_callback() {
+    reset_offers();
+    reset_captured();
+    CubinQueue q;
+    std::string vendor = body(4096, 'A');
+    const uint64_t want_crc = fnv1a(vendor.data(), vendor.size());
+
+    {
+        const CubinView view(vendor.data(), vendor.size());
+        assert(q.capture(view, fnv1a, record_capture, nullptr));
+    }
+
+    // The vendor's buffer now holds something else entirely, exactly as it
+    // does after an unload.
+    memset(&vendor[0], 0x5A, vendor.size());
+
+    assert(q.drain(record_offer, 1000) == 1);
+    assert(g_offers.size() == 1);
+    assert(g_offers[0].crc == want_crc);
+    assert(g_offers[0].bytes == body(4096, 'A'));
+    assert(g_offers[0].bytes != vendor);
+    assert(q.modules_captured() == 1);
+    assert(q.cubins_sent() == 1);
+    assert(q.cubin_send_failed() == 0);
+    printf("  copy-in-the-callback: 4096 bytes survive the vendor overwriting its buffer\n");
+}
+
+// gpu_module_load_v1 must be fired while the copy is exclusively ours, and
+// its bytes_ptr must name that copy - which is only checkable by asserting
+// the pointer handed to on_captured holds the right bytes at that instant.
+void test_the_record_fires_inside_capture_over_live_bytes() {
+    reset_offers();
+    reset_captured();
+    CubinQueue q;
+    const std::string vendor = body(1024, 'B');
+    const CubinView view(vendor.data(), vendor.size());
+    assert(q.capture(view, fnv1a, record_capture, nullptr));
+
+    assert(g_captured.calls == 1);
+    assert(g_captured.len == vendor.size());
+    assert(g_captured.crc == fnv1a(vendor.data(), vendor.size()));
+    assert(g_captured.bytes == vendor);
+    // ...and it fired BEFORE anything could have been offered, which is what
+    // makes bytes_ptr valid at the moment the probe reads it.
+    assert(g_offers.empty());
+    printf("  gpu_module_load_v1 fires inside capture, over the owned copy\n");
+}
+
+// The CRC comes from the copy. A crc function that is handed the vendor's
+// pointer could not tell the difference here - so the assertion is that the
+// bytes the crc function saw are the bytes that were offered.
+uint64_t g_crc_saw_len = 0;
+std::string g_crc_saw;
+uint64_t recording_crc(const void *bytes, size_t len) {
+    g_crc_saw.assign((const char *)bytes, len);
+    g_crc_saw_len = len;
+    return fnv1a(bytes, len);
+}
+
+void test_the_crc_runs_over_the_copy() {
+    reset_offers();
+    reset_captured();
+    g_crc_saw.clear();
+    CubinQueue q;
+    std::string vendor = body(2048, 'C');
+    const CubinView view(vendor.data(), vendor.size());
+    assert(q.capture(view, recording_crc, record_capture, nullptr));
+    memset(&vendor[0], 0, vendor.size());
+    assert(q.drain(record_offer, 1000) == 1);
+    assert(g_crc_saw_len == 2048);
+    assert(g_crc_saw == g_offers[0].bytes);
+    printf("  the CRC is computed over the copy, not over the borrowed buffer\n");
+}
+
+// A zero CRC would be a module record that joins to nothing, with every
+// other counter reading green. Counted, and never sent.
+uint64_t zero_crc(const void *, size_t) { return 0; }
+
+void test_a_crc_of_zero_is_counted_and_never_sent() {
+    reset_offers();
+    reset_captured();
+    CubinQueue q;
+    const std::string vendor = body(64, 'D');
+    const CubinView view(vendor.data(), vendor.size());
+    assert(!q.capture(view, zero_crc, record_capture, nullptr));
+    assert(q.cubin_crc_failed() == 1);
+    assert(q.modules_captured() == 0);
+    assert(g_captured.calls == 0);
+    assert(q.drain(record_offer, 1000) == 0);
+    assert(g_offers.empty());
+    printf("  a zero CRC is refused and counted: crc_failed=1\n");
+}
+
+void test_a_reload_of_the_same_crc_is_skipped_and_counted() {
+    reset_offers();
+    reset_captured();
+    CubinQueue q;
+    const std::string vendor = body(512, 'E');
+    {
+        const CubinView v(vendor.data(), vendor.size());
+        assert(q.capture(v, fnv1a, record_capture, nullptr));
+    }
+    // The same module loaded again - CUDA's lazy loading does this - from a
+    // different buffer with identical contents, which is what a content
+    // -addressed CRC means by "the same module".
+    const std::string again = body(512, 'E');
+    {
+        const CubinView v(again.data(), again.size());
+        assert(!q.capture(v, fnv1a, record_capture, nullptr));
+    }
+    assert(q.modules_captured() == 1);
+    assert(q.module_reload_skipped() == 1);
+    // And no second record: a duplicate gpu_module_load_v1 would announce a
+    // CRC the consumer already holds, with a bytes_ptr we did not keep.
+    assert(g_captured.calls == 1);
+    assert(q.drain(record_offer, 1000) == 1);
+    assert(g_offers.size() == 1);
+    printf("  a re-load of one CRC offers once: captured=1 reload_skipped=1\n");
+}
+
+void test_a_full_queue_drops_the_offer_and_counts_it() {
+    reset_offers();
+    reset_captured();
+    CubinQueueLimits lim;
+    lim.max_entries = 2;
+    CubinQueue q(lim);
+    for (int i = 0; i < 5; i++) {
+        const std::string vendor = body(128, (char)('a' + i));
+        const CubinView v(vendor.data(), vendor.size());
+        q.capture(v, fnv1a, record_capture, nullptr);
+    }
+    assert(q.modules_captured() == 2);
+    assert(q.cubin_queue_full() == 3);
+    assert(q.depth() == 2);
+    // The record still fired for every one of them: the consumer learns that
+    // five modules loaded and gets the bytes for two, which is a worse
+    // profile and never a wrong one.
+    assert(g_captured.calls == 5);
+    assert(q.drain(record_offer, 1000) == 2);
+    assert(g_offers.size() == 2);
+    printf("  a full queue drops 3 offers, counts them, and never blocks\n");
+}
+
+void test_the_byte_ceiling_is_a_second_full_condition() {
+    reset_offers();
+    reset_captured();
+    CubinQueueLimits lim;
+    lim.max_entries = 64;
+    lim.max_queued_bytes = 300;
+    CubinQueue q(lim);
+    for (int i = 0; i < 4; i++) {
+        const std::string vendor = body(128, (char)('m' + i));
+        const CubinView v(vendor.data(), vendor.size());
+        q.capture(v, fnv1a, record_capture, nullptr);
+    }
+    assert(q.modules_captured() == 2);   // 128 + 128 = 256; a third would pass 300
+    assert(q.cubin_queue_full() == 2);
+    printf("  the queued-bytes ceiling is the same drop with the same counter\n");
+}
+
+// The per-cubin ceiling is the ONLY bound on the memcpy the application pays
+// for, so it is checked before the copy and the copy never happens.
+void test_an_oversized_cubin_is_never_copied() {
+    reset_offers();
+    reset_captured();
+    CubinQueueLimits lim;
+    lim.max_cubin_bytes = 1024;
+    CubinQueue q(lim);
+    const std::string vendor = body(1025, 'F');
+    const CubinView v(vendor.data(), vendor.size());
+    assert(!q.capture(v, fnv1a, record_capture, nullptr));
+    assert(q.cubin_too_large() == 1);
+    assert(q.modules_captured() == 0);
+    assert(g_captured.calls == 0);
+    assert(q.depth() == 0);
+
+    // Exactly at the ceiling is accepted, so the refusal is one byte of
+    // policy rather than an off-by-one.
+    const std::string ok = body(1024, 'F');
+    const CubinView v2(ok.data(), ok.size());
+    assert(q.capture(v2, fnv1a, record_capture, nullptr));
+    assert(q.cubin_too_large() == 1);
+    printf("  a cubin over the per-cubin ceiling is refused before the memcpy\n");
+}
+
+void test_a_refused_offer_is_counted_as_a_send_failure() {
+    reset_offers();
+    reset_captured();
+    CubinQueue q;
+    const std::string vendor = body(256, 'G');
+    const CubinView v(vendor.data(), vendor.size());
+    assert(q.capture(v, fnv1a, record_capture, nullptr));
+    g_offer_result = kCubinOfferRefused;
+    assert(q.drain(record_offer, 1000) == 1);
+    assert(q.cubin_send_failed() == 1);
+    assert(q.cubins_sent() == 0);
+    assert(q.depth() == 0);   // dropped, not retried forever
+    printf("  a refused offer counts send_failed=1 and is not retried\n");
+}
+
+void test_drain_bounds_itself_and_empties() {
+    reset_offers();
+    reset_captured();
+    CubinQueue q;
+    for (int i = 0; i < 8; i++) {
+        const std::string vendor = body(64, (char)('0' + i));
+        const CubinView v(vendor.data(), vendor.size());
+        assert(q.capture(v, fnv1a, record_capture, nullptr));
+    }
+    assert(q.depth() == 8);
+    assert(q.drain(record_offer, 250) == 8);
+    assert(q.depth() == 0);
+    assert(q.drain(record_offer, 250) == 0);
+    for (const Offered &o : g_offers) assert(o.timeout_ms == 250);
+    printf("  drain empties the queue, is bounded, and passes the timeout through\n");
+}
+
+// The property that keeps the offer's timeout off the application's thread:
+// a capture must complete while a slow offer is in flight. If drain held the
+// mutex across the offer this deadlocks the test's own deadline.
+// std::atomic, not volatile: volatile orders nothing between threads, and a
+// test that races its own flags reports a data race that has nothing to do
+// with the queue - which is exactly how a real one in the queue would end up
+// being dismissed as "the usual TSan noise".
+std::atomic<bool> g_slow_offer_entered{false};
+std::atomic<bool> g_capture_finished{false};
+
+CubinOfferResult slow_offer(const void *, size_t, uint64_t, unsigned) {
+    g_slow_offer_entered.store(true);
+    for (int i = 0; i < 2000 && !g_capture_finished.load(); i++) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return kCubinOfferAccepted;
+}
+
+void test_a_slow_offer_does_not_block_a_capture() {
+    reset_offers();
+    reset_captured();
+    CubinQueue q;
+    const std::string first = body(64, 'H');
+    {
+        const CubinView v(first.data(), first.size());
+        assert(q.capture(v, fnv1a, record_capture, nullptr));
+    }
+    std::thread drainer([&] { q.drain(slow_offer, 1000); });
+    while (!g_slow_offer_entered.load()) std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    const std::string second = body(64, 'I');
+    const CubinView v(second.data(), second.size());
+    assert(q.capture(v, fnv1a, record_capture, nullptr));
+    g_capture_finished.store(true);
+    drainer.join();
+    assert(q.modules_captured() == 2);
+    printf("  a capture completes while a slow offer is in flight (no lock held across it)\n");
+}
+
+// Nothing here may be silent: on a healthy run every drop counter reads zero,
+// and this is the assertion that says so in the direction that matters.
+void test_a_healthy_run_reads_zero_on_every_drop_counter() {
+    reset_offers();
+    reset_captured();
+    CubinQueue q;
+    for (int i = 0; i < 4; i++) {
+        const std::string vendor = body(1000 + i, (char)('p' + i));
+        const CubinView v(vendor.data(), vendor.size());
+        assert(q.capture(v, fnv1a, record_capture, nullptr));
+    }
+    assert(q.drain(record_offer, 1000) == 4);
+    assert(q.modules_captured() == 4);
+    assert(q.cubins_sent() == 4);
+    assert(q.module_reload_skipped() == 0);
+    assert(q.cubin_queue_full() == 0);
+    assert(q.cubin_send_failed() == 0);
+    assert(q.cubin_too_large() == 0);
+    assert(q.cubin_crc_failed() == 0);
+    assert(q.cubin_alloc_failed() == 0);
+    printf("  healthy run: captured=4 sent=4 and every drop counter at zero\n");
+}
+
+// A queue destroyed with entries still in it must free them; ASan/valgrind
+// would catch the leak, and the assertion here is only that it does not
+// crash and that depth() reported the truth first.
+void test_destruction_releases_undrained_copies() {
+    reset_captured();
+    {
+        CubinQueue q;
+        for (int i = 0; i < 3; i++) {
+            const std::string vendor = body(256, (char)('x' + i));
+            const CubinView v(vendor.data(), vendor.size());
+            assert(q.capture(v, fnv1a, record_capture, nullptr));
+        }
+        assert(q.depth() == 3);
+    }
+    printf("  destroying a non-empty queue releases its copies\n");
+}
+
+}  // namespace
+
+int main() {
+    test_the_copy_is_taken_inside_the_callback();
+    test_the_record_fires_inside_capture_over_live_bytes();
+    test_the_crc_runs_over_the_copy();
+    test_a_crc_of_zero_is_counted_and_never_sent();
+    test_a_reload_of_the_same_crc_is_skipped_and_counted();
+    test_a_full_queue_drops_the_offer_and_counts_it();
+    test_the_byte_ceiling_is_a_second_full_condition();
+    test_an_oversized_cubin_is_never_copied();
+    test_a_refused_offer_is_counted_as_a_send_failure();
+    test_drain_bounds_itself_and_empties();
+    test_a_slow_offer_does_not_block_a_capture();
+    test_a_healthy_run_reads_zero_on_every_drop_counter();
+    test_destruction_releases_undrained_copies();
+    printf("cubinqueue_test: OK\n");
+    return 0;
+}

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -11,6 +11,8 @@
 // stack capture and the projection all work unchanged.
 #include "batch.h"
 #include "clock.h"
+#include "cubin.h"
+#include "cubinqueue.h"
 #include "drain.h"
 #include "enroll.h"
 #include "kernelnames.h"
@@ -19,6 +21,9 @@
 #include "usdt_probe.h"
 
 #include <cupti.h>
+// cuptiGetCubinCrc lives here, not in cupti.h. It is the ONLY thing this
+// adapter uses from the PC-sampling header today; Task 6 uses the rest.
+#include <cupti_pcsampling.h>
 
 #include <atomic>
 #include <cstdarg>
@@ -40,6 +45,12 @@ PERFAGENT_USDT_EMITTER(gpu_exec_v1, 48);
 // N unrelated launches.
 PERFAGENT_USDT_EMITTER(gpu_launch_sampled_v1, 56);
 PERFAGENT_USDT_EMITTER(gpu_kernel_name_v1, 272);
+// gpu_module_load_v1 fires UNBATCHED, one record per captured module. Module
+// loads are tens per process rather than hundreds of thousands per second, so
+// a batch would only delay the record behind a drain tick for no saving -- and
+// the record must be emitted at a very particular instant (see
+// on_cubin_captured), which a batch's flush would move.
+PERFAGENT_USDT_EMITTER(gpu_module_load_v1, 40);
 
 namespace {
 
@@ -183,11 +194,19 @@ perfagent::Batch<gpu_exec_v1, 32> *g_eb = nullptr;
 perfagent::Sampler *g_sampler = nullptr;
 perfagent::KernelNameTable *g_names = nullptr;
 perfagent::Drainer *g_drainer = nullptr;
+perfagent::CubinQueue *g_cubins = nullptr;
 CUpti_SubscriberHandle g_subscriber = nullptr;
 
 std::atomic<unsigned long> g_sampled_seq{0};
 std::atomic<unsigned long> g_name_seq{0};
+std::atomic<unsigned long> g_module_seq{0};
 std::atomic<uint64_t> g_launch_ordinal{0};
+
+// The offer budget, read once at init so the drain thread does not re-parse
+// an environment variable every 100ms. Zero disables offers outright.
+unsigned g_cubin_timeout_ms = 0;
+// True when the startup rendezvous confirmed a consumer. See capture_enabled.
+bool g_consumer_enrolled = false;
 
 // Every discard has a counter. Nothing here is allowed to be silent (§6.1).
 std::atomic<uint64_t> g_launch_unattached{0};   // no consumer at launch time
@@ -208,8 +227,109 @@ std::atomic<uint64_t> g_buffers{0};
 // declined request is not documented, so whatever it does with the records
 // for that window, the refusal itself is on the record here.
 std::atomic<uint64_t> g_buffer_alloc_failed{0};
+// A MODULE_LOADED callback we declined to copy because no consumer was
+// believed present, and one whose descriptor carried no bytes at all. Both
+// are modules that will read gpu_src_status "no-module" later, so both are
+// counted here rather than being invisible.
+std::atomic<uint64_t> g_module_unattached{0};
+std::atomic<uint64_t> g_module_no_bytes{0};
 
 bool g_names_was_attached = false;
+
+// ------------------------------------------------------------ module path
+
+// Whether a module's bytes are worth copying at all.
+//
+// The copy is a bounded memcpy on the APPLICATION's cuModuleLoad path, so an
+// unprofiled process must not pay it. But the probe semaphore alone is the
+// wrong gate here and issue #49 is why: at InitializeInjection the semaphore
+// read ZERO on the RTX 3090 across three runs even though four thousand
+// probes fired later in the same process, because it answers "has the kernel
+// told this process yet" and not "is a consumer attached". CUDA's lazy
+// loading can put the first MODULE_LOADED very close to that moment, and a
+// module missed there is missed permanently -- there is no "copy it later"
+// (spec 6.3 finding 2).
+//
+// So the gate is the same one #49's second fix settled on, plus the
+// semaphore: the rendezvous CONNECT succeeded, which the consumer performs
+// before it creates the uprobe link, or the semaphore has since armed. In an
+// unprofiled process both read false and no module is ever copied.
+bool capture_enabled() {
+    return g_consumer_enrolled || gpu_module_load_v1_enabled();
+}
+
+// The join key, over the adapter-owned COPY -- CubinQueue hands this function
+// the copy and cannot hand it anything else, which is the point of the shape
+// in cubinqueue.h.
+//
+// Returning 0 means "could not". A zero CRC on the wire would be a module
+// record joining to nothing, so CubinQueue counts it and sends nothing.
+uint64_t cupti_cubin_crc(const void *bytes, size_t len) {
+    CUpti_GetCubinCrcParams p;
+    memset(&p, 0, sizeof(p));
+    p.size = CUpti_GetCubinCrcParamsSize;
+    p.cubinSize = len;
+    p.cubin = bytes;
+    if (cuptiGetCubinCrc(&p) != CUPTI_SUCCESS) return 0;
+    return p.cubinCrc;
+}
+
+// Fired by CubinQueue::capture, on the application's thread, at the one
+// instant the copy is owned by nobody else: the CRC is computed and the entry
+// has not been pushed, so the drain thread cannot yet have offered and freed
+// it. That is what keeps bytes_ptr accurate.
+//
+// bytes_ptr stays in the ABI and stays true, and it is still NOT a transport:
+// it points into this process's address space and the consumer would need
+// CAP_SYS_PTRACE to read it. The bytes travel over the cubin channel
+// (core/cubin.h); this record announces THAT a module loaded, with its CRC
+// and size.
+void on_cubin_captured(void *ctx, uint64_t crc, const void *bytes, size_t len) {
+    if (!gpu_module_load_v1_enabled()) return;
+    gpu_module_load_v1 r{};
+    r.cubin_crc = crc;
+    r.module_id = (uint64_t)(uintptr_t)ctx;
+    r.size_bytes = (uint64_t)len;
+    r.load_ns = mono_ns();
+    r.bytes_ptr = (uint64_t)(uintptr_t)bytes;
+    gpu_module_load_v1_emit(&r, 1, g_module_seq.fetch_add(1, std::memory_order_relaxed));
+}
+
+// CUPTI_CBID_RESOURCE_MODULE_LOADED.
+//
+// Everything this function does with the vendor's buffer happens before it
+// returns, and the type system is what says so: CubinView has no copy, no
+// move, no assignment, no operator new and no accessor for its pointer, so
+// the pointer has exactly one consumer -- the memcpy inside capture(). See
+// core/cubinqueue.h and `make -C shim check-cubin-defer`, which fails the
+// build if any of five ways to defer the copy starts compiling.
+//
+// The reason the deadline is real: CUPTI's header says the module data is
+// valid only within this callback, and the spike measured what "invalid"
+// means here -- after cuModuleUnload the buffer is still mapped and still
+// readable, with DIFFERENT CONTENTS. A deferred read gets silently wrong
+// bytes, which parse into a wrong line table and produce confidently
+// incorrect source lines. A fault would have been the kinder failure.
+void on_module_loaded(const CUpti_ResourceData *rd) {
+    const CUpti_ModuleResourceData *m =
+        (const CUpti_ModuleResourceData *)rd->resourceDescriptor;
+    if (!m || !m->pCubin || m->cubinSize == 0) {
+        g_module_no_bytes.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    // g_cubins is constructed before cuptiSubscribe, so a callback cannot
+    // arrive ahead of it -- but a null here would be a segfault in somebody
+    // else's process, which is not a way to find that out.
+    if (!capture_enabled() || !g_cubins) {
+        g_module_unattached.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    const perfagent::CubinView view(m->pCubin, m->cubinSize);
+    // moduleId travels as the context, not as a captured pointer: nothing
+    // about this call may outlive the callback except the owned copy.
+    g_cubins->capture(view, cupti_cubin_crc, on_cubin_captured,
+                      (void *)(uintptr_t)m->moduleId);
+}
 
 // ------------------------------------------------------------ launch path
 
@@ -317,6 +437,12 @@ void CUPTIAPI on_callback(void *, CUpti_CallbackDomain domain, CUpti_CallbackId 
     if (domain == CUPTI_CB_DOMAIN_RESOURCE) {
         if (cbid < kResourceCbidMax)
             g_resource_events[cbid].fetch_add(1, std::memory_order_relaxed);
+        // The histogram stays: the RESOURCE subscription is enabled for the
+        // whole process and this is still the only way to see what it costs
+        // and which cbids actually arrive. What changes is that one of them
+        // is now read rather than only counted.
+        if (cbid == CUPTI_CBID_RESOURCE_MODULE_LOADED && cbdata)
+            on_module_loaded((const CUpti_ResourceData *)cbdata);
         return;
     }
     if (domain != CUPTI_CB_DOMAIN_RUNTIME_API) return;
@@ -410,6 +536,11 @@ void report(const char *why) {
          "activity_kernels=%llu activity_other=%llu buffers=%llu buffer_alloc_failed=%llu "
          "exec_unattached=%llu exec_batch_dropped=%llu exec_no_clock=%llu "
          "exec_no_time=%llu cupti_dropped=%llu names=%zu "
+         "modules_captured=%llu module_reload_skipped=%llu module_unattached=%llu "
+         "module_no_bytes=%llu cubin_too_large=%llu cubin_crc_failed=%llu "
+         "cubin_alloc_failed=%llu cubin_queue_full=%llu cubin_queue_depth=%zu "
+         "cubins_sent=%llu cubin_send_failed=%llu "
+         "cubins_offered=%llu cubin_transport_send_failed=%llu "
          "clock_steps=%llu clock_offset_ns=%lld sem_at_exit=%u\n",
          why, (int)getpid(),
          (unsigned long long)g_sampler->observed(),
@@ -426,6 +557,25 @@ void report(const char *why) {
          (unsigned long long)g_exec_no_time.load(),
          (unsigned long long)g_cupti_dropped.load(),
          g_names->size(),
+         // The four Task 5 counters, plus the three drop paths they do not
+         // cover and the two the transport itself keeps. A module counted
+         // anywhere but modules_captured/cubins_sent is a module whose PC
+         // samples will read gpu_src_status "no-module", so the gap between
+         // the first number here and cubins_sent is exactly the size of what
+         // this process could not explain.
+         (unsigned long long)(g_cubins ? g_cubins->modules_captured() : 0),
+         (unsigned long long)(g_cubins ? g_cubins->module_reload_skipped() : 0),
+         (unsigned long long)g_module_unattached.load(),
+         (unsigned long long)g_module_no_bytes.load(),
+         (unsigned long long)(g_cubins ? g_cubins->cubin_too_large() : 0),
+         (unsigned long long)(g_cubins ? g_cubins->cubin_crc_failed() : 0),
+         (unsigned long long)(g_cubins ? g_cubins->cubin_alloc_failed() : 0),
+         (unsigned long long)(g_cubins ? g_cubins->cubin_queue_full() : 0),
+         g_cubins ? g_cubins->depth() : (size_t)0,
+         (unsigned long long)(g_cubins ? g_cubins->cubins_sent() : 0),
+         (unsigned long long)(g_cubins ? g_cubins->cubin_send_failed() : 0),
+         (unsigned long long)perfagent::cubins_offered(),
+         (unsigned long long)perfagent::cubins_send_failed(),
          (unsigned long long)g_clock.steps(),
          (long long)g_clock.offset_ns(),
          gpu_launch_sampled_v1_semaphore_count());
@@ -461,6 +611,13 @@ void on_tick() {
         });
     }
     g_names_was_attached = now_attached;
+
+    // The SEND half of a cubin capture, and the whole reason this is here and
+    // not in the MODULE_LOADED callback: a connect() plus an up-to-8 MiB
+    // handover on the application's cuModuleLoad path would stall the
+    // application for the profiler's benefit. Nothing is waiting on this
+    // thread. The copy already happened, on time, in the callback.
+    if (g_cubins) g_cubins->drain(perfagent::cubin_offer_to_consumer, g_cubin_timeout_ms);
 }
 
 // The documented CUPTI shutdown hook. Without it the records still sitting in
@@ -470,6 +627,12 @@ void at_exit_handler() {
     cuptiActivityFlushAll(1);
     if (g_lb) g_lb->flush();
     if (g_eb) g_eb->flush();
+    // One last offer pass, for modules captured inside the final drain
+    // interval. Bounded: drain() offers at most the entries present when it
+    // was entered, the queue holds at most CubinQueueLimits::max_entries, and
+    // an offer to an absent listener refuses immediately -- so this cannot
+    // turn process exit into a multi-second wait.
+    if (g_cubins) g_cubins->drain(perfagent::cubin_offer_to_consumer, g_cubin_timeout_ms);
     report("exit");
 }
 
@@ -559,8 +722,19 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
     char enroll_name[128];
     if (!perfagent::enroll_self_name(enroll_name, sizeof(enroll_name)))
         snprintf(enroll_name, sizeof(enroll_name), "<no-address>");
+    // Logged for the same reason and compared against Stats.CubinsAddress:
+    // the two ends derive this name independently and never exchange it, so
+    // when they disagree every cubin counter on both sides reads zero and
+    // every module is unresolvable with nothing saying why.
+    char cubin_name[128];
+    if (!perfagent::cubin_self_name(cubin_name, sizeof(cubin_name)))
+        snprintf(cubin_name, sizeof(cubin_name), "<no-address>");
     perfagent::EnrollResult enrolled =
         perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(2000));
+    // The gate for cubin capture -- see capture_enabled(). A confirmed
+    // rendezvous is a positive statement that a consumer is attached, made
+    // at a moment when the probe semaphore may still read zero.
+    g_consumer_enrolled = (enrolled == perfagent::kEnrollConfirmed);
 
     // Leaked on purpose, never deleted: CUPTI worker threads keep calling
     // buffer_completed during process teardown, and a destroyed Batch or
@@ -572,6 +746,12 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
                                               perfagent::Sampler::kDefaultSeed));
     g_names = new perfagent::KernelNameTable();
     g_drainer = new perfagent::Drainer();
+    // Leaked with the rest, and for the same reason: a CUPTI worker thread
+    // can still be inside a RESOURCE callback during teardown, and a
+    // destroyed queue under it is a use-after-free in somebody else's
+    // process.
+    g_cubins = new perfagent::CubinQueue();
+    g_cubin_timeout_ms = perfagent::cubin_timeout_ms(2000);
 
     if (!check(cuptiSubscribe(&g_subscriber, (CUpti_CallbackFunc)on_callback, nullptr),
                "cuptiSubscribe"))
@@ -607,10 +787,11 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
     // fix gated the rendezvous on the semaphore and lost the CUDA path.
     logf("perfagent-cupti: initialized pid=%d sample_period=%u sample_seed=0x%016llx "
          "drain_ms=%u clock_offset_ns=%lld enroll=%s sem_at_init=%u sem_after_init=%u "
-         "enroll_addr=@%s\n",
+         "enroll_addr=@%s cubin_addr=@%s cubin_timeout_ms=%u\n",
          (int)getpid(), g_sampler->period(),
          (unsigned long long)g_sampler->seed(), drain_ms, (long long)g_clock.offset_ns(),
          perfagent::enroll_result_name(enrolled), sem_at_init,
-         gpu_launch_sampled_v1_semaphore_count(), enroll_name);
+         gpu_launch_sampled_v1_semaphore_count(), enroll_name, cubin_name,
+         g_cubin_timeout_ms);
     return 1;
 }

--- a/shim/stub/stub.cc
+++ b/shim/stub/stub.cc
@@ -3,6 +3,8 @@
 // (spec §14, Phase 3 gate).
 #include "batch.h"
 #include "clock.h"
+#include "cubin.h"
+#include "cubinqueue.h"
 #include "drain.h"
 #include "enroll.h"
 #include "kernelnames.h"
@@ -12,6 +14,8 @@
 
 #include <chrono>
 #include <cstdio>
+#include <string>
+#include <vector>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
@@ -35,11 +39,121 @@ PERFAGENT_USDT_EMITTER(gpu_exec_v1, 48);
 // stack to N unrelated launches, defeating the entire feature.
 PERFAGENT_USDT_EMITTER(gpu_launch_sampled_v1, 56);
 PERFAGENT_USDT_EMITTER(gpu_kernel_name_v1, 272);
+// gpu_module_load_v1 fires UNBATCHED, one record per module, exactly as the
+// CUPTI adapter fires it -- and from inside CubinQueue::capture, at the one
+// instant the copy is owned by nobody else, so bytes_ptr is true when the
+// probe reads it.
+PERFAGENT_USDT_EMITTER(gpu_module_load_v1, 40);
 
 static uint64_t mono_ns() {
     struct timespec t;
     clock_gettime(CLOCK_MONOTONIC, &t);
     return (uint64_t)t.tv_sec * 1000000000ULL + (uint64_t)t.tv_nsec;
+}
+
+// ------------------------------------------------------- the fake module load
+//
+// A GPU-free MODULE_LOADED. It reads a checked-in cubin from disk, runs it
+// through the SAME CubinQueue the CUPTI adapter uses -- same capture, same
+// CubinView, same crc-over-the-copy, same drain-thread offer -- and fires
+// gpu_module_load_v1 from inside capture(). That drives the cubin transport
+// (Task 3), the module store (Task 4), the consumer's decode (Task 7) and the
+// projection's source labels (Task 9) end to end on a machine with no GPU,
+// which is what the phase gate needs.
+//
+// PERFAGENT_STUB_CUBINS is a ':'-separated list of paths, in the shape PATH
+// itself uses, so a gate can drive several modules -- the -lineinfo fixture
+// and the no-lineinfo one -- through one run and reach more than one
+// gpu_src_status value.
+//
+// Reuse the fixtures in internal/cubin/testdata/ rather than inventing bytes:
+// the same cubins are then exercised by the reader's tests, by the module
+// store's, and by the transport's, so "the reader parses what the transport
+// delivers" is one fixture rather than two that agree by assumption.
+
+// The stand-in for cuptiGetCubinCrc(), and it is NOT that function.
+//
+// CUPTI's polynomial is unpublished and there is no CUDA toolkit on this
+// path. What the join actually requires is that ONE number identifies one set
+// of bytes and that the same number reaches both ends -- so a stub that
+// declares a content hash produces a pipeline that is exercised exactly as a
+// real one is, keyed on a number that means the same thing.
+//
+// FNV-1a, the same spelling hash_name() uses in the adapter, so a test can
+// recompute it independently and assert the key rather than read it back.
+static uint64_t stub_cubin_crc(const void *bytes, size_t len) {
+    const unsigned char *p = (const unsigned char *)bytes;
+    uint64_t h = 1469598103934665603ULL;
+    for (size_t i = 0; i < len; i++) {
+        h ^= p[i];
+        h *= 1099511628211ULL;
+    }
+    return h ? h : 1;   // zero is the ABI's "no module"
+}
+
+static unsigned long g_stub_module_seq = 0;
+
+// Fired by CubinQueue::capture, before the copy is visible to any drain, so
+// bytes_ptr names live adapter-owned bytes at the moment the probe reads it.
+// It is still not a transport: the consumer cannot read another process's
+// address space without CAP_SYS_PTRACE. The bytes go over the cubin channel.
+static void stub_on_cubin_captured(void *ctx, uint64_t crc, const void *bytes, size_t len) {
+    if (!gpu_module_load_v1_enabled()) return;
+    gpu_module_load_v1 r{};
+    r.cubin_crc = crc;
+    r.module_id = (uint64_t)(uintptr_t)ctx;
+    r.size_bytes = (uint64_t)len;
+    r.load_ns = mono_ns();
+    r.bytes_ptr = (uint64_t)(uintptr_t)bytes;
+    gpu_module_load_v1_emit(&r, 1, g_stub_module_seq++);
+}
+
+static bool read_whole_file(const char *path, std::vector<char> *out) {
+    FILE *f = fopen(path, "rbe");
+    if (!f) return false;
+    char buf[65536];
+    for (;;) {
+        const size_t n = fread(buf, 1, sizeof(buf), f);
+        if (n) out->insert(out->end(), buf, buf + n);
+        if (n < sizeof(buf)) break;
+    }
+    const bool ok = ferror(f) == 0;
+    fclose(f);
+    return ok;
+}
+
+// Captures every module named by PERFAGENT_STUB_CUBINS. Returns how many
+// reached the queue. Reading the file is the stub's stand-in for the vendor
+// handing us a buffer, so the CubinView is built over the file buffer and
+// dies with this function, exactly as the adapter's dies with its callback.
+static unsigned stub_capture_modules(perfagent::CubinQueue &q) {
+    const char *list = getenv("PERFAGENT_STUB_CUBINS");
+    if (!list || !*list) return 0;
+    unsigned n = 0;
+    std::string spec(list);
+    size_t pos = 0;
+    while (pos <= spec.size()) {
+        const size_t sep = spec.find(':', pos);
+        const std::string path =
+            spec.substr(pos, sep == std::string::npos ? std::string::npos : sep - pos);
+        pos = (sep == std::string::npos) ? spec.size() + 1 : sep + 1;
+        if (path.empty()) continue;
+
+        std::vector<char> bytes;
+        if (!read_whole_file(path.c_str(), &bytes) || bytes.empty()) {
+            fprintf(stderr, "stub: module read failed path=%s\n", path.c_str());
+            continue;
+        }
+        const uint64_t crc = stub_cubin_crc(bytes.data(), bytes.size());
+        const perfagent::CubinView view(bytes.data(), bytes.size());
+        const bool ok = q.capture(view, stub_cubin_crc, stub_on_cubin_captured,
+                                  (void *)(uintptr_t)(n + 1));
+        fprintf(stderr, "stub: module id=%u path=%s size=%zu crc=0x%016llx captured=%s\n",
+                n + 1, path.c_str(), bytes.size(), (unsigned long long)crc,
+                ok ? "yes" : "no");
+        if (ok) n++;
+    }
+    return n;
 }
 
 // Default visibility: this is the one symbol libperfagent-gpu-stub.so must
@@ -63,6 +177,12 @@ perfagent_stub_run(unsigned launches, unsigned period_us, unsigned sample_period
     char enroll_name[128];
     if (!perfagent::enroll_self_name(enroll_name, sizeof(enroll_name)))
         snprintf(enroll_name, sizeof(enroll_name), "<no-address>");
+    // The cubin channel's name, printed for the reason the rendezvous name is:
+    // the two ends derive it independently and never exchange it, so a
+    // disagreement makes every counter on both sides read zero.
+    char cubin_name[128];
+    if (!perfagent::cubin_self_name(cubin_name, sizeof(cubin_name)))
+        snprintf(cubin_name, sizeof(cubin_name), "<no-address>");
     perfagent::EnrollResult enrolled =
         perfagent::enroll_with_consumer(perfagent::enroll_timeout_ms(2000));
 
@@ -74,10 +194,19 @@ perfagent_stub_run(unsigned launches, unsigned period_us, unsigned sample_period
     unsigned long name_seq = 0;
     bool names_was_attached = false;
 
+    // The same queue the CUPTI adapter runs, wired the same way: capture on
+    // the caller's thread, offer on the drain thread.
+    perfagent::CubinQueue cubins;
+    const unsigned cubin_timeout_ms = perfagent::cubin_timeout_ms(2000);
+
     perfagent::Drainer drainer;
     drainer.on_tick([&] {
         lb.flush();
         eb.flush();
+        // The offer, on the drain thread and nowhere else. In an application
+        // this is what keeps a connect() and a multi-megabyte handover off
+        // the cuModuleLoad path; here it is what proves that wiring works.
+        cubins.drain(perfagent::cubin_offer_to_consumer, cubin_timeout_ms);
         // Late-attach replay: only on the unattached -> attached transition,
         // so an already-attached consumer does not get names re-sent every
         // tick (spec §6.1's replay contract).
@@ -91,6 +220,18 @@ perfagent_stub_run(unsigned launches, unsigned period_us, unsigned sample_period
         names_was_attached = now_attached;
     });
     drainer.start(100);
+
+    // Modules load before kernels run, as they do in a CUDA process. The
+    // capture is synchronous; the offers are not, so wait -- bounded -- for
+    // the drain thread to have emptied the queue before the launches start,
+    // so a gate can assert on a module the consumer provably already holds.
+    const unsigned modules = stub_capture_modules(cubins);
+    if (modules) {
+        const uint64_t wait_until = mono_ns() + 5000000000ULL;
+        while (cubins.depth() && mono_ns() < wait_until) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
 
     for (unsigned i = 1; i <= launches; i++) {
         const uint64_t now = mono_ns();
@@ -166,7 +307,30 @@ perfagent_stub_run(unsigned launches, unsigned period_us, unsigned sample_period
 
     lb.flush();
     eb.flush();
+    // A final pass for anything the tick did not reach. drain() is bounded by
+    // the depth it saw on entry, so this cannot become an unbounded wait.
+    cubins.drain(perfagent::cubin_offer_to_consumer, cubin_timeout_ms);
     drainer.stop();
+    // Every cubin counter, always -- not only when modules were requested.
+    // A run that asked for none must read zero everywhere, and a line that
+    // appears only on the interesting runs is a line no one checks on the
+    // boring ones.
+    fprintf(stderr, "stub: cubins requested=%u captured=%llu reload_skipped=%llu "
+                    "queue_full=%llu too_large=%llu crc_failed=%llu alloc_failed=%llu "
+                    "sent=%llu send_failed=%llu pending=%zu "
+                    "offered=%llu transport_send_failed=%llu timeout_ms=%u cubin_addr=@%s\n",
+            modules, (unsigned long long)cubins.modules_captured(),
+            (unsigned long long)cubins.module_reload_skipped(),
+            (unsigned long long)cubins.cubin_queue_full(),
+            (unsigned long long)cubins.cubin_too_large(),
+            (unsigned long long)cubins.cubin_crc_failed(),
+            (unsigned long long)cubins.cubin_alloc_failed(),
+            (unsigned long long)cubins.cubins_sent(),
+            (unsigned long long)cubins.cubin_send_failed(),
+            cubins.depth(),
+            (unsigned long long)perfagent::cubins_offered(),
+            (unsigned long long)perfagent::cubins_send_failed(),
+            cubin_timeout_ms, cubin_name);
     // seed= is part of the accounting, not decoration: the sampler's schedule
     // is a deterministic chain from (seed, period), so this line is what makes
     // the exact sampled= count above reproducible and auditable offline


### PR DESCRIPTION
**Task 5 of [the GPU PC sampling plan](docs/superpowers/plans/2026-08-25-gpu-pc-sampling.md).**

### The split, by deadline

In the CUPTI callback: bounds check → `malloc`+`memcpy` → `cuptiGetCubinCrc()` **over the copy** → intern by CRC → fire `gpu_module_load_v1` with `bytes_ptr` at the copy → bounded push. On the drain thread (the existing 100 ms tick, plus one bounded pass at `atexit`): pop → offer over Task 3's channel → free.

§6.3 finding 2 measured why the copy cannot wait: after `cuModuleUnload` the buffer is still mapped and readable but **its contents have changed**, so a late reader gets silently wrong bytes rather than a fault. CUDA's lazy loading puts loads and unloads at arbitrary points, so there is no safe definition of "copy later".

And the offer cannot happen there: a `connect()` plus an up-to-2 MB handover on the application's `cuModuleLoad` path would stall the application for the profiler's benefit. `drain()` never holds the queue mutex across an offer, or the offer's 2 s budget lands on the application's next module load.

The record fires *after* the CRC and *before* the push deliberately — that is the only instant the copy is owned by nobody else, so `bytes_ptr` is true when the probe reads it.

### The structural assertion, proven

`CubinView` has no copy, no move, no assignment, deleted `operator new`, and **no accessor for its pointer** — `copy_to()` is the only member that can reach it. `make -C shim check-cubin-defer` (a prerequisite of `make -C shim test`) compiles five deferrals that must fail, plus a control that must succeed:

| mode | attempt | error |
|---|---|---|
| 1 | store the view in a struct | deleted copy constructor |
| 2 | heap-allocate it | deleted `operator new` |
| 3 | move into a vector | deleted move constructor |
| 4 | read the pointer out | `bytes_` not accessible from this context |
| 5 | re-point a long-lived slot | deleted move assignment |

Mode 0 is the control — it is why this proves something instead of passing on a typo. `check-cubin-defer: OK - the compliant capture compiles, all 5 deferrals do not`.

### The stub drives it without a GPU

`PERFAGENT_STUB_CUBINS` (a `:`-separated path list) runs Task 1's checked-in fixtures through the **same** `CubinQueue` the adapter uses, over the real Task 3 channel, firing the real probe — exercising Tasks 3, 4, 7 and 9 with no hardware, and it is what the Task 13 gate will use. Its CRC is a documented FNV-1a stand-in, spelled independently in C++ and Go so the key is asserted rather than read back.

### Nine counters, not four

The plan named four; four left drop paths uncounted. Added `cubin_too_large` (refused *before* the memcpy), `cubin_crc_failed`, `alloc_failed`, `module_unattached` and `module_no_bytes`. All seven queue counters are asserted at zero on a healthy run and non-zero in a case of their own.

### The capture gate is not the semaphore alone

It is `enroll == confirmed || semaphore != 0`. Issue #49 measured the semaphore reading zero at `InitializeInjection`, and a module missed there is missed **permanently** — unlike a sample, there is no next one. This adds a fourth hardware unknown, below.

### One finding on already-merged code

`gpuprobe/cubin_test.go`'s `offerCubinFDs` helper `require.NoError`s its write, and `TestAPerPIDConsumerRefusesCubinsFromEveryOtherPID` fails **identically on unmodified `feat/cubin-transport`** (verified in a detached worktree): the listener rejects on peer credentials without reading, so it can close before the write lands. Fixed here; the transport itself is untouched and the `'X'` assertion is unchanged.

### Cannot verify — no `CUpti_` path in this commit has ever executed

1. That `MODULE_LOADED` fires at all for the test workload, and how often — lazy loading may push it past the first launch.
2. That a `cuModuleUnload` after capture leaves the copy's recomputed CRC unchanged, the direct test of finding 2. Offline this can only be *simulated* by overwriting the source buffer.
3. **That `cuptiGetCubinCrc()` over the copy matches the PC records' `cubinCrc` — check this first.** Task 3 notes the agent cannot recompute the CRC and trusts the header as the join key, so a disagreement makes every Tier B sample resolve `no-module` with all counters green.
4. That `capture_enabled()` reads true by the first `MODULE_LOADED`. `g_module_unattached` must read zero on a profiled run; non-zero is the signal to widen the gate, not the tolerance.