### PR TITLE
gpuprobe: decode PC samples, modules, the stall map, windows and config

### DIFF
--- a/.superpowers/sdd/task-7-decode-report.md
+++ b/.superpowers/sdd/task-7-decode-report.md
@@ -1,0 +1,268 @@
+# Task 7 — The consumer decodes PC samples, modules and the stall map
+
+Branch `feat/consumer-decodes-pc`, one commit on top of `origin/main` at `4f8cfcaf`.
+
+`gpuprobe/applyBatch` now has arms for all five PC-sampling kinds. `Stats.Undecoded`
+reads zero for every one of them, and a test asserts it for all five at once.
+
+Files: `gpuprobe/consumer.go`, `gpuprobe/stallnames.go` (new),
+`gpuprobe/consumer_test.go`, `gpuprobe/stallnames_test.go` (new).
+
+---
+
+## The five arms
+
+`decodeBatch` also grew arms for `kindModule` and `kindPC` — those two had a
+cookie, a BPF `record_size` and a `KIND_*`, but no Go decode at all, so the
+`batch` struct gained `Modules []gpuabi.ModuleLoad` and `PCSamples
+[]gpuabi.PCSample` alongside the three Task 2 already decoded.
+
+| kind | arm | what it produces |
+| --- | --- | --- |
+| `kindModule` (3) | `emitModuleLocked` | `gpu.GPUModule{Ref:{Backend, CRC}, SizeBytes, LoadedNs}` → `Sink.EmitModule` |
+| `kindPC` (4) | `emitPCSampleLocked` | `gpu.GPUPCSample{Correlation, Module:{Backend, CRC}, ClockDomain, PCOffset, StallReason, Count}` → `Sink.EmitPCSample`, or held for its stall name |
+| `kindStallMap` (7) | `learnStallNameLocked` | interns `index → name`, releases every PC sample waiting on that index |
+| `kindSamplingWindow` (8) | `noteSamplingWindowLocked` | counts the burst, and counts separately whether it was left open |
+| `kindConfig` (9) | `noteConfigLocked` | last-writer-wins gauges for `sampling_factor` / `sm_count` / `clock_hz`, plus a disagreement counter |
+
+Each arm does `c.stats.Records++` per record, which is what `Undecoded` stopped
+counting. The `default:` arm stays, and its doc comment now says what reaching
+it means: no kind the ABI defines can land there any more, so a non-zero
+`Undecoded` is the ABI having drifted — a `KIND_*` added on one side of the
+wire and not the other.
+
+### Three decisions inside the arms
+
+**`ModuleLoad.BytesPtr` is decoded and deliberately dropped.** It is a pointer
+into the *producer's* address space; following it needs `CAP_SYS_PTRACE`, which
+this agent does not have. The bytes come over the cubin channel (`cubin.go`).
+The record says *that* a module loaded, with its content hash and size, and
+nothing more. `ModulesDecoded` and `CubinsReceived` disagreeing is the ordinary
+Tier B failure — a module announced but unresolvable.
+
+**`GPUPCSample.TimeNs` stays zero.** `gpu_pc_sample_batch_v1` carries no
+timestamp and neither does the batch header. Stamping the arrival time would
+present a consumer-side clock reading as a measurement of when the instruction
+stalled. The consequence is stated rather than papered over: `Timeline`'s
+pending horizon does not age these out by time, and bounding them is Task 8a's
+second pending index, which keys on `{PID, CubinCRC, FunctionIndex}` and brings
+its own eviction counter.
+
+**`PCSample.FunctionIndex` is decoded off the wire and not carried onto
+`GPUPCSample`.** The field does not exist on that type yet; adding it is Task 8a
+by name ("neither Task 7 nor the old Task 8 added the field"). Flagged here so
+it is a known gap rather than an unnoticed one.
+
+---
+
+## How the stall-name table mirrors `kernelnames.go`
+
+`gpuprobe/stallnames.go` is `kernelnames.go` with the types swapped. Same
+structure, same invariants, same reasons:
+
+| `kernelnames.go` | `stallnames.go` |
+| --- | --- |
+| `kernelName{name, truncated}` / `.resolved()` | `stallName{name, truncated}` / `.resolved()` |
+| `truncatedNameSuffix` | `truncatedStallSuffix` (the same rune, aliased, not a second marker) |
+| `kernelNameTable` — map + FIFO `order` + `head` + `capacity`, `put` returns evictions, `compact()` | `stallNameTable`, identical |
+| re-intern replaces in place without appending, so an id appears at most once and `len(order)-head == len(byID)` | identical, and pinned by `TestStallNameOrderTracksLiveEntriesOnly` |
+| eviction by *first* insertion, so a replay does not renew a position | identical, `TestStallNameEvictionIsByFirstInsertion` |
+| `pendingNames` — bounded FIFO, `push` returns the oldest for release, `takeByKernel`, `drain`, `compact` | `pendingStallSamples`, `takeByIndex`, otherwise identical |
+| overflow **releases** the oldest rather than dropping it | identical |
+| `learnKernelNameLocked` interns, counts, releases waiters | `learnStallNameLocked`, identical |
+| `Flush` drains the queue, unnamed and counted | `Flush` also drains `unresolvedStall` |
+| not internally synchronized; `Consumer` calls it under `c.mu` | identical |
+
+### Where it deliberately does not mirror it
+
+**1. No sentinel index.** `resolveKernelNameLocked` short-circuits on
+`kernelID == 0` because the ABI defines zero as "no kernel". CUPTI's stall
+reason indices are opaque vendor numbers and **0 is an ordinary one**, so
+`resolveStallNameLocked` has no such branch. Treating it as absent would
+silently blank one real stall reason on every device where it lands at index 0.
+Pinned by `TestStallNameIndexZeroIsAnOrdinaryEntry` and by the `stallIndex: 0`
+case in `TestPCSamplesResolveStallNamesFromTheMap`.
+
+**2. No `waitsForNameLocked` gate.** A launch is held for a name only once the
+producer has *demonstrated* that names exist (`sawKernelName`), because holding
+one for a name that is never coming delays the join. A PC sample with an
+unmapped index is held **unconditionally**. The gate would break exactly the
+case the plan requires to work: the stall map is one-shot plus late-attach
+replay, so the *first* PC batch of a run routinely precedes it, and a
+"have we seen a map yet" gate would send precisely those samples out permanently
+blank. The cost of dropping the gate is bounded and does not lose a record — a
+producer that never maps its indices pays a fixed lag of
+`PendingStallSampleCapacity` samples, because the queue releases its oldest on
+every push. `TestPCSamplesFlowWhenNoStallMapEverArrives` drives 20 samples
+through a queue of 4 and asserts all 20 arrive, in order, all counted.
+
+**3. The pending entry holds a value, not pointers.** `unnamedEvent` holds
+`*launch` / `*exec` to avoid paying for both structs; `unresolvedSample` has one
+event type, so there is nothing to avoid.
+
+**Capacities.** `defaultStallNameCapacity = 256` (a device's stall reasons are a
+fixed enum — 38 on GA102 — so this is an order of magnitude of headroom);
+`defaultPendingStallSampleCapacity = 4096`, sized like `Timeline`'s own
+`pendingSampleCap` because the window it covers is the producer's 100 ms drain
+interval at full PC rate. Both overridable via `Config.StallNameCapacity` /
+`Config.PendingStallSampleCapacity`.
+
+---
+
+## Every new counter, healthy and worst
+
+Loss and anomaly counters — **all assertable at zero on a healthy run**, and all
+asserted at zero together in
+`TestHealthyTierBRunLeavesEveryNewLossCounterAtZero`:
+
+| counter | healthy | worst, and what it means |
+| --- | --- | --- |
+| `StallNamesMissing` | 0 | `== PCSamplesDecoded`: a profile full of PC samples with no stall reason at all — the entire point of PC sampling, silently absent if it were not counted. The samples are still delivered and their GPU time still measured. |
+| `StallNamesEvicted` | 0 | non-zero: the bounded table is churning, so the stall labels in the profile describe whichever indices happened to be resident. |
+| `StallNamesTruncated` | 0 | non-zero: the producer is cutting names, and two distinct reasons sharing a prefix would otherwise aggregate into one label value. The ABI's buffer is exactly CUPTI's `CUPTI_STALL_REASON_STRING_SIZE`, so a CUPTI producer cannot reach this. |
+| `SamplingWindowsOpen` | 0 | non-zero: a burst's end is unknown (hard exit mid-burst — the shim's `atexit` closes it on the ordinary path), so an unbounded tail of executions is `serialized="unknown"`, never `"false"`. |
+| `ConfigsDisagreed` | 0 | non-zero: `ConfigSamplingFactor` / `ConfigSMCount` / `ConfigClockHz` describe an arbitrary one of several producers and must not be used to scale anything. |
+| `Undecoded` (existing, meaning tightened) | 0 | equal to the record count of every batch of a kind the consumer cannot read — the ABI has drifted. |
+
+The one counter whose healthy reading is **not** zero, and the reason it exists:
+
+| counter | healthy | worst |
+| --- | --- | --- |
+| `PCSamplesWithoutCorrelation` | **Tier B: `== PCSamplesDecoded`.** Tier A: 0. | non-zero **in Tier A**, where CUPTI populates `correlationId` on every record (the spike measured 1,828 of 1,828). One such sample breaks Tier A's whole claim — that a PC sample joins to a launch exactly — and every one of them can then only be attributed by inference. |
+
+This is the defect the task names, in miniature. `ZeroCorrelation` aggregates two
+populations whose healthy values are **opposites**: a PC sample's zero is normal
+and dominant in Tier B, an execution's zero is a shim contract violation. With PC
+samples dominating the traffic, a Tier A violation would be invisible inside the
+aggregate — the same shape as issue #52, one population masking another. The two
+subsets are now kept apart: `ZeroCorrelationExecs` (existing) and
+`PCSamplesWithoutCorrelation` (new). `ZeroCorrelation` keeps counting both, and
+its doc comment now says it must never be read alone.
+`TestTierBZeroCorrelationIsCountedApartFromTheAggregate` asserts a PC sample's
+zero does not move `ZeroCorrelationExecs`;
+`TestTierAPCSampleCarriesTheProcessQualifiedCorrelation` asserts the opposite
+condition.
+
+Volume counters — the answer to "did this kind arrive at all", which no existing
+counter gives because `Records` aggregates every kind:
+
+| counter | healthy | worst |
+| --- | --- | --- |
+| `PCSamplesDecoded` | non-zero with a tier enabled | **0 with a tier enabled**: the shim never drained a PC buffer. A total, silent absence that looks exactly like an idle GPU. |
+| `ModulesDecoded` | one per distinct module loaded | 0 while executions flow: no module ever reached the agent, so nothing Tier B can attribute through. |
+| `StallNamesLearned` | ≥ one full table per producer (38 on GA102) | 0 while PC samples flow → `StallNamesMissing == PCSamplesDecoded`. |
+| `SamplingWindowsDecoded` | many in Tier A, ≤1 in Tier B | **0 in Tier A**: nothing says which executions ran perturbed. |
+| `ConfigsDecoded` | ≥ one per producer | 0: the three gauges are unset and the sampling period behind every PC sample is unknown. |
+
+Gauges: `PendingStallSamples`, `KnownStallNames`, `ConfigSamplingFactor`,
+`ConfigSMCount`, `ConfigClockHz`.
+
+**`SamplingWindowsDecoded` is deliberately the whole of what the consumer does
+with a window.** The serialization disclosure that consumes the content is
+Task 10; building half of it here would leave a store nothing reads. The counter
+makes the discard *sized and visible*, which is the standing rule — it is not a
+claim the windows have been used, and the doc comment says so.
+
+---
+
+## `""`, never `"stall#17"`
+
+`GPUPCSample.StallReason` is a string, and an unresolved index becomes the empty
+string. The index is the **vendor's** — not stable across devices or driver
+versions — so rendering it would put an unstable internal number into a label
+value that consumers aggregate on, and would merge two different stall reasons
+from two driver versions into one bucket. `TestUnmappedStallIndexYieldsEmptyStringAndIsCounted`
+asserts the empty string, asserts the rendered index does not appear, asserts
+the sample itself is delivered intact, and asserts `StallNamesMissing == 1`.
+
+## The pending-map test
+
+`TestPCBatchBeforeItsStallMapStillResolves` is the one the task calls for. It
+applies a PC batch with index 17 **before** any stall map, asserts nothing
+reached the sink and `PendingStallSamples == 2`, then applies the map and
+asserts both samples arrive with `"long_scoreboard"`, oldest first, with
+`StallNamesMissing == 0` — a sample that resolved late is not a missing name.
+
+Other tests added: the five-kind `Undecoded == 0` table
+(`TestTheFivePCSamplingKindsAreDecodedNotCountedUndecoded`), module
+normalization and `bytes_ptr` non-following, ordinary map-then-samples order
+with index 0 as a real index, no-map-ever, truncation marking, table eviction,
+replay-does-not-evict-itself, Tier A / Tier B correlation, open vs closed
+sampling window, inverted window refused at the boundary, config decode and
+disagreement, sequence gaps on the new kinds (including that a different pid
+and a different kind are independent streams), sink rejection counted, and the
+all-counters-zero healthy run. Plus six table/FIFO tests in
+`stallnames_test.go` mirroring `kernelnames_test.go`.
+
+Two existing tests were flipped rather than deleted:
+`TestNewKindsAreCarriedUndecodedAndCounted` became
+`TestTheFivePCSamplingKindsAreDecodedNotCountedUndecoded`, and
+`TestUndecodedKindsAreCountedNotDropped` now drives kind 15 — below `kindMax`,
+above every kind either side defines — so it still proves `Undecoded` counts
+rather than drops.
+
+---
+
+## One discrepancy with the plan's prose, resolved in favour of the code
+
+The task says `Correlation` "gets the PID from the batch header in both tiers,
+with the value only when non-zero — which is already what `correlationOf` does".
+Those two clauses disagree. `correlationOf` returns the **whole zero
+`CorrelationID`** on a wire zero, not one carrying only the pid, and its doc
+comment gives the reason at length: so that the older `== gpu.CorrelationID{}`
+reading and the `Present()` reading agree on these records.
+
+I took the operative half of the instruction — use `correlationOf`, do not
+invent a second rule — so a Tier B sample's correlation is
+`gpu.CorrelationID{}` and a Tier A sample's is
+`{Backend, PID: <batch header>, Value: "<n>"}`. Nothing needs the pid on a
+Tier B correlation: Task 8a's index carries it in the key itself
+(`{PID, CubinCRC, FunctionIndex}`), which is issue #52's discipline —
+cross-process refusal is structural, not a check someone can forget.
+
+---
+
+## Verification
+
+Run in the worktree with the plan's build environment.
+
+```
+go build ./...                                   ok
+go vet ./...                                     ok
+go test ./gpu/ ./gpuprobe/ ./internal/... -count=1
+                                                 all ok
+go test ./gpuprobe/ -race -count=4               ok (15.8s)
+make -C shim && make -C shim test                ok
+~/go/bin/golangci-lint run --timeout=5m          0 issues
+```
+
+The four things the plan asks this task to prove offline, and where:
+
+- `Undecoded == 0` for all five kinds — `TestTheFivePCSamplingKindsAreDecodedNotCountedUndecoded`.
+- a PC batch arriving before its stall map still resolves once the map arrives — `TestPCBatchBeforeItsStallMapStillResolves`.
+- a stall index with no map entry yields `""` and a non-zero `StallNamesMissing` — `TestUnmappedStallIndexYieldsEmptyStringAndIsCounted`.
+- sequence-gap accounting works on the new kinds — `TestSequenceGapsAreCountedOnTheNewKinds`.
+
+## Cannot verify
+
+`CapEff: 0`, no GPU on this machine. Everything above is decode and accounting
+against synthetic wire batches built in the test file; **no real
+`gpu_pc_sample_batch_v1`, `gpu_stall_reason_map_v1`, `gpu_config_v1`,
+`gpu_sampling_window_v1` or `gpu_module_load_v1` record produced by CUPTI has
+been through this code.** In particular, unverified here:
+
+- that a real device's stall indices and names decode as this assumes — Task 6 measures whether 38 stall reasons arrive on GA102 and what they are called;
+- that Tier A really populates `correlationId` on every PC record, which is what makes `PCSamplesWithoutCorrelation == 0` a meaningful Tier A assertion;
+- that `pcOffset` means what the line table will need it to mean, and whether `functionIndex` is the cubin `.symtab` index — the finding-2 question, and the trigger for `gpu_pc_sample_batch_v2`;
+- the real PC-record rate, which is what decides whether `defaultPendingStallSampleCapacity = 4096` is generous or tight in the window before the stall map replays.
+
+Per the plan, this task's line is: **must be measured on the RTX 3090
+afterwards — nothing.** The unverified items above all belong to Task 6's
+hardware list, not to this one.
+
+## Out of scope, as instructed
+
+No `gpu.ModuleStore` wiring (Task 4, PR #77, unmerged). No timeline join, no
+`gpu_pc_attrib`, no source-line resolution (Tasks 8a/8b/9). No change to the
+enrollment or cubin transport paths, no change to any frozen record layout, no
+change to `MAX_BATCHED_RECORD_BYTES`, no change to `bpf/`.

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -13,7 +13,10 @@
 // Stats.SequenceGaps; record kinds this phase carries but does not yet
 // normalize are counted as Stats.Undecoded; records whose wire correlation is
 // zero — the ABI's "no correlation", which demotes them to the timeline's
-// heuristic join — are counted as Stats.ZeroCorrelation. Samples that did not
+// heuristic join — are counted as Stats.ZeroCorrelation, and separately in
+// Stats.ZeroCorrelationExecs and Stats.PCSamplesWithoutCorrelation, because
+// those two populations have opposite healthy readings and one counter
+// cannot be read for both. Samples that did not
 // decode at all are counted as Stats.Malformed, and *why* they did not decode
 // is kept in Stats.DecodeFailures: a count of malformed samples with no
 // reason attached is loss that is visible but not diagnosable.
@@ -300,6 +303,16 @@ type Config struct {
 	// Zero means defaultPendingNamedEventCapacity. See pendingNames.
 	PendingNamedEventCapacity int
 
+	// StallNameCapacity bounds the stall_index -> name table. Zero means
+	// defaultStallNameCapacity. A ceiling, not a dial: a device's stall
+	// reasons are a fixed enum, but nothing on the wire promises that.
+	StallNameCapacity int
+
+	// PendingStallSampleCapacity bounds how many PC samples may be held at
+	// once waiting for a stall name that has not arrived yet. Zero means
+	// defaultPendingStallSampleCapacity. See pendingStallSamples.
+	PendingStallSampleCapacity int
+
 	// UnwindPIDCapacity bounds how many processes hold CFI tables for the
 	// stack walker at once. Zero means defaultUnwindPIDCapacity. A
 	// system-wide attach learns PIDs from the records that arrive, so the
@@ -351,6 +364,23 @@ const (
 	// launches and execs rather than for steady state - in steady state the
 	// name is already interned and nothing waits at all.
 	defaultPendingNamedEventCapacity = 512
+
+	// defaultStallNameCapacity bounds the interned stall-reason table. A
+	// device's stall reasons are a fixed enum - 38 on GA102 - so 256 is an
+	// order of magnitude of headroom over anything a CUPTI device can
+	// report, and a run that evicts from this table is a run whose producer
+	// is not describing one device.
+	defaultStallNameCapacity = 256
+
+	// defaultPendingStallSampleCapacity bounds the PC samples held for a
+	// stall name that has not arrived. The window it has to cover is the
+	// gap between the consumer attaching and the producer's late-attach
+	// replay of the stall map - up to one drain interval (100ms in the
+	// shim) - during which PC batches arrive at their full rate. It is
+	// sized like Timeline's own pendingSampleCap for that reason. Nothing
+	// is dropped when it bites: the oldest sample is RELEASED, unresolved
+	// and counted in StallNamesMissing.
+	defaultPendingStallSampleCapacity = 4096
 )
 
 // Stats is the consumer's loss record. Every discard has a counter here or
@@ -369,11 +399,17 @@ type Stats struct {
 	// SinkRejected counts events the sink refused (full, or invalid).
 	SinkRejected uint64
 	// Undecoded counts records of a kind this phase carries on the wire but
-	// does not yet normalize: module loads and PC samples. Sampled launches
-	// and interned kernel names are no longer in this class - the first has
-	// its stack attached to the batched launch it belongs to, the second
-	// names the launches and executions that refer to its kernel id.
-	// Counted so the loss is visible rather than silent.
+	// does not yet normalize. Nothing the ABI defines is in that class any
+	// more: launches, executions, sampled launches, kernel names, module
+	// loads, PC samples, the stall-reason map, sampling windows and the
+	// config record all have an applyBatch arm. What is left is a kind the
+	// producer invented, or a KIND_* added on one side of the wire and not
+	// the other - both of which are silent loss unless counted, which is
+	// why the counter stays after its original population emptied.
+	//
+	// Healthy: zero, and gate_test.go asserts it. Worst: equal to the
+	// record count of every batch of some kind the consumer cannot read,
+	// which is the ABI having drifted.
 	Undecoded uint64
 	// Malformed counts ringbuf samples that did not decode: a short header,
 	// a payload shorter than the header claims, or a truncated record.
@@ -407,7 +443,37 @@ type Stats struct {
 	// them to the timeline's heuristic join instead of the exact one. The
 	// counter exists because that demotion changes how confidently the join
 	// can be read, and a silent demotion is as bad as silent loss.
+	//
+	// It is an aggregate over populations whose healthy values are
+	// OPPOSITE, so it must never be read alone. ZeroCorrelationExecs and
+	// PCSamplesWithoutCorrelation are the two subsets that carry the
+	// meaning; see both.
 	ZeroCorrelation uint64
+	// PCSamplesWithoutCorrelation is the subset of ZeroCorrelation that
+	// arrived on a gpu_pc_sample_batch_v1 record. It is the PC-sample twin
+	// of ZeroCorrelationExecs and exists for the same reason: one counter
+	// cannot serve two populations whose healthy readings are opposites.
+	//
+	// In Tier B (CONTINUOUS) CUPTI populates no correlation at all, so
+	// EVERY PC record carries zero by design and this counter equals
+	// PCSamplesDecoded on a perfectly healthy run. In Tier A
+	// (KERNEL_SERIALIZED) CUPTI populates it on every record - the spike
+	// measured 1,828 of 1,828 - so a single non-zero here is the shim
+	// breaking Tier A's whole claim, that a PC sample joins to a launch
+	// exactly.
+	//
+	// That is why it is not folded into ZeroCorrelation: with PC samples
+	// dominating the traffic, ZeroCorrelation is enormous and healthy in
+	// Tier B, and a Tier A contract violation would be invisible inside it
+	// - the same defect issue #52 found for executions. Nothing is dropped
+	// either way; the sample is normalized with the zero CorrelationID,
+	// which routes it to the module-granularity attribution Tier B is
+	// built on.
+	//
+	// Healthy: zero in Tier A, PCSamplesDecoded in Tier B. Worst: non-zero
+	// in Tier A, where every such sample can only ever be attributed by
+	// inference.
+	PCSamplesWithoutCorrelation uint64
 	// ZeroCorrelationExecs is the subset of ZeroCorrelation that arrived on a
 	// gpu_exec_v1 record, and it means something completely different from
 	// the rest of that counter — issue #52.
@@ -938,6 +1004,144 @@ type Stats struct {
 	PendingLaunches    int
 	PendingNamedEvents int
 	KnownKernelNames   int
+
+	// ----- PC sampling: the five kinds applyBatch decodes for Tier A and
+	// Tier B. None of these resolves a source line or attributes a sample
+	// to an execution; that is the module store's and the timeline's work.
+	// These say what arrived and what could not be read.
+
+	// PCSamplesDecoded counts gpu_pc_sample_batch_v1 records normalized
+	// into gpu.GPUPCSample and handed to the sink. It is the denominator
+	// the counters below are read against, and the answer to "did PC
+	// sampling produce anything at all", which no other counter gives:
+	// Records aggregates every kind.
+	//
+	// Healthy: non-zero whenever a tier is enabled. Worst: zero with a
+	// tier enabled, which means the shim never drained a PC buffer - a
+	// silent, total absence that looks exactly like an idle GPU.
+	PCSamplesDecoded uint64
+	// ModulesDecoded counts gpu_module_load_v1 records normalized into
+	// gpu.GPUModule. It records that a module loaded, with its CRC and
+	// size; it does NOT mean the module's BYTES arrived. Those travel the
+	// cubin channel and are counted in CubinsReceived, and the two
+	// disagreeing is the ordinary Tier B failure - a module announced but
+	// unresolvable, every one of whose PC samples reads gpu_src_status
+	// "no-module".
+	//
+	// ModuleLoad.BytesPtr is decoded and deliberately unused: it is a
+	// pointer into the PRODUCER's address space, and following it would
+	// need CAP_SYS_PTRACE, which this agent does not have and will not
+	// take. See cubin.go.
+	//
+	// Healthy: one per distinct module the process loaded. Worst: zero
+	// while executions flow, meaning no module ever reached the agent.
+	ModulesDecoded uint64
+	// StallNamesLearned counts gpu_stall_reason_map_v1 records interned.
+	// The producer replays its whole table on late attach, so an index may
+	// be learned more than once; this counts records, not distinct indices
+	// (KnownStallNames is the gauge for the latter).
+	//
+	// Healthy: at least one full table - 38 entries on GA102 - per
+	// producer. Worst: zero while PC samples flow, in which case every
+	// sample's stall reason is "" and StallNamesMissing equals
+	// PCSamplesDecoded.
+	StallNamesLearned uint64
+	// StallNamesTruncated counts stall names the producer had to cut off
+	// at GPU_STALL_NAME_MAX. Those names still resolve, marked with
+	// truncatedStallSuffix, so a truncated name is never presented as
+	// complete.
+	//
+	// Healthy: zero. The ABI's buffer is exactly CUPTI's own
+	// CUPTI_STALL_REASON_STRING_SIZE, so a CUPTI producer cannot overflow
+	// it. Worst: non-zero, meaning stall names are being cut and two
+	// distinct reasons sharing a prefix would otherwise have aggregated
+	// into one label value.
+	StallNamesTruncated uint64
+	// StallNamesEvicted counts stall names pushed out of the bounded
+	// table. Not record loss: the PC samples still flow, with an empty
+	// stall reason, and count in StallNamesMissing.
+	//
+	// Healthy: zero - a device's stall reasons are a fixed enum far below
+	// the bound. Worst: non-zero, meaning the table is churning and the
+	// stall labels in the profile describe whichever indices happened to
+	// be resident.
+	StallNamesEvicted uint64
+	// StallNamesMissing counts PC samples emitted with an EMPTY stall
+	// reason: the producer never mapped that index, the name was evicted,
+	// or the sample was released (by the pending queue's bound, or by a
+	// Flush) before its name arrived.
+	//
+	// The sample is never dropped for this - it reaches the sink and its
+	// GPU time is still measured - and the stall reason is never faked. An
+	// index with no name becomes "", never "stall#17": the index is the
+	// vendor's own and is not stable across devices or driver versions, so
+	// rendering it would leak an unstable internal number into a label
+	// value where a consumer would aggregate on it. This counter is what
+	// makes the resulting blank visible instead of mysterious.
+	//
+	// Healthy: zero. Worst: equal to PCSamplesDecoded, which is a profile
+	// full of PC samples with no stall reason at all - the whole point of
+	// PC sampling, silently absent, if it were not counted.
+	StallNamesMissing uint64
+	// SamplingWindowsDecoded counts gpu_sampling_window_v1 records read.
+	// One record is one PC-sampling burst. Tier A duty-cycles, so a Tier A
+	// run produces many; Tier B does not burst, so a Tier B run produces
+	// at most one.
+	//
+	// The windows' CONTENT is not retained yet - the serialization
+	// disclosure that consumes it is Task 10 - so this counter is
+	// deliberately the whole of what the consumer does with them. That
+	// makes the discard sized and visible rather than silent, which is the
+	// contract; it is not a claim that the windows have been used.
+	//
+	// Healthy: non-zero in Tier A, zero or one in Tier B. Worst: zero in
+	// Tier A, where nothing would then say which executions ran perturbed.
+	SamplingWindowsDecoded uint64
+	// SamplingWindowsOpen is the subset of SamplingWindowsDecoded that
+	// arrived with end_ns == 0, which the ABI defines as "still open when
+	// the producer stopped reporting" - a hard exit mid-burst, since the
+	// shim's atexit handler closes the window on the ordinary path. It is
+	// NOT a zero-length window, and the two must never be conflated: an
+	// open window means every execution at or after its start_ns is
+	// serialized="unknown", never "false".
+	//
+	// Healthy: zero. Worst: non-zero, meaning a burst's end is unknown and
+	// an unbounded tail of executions cannot be said to have run
+	// unperturbed.
+	SamplingWindowsOpen uint64
+	// ConfigsDecoded counts gpu_config_v1 records read. The producer emits
+	// one per process and replays it on late attach, so this counts
+	// records rather than producers.
+	//
+	// Healthy: at least one per producer. Worst: zero, in which case the
+	// three gauges below are unset and the sampling period behind every PC
+	// sample is unknown.
+	ConfigsDecoded uint64
+	// ConfigsDisagreed counts config records whose values differ from the
+	// ones already held. The three gauges below are last-writer-wins, so
+	// with a system-wide attach they describe whichever producer reported
+	// most recently; this counter is what says the answer is ambiguous
+	// instead of letting one process's configuration stand for the
+	// machine's.
+	//
+	// Healthy: zero - one producer, one configuration, replayed
+	// identically. Worst: non-zero, meaning ConfigSamplingFactor,
+	// ConfigSMCount and ConfigClockHz describe an arbitrary one of several
+	// producers and must not be used to scale anything.
+	ConfigsDisagreed uint64
+	// ConfigSamplingFactor, ConfigSMCount and ConfigClockHz are the
+	// producer's own sampling configuration, from the most recent
+	// gpu_config_v1. Gauges, not counters, and meaningful only while
+	// ConfigsDisagreed is zero. Zero means no config record has arrived.
+	ConfigSamplingFactor uint32
+	ConfigSMCount        uint32
+	ConfigClockHz        uint64
+	// PendingStallSamples and KnownStallNames are gauges: what the two
+	// stall-reason side tables hold right now. PendingStallSamples is also
+	// how many PC samples the consumer is currently holding back - see
+	// Consumer.Flush.
+	PendingStallSamples int
+	KnownStallNames     int
 	// KernelStacksMissing is the same event counted on the BPF side, read
 	// from the `stacks_missing` map. It is kept separate from StacksMissing
 	// rather than replacing it because the two disagree exactly when a batch
@@ -1156,6 +1360,16 @@ type Consumer struct {
 	deferred    *deferredLaunches
 	names       *kernelNameTable
 	unnamed     *pendingNames
+	// stalls and unresolvedStalls are the stall-reason twins of names and
+	// unnamed: the bounded stall_index -> name table, and the bounded FIFO
+	// of PC samples held until their index resolves. See stallnames.go.
+	stalls          *stallNameTable
+	unresolvedStall *pendingStallSamples
+	// config is the most recent gpu_config_v1, and configSeen says whether
+	// one has arrived at all - which the zero value cannot, because a
+	// producer may legitimately report a zero sampling factor.
+	config     gpuabi.Config
+	configSeen bool
 	// shim is the attribution guard's view of what the consumer attached
 	// to: whether the shim is an injected library or the program itself,
 	// and which module paths are the shim's own. Immutable after
@@ -1186,6 +1400,9 @@ func newConsumer(cfg Config) *Consumer {
 		deferred:    newDeferredLaunches(cfg.DeferredLaunchCapacity),
 		names:       newKernelNameTable(cfg.KernelNameCapacity),
 		unnamed:     newPendingNames(cfg.PendingNamedEventCapacity),
+
+		stalls:          newStallNameTable(cfg.StallNameCapacity),
+		unresolvedStall: newPendingStallSamples(cfg.PendingStallSampleCapacity),
 	}
 }
 
@@ -1379,9 +1596,8 @@ type batch struct {
 	Execs           []gpuabi.Exec
 	SampledLaunches []gpuabi.LaunchSampled
 	KernelNames     []gpuabi.KernelName
-	// Decoded here, normalized in a later phase. Until applyBatch grows arms
-	// for these kinds they still land in its default: case and are counted as
-	// Stats.Undecoded, so nothing about them is silent in the meantime.
+	Modules         []gpuabi.ModuleLoad
+	PCSamples       []gpuabi.PCSample
 	StallReasons    []gpuabi.StallReason
 	SamplingWindows []gpuabi.SamplingWindow
 	Configs         []gpuabi.Config
@@ -1434,6 +1650,30 @@ func decodeBatch(b []byte) (batch, error) {
 				return batch{}, err
 			}
 			out.Execs = append(out.Execs, rec)
+		}
+	case kindModule:
+		if count > len(payload)/gpuabi.SizeModuleLoad {
+			return batch{}, gpuabi.ErrShortRecord
+		}
+		out.Modules = make([]gpuabi.ModuleLoad, 0, count)
+		for i := 0; i < count; i++ {
+			rec, err := gpuabi.DecodeModuleLoad(payload[i*gpuabi.SizeModuleLoad:])
+			if err != nil {
+				return batch{}, err
+			}
+			out.Modules = append(out.Modules, rec)
+		}
+	case kindPC:
+		if count > len(payload)/gpuabi.SizePCSample {
+			return batch{}, gpuabi.ErrShortRecord
+		}
+		out.PCSamples = make([]gpuabi.PCSample, 0, count)
+		for i := 0; i < count; i++ {
+			rec, err := gpuabi.DecodePCSample(payload[i*gpuabi.SizePCSample:])
+			if err != nil {
+				return batch{}, err
+			}
+			out.PCSamples = append(out.PCSamples, rec)
 		}
 	case kindLaunchSampled:
 		// One header, one stack id, one launch. See errSampledBatchNotSingular.
@@ -1689,10 +1929,218 @@ func (c *Consumer) applyBatch(b batch) {
 			c.stats.Records++
 			c.learnKernelNameLocked(n)
 		}
+	case kindModule:
+		for _, m := range b.Modules {
+			c.stats.Records++
+			c.emitModuleLocked(m)
+		}
+	case kindPC:
+		for _, p := range b.PCSamples {
+			c.stats.Records++
+			c.emitPCSampleLocked(b.PID, p)
+		}
+	case kindStallMap:
+		for _, s := range b.StallReasons {
+			c.stats.Records++
+			c.learnStallNameLocked(s)
+		}
+	case kindSamplingWindow:
+		for _, w := range b.SamplingWindows {
+			c.stats.Records++
+			c.noteSamplingWindowLocked(w)
+		}
+	case kindConfig:
+		for _, cfg := range b.Configs {
+			c.stats.Records++
+			c.noteConfigLocked(cfg)
+		}
 	default:
-		// Carried on the wire, not yet normalized. Counted, never silent.
+		// Carried on the wire, not normalized. Counted, never silent. No
+		// kind the ABI defines reaches here any more; see Stats.Undecoded
+		// for what it means when one does.
 		c.stats.Undecoded += uint64(b.RawCount)
 	}
+}
+
+// emitModuleLocked normalizes one gpu_module_load_v1 record and hands it to
+// the sink. Caller holds mu.
+//
+// ModuleLoad.BytesPtr is decoded and deliberately NOT used. It is a pointer
+// into the producer's address space; reading it would need /proc/<pid>/mem
+// or process_vm_readv, both of which need CAP_SYS_PTRACE, which this agent
+// does not have and does not take. The bytes travel the cubin channel
+// instead (cubin.go). This record says that a module loaded, with its CRC
+// and size, and nothing more.
+func (c *Consumer) emitModuleLocked(rec gpuabi.ModuleLoad) {
+	c.stats.ModulesDecoded++
+	ev := gpu.GPUModule{
+		Ref:       gpu.ModuleRef{Backend: c.cfg.Backend, CRC: rec.CubinCRC},
+		SizeBytes: rec.SizeBytes,
+		LoadedNs:  rec.LoadNs,
+	}
+	if err := c.cfg.Sink.EmitModule(ev); err != nil {
+		c.stats.SinkRejected++
+	}
+}
+
+// emitPCSampleLocked normalizes one gpu_pc_sample_batch_v1 record, resolving
+// its stall index, and either hands it to the sink or holds it until the
+// stall map arrives. Caller holds mu.
+//
+// The identity that always arrives is the MODULE, not the correlation:
+// {Backend, CRC}, content-addressed, which is what Tier B attribution runs
+// through. The correlation is taken from the batch header's pid through
+// correlationOf, so a wire value of zero yields the zero CorrelationID (not
+// one carrying only a pid) and a non-zero one is qualified by the process
+// that produced it - the same rule launches and executions follow, for the
+// same reason: vendor correlation counters restart in every process.
+func (c *Consumer) emitPCSampleLocked(pid uint32, rec gpuabi.PCSample) {
+	c.stats.PCSamplesDecoded++
+	if rec.Correlation == 0 {
+		// Counted here rather than inside correlationOf, which is shared
+		// with the launch, exec and sampled-stack paths and cannot tell
+		// them apart. See Stats.PCSamplesWithoutCorrelation for why a PC
+		// sample's zero is routine in Tier B and a contract violation in
+		// Tier A - two opposite healthy values that one counter cannot
+		// carry.
+		c.stats.PCSamplesWithoutCorrelation++
+	}
+	ev := gpu.GPUPCSample{
+		Correlation: c.correlationOf(pid, rec.Correlation),
+		Module:      gpu.ModuleRef{Backend: c.cfg.Backend, CRC: rec.CubinCRC},
+		// The shim stamps CLOCK_MONOTONIC, which is the only domain the
+		// core accepts; say so rather than leaning on
+		// NormalizeClockDomain's zero-value default.
+		//
+		// TimeNs stays zero: gpu_pc_sample_batch_v1 carries no timestamp
+		// and neither does the batch header, so there is nothing to put
+		// there. Stamping the arrival time would present a consumer-side
+		// clock reading as a measurement of when the instruction stalled,
+		// which is exactly the inference-as-measurement this project
+		// forbids. The timeline's pending horizon therefore does not age
+		// these out by time; bounding them is Task 8a's second pending
+		// index.
+		ClockDomain: gpu.ClockDomainCPUMonotonic,
+		PCOffset:    rec.PCOffset,
+		Count:       uint64(rec.Count),
+	}
+	if name, ok := c.resolveStallNameLocked(rec.StallIndex); ok {
+		ev.StallReason = name
+		c.sinkPCSampleLocked(ev, true)
+		return
+	}
+	c.holdForStallNameLocked(unresolvedSample{stallIndex: rec.StallIndex, sample: ev})
+}
+
+// sinkPCSampleLocked is the only place a PC sample reaches the sink.
+// resolved reports whether a stall name was found; an unresolved sample is
+// delivered anyway - a missing name must never cost a record - with an
+// EMPTY stall reason and a counter, never with the raw index rendered into
+// it. Caller holds mu.
+func (c *Consumer) sinkPCSampleLocked(ev gpu.GPUPCSample, resolved bool) {
+	if !resolved {
+		c.stats.StallNamesMissing++
+	}
+	if err := c.cfg.Sink.EmitPCSample(ev); err != nil {
+		c.stats.SinkRejected++
+	}
+}
+
+// resolveStallNameLocked looks a stall index up in the interned table.
+//
+// Deliberate divergence from resolveKernelNameLocked: there is no sentinel
+// index. A kernel id of zero is the ABI's "no kernel", so that path can
+// short-circuit; CUPTI's stall reason indices are opaque vendor numbers and
+// zero is a perfectly ordinary one, so treating it as "none" would silently
+// blank one real stall reason on every device where it happens to be index
+// 0. Caller holds mu.
+func (c *Consumer) resolveStallNameLocked(index uint32) (string, bool) {
+	s, ok := c.stalls.get(index)
+	if !ok {
+		return "", false
+	}
+	return s.resolved(), true
+}
+
+// holdForStallNameLocked queues a PC sample until its stall name arrives,
+// releasing the oldest held sample if the queue is full. Caller holds mu.
+//
+// The second deliberate divergence from the kernel-name path: there is no
+// waitsForNameLocked gate here, so a sample with an unknown index is held
+// whether or not a stall map has ever been seen. A launch is held only once
+// the producer has demonstrated that names exist, because holding one for a
+// name that is never coming delays the join; a PC sample is not on that
+// path, and the case the gate would break is the one the ABI makes normal -
+// the stall map is one-shot plus replay, so the FIRST PC batch of a run
+// routinely precedes it, and a gate keyed on "have we seen a map yet" would
+// send exactly those samples out permanently unresolved. A producer that
+// never maps its indices costs a fixed lag of PendingStallSampleCapacity
+// samples and nothing else: the queue releases its oldest on every push, so
+// every sample is still delivered, counted in StallNamesMissing.
+func (c *Consumer) holdForStallNameLocked(s unresolvedSample) {
+	if released, ok := c.unresolvedStall.push(s); ok {
+		c.releaseUnresolvedStallLocked(released, "")
+	}
+}
+
+// releaseUnresolvedStallLocked sends one held PC sample on, with the stall
+// name if one was found and without it otherwise. Caller holds mu.
+func (c *Consumer) releaseUnresolvedStallLocked(s unresolvedSample, name string) {
+	s.sample.StallReason = name
+	c.sinkPCSampleLocked(s.sample, name != "")
+}
+
+// learnStallNameLocked interns one stall reason name and releases every PC
+// sample waiting on it. The twin of learnKernelNameLocked. Caller holds mu.
+func (c *Consumer) learnStallNameLocked(rec gpuabi.StallReason) {
+	c.stats.StallNamesLearned++
+	if rec.Truncated {
+		c.stats.StallNamesTruncated++
+	}
+	s := stallName{name: rec.Name, truncated: rec.Truncated}
+	c.stats.StallNamesEvicted += uint64(c.stalls.put(rec.Index, s))
+	// A name that arrives empty resolves nothing, so held samples would be
+	// released unresolved anyway; releasing them here keeps that decision
+	// in one place.
+	name := s.resolved()
+	for _, waiting := range c.unresolvedStall.takeByIndex(rec.Index) {
+		c.releaseUnresolvedStallLocked(waiting, name)
+	}
+}
+
+// noteSamplingWindowLocked records one PC-sampling burst. Caller holds mu.
+//
+// The window's content is not retained: the serialization disclosure that
+// consumes it - marking which executions ran perturbed - is a later task,
+// and building half of it here would leave a store nothing reads. What this
+// does is make the discard sized and visible, which is the standing rule:
+// counted is not the same as used, and Stats.SamplingWindowsDecoded says so.
+func (c *Consumer) noteSamplingWindowLocked(w gpuabi.SamplingWindow) {
+	c.stats.SamplingWindowsDecoded++
+	if w.Open() {
+		// end_ns == 0 is the ABI's "still open when the producer stopped
+		// reporting", not a zero-length window. DecodeSamplingWindow has
+		// already refused a genuinely inverted one.
+		c.stats.SamplingWindowsOpen++
+	}
+}
+
+// noteConfigLocked records the producer's sampling configuration. Caller
+// holds mu.
+//
+// Last writer wins, and ConfigsDisagreed is what stops that being a lie: a
+// system-wide attach sees one of these per producer, so without the counter
+// one process's sampling factor would silently stand for the machine's.
+func (c *Consumer) noteConfigLocked(cfg gpuabi.Config) {
+	c.stats.ConfigsDecoded++
+	if c.configSeen && cfg != c.config {
+		c.stats.ConfigsDisagreed++
+	}
+	c.config = cfg
+	c.configSeen = true
+	c.stats.ConfigSamplingFactor = cfg.SamplingFactor
+	c.stats.ConfigSMCount = cfg.SMCount
+	c.stats.ConfigClockHz = cfg.ClockHz
 }
 
 // admitLaunchLocked decides whether a normalized launch goes to the sink now
@@ -2218,8 +2666,17 @@ func (c *Consumer) releaseUnnamedAllLocked() {
 	}
 }
 
-// Flush releases every launch the consumer is holding back for a possible
-// sampled stack, in arrival order.
+// releaseUnresolvedStallAllLocked sends on every PC sample still waiting for
+// a stall name, unresolved and counted. Caller holds mu.
+func (c *Consumer) releaseUnresolvedStallAllLocked() {
+	for _, s := range c.unresolvedStall.drain() {
+		c.releaseUnresolvedStallLocked(s, "")
+	}
+}
+
+// Flush releases everything the consumer is holding back, in arrival order:
+// launches waiting for a sampled stack, launches and executions waiting for
+// a kernel name, and PC samples waiting for a stall name.
 //
 // Run calls it on the way out and Close calls it too, so a consumer that is
 // finished never leaves a launch behind. It is exported for the other case:
@@ -2239,6 +2696,9 @@ func (c *Consumer) Flush() {
 	// after, leaving nothing behind in either.
 	c.releaseDeferredLocked()
 	c.releaseUnnamedAllLocked()
+	// PC samples held for a stall name are on their own queue and are
+	// independent of the two above; a snapshot must not miss them either.
+	c.releaseUnresolvedStallAllLocked()
 }
 
 // Stats returns the loss record, including the BPF-side drop counters read
@@ -2310,6 +2770,8 @@ func (c *Consumer) Stats() Stats {
 	out.PendingLaunches = c.deferred.len()
 	out.PendingNamedEvents = c.unnamed.len()
 	out.KnownKernelNames = c.names.len()
+	out.PendingStallSamples = c.unresolvedStall.len()
+	out.KnownStallNames = c.stalls.len()
 	return out
 }
 

--- a/gpuprobe/consumer_test.go
+++ b/gpuprobe/consumer_test.go
@@ -52,10 +52,12 @@ func newTestConsumer(sink gpu.EventSink) *Consumer {
 // reject so the SinkRejected accounting is exercised. It is mutex-guarded
 // because the lifecycle tests below drive it from Run's goroutine.
 type recordingSink struct {
-	mu       sync.Mutex
-	launches []gpu.GPUKernelLaunch
-	execs    []gpu.GPUKernelExec
-	err      error
+	mu        sync.Mutex
+	launches  []gpu.GPUKernelLaunch
+	execs     []gpu.GPUKernelExec
+	pcSamples []gpu.GPUPCSample
+	modules   []gpu.GPUModule
+	err       error
 	// onEmit, if set, is called after each accepted event. The lifecycle
 	// tests use it to know Run has completed a loop iteration.
 	onEmit func()
@@ -89,8 +91,28 @@ func (s *recordingSink) EmitExec(e gpu.GPUKernelExec) error {
 	return nil
 }
 
-func (s *recordingSink) EmitPCSample(gpu.GPUPCSample) error   { return s.errOnly() }
-func (s *recordingSink) EmitModule(gpu.GPUModule) error       { return s.errOnly() }
+func (s *recordingSink) EmitPCSample(p gpu.GPUPCSample) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.pcSamples = append(s.pcSamples, p)
+	s.note()
+	return nil
+}
+
+func (s *recordingSink) EmitModule(m gpu.GPUModule) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.modules = append(s.modules, m)
+	s.note()
+	return nil
+}
+
 func (s *recordingSink) EmitEvent(gpu.GPUTimelineEvent) error { return s.errOnly() }
 
 func (s *recordingSink) errOnly() error {
@@ -187,13 +209,15 @@ func TestProbeKindCookiesMatchTheBPFProgram(t *testing.T) {
 	assert.Equal(t, uint64(0), cookieFor("gpu_unknown_v9"), "unknown probes are not attached")
 }
 
-// Module and PC-sample records are on the wire in Phase 3 but are not turned
-// into canonical events until Phases 4 and 6. They must be counted, not
-// silently discarded — §6.1 admits no silent loss anywhere.
+// Stats.Undecoded is the "carried but not interpreted" counter. Every kind
+// the ABI defines now has an applyBatch arm, so the only way to reach it is
+// with a kind neither side of the wire knows - which is the ABI having
+// drifted, and which must still be counted rather than dropped quietly
+// (§6.1 admits no silent loss anywhere).
 func TestUndecodedKindsAreCountedNotDropped(t *testing.T) {
 	c := newTestConsumer(&recordingSink{})
 	buf := make([]byte, batchHdrSize+40)
-	putU32(buf[0:], kindModule)
+	putU32(buf[0:], 15) // below kindMax, above every kind either side defines
 	putU32(buf[4:], 1)
 	putU64(buf[24:], 40)
 
@@ -2793,15 +2817,21 @@ func TestDecodeRejectsCountBeyondPayloadForTheNewKinds(t *testing.T) {
 	}
 }
 
-// Until applyBatch grows arms for them, the new kinds are carried undecoded
-// and counted. "Counted" is the whole point: spec §6.1 admits no silent loss,
-// and a kind the consumer ignores without counting is exactly that.
-func TestNewKindsAreCarriedUndecodedAndCounted(t *testing.T) {
+// ----- Task 7: the five PC-sampling kinds are normalized, not carried.
+//
+// This is the assertion Task 2 left to be flipped. Undecoded was the
+// contract while the kinds were on the wire and uninterpreted; now every one
+// of them has an applyBatch arm, so the counter must read zero for all five
+// and the records must be counted in Records instead.
+
+func TestTheFivePCSamplingKindsAreDecodedNotCountedUndecoded(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		kind uint32
 		size int
 	}{
+		{"module", kindModule, gpuabi.SizeModuleLoad},
+		{"pc", kindPC, gpuabi.SizePCSample},
 		{"stallmap", kindStallMap, gpuabi.SizeStallReason},
 		{"samplingwindow", kindSamplingWindow, gpuabi.SizeSamplingWindow},
 		{"config", kindConfig, gpuabi.SizeConfig},
@@ -2811,16 +2841,490 @@ func TestNewKindsAreCarriedUndecodedAndCounted(t *testing.T) {
 			putU32(buf[0:], tc.kind)
 			putU32(buf[4:], 1)
 			putU64(buf[24:], uint64(tc.size))
+			// A sampling window with end_ns == 0 is the "open" case, which
+			// is legal; give this one a real end so the healthy-run
+			// assertions below hold for every kind alike.
+			if tc.kind == kindSamplingWindow {
+				putU64(buf[batchHdrSize:], 1_000)
+				putU64(buf[batchHdrSize+8:], 2_000)
+				buf[batchHdrSize+16] = gpuabi.SamplingModeContinuous
+			}
 
 			b, err := decodeBatch(buf)
 			require.NoError(t, err)
 
 			c := newTestConsumer(&recordingSink{})
 			c.applyBatch(b)
-			assert.Equal(t, uint64(1), c.Stats().Undecoded,
-				"a kind the transport carries but applyBatch does not normalize must be counted")
+			c.Flush()
+			st := c.Stats()
+			assert.Zero(t, st.Undecoded,
+				"applyBatch has an arm for this kind now; Undecoded reading non-zero means it fell through to default:")
+			assert.Equal(t, uint64(1), st.Records,
+				"a decoded record is counted in Records, which is what Undecoded stopped counting")
+			assert.Zero(t, st.SinkRejected)
+			assert.Zero(t, st.Malformed)
+			assert.Zero(t, st.SamplingWindowsOpen)
+			assert.Zero(t, st.ConfigsDisagreed)
+			assert.Zero(t, st.StallNamesEvicted)
+			assert.Zero(t, st.StallNamesTruncated)
 		})
 	}
+}
+
+// moduleBatch builds one gpu_module_load_v1 batch.
+func moduleBatch(pid uint32, crc, moduleID, size, loadNs, bytesPtr uint64) []byte {
+	buf := make([]byte, batchHdrSize+gpuabi.SizeModuleLoad)
+	putU32(buf[0:], kindModule)
+	putU32(buf[4:], 1)
+	putU32(buf[16:], pid)
+	putU64(buf[24:], uint64(gpuabi.SizeModuleLoad))
+	putU32(buf[32:], ^uint32(0)) // stack_id = -1 on every non-sampled kind
+	rec := buf[batchHdrSize:]
+	putU64(rec[0:], crc)
+	putU64(rec[8:], moduleID)
+	putU64(rec[16:], size)
+	putU64(rec[24:], loadNs)
+	putU64(rec[32:], bytesPtr)
+	return buf
+}
+
+// pcSample is one wire gpu_pc_sample_batch_v1 record's worth of fields.
+type pcSample struct {
+	crc         uint64
+	correlation uint64
+	pcOffset    uint64
+	fnIndex     uint32
+	stallIndex  uint32
+	count       uint32
+}
+
+// pcBatch builds one gpu_pc_sample_batch_v1 batch of n records.
+func pcBatch(pid uint32, seq uint64, samples ...pcSample) []byte {
+	n := len(samples)
+	buf := make([]byte, batchHdrSize+n*gpuabi.SizePCSample)
+	putU32(buf[0:], kindPC)
+	putU32(buf[4:], uint32(n))
+	putU64(buf[8:], seq)
+	putU32(buf[16:], pid)
+	putU64(buf[24:], uint64(n*gpuabi.SizePCSample))
+	putU32(buf[32:], ^uint32(0))
+	for i, s := range samples {
+		rec := buf[batchHdrSize+i*gpuabi.SizePCSample:]
+		putU64(rec[0:], s.crc)
+		putU64(rec[8:], s.correlation)
+		putU64(rec[16:], s.pcOffset)
+		putU32(rec[24:], s.fnIndex)
+		putU32(rec[28:], s.stallIndex)
+		putU32(rec[32:], s.count)
+	}
+	return buf
+}
+
+// stallMapBatch builds one gpu_stall_reason_map_v1 batch from index -> name
+// pairs, in the given order.
+func stallMapBatch(seq uint64, indices []uint32, names []string, truncated bool) []byte {
+	n := len(indices)
+	buf := make([]byte, batchHdrSize+n*gpuabi.SizeStallReason)
+	putU32(buf[0:], kindStallMap)
+	putU32(buf[4:], uint32(n))
+	putU64(buf[8:], seq)
+	putU64(buf[24:], uint64(n*gpuabi.SizeStallReason))
+	putU32(buf[32:], ^uint32(0))
+	for i := range indices {
+		rec := buf[batchHdrSize+i*gpuabi.SizeStallReason:]
+		putU32(rec[0:], indices[i])
+		binary.LittleEndian.PutUint16(rec[4:], uint16(len(names[i])))
+		if truncated {
+			rec[6] = 1
+		}
+		copy(rec[8:], names[i])
+	}
+	return buf
+}
+
+func samplingWindowBatch(startNs, endNs uint64, mode uint8) []byte {
+	buf := make([]byte, batchHdrSize+gpuabi.SizeSamplingWindow)
+	putU32(buf[0:], kindSamplingWindow)
+	putU32(buf[4:], 1)
+	putU64(buf[24:], uint64(gpuabi.SizeSamplingWindow))
+	putU32(buf[32:], ^uint32(0))
+	putU64(buf[batchHdrSize:], startNs)
+	putU64(buf[batchHdrSize+8:], endNs)
+	buf[batchHdrSize+16] = mode
+	return buf
+}
+
+func configBatch(clockHz uint64, factor, smCount uint32) []byte {
+	buf := make([]byte, batchHdrSize+gpuabi.SizeConfig)
+	putU32(buf[0:], kindConfig)
+	putU32(buf[4:], 1)
+	putU64(buf[24:], uint64(gpuabi.SizeConfig))
+	putU32(buf[32:], ^uint32(0))
+	putU64(buf[batchHdrSize:], clockHz)
+	putU32(buf[batchHdrSize+8:], factor)
+	putU32(buf[batchHdrSize+12:], smCount)
+	buf[batchHdrSize+16] = 1 // vendor
+	return buf
+}
+
+// A module load says THAT a module loaded, with its content hash and size.
+// bytes_ptr is decoded and deliberately dropped: it points into the
+// producer's address space and following it would need CAP_SYS_PTRACE.
+func TestModuleLoadIsNormalizedAndBytesPtrIsNotFollowed(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+	apply(t, c, moduleBatch(4242, 0xC0FFEE, 9, 8192, 1_700_000, 0x7f1234560000))
+
+	require.Len(t, sink.modules, 1)
+	assert.Equal(t, gpu.ModuleRef{Backend: gpu.BackendCUPTI, CRC: 0xC0FFEE}, sink.modules[0].Ref,
+		"a module is identified by content hash, never by the producer's module id")
+	assert.Equal(t, uint64(8192), sink.modules[0].SizeBytes)
+	assert.Equal(t, uint64(1_700_000), sink.modules[0].LoadedNs)
+
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.ModulesDecoded)
+	assert.Zero(t, st.Undecoded)
+	assert.Zero(t, st.SinkRejected)
+}
+
+// The ordinary Tier B order: the stall map first, then the PC samples that
+// refer to it. Every sample resolves, nothing waits, nothing is missing.
+func TestPCSamplesResolveStallNamesFromTheMap(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+	apply(t, c, stallMapBatch(1,
+		[]uint32{0, 17, 23},
+		[]string{"selected", "long_scoreboard", "mio_throttle"}, false))
+	apply(t, c, pcBatch(4242, 1,
+		pcSample{crc: 0xAA, pcOffset: 0x40, fnIndex: 3, stallIndex: 17, count: 5},
+		pcSample{crc: 0xAA, pcOffset: 0x50, fnIndex: 3, stallIndex: 0, count: 2},
+	))
+
+	require.Len(t, sink.pcSamples, 2)
+	assert.Equal(t, "long_scoreboard", sink.pcSamples[0].StallReason)
+	assert.Equal(t, "selected", sink.pcSamples[1].StallReason,
+		"stall index 0 is an ordinary vendor index, not a sentinel meaning 'no stall reason'")
+	assert.Equal(t, gpu.ModuleRef{Backend: gpu.BackendCUPTI, CRC: 0xAA}, sink.pcSamples[0].Module)
+	assert.Equal(t, uint64(0x40), sink.pcSamples[0].PCOffset)
+	assert.Equal(t, uint64(5), sink.pcSamples[0].Count)
+	assert.Equal(t, gpu.ClockDomainCPUMonotonic, sink.pcSamples[0].ClockDomain)
+
+	st := c.Stats()
+	assert.Zero(t, st.Undecoded)
+	assert.Zero(t, st.StallNamesMissing, "every index was in the map")
+	assert.Zero(t, st.PendingStallSamples)
+	assert.Equal(t, uint64(2), st.PCSamplesDecoded)
+	assert.Equal(t, uint64(3), st.StallNamesLearned)
+	assert.Equal(t, 3, st.KnownStallNames)
+}
+
+// The order the ABI actually produces on a fresh attach: the stall map is
+// one-shot plus late-attach replay, so the FIRST PC batch of a run routinely
+// precedes it. Those samples must be held and resolved when the map lands,
+// not sent out permanently blank.
+func TestPCBatchBeforeItsStallMapStillResolves(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+
+	apply(t, c, pcBatch(4242, 1,
+		pcSample{crc: 0xAA, pcOffset: 0x40, stallIndex: 17, count: 5},
+		pcSample{crc: 0xAA, pcOffset: 0x50, stallIndex: 17, count: 1},
+	))
+	assert.Empty(t, sink.pcSamples, "a sample with an unmapped index waits rather than going out blank")
+	assert.Equal(t, 2, c.Stats().PendingStallSamples)
+
+	apply(t, c, stallMapBatch(1, []uint32{17}, []string{"long_scoreboard"}, false))
+
+	require.Len(t, sink.pcSamples, 2)
+	assert.Equal(t, "long_scoreboard", sink.pcSamples[0].StallReason)
+	assert.Equal(t, "long_scoreboard", sink.pcSamples[1].StallReason)
+	assert.Equal(t, uint64(0x40), sink.pcSamples[0].PCOffset,
+		"held samples are released oldest first")
+
+	st := c.Stats()
+	assert.Zero(t, st.StallNamesMissing, "a sample that resolved late is not a missing name")
+	assert.Zero(t, st.PendingStallSamples)
+	assert.Zero(t, st.Undecoded)
+}
+
+// An index the map never carried has no name and never will. It becomes the
+// empty string - never "stall#17", which would put an unstable vendor number
+// into a label value - and it is counted, because a blank stall reason with
+// no counter behind it is a mystery rather than a measurement.
+func TestUnmappedStallIndexYieldsEmptyStringAndIsCounted(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+
+	apply(t, c, stallMapBatch(1, []uint32{17}, []string{"long_scoreboard"}, false))
+	apply(t, c, pcBatch(4242, 1, pcSample{crc: 0xAA, pcOffset: 0x40, stallIndex: 99, count: 3}))
+	// The map for 99 is never coming; the sample is held until Flush, then
+	// released unresolved rather than dropped.
+	c.Flush()
+
+	require.Len(t, sink.pcSamples, 1)
+	assert.Equal(t, "", sink.pcSamples[0].StallReason,
+		"an unresolved stall index must be empty, never a rendered index")
+	assert.NotContains(t, sink.pcSamples[0].StallReason, "99")
+	assert.Equal(t, uint64(3), sink.pcSamples[0].Count,
+		"the sample itself is delivered intact; only its stall reason is missing")
+
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.StallNamesMissing)
+	assert.Equal(t, uint64(1), st.PCSamplesDecoded)
+	assert.Zero(t, st.Undecoded)
+	assert.Zero(t, st.SinkRejected)
+}
+
+// A producer that never emits a stall map at all must not cost a record. The
+// pending queue releases its oldest on every push, so the samples flow with
+// a bounded lag and every one of them is counted as missing.
+func TestPCSamplesFlowWhenNoStallMapEverArrives(t *testing.T) {
+	sink := &recordingSink{}
+	c := newConsumer(Config{
+		Backend:                    gpu.BackendCUPTI,
+		Sink:                       sink,
+		PendingStallSampleCapacity: 4,
+	})
+	for i := 0; i < 20; i++ {
+		apply(t, c, pcBatch(4242, uint64(i+1),
+			pcSample{crc: 0xAA, pcOffset: uint64(i), stallIndex: 7, count: 1}))
+	}
+	assert.Equal(t, 4, c.Stats().PendingStallSamples, "the queue is bounded")
+	c.Flush()
+
+	require.Len(t, sink.pcSamples, 20, "a missing stall name must never cost a record")
+	for i, s := range sink.pcSamples {
+		assert.Equalf(t, uint64(i), s.PCOffset, "released in arrival order")
+		assert.Equal(t, "", s.StallReason)
+	}
+	st := c.Stats()
+	assert.Equal(t, uint64(20), st.StallNamesMissing)
+	assert.Equal(t, uint64(20), st.PCSamplesDecoded)
+	assert.Zero(t, st.KnownStallNames)
+	assert.Zero(t, st.PendingStallSamples)
+}
+
+// A truncated stall name still resolves, marked, so it is never presented as
+// complete. The ABI's buffer is exactly CUPTI's own maximum, so this counter
+// reading non-zero says the producer is not the producer we think it is.
+func TestTruncatedStallNameIsMarkedAndCounted(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+	apply(t, c, stallMapBatch(1, []uint32{17}, []string{"long_scoreb"}, true))
+	apply(t, c, pcBatch(4242, 1, pcSample{crc: 0xAA, stallIndex: 17, count: 1}))
+
+	require.Len(t, sink.pcSamples, 1)
+	assert.Equal(t, "long_scoreb"+truncatedStallSuffix, sink.pcSamples[0].StallReason)
+	assert.Equal(t, uint64(1), c.Stats().StallNamesTruncated)
+	assert.Zero(t, c.Stats().StallNamesMissing, "a truncated name resolved; it is not a missing one")
+}
+
+// The bounded table is a ceiling, not a dial. When it bites the PC samples
+// still flow - unresolved, and counted twice over: once as an eviction and
+// once as a missing name.
+func TestStallNameTableEvictionIsCountedAndCostsNoRecord(t *testing.T) {
+	sink := &recordingSink{}
+	c := newConsumer(Config{Backend: gpu.BackendCUPTI, Sink: sink, StallNameCapacity: 2})
+	apply(t, c, stallMapBatch(1, []uint32{1, 2, 3}, []string{"a", "b", "c"}, false))
+	assert.Equal(t, uint64(1), c.Stats().StallNamesEvicted)
+	assert.Equal(t, 2, c.Stats().KnownStallNames)
+
+	apply(t, c, pcBatch(4242, 1, pcSample{crc: 0xAA, stallIndex: 1, count: 1}))
+	c.Flush()
+	require.Len(t, sink.pcSamples, 1)
+	assert.Equal(t, "", sink.pcSamples[0].StallReason, "index 1 was evicted")
+	assert.Equal(t, uint64(1), c.Stats().StallNamesMissing)
+}
+
+// A re-interned index (the late-attach replay case) replaces the value in
+// place without taking a second FIFO position, exactly as kernelNameTable
+// does - otherwise a replayed table would evict itself.
+func TestStallMapReplayDoesNotEvictItself(t *testing.T) {
+	c := newConsumer(Config{Backend: gpu.BackendCUPTI, Sink: &recordingSink{}, StallNameCapacity: 3})
+	for range 5 {
+		apply(t, c, stallMapBatch(1, []uint32{1, 2, 3}, []string{"a", "b", "c"}, false))
+	}
+	st := c.Stats()
+	assert.Zero(t, st.StallNamesEvicted, "a replayed table must not push itself out")
+	assert.Equal(t, 3, st.KnownStallNames)
+	assert.Equal(t, uint64(15), st.StallNamesLearned, "records, not distinct indices")
+}
+
+// Tier B populates no correlation at all, so every PC record carries zero by
+// design. That is exactly why it needs a counter of its own: ZeroCorrelation
+// is enormous and healthy here, and a Tier A contract violation - where
+// CUPTI populates every record - would be invisible inside it (issue #52's
+// defect, in the PC-sample population).
+func TestTierBZeroCorrelationIsCountedApartFromTheAggregate(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+	apply(t, c, stallMapBatch(1, []uint32{17}, []string{"long_scoreboard"}, false))
+	apply(t, c, pcBatch(4242, 1,
+		pcSample{crc: 0xAA, correlation: 0, stallIndex: 17, count: 1},
+		pcSample{crc: 0xAA, correlation: 0, stallIndex: 17, count: 1},
+		pcSample{crc: 0xAA, correlation: 0, stallIndex: 17, count: 1},
+	))
+
+	st := c.Stats()
+	assert.Equal(t, uint64(3), st.PCSamplesWithoutCorrelation,
+		"in Tier B this equals PCSamplesDecoded on a perfectly healthy run")
+	assert.Equal(t, st.PCSamplesDecoded, st.PCSamplesWithoutCorrelation)
+	assert.Equal(t, uint64(3), st.ZeroCorrelation, "the aggregate still counts them")
+	assert.Zero(t, st.ZeroCorrelationExecs,
+		"an execution's zero is a different fact and must not be moved by a PC sample")
+
+	require.Len(t, sink.pcSamples, 3)
+	for _, s := range sink.pcSamples {
+		assert.False(t, s.Correlation.Present(),
+			"a wire zero must yield the zero CorrelationID, not one carrying only a pid")
+		assert.Equal(t, gpu.CorrelationID{}, s.Correlation)
+	}
+}
+
+// Tier A is the opposite condition: CUPTI populates correlationId on every
+// record, so PCSamplesWithoutCorrelation must read zero and the correlation
+// must carry the batch header's pid, exactly as launches and executions do.
+func TestTierAPCSampleCarriesTheProcessQualifiedCorrelation(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+	apply(t, c, stallMapBatch(1, []uint32{17}, []string{"long_scoreboard"}, false))
+	apply(t, c, pcBatch(4242, 1, pcSample{crc: 0xAA, correlation: 99, stallIndex: 17, count: 1}))
+
+	require.Len(t, sink.pcSamples, 1)
+	assert.Equal(t, gpu.CorrelationID{Backend: gpu.BackendCUPTI, PID: 4242, Value: "99"},
+		sink.pcSamples[0].Correlation,
+		"vendor correlation counters restart in every process, so the pid is part of the id")
+
+	st := c.Stats()
+	assert.Zero(t, st.PCSamplesWithoutCorrelation,
+		"a single non-zero here breaks Tier A's whole claim of exact launch attribution")
+	assert.Zero(t, st.ZeroCorrelation)
+}
+
+// A sampling window is decoded and counted; end_ns == 0 is the ABI's "open
+// when the producer stopped reporting" and is counted apart, because an open
+// window means the executions after its start are serialized="unknown"
+// rather than "false".
+func TestSamplingWindowsAreCountedAndTheOpenOneIsSeparate(t *testing.T) {
+	c := newTestConsumer(&recordingSink{})
+	apply(t, c, samplingWindowBatch(1_000, 51_000, gpuabi.SamplingModeKernelSerialized))
+	assert.Zero(t, c.Stats().SamplingWindowsOpen)
+
+	apply(t, c, samplingWindowBatch(100_000, 0, gpuabi.SamplingModeKernelSerialized))
+	st := c.Stats()
+	assert.Equal(t, uint64(2), st.SamplingWindowsDecoded)
+	assert.Equal(t, uint64(1), st.SamplingWindowsOpen,
+		"end_ns == 0 is a hard exit mid-burst, not a zero-length window")
+	assert.Zero(t, st.Undecoded)
+}
+
+// An inverted window is a producer contract violation, not a short buffer.
+// It is refused at the batch boundary so a negative duration can never reach
+// the serialization disclosure.
+func TestInvertedSamplingWindowIsRefusedAtTheBoundary(t *testing.T) {
+	_, err := decodeBatch(samplingWindowBatch(51_000, 1_000, gpuabi.SamplingModeKernelSerialized))
+	require.ErrorIs(t, err, gpuabi.ErrWindowInverted)
+}
+
+// gpu_config_v1 has been on the wire since Phase 3 with nothing reading it.
+// Its three fields are reachable now, and a second producer disagreeing with
+// the first is counted rather than silently overwriting the answer.
+func TestConfigIsDecodedAndDisagreementIsCounted(t *testing.T) {
+	c := newTestConsumer(&recordingSink{})
+	apply(t, c, configBatch(1_695_000_000, 5, 82))
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.ConfigsDecoded)
+	assert.Equal(t, uint32(5), st.ConfigSamplingFactor)
+	assert.Equal(t, uint32(82), st.ConfigSMCount)
+	assert.Equal(t, uint64(1_695_000_000), st.ConfigClockHz)
+	assert.Zero(t, st.ConfigsDisagreed)
+	assert.Zero(t, st.Undecoded)
+
+	// The late-attach replay: the same record again is not a disagreement.
+	apply(t, c, configBatch(1_695_000_000, 5, 82))
+	assert.Zero(t, c.Stats().ConfigsDisagreed)
+
+	// A second producer with a different configuration is.
+	apply(t, c, configBatch(1_695_000_000, 9, 82))
+	st = c.Stats()
+	assert.Equal(t, uint64(1), st.ConfigsDisagreed,
+		"last-writer-wins gauges must say when they describe an arbitrary one of several producers")
+	assert.Equal(t, uint32(9), st.ConfigSamplingFactor)
+}
+
+// Sequence-gap accounting is per (kind, pid) and must work on the new kinds
+// exactly as it does on launches: a jump in a probe's monotonic sequence is
+// a whole batch the consumer never saw.
+func TestSequenceGapsAreCountedOnTheNewKinds(t *testing.T) {
+	c := newTestConsumer(&recordingSink{})
+	apply(t, c, pcBatch(4242, 1, pcSample{crc: 0xAA, stallIndex: 17, count: 1}))
+	apply(t, c, pcBatch(4242, 4, pcSample{crc: 0xAA, stallIndex: 17, count: 1}))
+	assert.Equal(t, uint64(2), c.Stats().SequenceGaps,
+		"seq 2 and 3 never arrived; each is a whole batch of PC records")
+
+	// A different pid is an independent stream, not a gap.
+	apply(t, c, pcBatch(7, 1, pcSample{crc: 0xAA, stallIndex: 17, count: 1}))
+	assert.Equal(t, uint64(2), c.Stats().SequenceGaps)
+
+	// And so is a different kind from the same pid.
+	apply(t, c, stallMapBatch(1, []uint32{17}, []string{"long_scoreboard"}, false))
+	assert.Equal(t, uint64(2), c.Stats().SequenceGaps)
+}
+
+// A sink at capacity refuses PC samples and modules the same way it refuses
+// launches: the record is not retried and not silently dropped, it is
+// counted in SinkRejected.
+func TestRejectedPCSamplesAndModulesAreCounted(t *testing.T) {
+	sink := &recordingSink{err: errors.New("full")}
+	c := newTestConsumer(sink)
+	apply(t, c, stallMapBatch(1, []uint32{17}, []string{"long_scoreboard"}, false))
+	apply(t, c, pcBatch(4242, 1, pcSample{crc: 0xAA, stallIndex: 17, count: 1}))
+	apply(t, c, moduleBatch(4242, 0xC0FFEE, 9, 8192, 1_700_000, 0))
+
+	st := c.Stats()
+	assert.Equal(t, uint64(2), st.SinkRejected)
+	assert.Zero(t, st.Undecoded)
+}
+
+// A whole Tier B run's worth of the five kinds, in the order a late-attaching
+// consumer sees them: PC samples first, then the replayed map, config and
+// module. Every loss counter must read zero at the end - which is the
+// "assertable at zero on a healthy run" rule for all of them at once.
+func TestHealthyTierBRunLeavesEveryNewLossCounterAtZero(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+
+	apply(t, c, pcBatch(4242, 1,
+		pcSample{crc: 0xAA, pcOffset: 0x40, fnIndex: 3, stallIndex: 17, count: 5},
+		pcSample{crc: 0xAA, pcOffset: 0x50, fnIndex: 3, stallIndex: 23, count: 2},
+	))
+	apply(t, c, stallMapBatch(1,
+		[]uint32{17, 23}, []string{"long_scoreboard", "mio_throttle"}, false))
+	apply(t, c, configBatch(1_695_000_000, 5, 82))
+	apply(t, c, moduleBatch(4242, 0xAA, 9, 8192, 1_700_000, 0x7f0000000000))
+	apply(t, c, samplingWindowBatch(1_000, 51_000, gpuabi.SamplingModeContinuous))
+	c.Flush()
+
+	require.Len(t, sink.pcSamples, 2)
+	require.Len(t, sink.modules, 1)
+
+	st := c.Stats()
+	assert.Zero(t, st.Undecoded)
+	assert.Zero(t, st.Malformed)
+	assert.Zero(t, st.SequenceGaps)
+	assert.Zero(t, st.SinkRejected)
+	assert.Zero(t, st.StallNamesMissing)
+	assert.Zero(t, st.StallNamesEvicted)
+	assert.Zero(t, st.StallNamesTruncated)
+	assert.Zero(t, st.SamplingWindowsOpen)
+	assert.Zero(t, st.ConfigsDisagreed)
+	assert.Zero(t, st.PendingStallSamples)
+	assert.Zero(t, st.ZeroCorrelationExecs)
+	// The one new counter that is NOT zero on a healthy Tier B run, and the
+	// reason it is its own counter rather than a share of ZeroCorrelation.
+	assert.Equal(t, uint64(2), st.PCSamplesWithoutCorrelation)
+	assert.Equal(t, uint64(7), st.Records,
+		"2 PC samples + 2 stall names + 1 config + 1 module + 1 window")
 }
 
 func TestCookieForCoversTheNewProbes(t *testing.T) {

--- a/gpuprobe/stallnames.go
+++ b/gpuprobe/stallnames.go
@@ -1,0 +1,209 @@
+package gpuprobe
+
+import (
+	"github.com/dpsoft/perf-agent/gpu"
+)
+
+// Stall reason names arrive on their own probe, out of band from the PC
+// samples that reference them, exactly as kernel names do for launches and
+// executions. This file is deliberately the same shape as kernelnames.go:
+// one bounded index -> name table, one bounded FIFO of events waiting for a
+// name, and one release path when the name lands. Where it diverges from
+// that file it says so and why; a second, subtly different shape for the
+// same problem is how the two drift apart.
+//
+// gpu_stall_reason_map_v1 carries stall_index -> name, emitted once when the
+// producer queries the device's stall reasons and replayed in full when a
+// consumer attaches late (spec §6.1's replay contract). A PC sample refers
+// to a stall reason by its numeric index only, and that index is the
+// VENDOR's, not ours: it is not stable across devices or driver versions, so
+// it is not a portable identity and must never reach a label. The name is
+// the only portable identity a stall reason has.
+//
+// Hence gpu.GPUPCSample.StallReason being a string, and hence an unresolved
+// index becoming "" rather than "stall#17". A rendered index would put an
+// unstable internal number in front of a human as though it meant
+// something, and would aggregate two different stall reasons from two
+// different driver versions into one label value. Stats.StallNamesMissing
+// counts the empties, so an unresolved stall reason is visible rather than
+// silently blank.
+
+// truncatedStallSuffix marks a stall name the producer had to cut off at
+// GPU_STALL_NAME_MAX (CUPTI's CUPTI_STALL_REASON_STRING_SIZE, 128). It is
+// the same marker kernel names use, for the same reason: a truncated name
+// that reads as complete is a lie about which stall reason was sampled.
+// Truncation should never happen for a CUPTI device — the ABI's buffer is
+// exactly CUPTI's own maximum — so a non-zero Stats.StallNamesTruncated
+// means the producer is not the producer we think it is.
+const truncatedStallSuffix = truncatedNameSuffix
+
+// stallName is one interned stall reason name and whether it arrived
+// complete. The twin of kernelName.
+type stallName struct {
+	name      string
+	truncated bool
+}
+
+// resolved renders the name as it should appear downstream.
+func (s stallName) resolved() string {
+	if s.truncated {
+		return s.name + truncatedStallSuffix
+	}
+	return s.name
+}
+
+// stallNameTable is the bounded stall_index -> name map.
+//
+// Eviction is FIFO by first insertion and a re-intern (the replay case)
+// replaces the value in place without touching the order, so an index
+// appears at most once in the FIFO and no position can go stale — the same
+// invariant kernelNameTable keeps, which is what makes len(order)-head
+// exactly equal to len(byIndex).
+//
+// The bound is a ceiling, not a dial. A device's stall reasons are a fixed
+// enum (38 on GA102), so a healthy run uses a few dozen entries and never
+// evicts; the bound exists because nothing on the wire promises that.
+//
+// Not internally synchronized; Consumer calls it under its own mutex.
+type stallNameTable struct {
+	byIndex  map[uint32]stallName
+	order    []uint32
+	head     int
+	capacity int
+}
+
+func newStallNameTable(capacity int) *stallNameTable {
+	if capacity <= 0 {
+		capacity = defaultStallNameCapacity
+	}
+	return &stallNameTable{byIndex: make(map[uint32]stallName), capacity: capacity}
+}
+
+// put interns a name, returning how many older names had to be evicted to
+// make room. An evicted name is not record loss — the PC samples still flow
+// — but every sample referring to that index from then on is unresolved, so
+// the caller counts it.
+func (t *stallNameTable) put(index uint32, s stallName) (evicted int) {
+	if _, exists := t.byIndex[index]; !exists {
+		t.order = append(t.order, index)
+	}
+	t.byIndex[index] = s
+	for len(t.byIndex) > t.capacity && t.head < len(t.order) {
+		oldest := t.order[t.head]
+		t.head++
+		delete(t.byIndex, oldest)
+		evicted++
+	}
+	t.compact()
+	return evicted
+}
+
+func (t *stallNameTable) get(index uint32) (stallName, bool) {
+	s, ok := t.byIndex[index]
+	return s, ok
+}
+
+func (t *stallNameTable) len() int { return len(t.byIndex) }
+
+func (t *stallNameTable) compact() {
+	if t.head == 0 || t.head*2 < len(t.order) {
+		return
+	}
+	n := copy(t.order, t.order[t.head:])
+	t.order = t.order[:n]
+	t.head = 0
+}
+
+// unresolvedSample is one normalized PC sample held until its stall
+// reason's name arrives. The twin of unnamedEvent — but a value rather than
+// a pointer, because unlike unnamedEvent there is only one event type here,
+// so there is no "size of both structs" to avoid.
+type unresolvedSample struct {
+	stallIndex uint32
+	sample     gpu.GPUPCSample
+}
+
+// pendingStallSamples is the bounded FIFO of PC samples waiting for a stall
+// name. As with pendingNames, overflow RELEASES the oldest sample rather
+// than dropping it: a missing name must never cost a record.
+//
+// Not internally synchronized; Consumer calls it under its own mutex.
+type pendingStallSamples struct {
+	buf      []unresolvedSample
+	head     int
+	capacity int
+}
+
+func newPendingStallSamples(capacity int) *pendingStallSamples {
+	if capacity <= 0 {
+		capacity = defaultPendingStallSampleCapacity
+	}
+	return &pendingStallSamples{capacity: capacity}
+}
+
+// push queues a sample, returning the oldest one for immediate release if
+// the queue was already full.
+func (p *pendingStallSamples) push(s unresolvedSample) (released unresolvedSample, ok bool) {
+	if p.len() >= p.capacity {
+		released, ok = p.pop()
+	}
+	p.buf = append(p.buf, s)
+	return released, ok
+}
+
+func (p *pendingStallSamples) pop() (unresolvedSample, bool) {
+	if p.head >= len(p.buf) {
+		return unresolvedSample{}, false
+	}
+	s := p.buf[p.head]
+	p.buf[p.head] = unresolvedSample{}
+	p.head++
+	p.compact()
+	return s, true
+}
+
+// takeByIndex removes every sample waiting on this stall index, oldest
+// first.
+func (p *pendingStallSamples) takeByIndex(index uint32) []unresolvedSample {
+	var out []unresolvedSample
+	n := p.head
+	for i := p.head; i < len(p.buf); i++ {
+		if p.buf[i].stallIndex == index {
+			out = append(out, p.buf[i])
+			continue
+		}
+		p.buf[n] = p.buf[i]
+		n++
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	clear(p.buf[n:])
+	p.buf = p.buf[:n]
+	return out
+}
+
+// drain empties the queue in arrival order.
+func (p *pendingStallSamples) drain() []unresolvedSample {
+	if p.len() == 0 {
+		return nil
+	}
+	out := make([]unresolvedSample, p.len())
+	copy(out, p.buf[p.head:])
+	clear(p.buf)
+	p.buf = p.buf[:0]
+	p.head = 0
+	return out
+}
+
+func (p *pendingStallSamples) len() int { return len(p.buf) - p.head }
+
+func (p *pendingStallSamples) compact() {
+	if p.head == 0 || p.head*2 < len(p.buf) {
+		return
+	}
+	n := copy(p.buf, p.buf[p.head:])
+	clear(p.buf[n:])
+	p.buf = p.buf[:n]
+	p.head = 0
+}

--- a/gpuprobe/stallnames_test.go
+++ b/gpuprobe/stallnames_test.go
@@ -1,0 +1,117 @@
+package gpuprobe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dpsoft/perf-agent/gpu"
+)
+
+// The same pins kernelnames_test.go puts on the kernel-name table, on the
+// stall-reason table. The two stores are the same shape on purpose, and a
+// shape that is only correct in one of them is not the shape it claims to
+// be.
+
+// A FIFO whose positions are not reclaimed grows with the number of records
+// seen rather than with the work it tracks. A re-intern replaces in place
+// without appending, so an index appears at most once.
+func TestStallNameOrderTracksLiveEntriesOnly(t *testing.T) {
+	tbl := newStallNameTable(4)
+	for i := range 20000 {
+		tbl.put(uint32(i), stallName{name: "s"})
+		tbl.put(1, stallName{name: "replayed"}) // the replay case
+	}
+	assert.LessOrEqual(t, tbl.len(), 4)
+	assert.Equal(t, tbl.len(), len(tbl.order)-tbl.head,
+		"every order position must describe a live entry")
+	assert.LessOrEqual(t, len(tbl.order), 4*tbl.capacity)
+	assert.LessOrEqual(t, cap(tbl.order), 16*tbl.capacity)
+}
+
+// Eviction is by first insertion and a replay must not renew an entry's
+// position: the producer replays its whole stall map on every late attach,
+// and a renewing replay would make the first-seen indices immortal.
+func TestStallNameEvictionIsByFirstInsertion(t *testing.T) {
+	tbl := newStallNameTable(2)
+	tbl.put(1, stallName{name: "one"})
+	tbl.put(2, stallName{name: "two"})
+	require.Zero(t, tbl.put(1, stallName{name: "one-replayed"}))
+
+	assert.Equal(t, 1, tbl.put(3, stallName{name: "three"}))
+	_, ok := tbl.get(1)
+	assert.False(t, ok, "index 1 was interned first, so it goes first despite the replay")
+	_, ok = tbl.get(2)
+	assert.True(t, ok)
+}
+
+// Index 0 is an ordinary vendor stall index, not a sentinel. kernelNameTable
+// can short-circuit on id 0 because the ABI defines it as "no kernel"; there
+// is no such definition here, and treating 0 as absent would silently blank
+// one real stall reason on every device where it happens to be index 0.
+func TestStallNameIndexZeroIsAnOrdinaryEntry(t *testing.T) {
+	tbl := newStallNameTable(4)
+	tbl.put(0, stallName{name: "selected"})
+	s, ok := tbl.get(0)
+	require.True(t, ok)
+	assert.Equal(t, "selected", s.resolved())
+}
+
+// A truncated name is marked wherever it is read, so no consumer has to
+// remember to check a flag that does not travel with the string.
+func TestTruncatedStallNameResolvesWithItsMarker(t *testing.T) {
+	assert.Equal(t, "mio_throttle", stallName{name: "mio_throttle"}.resolved())
+	assert.Equal(t, "mio"+truncatedStallSuffix, stallName{name: "mio", truncated: true}.resolved())
+}
+
+// Overflow RELEASES the oldest sample rather than dropping it. A missing
+// stall name must never cost a record.
+func TestPendingStallSamplesReleaseOldestOnOverflow(t *testing.T) {
+	p := newPendingStallSamples(2)
+	_, ok := p.push(unresolvedSample{stallIndex: 1, sample: gpu.GPUPCSample{PCOffset: 1}})
+	assert.False(t, ok)
+	_, ok = p.push(unresolvedSample{stallIndex: 1, sample: gpu.GPUPCSample{PCOffset: 2}})
+	assert.False(t, ok)
+
+	released, ok := p.push(unresolvedSample{stallIndex: 1, sample: gpu.GPUPCSample{PCOffset: 3}})
+	require.True(t, ok, "a full queue hands back its oldest instead of dropping the new one")
+	assert.Equal(t, uint64(1), released.sample.PCOffset)
+	assert.Equal(t, 2, p.len())
+}
+
+// takeByIndex removes exactly the samples waiting on one index, oldest
+// first, and leaves the rest in arrival order.
+func TestPendingStallSamplesTakeByIndexIsSelectiveAndOrdered(t *testing.T) {
+	p := newPendingStallSamples(8)
+	for i, idx := range []uint32{7, 9, 7, 9, 7} {
+		p.push(unresolvedSample{stallIndex: idx, sample: gpu.GPUPCSample{PCOffset: uint64(i)}})
+	}
+
+	got := p.takeByIndex(7)
+	require.Len(t, got, 3)
+	assert.Equal(t, []uint64{0, 2, 4}, []uint64{
+		got[0].sample.PCOffset, got[1].sample.PCOffset, got[2].sample.PCOffset,
+	})
+	assert.Equal(t, 2, p.len())
+
+	rest := p.drain()
+	require.Len(t, rest, 2)
+	assert.Equal(t, uint64(1), rest[0].sample.PCOffset)
+	assert.Equal(t, uint64(3), rest[1].sample.PCOffset)
+	assert.Nil(t, p.takeByIndex(7), "nothing is left waiting on 7")
+}
+
+// The buffer must not grow with the number of samples that have passed
+// through it, only with what it currently holds.
+func TestPendingStallSamplesBufferDoesNotGrowWithChurn(t *testing.T) {
+	p := newPendingStallSamples(4)
+	for i := range 20000 {
+		p.push(unresolvedSample{stallIndex: uint32(i % 3), sample: gpu.GPUPCSample{PCOffset: uint64(i)}})
+		if i%7 == 0 {
+			p.takeByIndex(uint32(i % 3))
+		}
+	}
+	assert.LessOrEqual(t, p.len(), 4)
+	assert.LessOrEqual(t, cap(p.buf), 16*p.capacity)
+}


### PR DESCRIPTION
**Task 7 of [the GPU PC sampling plan](docs/superpowers/plans/2026-08-25-gpu-pc-sampling.md).** Decode and count only — no source resolution, no timeline join.

Five `applyBatch` arms for `kindPC`, `kindModule`, `kindStallMap`, `kindSamplingWindow` and `kindConfig`. Task 2 deliberately left these falling into `default:` counted as `Stats.Undecoded`, with `TestNewKindsAreCarriedUndecodedAndCounted` as the assertion to flip; it now reads zero for all five.

### A gap found on the way

**`decodeBatch` was missing arms for `kindModule` and `kindPC` entirely** — both had a cookie and a BPF `record_size` but no Go decode at all. `batch` gained `Modules`/`PCSamples`. The `default:` arm stays, with its doc retargeted to what reaching it now means: an ABI drift on one side of the wire.

### The stall-name table mirrors , with two deliberate divergences

`gpuprobe/stallnames.go` is `kernelnames.go` with the types swapped — same map+FIFO with in-place re-intern, same eviction by first insertion, same release-oldest-on-overflow pending queue, same `Flush` drain. Both divergences are documented at the call site and tested:

- **No sentinel index.** `kernelID == 0` means "no kernel"; stall index 0 is an ordinary vendor index, so short-circuiting on it would blank one real stall reason per device.
- **No `waitsForNameLocked` gate.** It would break exactly the case the plan requires — the stall map is one-shot plus replay, so the first PC batch routinely precedes it. Holding unconditionally costs a bounded lag and never a record, because the queue releases its oldest on every push.

### Counters kept apart on purpose

`PCSamplesWithoutCorrelation` is separate from `ZeroCorrelation`, whose doc now says it must never be read alone: its two subsets have **opposite healthy readings**. In Tier B every PC record has a zero correlation by design; in Tier A a single zero is a contract violation. One counter across both populations is unreadable in both directions.

An unresolved stall index yields `""` and increments `StallNamesMissing` — never `"stall#17"`, which would leak an unstable internal index into a label value.

### Two judgement calls

**`GPUPCSample.TimeNs` stays zero.** No timestamp exists on the record or the batch header, and stamping arrival time would present a consumer clock reading as a measurement. The consequence is stated rather than papered over: the timeline's pending horizon cannot age these out by time, which is why Task 8a needs a second index.

**The plan contradicts itself on `Correlation`.** It says the PID is carried "in both tiers … which is already what `correlationOf` does" — but `correlationOf` deliberately returns the *whole* zero `CorrelationID` on a wire zero, and documents why. Took the operative half: use `correlationOf`, do not invent a second rule. Nothing needs the PID there — Task 8a's index carries it in the key.

`PCSample.FunctionIndex` is decoded but not yet carried onto the type; that is Task 8a by name.

### Verified offline, as the plan specifies

`TestTheFivePCSamplingKindsAreDecodedNotCountedUndecoded`, `TestPCBatchBeforeItsStallMapStillResolves`, `TestUnmappedStallIndexYieldsEmptyStringAndIsCounted`, `TestSequenceGapsAreCountedOnTheNewKinds`.

**Cannot verify:** `CapEff: 0`, no GPU — nothing here has seen a real CUPTI record. Open: the stall indices and names on GA102, whether Tier A truly populates every `correlationId`, `pcOffset`/`functionIndex` semantics, and the real PC rate that decides whether the 4,096 pending bound is generous or tight. All belong to Task 6's hardware list; this task's own line in the plan is "must be measured on the RTX 3090 afterwards: nothing."