### PR TITLE
gpu: key correlation-less PC samples on {pid, cubin, function}

### DIFF
--- a/.superpowers/sdd/task-8a-pending-index-report.md
+++ b/.superpowers/sdd/task-8a-pending-index-report.md
@@ -1,0 +1,239 @@
+# Task 8a — `GPUPCSample.FunctionIndex` and the second pending index
+
+Branch `feat/pc-pending-module-index`, one commit off `origin/main` (`ccd0fe5a`).
+
+Scope: get correlation-less (Tier B / `CONTINUOUS`) PC samples into a correctly-keyed
+index. **The `Snapshot` join is deliberately not here** — that is Task 8b. Nothing
+attaches out of the new store yet, and `AttributedPCSamples` is unchanged by this work.
+
+---
+
+## 1. The field
+
+`gpu/types.go`, additive on the capability-gated `GPUPCSample`:
+
+```go
+FunctionIndex uint32 `json:"function_index,omitempty"`
+```
+
+CUPTI's per-module `functionIndex`. It has been on `gpu_pc_sample_batch_v1` since the
+ABI froze (`internal/gpuabi/records.go:83`, decoded at `records.go:146`) and was simply
+never carried through to the canonical type. Meaningless without `Module`, exactly as
+`PCOffset` is: `(Module.CRC, FunctionIndex)` names a device function,
+`(Module.CRC, FunctionIndex, PCOffset)` names an instruction.
+
+**`gpu/types_test.go:44` checked, not assumed.** That test's forbidden-name list
+(`pc`, `stall`, `module`, `cubin`, `sass`) is iterated over
+`reflect.TypeOf(GPUKernelExec{})` — the lean shared execution type — and its second half
+asserts positively that `PCOffset`/`StallReason`/`Module` *do* live on `GPUPCSample`.
+Adding a field to `GPUPCSample` is what that test wants, not what it forbids;
+`TestPCSamplingFieldsDoNotWidenExecution` passes unchanged.
+
+**Not populated by the consumer in this commit.** `gpuprobe/consumer.go` has no
+`kindPC` decode arm on `main` at all — `kindPC` lands in the `default:` arm and is
+counted in `Stats.Undecoded`. Building that arm is Task 7's diff (in flight in
+`.worktrees/consumer-decode`, which also populates `Module`). Adding a competing decode
+path here would have been a real conflict for no benefit, so this commit supplies the
+field and the index and leaves the wire→field assignment to Task 7's one-line addition
+(`FunctionIndex: rec.FunctionIndex`).
+
+## 2. The index
+
+`gpu/timeline.go`. A second pending store, entered on `!p.Correlation.Present()` and
+nothing else — the same gate `Snapshot` already uses to route a correlation-less
+*execution* to the heuristic join.
+
+| | correlation-keyed (`pending`) | module-keyed (`pendingModule`) |
+|---|---|---|
+| key | `CorrelationID` | `pendingModuleKey{Backend, PID, CubinCRC, FunctionIndex}` |
+| cardinality cap | `pendingCap` = `LaunchCache.Capacity` (65,536) | `pendingModuleCap` = `MaxPendingModuleGroups`, default **4,096** |
+| per-group sample cap | `pendingSampleCap` (4,096) | `pendingSampleCap` — shared |
+| horizon | `pendingHorizonNs` | `pendingHorizonNs` — shared, per the plan |
+| anchor | `pendingNewestNs` | `pendingNewestNs` — shared |
+| order/liveness walk | `orderedFIFO[CorrelationID]` | `orderedFIFO[pendingModuleKey]` |
+| eviction counter | `Dropped.EvictedPendingSamples` | `Dropped.EvictedPendingModuleSamples` |
+| gauges | `PendingSamples` / `PendingCorrelations` | `PendingModuleSamples` / `PendingModuleGroups` |
+
+**Cardinality cap is its own dial and deliberately not `LaunchCache.Capacity`,** which
+every other store here reuses. That capacity tracks *launch volume*, a function of run
+length. This store's cardinality is a function of the profiled *binary* — one group per
+device function per process, tens to low hundreds for a real workload. Sizing it off
+launch volume would reserve a 65,536-entry map to hold fifty.
+
+**Horizon reuses `pendingHorizonNs` by value, and the anchor `pendingNewestNs` by
+sharing.** One PC-sample stream, one clock domain, one anomalous-jump clamp
+(`defaultMaxAdvanceNs`). The tiers are mutually exclusive (Task 11), so a Tier A stream
+advancing the anchor past a Tier B group cannot arise in practice.
+
+**`orderedFIFO` reused, as the plan requires** — no third eviction walk.
+`isPendingModuleLiveLocked` mirrors `isPendingLiveLocked`, and the
+absent-to-present-only sequence bump is the same: a group accumulates into one live
+generation across many `EmitPCSample` calls, so re-stamping per append would orphan its
+own live order position. That is exactly the deleted-then-reused hazard `LaunchCache`
+and `Timeline.pending` each hit separately before `orderedFIFO` existed.
+
+*Contrast with Task 4.* `ModuleStore` deliberately did **not** reuse `orderedFIFO`,
+because an LRU must move an entry to the front on every *read* and `orderedFIFO` has no
+notion of a read. `pendingModule` is pure FIFO by arrival, like `pending`, so that
+reason does not apply.
+
+**One documented widening of the plan's key.** The plan writes
+`{PID, CubinCRC, FunctionIndex}`; the implementation is
+`{Backend, PID, CubinCRC, FunctionIndex}`. Nothing today emits PC samples from two
+backends into one `Timeline` (ROCm does not advertise `CapabilityPCSampling`), so
+`Backend` changes no behaviour — it is present for the same reason `CorrelationID`
+carries it, and costs nothing to make impossible. Flagged here rather than absorbed
+silently.
+
+## 3. Cross-process refusal is structural
+
+`PID` is a **field of the map key**, taken from `Correlation.PID` — which a
+correlation-less sample still carries, since PID and Backend are context the producer
+knows regardless (`CorrelationID.Present`'s doc comment). There is no cross-process
+check anywhere in the new path, because there is nothing to check: two processes
+running the identical binary produce the identical cubin CRC and the identical function
+index, so a store keyed on the module alone would merge them, and a store keyed on the
+module *plus a guard* would merge them the day someone edits the guard out. Issue #52's
+discipline.
+
+`TestTierBSamplesStayWithTheirProcess` pins it with the worst case — same CRC, same
+function index, two PIDs. Deleting `PID` from `pendingModuleKeyFor` fails it (mutation
+M2 below).
+
+## 4. Pre-fix failure of the anti-collapse test
+
+The deliverable test drives 10,000 Tier B samples over 50 distinct
+`(crc, functionIndex)` pairs and asserts none are lost to `EvictedPendingSamples`.
+
+**(a) Against pristine `main`** it does not compile — the key it needs cannot be
+expressed:
+
+```
+# github.com/dpsoft/perf-agent/gpu [github.com/dpsoft/perf-agent/gpu.test]
+gpu/pendingmodule_test.go:19:3: unknown field FunctionIndex in struct literal of type GPUPCSample
+gpu/pendingmodule_test.go:65:30: snap.Dropped.EvictedPendingModuleSamples undefined (type TimelineDropStats has no field or method EvictedPendingModuleSamples)
+gpu/pendingmodule_test.go:68:32: snap.PendingModuleSamples undefined (type Snapshot has no field or method PendingModuleSamples)
+gpu/pendingmodule_test.go:70:37: snap.PendingModuleGroups undefined (type Snapshot has no field or method PendingModuleGroups)
+gpu/pendingmodule_test.go:91:20: tl.pendingModule undefined (type *Timeline has no field or method pendingModule)
+...
+FAIL	github.com/dpsoft/perf-agent/gpu [build failed]
+```
+
+A compile failure is weak evidence, so:
+
+**(b) The same drive expressed in `main`'s own types** (pair index riding in `PCOffset`,
+which exists on `main`), run against unmodified `origin/main`:
+
+```
+--- FAIL: TestPreFixTierBCollapse (0.01s)
+    zz_prefix_probe_test.go:34:
+        	Error:      	Should be zero, but was 5904
+        	Messages:   	10,000 Tier B samples over 50 distinct (crc, functionIndex) groups: none may be lost
+    zz_prefix_probe_test.go:36:
+        	Error:      	Not equal:
+        	            	expected: 50
+        	            	actual  : 1
+        	Messages:   	the samples must be spread over one group per (crc, functionIndex) pair
+FAIL
+FAIL	github.com/dpsoft/perf-agent/gpu	0.010s
+```
+
+**50 groups collapsed to 1, and 5,904 of 10,000 samples evicted** — precisely
+`10,000 − pendingSampleCap`. And the 4,096 that *survived* would have been matched by
+nothing, because no execution carries an empty correlation value. That probe file was
+deleted after the run; the shipped test is the typed version.
+
+## 5. Mutation checks — the tests bite
+
+Each mutation applied alone to the finished code, `go test ./gpu/ -run 'TestTierA|TestTierB'`:
+
+| mutation | result |
+|---|---|
+| M1 — key ignores `FunctionIndex` | 3 failures, incl. "two device functions in one cubin must key apart" and 50 groups → 10 |
+| M2 — key ignores `PID` | `TestTierBSamplesStayWithTheirProcess`: "identical (crc, functionIndex) from two processes must be two groups, not one" |
+| M3 — module evictions charged to `EvictedPendingSamples` | 4 failures, incl. "a Tier B eviction must never be charged to the Tier A counter" |
+| M4 — routing on `Correlation.Present()` removed | the pre-fix pathology returns exactly: "Should be zero, but was 5904" |
+
+## 6. Counters, and what each reads when things are worst
+
+All three are zero on a healthy run and each of my tests asserts them so.
+
+- **`Dropped.EvictedPendingModuleSamples`** — correlation-less samples destroyed before
+  anything could use them. Non-zero means one of exactly three things, and the
+  `joinhealth` line names all three: the group index is too small for the workload's
+  distinct device functions (`MaxPendingModuleGroups`), the horizon is shorter than the
+  gap between a sample and its execution, or one device function's samples outran
+  `MaxPendingSamplesPerCorrelation` because its execution never arrived. At its worst it
+  reads as a large fraction of everything the producer emitted, and the stall detail on
+  those kernels is simply absent from the profile. **Kept separate from
+  `EvictedPendingSamples` on purpose** — a non-zero `EvictedPendingSamples` says
+  executions are not arriving for the correlations their samples carry, which is a
+  different problem with a different fix, and one counter for both would make the two
+  indistinguishable at exactly the moment they matter.
+- **`PendingModuleSamples` / `PendingModuleGroups`** — gauges, not deltas. Until Task 8b
+  lands they rise monotonically to their bounds while `AttributedPCSamples` stays flat,
+  which is the honest reading of "collected, correctly grouped, not yet attributed".
+  After 8b, a persistently high `PendingModuleSamples` with a low attribution rate means
+  the join is not finding executions for these kernels.
+
+**Reconciliation identity extended** (`assertPCSampleLossesAccounted`,
+`gpu/conformance_test.go`): `accepted == attributed + pending + evicted +
+pendingModule + evictedPendingModule`. Without the new terms every continuous-mode
+sample would read as unaccounted-for the moment such a scenario exists.
+`TestTierBSamplesReconcile` forces all three module-store terms non-zero in one run —
+per-group cap, cardinality cap and horizon all firing — so they are not dead terms.
+
+**`joinhealth`** gained one summary clause (present only when the store is non-empty)
+and one anomaly line. Both are absent on a healthy run; `TestJoinHealthHealthyRunIsOneShortLine`
+is unchanged and passes.
+
+## 7. Verification
+
+`CapEff: 0`, no GPU, no capabilities. All from the worktree with the plan's build env.
+
+```
+go build ./...                                     ok
+go vet ./...                                       ok
+go test ./gpu/ ./gpuprobe/ ./internal/... -count=1 all ok (12 packages)
+go test ./gpu/ -race -count=4                      ok  19.4s
+~/go/bin/golangci-lint run --timeout=5m            0 issues.
+```
+
+New tests, all in `gpu/pendingmodule_test.go`:
+
+- `TestTierBPCSamplesDoNotCollapseOntoOneKey` — the deliverable regression.
+- `TestTierBHorizonEvictionCountsSeparately`
+- `TestTierBCardinalityEvictionCountsSeparately`
+- `TestTierBPerGroupSampleCapCountsSeparately`
+- `TestTierBSamplesStayWithTheirProcess`
+- `TestTierBDistinctFunctionIndexSplitsGroups`
+- `TestTierBSamplesReconcile`
+- `TestTierAPCSamplesStillUseTheCorrelationIndex` — non-regression: a correlation-bearing
+  sample never enters the new store, still joins exactly, and carries `FunctionIndex`
+  through the exact path unchanged.
+
+## 8. Cannot verify
+
+**I cannot verify anything about real hardware, and nothing here was run against a GPU.**
+The plan states for this task: *"Must be measured on the RTX 3090 afterwards: nothing."*
+That is accurate — every claim above is about in-process data structures driven by
+synthetic samples, and all of it is exercised by the tests. What is *not* established by
+this commit, and must not be read into it:
+
+- **That `functionIndex` is the cubin's `.symtab` index.** Task 6 measures it. If it is
+  not, the plan's pre-approved fallback is `gpu_pc_sample_batch_v2` with an appended
+  `kernel_id`. The index built here is unaffected either way — it groups on whatever
+  `functionIndex` is, and only Task 8b's *resolution* of that index to a name depends on
+  the answer.
+- **That real Tier B samples arrive with a usable `cubin_crc` at all.** No consumer decode
+  arm exists yet (Task 7), so no `GPUPCSample` in this repository has ever been populated
+  from a wire record. If `Module.CRC` and `FunctionIndex` both arrive zero, every sample
+  from a process lands in one group — honest, since they would genuinely be
+  indistinguishable, but no better than today.
+- **That the shared `pendingHorizonNs` is long enough** for the gap between a PC sample
+  and its execution at the shim's 100 ms drain period. Task 8b's hardware note owns this.
+- **That the 4,096-group default is right.** It is reasoned from "one group per device
+  function per process", not measured. Worst case with the defaults is 4,096 groups ×
+  4,096 samples of `GPUPCSample`, reachable only by a producer emitting thousands of
+  distinct device functions whose executions never arrive — which is itself the
+  condition `EvictedPendingModuleSamples` exists to report.

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -390,8 +390,17 @@ func assertPCSampleLossesAccounted(t *testing.T, snap Snapshot, sinkStats SinkSt
 	accepted := sinkStats.PCSamples.Accepted
 	require.Equal(t, pcAttempts, accepted+rejected,
 		"every attempted PC sample must have been either accepted by the sink or rejected and counted")
-	assert.Equal(t, accepted, snap.AttributedPCSamples+uint64(snap.PendingSamples)+snap.Dropped.EvictedPendingSamples,
-		"every PC sample the sink accepted must be attributed, still pending, or evicted from the pending store - never unaccounted for")
+	// There are two pending stores, not one: a sample carrying no correlation
+	// value goes to the module-keyed index instead (Timeline.pendingModule),
+	// with its own bound and its own eviction counter. Both stores' terms
+	// belong in the identity - counting only the correlation-keyed one would
+	// make every continuous-mode sample read as unaccounted-for the moment
+	// such a scenario exists.
+	assert.Equal(t, accepted,
+		snap.AttributedPCSamples+
+			uint64(snap.PendingSamples)+snap.Dropped.EvictedPendingSamples+
+			uint64(snap.PendingModuleSamples)+snap.Dropped.EvictedPendingModuleSamples,
+		"every PC sample the sink accepted must be attributed, still pending in one of the two pending stores, or evicted from one of them - never unaccounted for")
 }
 
 // TestConformance runs the producer-scenario table against every invariant.

--- a/gpu/joinhealth.go
+++ b/gpu/joinhealth.go
@@ -109,6 +109,18 @@ func joinSummary(snap Snapshot, anomalies int) string {
 			snap.AttributedPCSamples, snap.PendingSamples)
 	}
 
+	// Its own clause rather than folded into the one above, for the same
+	// reason it has its own counter: these samples carried no correlation, so
+	// they are pending on a different index under different bounds, and a
+	// reader who sees one number cannot tell which. Continuous-mode
+	// collection is optional and off by default, so the clause is absent
+	// entirely when nothing produced such samples.
+	if snap.PendingModuleSamples > 0 {
+		fmt.Fprintf(&b, "; %d correlation-less pc samples pending over %d %s",
+			snap.PendingModuleSamples, snap.PendingModuleGroups,
+			plural(uint64(snap.PendingModuleGroups), "kernel group", "kernel groups"))
+	}
+
 	switch anomalies {
 	case 0:
 		b.WriteString("; no anomalies")
@@ -222,6 +234,12 @@ func joinAnomalies(snap Snapshot) []string {
 		add("%s evicted while waiting for their execution — never attributed, so the "+
 			"stall detail on those kernels is under-reported",
 			plural(dr.EvictedPendingSamples, "PC sample", "PC samples"))
+	}
+	if dr.EvictedPendingModuleSamples > 0 {
+		add("%s evicted while waiting for their kernel — these carried no correlation, so "+
+			"they were grouped by module and function; the group index is too small, its "+
+			"horizon too short, or their executions never arrived at all",
+			plural(dr.EvictedPendingModuleSamples, "correlation-less PC sample", "correlation-less PC samples"))
 	}
 	if dr.EvictedExecutions > 0 {
 		add("%s evicted from the timeline ring before this snapshot — that GPU time is "+

--- a/gpu/pendingmodule_test.go
+++ b/gpu/pendingmodule_test.go
@@ -1,0 +1,285 @@
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tierBSample builds a Tier B (CONTINUOUS-mode) PC sample: no correlation
+// value, the producing PID set, and the module identity that has to carry
+// the attribution instead. CUPTI populates correlationId only in
+// KERNEL_SERIALIZED collection; in continuous mode it is always zero, which
+// is what Correlation.Present() == false means here.
+func tierBSample(pid uint32, crc uint64, fnIndex uint32, timeNs uint64) GPUPCSample {
+	return GPUPCSample{
+		Correlation:   CorrelationID{Backend: BackendCUPTI, PID: pid},
+		Module:        ModuleRef{Backend: BackendCUPTI, CRC: crc},
+		FunctionIndex: fnIndex,
+		ClockDomain:   ClockDomainCPUMonotonic,
+		TimeNs:        timeNs,
+		PCOffset:      uint64(fnIndex)<<32 | timeNs,
+		Count:         1,
+	}
+}
+
+// TestTierBPCSamplesDoNotCollapseOntoOneKey is the anti-collapse regression.
+//
+// Timeline.pending keys on the whole CorrelationID. A Tier B sample has
+// Correlation.Value == "" with Correlation.PID set, so every Tier B sample
+// from one process hashes to the single key {BackendCUPTI, pid, ""}.
+// pendingSampleCap (4,096 by default) then bounds an entire process's PC
+// samples to that one entry and evicts everything past it into
+// EvictedPendingSamples - and Snapshot matches none of them anyway, because
+// no execution ever carries an empty correlation value. That is the
+// pathology spec §6.1 describes for correlation-less launches, and it
+// presents as "PC sampling produces almost nothing" with an eviction counter
+// as the only clue.
+//
+// 10,000 samples across 50 distinct (crc, functionIndex) pairs is 200
+// samples per pair - two orders of magnitude below any per-group bound - so
+// with a correctly-keyed index nothing is lost. Against the single-key store
+// 5,904 of them are evicted.
+func TestTierBPCSamplesDoNotCollapseOntoOneKey(t *testing.T) {
+	const (
+		pid          = 4242
+		crcCount     = 10
+		fnCount      = 5
+		distinctKeys = crcCount * fnCount // 50
+		samples      = 10_000
+	)
+
+	tl := NewTimeline(TimelineConfig{})
+	for i := range samples {
+		crc := uint64(0xC0DE0000 + i%crcCount)
+		fnIndex := uint32((i / crcCount) % fnCount)
+		require.NoError(t, tl.EmitPCSample(tierBSample(pid, crc, fnIndex, uint64(i+1))))
+	}
+
+	snap := tl.Snapshot()
+
+	assert.Zero(t, snap.Dropped.EvictedPendingSamples,
+		"a Tier B sample must never reach the correlation-keyed pending store, "+
+			"whose single {backend, pid, \"\"} key collapses a whole process's PC samples onto one entry")
+	assert.Zero(t, snap.Dropped.EvictedPendingModuleSamples,
+		"%d samples over %d distinct (crc, functionIndex) groups is far below every bound; "+
+			"nothing should have been evicted", samples, distinctKeys)
+	assert.Equal(t, samples, snap.PendingModuleSamples,
+		"every Tier B sample must still be held, waiting for Task 8b's join")
+	assert.Equal(t, distinctKeys, snap.PendingModuleGroups,
+		"the samples must be spread over one group per (crc, functionIndex) pair, not collapsed")
+	assert.Zero(t, snap.PendingSamples,
+		"the correlation-keyed store must hold nothing at all in a pure Tier B run")
+	assert.Zero(t, snap.PendingCorrelations)
+}
+
+// TestTierBHorizonEvictionCountsSeparately pins the counter split: a Tier B
+// eviction storm must be distinguishable from a Tier A one, so an operator
+// reading joinhealth can tell "the module index is too small / the horizon is
+// too short" apart from "executions are not arriving for their correlations".
+// Sharing one counter would make the two diagnoses indistinguishable at
+// exactly the moment they matter.
+func TestTierBHorizonEvictionCountsSeparately(t *testing.T) {
+	const pid = 4242
+	tl := NewTimeline(TimelineConfig{PendingSampleHorizonNs: 100})
+
+	// Three samples in one group, all near the anchor's start.
+	for i := range 3 {
+		require.NoError(t, tl.EmitPCSample(tierBSample(pid, 0xAAAA, 1, uint64(i+1))))
+	}
+	require.Len(t, tl.pendingModule, 1)
+
+	// A later group drags the shared anchor far past the horizon, aging the
+	// first group out.
+	require.NoError(t, tl.EmitPCSample(tierBSample(pid, 0xBBBB, 2, 5_000)))
+
+	snap := tl.Snapshot()
+	assert.Equal(t, uint64(3), snap.Dropped.EvictedPendingModuleSamples,
+		"the aged-out group's three samples must be counted as Tier B evictions")
+	assert.Zero(t, snap.Dropped.EvictedPendingSamples,
+		"a Tier B eviction must never be charged to the Tier A counter")
+	assert.Equal(t, 1, snap.PendingModuleGroups, "only the newest group survives the horizon")
+	assert.Equal(t, 1, snap.PendingModuleSamples)
+}
+
+// TestTierBSamplesStayWithTheirProcess is issue #52's discipline applied to
+// the module index: the PID is IN the key, so a sample from one process
+// cannot land in another's group. There is no cross-process check to forget,
+// because there is no check - two processes running the identical binary
+// produce the identical cubin CRC and the identical function index, and only
+// the PID separates them.
+func TestTierBSamplesStayWithTheirProcess(t *testing.T) {
+	const (
+		pidA = 4242
+		pidB = 5353
+	)
+	tl := NewTimeline(TimelineConfig{})
+
+	// Same CRC, same function index, different processes: the worst case for
+	// a store that keyed on the module alone.
+	require.NoError(t, tl.EmitPCSample(tierBSample(pidA, 0xF00D, 7, 10)))
+	require.NoError(t, tl.EmitPCSample(tierBSample(pidA, 0xF00D, 7, 11)))
+	require.NoError(t, tl.EmitPCSample(tierBSample(pidB, 0xF00D, 7, 12)))
+
+	require.Len(t, tl.pendingModule, 2,
+		"identical (crc, functionIndex) from two processes must be two groups, not one")
+
+	keyA := pendingModuleKey{Backend: BackendCUPTI, PID: pidA, CubinCRC: 0xF00D, FunctionIndex: 7}
+	keyB := pendingModuleKey{Backend: BackendCUPTI, PID: pidB, CubinCRC: 0xF00D, FunctionIndex: 7}
+
+	groupA, ok := tl.pendingModule[keyA]
+	require.True(t, ok)
+	groupB, ok := tl.pendingModule[keyB]
+	require.True(t, ok)
+
+	require.Len(t, groupA.samples, 2)
+	require.Len(t, groupB.samples, 1)
+	for _, s := range groupA.samples {
+		assert.Equal(t, uint32(pidA), s.Correlation.PID,
+			"pid %d's group holds a sample from pid %d", pidA, s.Correlation.PID)
+	}
+	assert.Equal(t, uint32(pidB), groupB.samples[0].Correlation.PID)
+
+	snap := tl.Snapshot()
+	assert.Equal(t, 2, snap.PendingModuleGroups)
+	assert.Equal(t, 3, snap.PendingModuleSamples)
+	assert.Zero(t, snap.Dropped.EvictedPendingModuleSamples)
+	assert.Zero(t, snap.Dropped.EvictedPendingSamples)
+}
+
+// TestTierBDistinctFunctionIndexSplitsGroups isolates the field this task
+// adds. Same process, same cubin, different device functions: without
+// FunctionIndex on GPUPCSample the two are one key and Task 8b could never
+// resolve them to different kernels.
+func TestTierBDistinctFunctionIndexSplitsGroups(t *testing.T) {
+	const pid = 4242
+	tl := NewTimeline(TimelineConfig{})
+	require.NoError(t, tl.EmitPCSample(tierBSample(pid, 0x1234, 0, 10)))
+	require.NoError(t, tl.EmitPCSample(tierBSample(pid, 0x1234, 1, 11)))
+
+	snap := tl.Snapshot()
+	assert.Equal(t, 2, snap.PendingModuleGroups,
+		"two device functions in one cubin must key apart")
+	assert.Equal(t, 2, snap.PendingModuleSamples)
+}
+
+// TestTierBCardinalityEvictionCountsSeparately drives the module index's own
+// cardinality cap - the bound that reads non-zero when a JIT- or
+// template-explosion workload loads more distinct device functions than the
+// index can hold - and pins that it too stays off the Tier A counter.
+func TestTierBCardinalityEvictionCountsSeparately(t *testing.T) {
+	const pid = 4242
+	tl := NewTimeline(TimelineConfig{MaxPendingModuleGroups: 4})
+
+	for i := range 6 {
+		require.NoError(t, tl.EmitPCSample(tierBSample(pid, uint64(i), uint32(i), uint64(i+1))))
+	}
+
+	snap := tl.Snapshot()
+	assert.Equal(t, 4, snap.PendingModuleGroups, "the cap bounds distinct groups")
+	assert.Equal(t, uint64(2), snap.Dropped.EvictedPendingModuleSamples,
+		"the two oldest groups' samples were evicted, oldest first")
+	assert.Zero(t, snap.Dropped.EvictedPendingSamples)
+	assert.Equal(t, 4, snap.PendingModuleSamples)
+}
+
+// TestTierBPerGroupSampleCapCountsSeparately covers the third way a Tier B
+// sample can be lost: one group accumulating past MaxPendingSamplesPerCorrelation
+// because its execution never arrives. All three losses land on
+// EvictedPendingModuleSamples and none on EvictedPendingSamples.
+func TestTierBPerGroupSampleCapCountsSeparately(t *testing.T) {
+	const pid = 4242
+	tl := NewTimeline(TimelineConfig{MaxPendingSamplesPerCorrelation: 3})
+
+	for i := range 5 {
+		require.NoError(t, tl.EmitPCSample(tierBSample(pid, 0xABC, 0, uint64(i+1))))
+	}
+
+	snap := tl.Snapshot()
+	assert.Equal(t, 1, snap.PendingModuleGroups)
+	assert.Equal(t, 3, snap.PendingModuleSamples)
+	assert.Equal(t, uint64(2), snap.Dropped.EvictedPendingModuleSamples)
+	assert.Zero(t, snap.Dropped.EvictedPendingSamples)
+}
+
+// TestTierBSamplesReconcile is the accounting invariant for the new store,
+// with every one of its terms forced non-zero in a single run: some samples
+// still pending, some evicted by the cardinality cap, some by the horizon,
+// some by the per-group sample cap. If any bound stopped counting, or counted
+// into the wrong store, the sum stops matching what was emitted.
+func TestTierBSamplesReconcile(t *testing.T) {
+	const pid = 4242
+	tl := NewTimeline(TimelineConfig{
+		MaxPendingModuleGroups:          3,
+		MaxPendingSamplesPerCorrelation: 2,
+		PendingSampleHorizonNs:          1_000,
+	})
+
+	emitted := uint64(0)
+	emit := func(crc uint64, fn uint32, timeNs uint64) {
+		t.Helper()
+		require.NoError(t, tl.EmitPCSample(tierBSample(pid, crc, fn, timeNs)))
+		emitted++
+	}
+
+	// Per-group sample cap: 4 samples into a group that holds 2.
+	for i := range 4 {
+		emit(0x10, 0, uint64(i+1))
+	}
+	// Cardinality: five more distinct groups against a cap of 3.
+	for i := range 5 {
+		emit(uint64(0x20+i), uint32(i), uint64(10+i))
+	}
+	// Horizon: a jump far past 1,000 ns ages everything before it out.
+	emit(0x99, 9, 500_000)
+
+	snap := tl.Snapshot()
+
+	assert.Equal(t, emitted,
+		snap.AttributedPCSamples+
+			uint64(snap.PendingSamples)+snap.Dropped.EvictedPendingSamples+
+			uint64(snap.PendingModuleSamples)+snap.Dropped.EvictedPendingModuleSamples,
+		"every emitted sample must be attributed, pending, or evicted - never unaccounted for")
+
+	assert.Zero(t, snap.AttributedPCSamples, "no execution was ever emitted")
+	assert.Zero(t, snap.PendingSamples, "not one of these carried a correlation value")
+	assert.Zero(t, snap.Dropped.EvictedPendingSamples,
+		"the Tier A counter must stay assertably zero through every Tier B loss")
+	assert.Positive(t, snap.Dropped.EvictedPendingModuleSamples,
+		"all three bounds fired; a zero here means at least one stopped counting")
+	assert.Equal(t, 1, snap.PendingModuleGroups, "only the post-horizon group survives")
+	assert.Equal(t, 1, snap.PendingModuleSamples)
+}
+
+// TestTierAPCSamplesStillUseTheCorrelationIndex is the non-regression half:
+// a sample that DOES carry a correlation value must keep taking the exact
+// path untouched, and must never appear in the module index. Task 8a routes
+// on Correlation.Present() and nothing else.
+func TestTierAPCSamplesStillUseTheCorrelationIndex(t *testing.T) {
+	const pid = 4242
+	tl := NewTimeline(TimelineConfig{})
+	corr := CorrelationID{Backend: BackendCUPTI, PID: pid, Value: "77"}
+
+	require.NoError(t, tl.EmitLaunch(launchIn(pid, "77", 10, "a_work")))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation:   corr,
+		Module:        ModuleRef{Backend: BackendCUPTI, CRC: 0xF00D},
+		FunctionIndex: 7,
+		TimeNs:        25,
+		PCOffset:      0xAAA,
+		Count:         1,
+	}))
+	require.NoError(t, tl.EmitExec(execIn(pid, "77", 20, 30)))
+
+	assert.Empty(t, tl.pendingModule, "a correlation-bearing sample must never enter the module index")
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.Len(t, snap.Executions[0].PCSamples, 1)
+	assert.Equal(t, uint32(7), snap.Executions[0].PCSamples[0].FunctionIndex,
+		"FunctionIndex must survive the exact-correlation path unchanged")
+	assert.Equal(t, uint64(1), snap.AttributedPCSamples)
+	assert.Zero(t, snap.PendingModuleSamples)
+	assert.Zero(t, snap.PendingModuleGroups)
+}

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -45,6 +45,24 @@ type TimelineDropStats struct {
 	EvictedEvents         uint64 `json:"evicted_events,omitempty"`
 	EvictedModules        uint64 `json:"evicted_modules,omitempty"`
 	EvictedPendingSamples uint64 `json:"evicted_pending_samples,omitempty"`
+
+	// EvictedPendingModuleSamples is EvictedPendingSamples' counterpart for
+	// the correlation-less (continuous-mode) pending store — see
+	// Timeline.pendingModule. Kept deliberately SEPARATE rather than summed
+	// into EvictedPendingSamples: the two stores are keyed differently, are
+	// bounded by different things, and fail for different reasons, so one
+	// counter for both would make the two diagnoses indistinguishable at
+	// exactly the moment they matter. A non-zero EvictedPendingSamples says
+	// executions are not arriving for the correlations their samples carry;
+	// a non-zero EvictedPendingModuleSamples says the module index is too
+	// small for the workload's distinct device functions, its horizon is
+	// shorter than the gap between a sample and its execution, or one
+	// device function's samples outran MaxPendingSamplesPerCorrelation
+	// because its execution never came. All three of the latter are Tier B
+	// eviction storms and none of them is a Tier A problem.
+	//
+	// Zero on a healthy run of either tier.
+	EvictedPendingModuleSamples uint64 `json:"evicted_pending_module_samples,omitempty"`
 }
 
 // Snapshot is a point-in-time, fully-joined view of everything Timeline
@@ -90,6 +108,25 @@ type Snapshot struct {
 	// evicted.
 	PendingSamples      int `json:"pending_samples,omitempty"`
 	PendingCorrelations int `json:"pending_correlations,omitempty"`
+
+	// PendingModuleSamples and PendingModuleGroups are the same pair of
+	// gauges for the correlation-less pending store (Timeline.pendingModule):
+	// PendingModuleGroups counts distinct {backend, pid, cubin CRC, function
+	// index} groups held, PendingModuleSamples the individual GPUPCSample
+	// entries across them. Together with Dropped.EvictedPendingModuleSamples
+	// they close the reconciliation identity for continuous-mode samples the
+	// same way the correlation-keyed trio does for correlation-bearing ones:
+	// every PC sample the sink accepted is attributed, still pending in one
+	// of the two stores, or evicted from one of them.
+	//
+	// Nothing joins out of this store yet — that is the Snapshot join, and it
+	// is deliberately NOT part of this change. Until it lands, a continuous-
+	// mode run shows these two gauges rising and AttributedPCSamples flat,
+	// which is the honest reading of "collected, correctly grouped, not yet
+	// attributed" rather than the previous "collapsed onto one key and
+	// silently evicted".
+	PendingModuleSamples int `json:"pending_module_samples,omitempty"`
+	PendingModuleGroups  int `json:"pending_module_groups,omitempty"`
 }
 
 // TimelineConfig configures Timeline's storage bounds.
@@ -145,8 +182,27 @@ type TimelineConfig struct {
 	// fall before that correlation is evicted as an orphan, in addition to
 	// the cardinality bound (pendingCap). Mirrors LaunchCacheConfig.HorizonNs.
 	// Zero disables horizon-based pending eviction, leaving only the
-	// cardinality bound.
+	// cardinality bound. It applies to BOTH pending stores: the
+	// correlation-keyed one and the module-keyed one (Timeline.pendingModule)
+	// share this horizon, because they hold the same kind of thing (a PC
+	// sample waiting for its execution) for the same reason and over the same
+	// producer drain interval. What they do not share is the counter the
+	// eviction lands on.
 	PendingSampleHorizonNs uint64
+
+	// MaxPendingModuleGroups bounds how many distinct {backend, pid, cubin
+	// CRC, function index} groups the correlation-less pending store may hold
+	// before the oldest are evicted into
+	// Dropped.EvictedPendingModuleSamples. It is deliberately NOT
+	// LaunchCache.Capacity, which every other store here reuses: that
+	// capacity tracks launch volume, and launch volume is a function of run
+	// length, whereas this store's cardinality is a function of the profiled
+	// *binary* — one group per device function per process, tens to low
+	// hundreds for a real workload. Sizing it off launch volume would reserve
+	// a 65,536-entry map for a workload that will only ever fill fifty of it.
+	//
+	// Zero means defaultMaxPendingModuleGroups.
+	MaxPendingModuleGroups int
 }
 
 // Timeline is the indexed join point: it ingests launches, executions, PC
@@ -249,6 +305,59 @@ type Timeline struct {
 	// O(pendingCap) cost to every snapshot even when nothing changed.
 	pendingSampleTotal uint64
 
+	// pendingModule is the second pending index: the one a PC sample that
+	// carries NO correlation value lands in. CUPTI populates a PC record's
+	// correlationId only in KERNEL_SERIALIZED collection; in CONTINUOUS mode
+	// — the only mode that is a candidate for always-on, because it does not
+	// serialize kernels — it is zero on every record.
+	//
+	// Why a second index at all, rather than letting those samples share
+	// pending above. pending keys on the whole CorrelationID, and a
+	// correlation-less sample still arrives with Backend and PID filled in
+	// (they are context the producer knows regardless — see
+	// CorrelationID.Present), so EVERY such sample from one process hashes to
+	// the single key {backend, pid, ""}. Two things then go wrong at once and
+	// neither is visible as what it is: pendingSampleCap bounds an entire
+	// process's PC samples to that one entry and evicts the rest, and
+	// Snapshot's t.pending[exec.Correlation] lookup matches none of them
+	// anyway, because no execution ever carries an empty correlation value.
+	// The observable symptom is "PC sampling produces almost nothing" with an
+	// eviction counter as the only clue — spec §6.1's pathology for
+	// correlation-less launches, reached here through a different door.
+	//
+	// The key is {Backend, PID, CubinCRC, FunctionIndex}: the coarsest
+	// identity a continuous-mode sample actually carries, and the one the
+	// module store can resolve back to a device function. The PID is IN the
+	// key rather than in a check performed somewhere else, which is issue
+	// #52's discipline: two processes running the identical binary produce
+	// the identical cubin CRC and the identical function index, so the only
+	// thing separating their samples is the PID, and a structural refusal
+	// cannot be forgotten by a later edit the way a guard can. Backend is
+	// present for the same reason CorrelationID carries it — nothing today
+	// emits PC samples from two backends into one Timeline, and this costs
+	// nothing to make impossible.
+	//
+	// pendingModule holds pendingSamples values, identical in shape and
+	// contract to pending's: the seq/generation pairing with an orderedFIFO
+	// (see the pending field's doc comment for the deleted-then-reused hazard
+	// it exists to solve, which applies here unchanged) and anchorNs as the
+	// O(1) horizon anchor. Reusing orderedFIFO rather than writing a third
+	// eviction walk is deliberate — LaunchCache and pending each grew a
+	// hand-written copy of it and each hit the same liveness bug separately.
+	// (ModuleStore deliberately does not reuse it, but for a reason specific
+	// to LRU touching: an LRU has to move an entry to the front on every
+	// *read*, which orderedFIFO has no notion of. This store is pure FIFO by
+	// arrival like pending, so that reason does not apply.)
+	//
+	// Nothing joins out of this store yet. Getting samples into a correctly
+	// keyed index and getting them attached to an execution are separate
+	// changes on purpose; the second one is where the module store, the
+	// kernel-name match and the attribution-quality label live.
+	pendingModule            map[pendingModuleKey]pendingSamples
+	pendingModuleOrder       *orderedFIFO[pendingModuleKey]
+	pendingModuleCap         int
+	pendingModuleSampleTotal uint64
+
 	events  *ring[GPUTimelineEvent]
 	modules *ring[GPUModule]
 
@@ -278,6 +387,53 @@ type pendingSamples struct {
 // unbounded append.
 const defaultMaxPendingSamplesPerCorrelation = 4096
 
+// pendingModuleKey is Timeline.pendingModule's key: the identity a PC sample
+// with no correlation value still carries. Every field is comparable and
+// sized, so this is a plain map key with no allocation and no hashing helper.
+//
+// The PID is a field of the key, not a filter applied to it. See the
+// pendingModule doc comment.
+type pendingModuleKey struct {
+	Backend       GPUBackendID
+	PID           uint32
+	CubinCRC      uint64
+	FunctionIndex uint32
+}
+
+// pendingModuleKeyFor derives the key from the sample. It reads the PID off
+// the Correlation (which carries it even when Value is empty) and the CRC and
+// backend off the Module, so a producer that fills in neither still keys
+// consistently — into a single group per process, which is the honest answer
+// when a sample genuinely carries no module identity, rather than a fabricated
+// distinction.
+func pendingModuleKeyFor(p GPUPCSample) pendingModuleKey {
+	backend := p.Module.Backend
+	if backend == "" {
+		backend = p.Correlation.Backend
+	}
+	return pendingModuleKey{
+		Backend:       backend,
+		PID:           p.Correlation.PID,
+		CubinCRC:      p.Module.CRC,
+		FunctionIndex: p.FunctionIndex,
+	}
+}
+
+// defaultMaxPendingModuleGroups bounds Timeline.pendingModule's cardinality
+// when TimelineConfig doesn't set MaxPendingModuleGroups. One group is one
+// device function in one process; a real workload has tens to low hundreds,
+// and even a template- or JIT-heavy one that loads thousands of cubins is
+// covered here with room to spare. It is not sized off launch volume — see
+// TimelineConfig.MaxPendingModuleGroups for why that would be the wrong
+// dial.
+//
+// Worst case with the defaults, and it is worth stating plainly: 4,096 groups
+// x 4,096 samples per group of GPUPCSample. That ceiling is only reachable by
+// a producer emitting thousands of distinct device functions whose executions
+// never arrive at all, which is itself the condition
+// EvictedPendingModuleSamples exists to report.
+const defaultMaxPendingModuleGroups = 4096
+
 // NewTimeline constructs a Timeline. cfg.LaunchCache is passed through to
 // NewLaunchCache unmodified (including its own zero-value defaulting); the
 // cache's own normalized capacity is reused for the exec/module rings and
@@ -299,6 +455,11 @@ func NewTimeline(cfg TimelineConfig) *Timeline {
 		sampleCap = defaultMaxPendingSamplesPerCorrelation
 	}
 
+	moduleGroupCap := cfg.MaxPendingModuleGroups
+	if moduleGroupCap <= 0 {
+		moduleGroupCap = defaultMaxPendingModuleGroups
+	}
+
 	return &Timeline{
 		cache:            cache,
 		joinWindowNs:     cfg.LaunchEventJoinWindowNs,
@@ -310,6 +471,13 @@ func NewTimeline(cfg TimelineConfig) *Timeline {
 		pendingCap:       capacity,
 		pendingSampleCap: sampleCap,
 		pendingHorizonNs: cfg.PendingSampleHorizonNs,
+
+		pendingModule: make(map[pendingModuleKey]pendingSamples),
+		// No capacity hint, matching pending's orderedFIFO: the store is
+		// bounded by cardinality but a workload that never uses continuous-
+		// mode sampling should not pay for a preallocated slice.
+		pendingModuleOrder: newOrderedFIFO[pendingModuleKey](0),
+		pendingModuleCap:   moduleGroupCap,
 	}
 }
 
@@ -318,6 +486,15 @@ func NewTimeline(cfg TimelineConfig) *Timeline {
 // with exactly seq. The caller must hold t.mu.
 func (t *Timeline) isPendingLiveLocked(id CorrelationID, seq uint64) bool {
 	cur, ok := t.pending[id]
+	return ok && cur.seq == seq
+}
+
+// isPendingModuleLiveLocked is isPendingLiveLocked for pendingModuleOrder. The
+// hazard it answers is identical and is described on the pending field; the
+// stores are separate only so their bounds and their loss counters are.
+// The caller must hold t.mu.
+func (t *Timeline) isPendingModuleLiveLocked(k pendingModuleKey, seq uint64) bool {
+	cur, ok := t.pendingModule[k]
 	return ok && cur.seq == seq
 }
 
@@ -343,6 +520,18 @@ func (t *Timeline) EmitPCSample(p GPUPCSample) error {
 	defer t.mu.Unlock()
 
 	t.observePendingTimestampLocked(p.TimeNs)
+
+	// Correlation.Present() — the presence of a vendor correlation VALUE, not
+	// of a non-zero CorrelationID — is the whole of the routing decision, and
+	// it is the same gate Snapshot already uses to route a correlation-less
+	// execution to the heuristic join. A sample that carries a value keeps
+	// taking the exact-correlation path below, unchanged; one that does not
+	// would otherwise collapse onto {backend, pid, ""} there. See the
+	// pendingModule field's doc comment.
+	if !p.Correlation.Present() {
+		t.emitPendingModuleLocked(p)
+		return nil
+	}
 
 	entry, exists := t.pending[p.Correlation]
 	if !exists {
@@ -434,6 +623,83 @@ func (t *Timeline) evictPendingLocked() {
 		delete(t.pending, id)
 		t.pendingSampleTotal -= uint64(len(cur.samples))
 		t.dropped.EvictedPendingSamples += uint64(len(cur.samples))
+	}
+}
+
+// emitPendingModuleLocked is EmitPCSample's body for a sample with no
+// correlation value: the same three bounds as the correlation-keyed path
+// (per-group sample cap, horizon, cardinality), the same generation
+// discipline, and its own counter. Deliberately a near-mirror rather than a
+// shared generic: the two stores' keys, bounds and loss counters all differ,
+// and the only piece worth sharing — the order/liveness walk, which is where
+// both of the earlier hand-written copies had a real bug — already is, via
+// orderedFIFO. Caller holds t.mu.
+func (t *Timeline) emitPendingModuleLocked(p GPUPCSample) {
+	key := pendingModuleKeyFor(p)
+
+	entry, exists := t.pendingModule[key]
+	if !exists {
+		// Absent-to-present transition only, exactly as pending does it: a
+		// group accumulates samples into one live generation across many
+		// calls, so re-stamping per append would orphan its own live order
+		// position. See the pending field's doc comment.
+		entry.seq = t.pendingModuleOrder.insert(key)
+	}
+
+	if len(entry.samples) >= t.pendingSampleCap {
+		// The per-group bound is MaxPendingSamplesPerCorrelation, shared with
+		// the correlation-keyed store: it answers the same question ("how
+		// many samples may one not-yet-matched thing accumulate") about the
+		// same objects over the same drain interval, and a second dial for it
+		// would be two names for one decision. The eviction it causes is
+		// still counted separately.
+		t.dropped.EvictedPendingModuleSamples++
+		t.pendingModule[key] = entry
+		t.evictPendingModuleLocked()
+		return
+	}
+
+	entry.samples = append(entry.samples, p)
+	if p.TimeNs > entry.anchorNs {
+		entry.anchorNs = p.TimeNs
+	}
+	t.pendingModule[key] = entry
+	t.pendingModuleSampleTotal++
+	t.evictPendingModuleLocked()
+}
+
+// evictPendingModuleLocked is evictPendingLocked for the module-keyed store:
+// horizon first, then cardinality, both delegating the superseded-position
+// walk to orderedFIFO. pendingNewestNs is shared with the correlation-keyed
+// store — one PC-sample stream, one clock domain, one anomalous-jump clamp —
+// while pendingHorizonNs is shared by value and the counter is not shared at
+// all. Caller holds t.mu.
+func (t *Timeline) evictPendingModuleLocked() {
+	if t.pendingHorizonNs > 0 {
+		for {
+			key, ok := t.pendingModuleOrder.peekOldestLive(t.isPendingModuleLiveLocked)
+			if !ok {
+				break
+			}
+			cur := t.pendingModule[key] // guaranteed present: peekOldestLive just confirmed liveness
+			if t.pendingNewestNs <= cur.anchorNs || t.pendingNewestNs-cur.anchorNs <= t.pendingHorizonNs {
+				break
+			}
+			t.pendingModuleOrder.evictOldestLive(t.isPendingModuleLiveLocked)
+			delete(t.pendingModule, key)
+			t.pendingModuleSampleTotal -= uint64(len(cur.samples))
+			t.dropped.EvictedPendingModuleSamples += uint64(len(cur.samples))
+		}
+	}
+	for len(t.pendingModule) > t.pendingModuleCap {
+		key, ok := t.pendingModuleOrder.evictOldestLive(t.isPendingModuleLiveLocked)
+		if !ok {
+			break
+		}
+		cur := t.pendingModule[key]
+		delete(t.pendingModule, key)
+		t.pendingModuleSampleTotal -= uint64(len(cur.samples))
+		t.dropped.EvictedPendingModuleSamples += uint64(len(cur.samples))
 	}
 }
 
@@ -539,6 +805,12 @@ func (t *Timeline) Snapshot() Snapshot {
 	}
 	pendingCorrelations := len(t.pending)
 	pendingSamples := t.pendingSampleTotal
+	// Read, never drained: nothing joins out of the module-keyed store yet,
+	// so every group here survives this Snapshot. When the join lands it
+	// consumes from this store the same way the loop above consumes from the
+	// correlation-keyed one.
+	pendingModuleGroups := len(t.pendingModule)
+	pendingModuleSamples := t.pendingModuleSampleTotal
 	t.mu.Unlock()
 
 	// The heuristic's candidate set is built lazily - only once the loop
@@ -697,6 +969,9 @@ func (t *Timeline) Snapshot() Snapshot {
 		AttributedPCSamples: attributedPCSamples,
 		PendingSamples:      int(pendingSamples),
 		PendingCorrelations: pendingCorrelations,
+
+		PendingModuleSamples: int(pendingModuleSamples),
+		PendingModuleGroups:  pendingModuleGroups,
 	}
 }
 

--- a/gpu/types.go
+++ b/gpu/types.go
@@ -337,14 +337,26 @@ type GPUModule struct {
 // When a correlation IS supplied, it carries the producing process with it
 // (see CorrelationID), so a sample can only ever be handed to an execution
 // from the same process.
+// FunctionIndex is the sampled instruction's device function within Module —
+// CUPTI's per-module functionIndex, carried on gpu_pc_sample_batch_v1 since
+// the ABI froze and populated by the consumer straight off the wire. It is
+// meaningless without Module, exactly as PCOffset is: the pair
+// (Module.CRC, FunctionIndex) is what names a device function, and
+// (Module.CRC, FunctionIndex, PCOffset) is what names an instruction.
+//
+// It is load-bearing for continuous-mode collection specifically. With no
+// correlation, {PID, Module.CRC, FunctionIndex} is the only key a sample can
+// be grouped under, and without this field every sample a process produces
+// keys identically — see Timeline.pendingModule.
 type GPUPCSample struct {
-	Correlation CorrelationID `json:"correlation"`
-	Module      ModuleRef     `json:"module"`
-	ClockDomain ClockDomain   `json:"clock_domain,omitempty"`
-	TimeNs      uint64        `json:"time_ns"`
-	PCOffset    uint64        `json:"pc_offset"`
-	StallReason string        `json:"stall_reason,omitempty"`
-	Count       uint64        `json:"count"`
+	Correlation   CorrelationID `json:"correlation"`
+	Module        ModuleRef     `json:"module"`
+	FunctionIndex uint32        `json:"function_index,omitempty"`
+	ClockDomain   ClockDomain   `json:"clock_domain,omitempty"`
+	TimeNs        uint64        `json:"time_ns"`
+	PCOffset      uint64        `json:"pc_offset"`
+	StallReason   string        `json:"stall_reason,omitempty"`
+	Count         uint64        `json:"count"`
 }
 
 // TimelineEventKind classifies a GPUTimelineEvent.

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -2022,7 +2022,14 @@ func (c *Consumer) emitPCSampleLocked(pid uint32, rec gpuabi.PCSample) {
 		// index.
 		ClockDomain: gpu.ClockDomainCPUMonotonic,
 		PCOffset:    rec.PCOffset,
-		Count:       uint64(rec.Count),
+		// Carried, not dropped: FunctionIndex is half of the key
+		// Timeline.pendingModule groups Tier B samples by. Leaving it zero
+		// would put every sample of a process into one group per cubin -
+		// a partial re-run of the collapse Task 8a exists to fix, and one
+		// that reads as perfectly healthy because the counters only see
+		// samples arriving and being grouped, not which group.
+		FunctionIndex: rec.FunctionIndex,
+		Count:         uint64(rec.Count),
 	}
 	if name, ok := c.resolveStallNameLocked(rec.StallIndex); ok {
 		ev.StallReason = name

--- a/gpuprobe/consumer_test.go
+++ b/gpuprobe/consumer_test.go
@@ -3047,6 +3047,27 @@ func TestPCBatchBeforeItsStallMapStillResolves(t *testing.T) {
 	assert.Zero(t, st.Undecoded)
 }
 
+// FunctionIndex is half of the key Timeline.pendingModule groups Tier B samples
+// by, so dropping it on the decode path would put every sample of a process into
+// one group per cubin - a partial re-run of the collapse Task 8a exists to fix.
+// It reads as healthy from the counters alone, which only see samples arriving
+// and being grouped, never which group. Hence a test on the value, not a count.
+func TestDecodedPCSamplesCarryTheirFunctionIndex(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+
+	apply(t, c, stallMapBatch(1, []uint32{3}, []string{"mio_throttle"}, false))
+	apply(t, c, pcBatch(4242, 2,
+		pcSample{crc: 0xAA, pcOffset: 0x40, fnIndex: 7, stallIndex: 3, count: 5},
+		pcSample{crc: 0xAA, pcOffset: 0x80, fnIndex: 11, stallIndex: 3, count: 2},
+	))
+
+	require.Len(t, sink.pcSamples, 2)
+	assert.Equal(t, uint32(7), sink.pcSamples[0].FunctionIndex)
+	assert.Equal(t, uint32(11), sink.pcSamples[1].FunctionIndex,
+		"two samples in one cubin must keep distinct function indices, or they group as one")
+}
+
 // An index the map never carried has no name and never will. It becomes the
 // empty string - never "stall#17", which would put an unstable vendor number
 // into a label value - and it is counted, because a blank stall reason with


### PR DESCRIPTION
**Task 8a of [the GPU PC sampling plan](docs/superpowers/plans/2026-08-25-gpu-pc-sampling.md).** Targets `feat/consumer-decodes-pc` (PR #79) and will retarget `main` when that merges.

### The collapse

`Timeline.pending` keys on the whole `CorrelationID`, and a Tier B sample has `Correlation.Value == ""` with only the PID set. So **every PC sample from one process collapses onto the single key `{Backend, PID, ""}`** — `pendingSampleCap` (4,096) bounds an entire process's PC samples to one entry and evicts the rest, and `Snapshot` matches none of them anyway, because no execution carries an empty correlation value.

That is the pathology spec §6.1 describes for correlation-less launches. It would have presented as "PC sampling produces almost nothing", with an eviction counter as the only clue.

### Pre-fix, measured

The typed test cannot compile against `main` (no `FunctionIndex` field), which is weak evidence — so the same 10,000-sample / 50-pair drive was re-expressed in main's own types:

```
Should be zero, but was 5904
  10,000 Tier B samples over 50 distinct (crc, functionIndex) groups: none may be lost
Not equal: expected 50, actual 1
  the samples must be spread over one group per (crc, functionIndex) pair
```

50 groups collapsed to 1; **5,904 of 10,000 evicted — exactly `10,000 − pendingSampleCap`**. Removing the routing branch from the finished code reproduces `5904` exactly.

### What landed

`GPUPCSample.FunctionIndex`, and a second pending index `pendingModule`, entered on `!p.Correlation.Present()` and nothing else. Key `{Backend, PID, CubinCRC, FunctionIndex}`; own cardinality cap sized off the **binary** rather than off launch volume like every other store here; shares `pendingHorizonNs`/`pendingNewestNs`/`pendingSampleCap`; own counter `EvictedPendingModuleSamples` so a Tier B eviction storm is distinguishable from a Tier A one; order and liveness through the existing `orderedFIFO`, no third eviction walk.

Cross-process is refused **structurally** — the PID is in the key, not in a check that can be forgotten (#52's discipline).

Four mutation checks, all caught: key without `FunctionIndex` (3 failures), key without `PID` (cross-process test fails), evictions charged to the wrong counter (4 failures), routing removed (the pathology returns).

### The wiring, and why it has its own test

Task 8a's report flagged that `FunctionIndex` was decoded but never carried onto the type, because `main` had no `kindPC` arm at all — that arm is Task 7's. Added here, on top of #79, with `TestDecodedPCSamplesCarryTheirFunctionIndex`.

It is a test on a **value**, not a count, deliberately: leaving the field zero would put every sample of a process into one group per cubin — a partial re-run of the collapse this task exists to fix — and it reads as perfectly healthy from the counters, which only see samples arriving and being grouped, never *which* group. Mutation-checked: removing the assignment gives `expected 0x7, actual 0x0`.

### Deliberate deviation

The key is `{Backend, PID, CubinCRC, FunctionIndex}`, not the plan's literal `{PID, CubinCRC, FunctionIndex}`. Behaviour-neutral today (ROCm does not advertise `CapabilityPCSampling`), present for the same reason `CorrelationID` carries it. Documented in code and report.

Also extended `assertPCSampleLossesAccounted` so the reconciliation identity covers both pending stores — otherwise every continuous-mode sample would read as unaccounted-for — plus a `joinhealth` summary clause and anomaly line, both absent on a healthy run.

**No `Snapshot` join** — that is 8b.

**Cannot verify:** `CapEff: 0`, no GPU. The plan's line for this task is "must be measured on the RTX 3090 afterwards: nothing."