### PR TITLE
flamegraph: add the icicle, the tree view and a first-class search

### DIFF
--- a/.superpowers/sdd/flamegraph-views-report.md
+++ b/.superpowers/sdd/flamegraph-views-report.md
@@ -1,0 +1,416 @@
+# Flame graph: invert, tree view, and a search worth the name
+
+Branch `feat/flamegraph-views`, one commit on top of `main` (which now
+contains #75). Everything is in `internal/flamegraph/`; no other package is
+touched.
+
+## What async-profiler's Invert actually does
+
+**It is a visual flip. It is not a reverse merge.** From `src/res/flame.html`:
+
+```js
+document.getElementById('inverted').onclick = function() {
+    inverted = !inverted;
+    render();
+}
+```
+
+and the only thing `inverted` reaches, in the whole file, is the y of a row
+and the y of the hit test:
+
+```js
+const y = inverted ? h * 16 : canvasHeight - (h + 1) * 16;
+```
+
+`levels[]` — their frame array — is never rebuilt, never re-bucketed, never
+re-summed. Pressing `I` moves the picture, not the data.
+
+The callee-centric aggregation the brief asked about **does exist in
+async-profiler, and it is a different feature**: the `--reverse` flag on
+their JFR/collapsed converter. `src/converter/one/convert/FlameGraph.java`:
+
+```java
+public void addSample(CallStack stack, long ticks) {
+    Frame frame = root;
+    if (args.reverse) {
+        …
+        for (int i = stack.size; --i >= skip; ) {
+            frame = addChild(frame, stack.names[i], stack.types[i], ticks);
+        }
+    } else {
+        for (int i = args.skip; i < stack.size; i++) { … }
+    }
+```
+
+That walks each stack backwards as it is inserted, so leaves become roots and
+hot leaves merge across call paths — a genuinely different tree, built in
+Java before the HTML exists. The two features meet in exactly one line:
+
+```java
+// inverted toggles the layout for reversed stacktraces from icicle to flamegraph
+out.print(args.reverse ^ args.inverted);
+```
+
+A reversed graph ships with `inverted` preset to true (so it draws downward,
+which is the conventional rendering for a callee-centric view), and the `I`
+key flips it back. `--reverse` decides *what tree*; `I` decides *which way up*.
+
+**So I implemented the flip**, as instructed ("match their semantics"). I did
+not build reverse-merge: it is not what `I` is, and it is a build-time
+transformation of the fold, not a client-side view. If it is wanted it
+belongs in `internal/foldedstacks`, beside the fold, as a second `Result` —
+which would also let it keep the honesty notes straight, since a reverse
+merge makes `[gpu:launch unsampled]` a *leaf* under every kernel and the
+sample-period note would need rewording.
+
+### How the flip is done here
+
+Ours is a DOM, not a canvas, so there is no `render()` to call with a
+different y. The rows used to be `.d3{bottom:54px}`. They now carry a
+**number** and the frame turns it into an offset:
+
+```css
+.frame{bottom:calc(var(--d)*18px)}
+.inv .frame{bottom:auto;top:calc(var(--d)*18px)}
+.d0{--d:0}.d1{--d:1}…
+```
+
+`toggleInvert` is `chart.classList.toggle("inv")` and one `aria-label`
+rewrite. Nothing else in the script knows the graph inverted. Three
+consequences worth stating:
+
+- **It is cheaper than what it replaced.** `.d16{--d:16}` is 12 bytes where
+  `.d16{bottom:288px}` was 18; the ladder for this profile went 289 B → 268 B,
+  and the gap widens with depth (`.d59{--d:59}` vs `.d59{bottom:1062px}`).
+  The two positioning rules cost 76 B, so the icicle is +55 B here and
+  *negative* on anything deeper than ~24 frames.
+- **The row pitch survives.** It is still one px literal in a stylesheet.
+  Measured in Chrome at 800/1280/1990 px, inverted: `font-size` 11 px, frame
+  height 17 px, pitch 18 px — the same three numbers as the flame view, at
+  every width.
+- **It is lossless.** Verified by reading every frame's `style.left` and
+  `style.width` before `I`, after `I`, and after `I` again: identical
+  strings. Widths, values, zoom state and search state are untouched because
+  nothing writes them.
+
+`aria-label` on the chart becomes `"Flame graph, gpu/nanoseconds, inverted:
+root at top"` while inverted, and reverts. A reader who cannot see the flip
+is told about it.
+
+## The tree view (`T`)
+
+### Markup and semantics
+
+```html
+<div id="tree" role="group" aria-label="Call tree, gpu/nanoseconds" hidden>
+  <ul>
+    <li><details open><summary>
+          <span class="p">100.00%</span>
+          <span class="v">5.99 ms</span>
+          <span class="sw" data-domain="root" aria-hidden="true"></span>
+          <span>all</span>
+        </summary>
+        <ul><li>…</li></ul>
+    </details></li>
+  </ul>
+</div>
+```
+
+A leaf is the same row in a `<div class="leaf">` instead of a `<summary>`,
+inside the same `<li>`.
+
+**I chose a nested list of native disclosures over `role="tree"`, and that is
+the one decision here worth arguing about.** `role="tree"` /
+`role="treeitem"` / `aria-expanded` is the textbook answer and I rejected it:
+a tree role promises the reader a widget interaction model — one tab stop,
+arrow keys to move, left/right to collapse and expand, type-ahead — and a
+`role="tree"` that does not implement roving `tabindex` and arrow keys is a
+worse outcome than no role at all, because the reader is told to expect
+navigation that is not there. What `<ul>` + `<details>` buys instead, for
+free and correctly:
+
+- **list semantics** — a screen reader announces "list, 2 items" and the
+  nesting depth, which is the structure this view exists to convey;
+- **real disclosure semantics** — a `<summary>` *is* a button that announces
+  expanded or collapsed, and the browser maintains that state. There is no
+  `aria-expanded` for the script to desync;
+- **keyboard for free** — Tab reaches a row, Enter/Space opens it, and
+  `#tree summary:focus-visible` gives it a visible ring;
+- **it matches the precedent this branch inherited.** #75 made the info panel
+  a native `<details>` for exactly this reason. A second, hand-rolled
+  disclosure with hand-maintained ARIA beside it would have been two answers
+  to one question.
+
+The swatch is `aria-hidden` — the colour is redundant with information the
+row already carries, and "square, square, square" down a 60-row tree is
+noise. The percentage and value are plain text in the row, so they are
+announced.
+
+### How it is built
+
+**From the frames already in the document.** `writeNode` emits frames in
+pre-order and each carries its depth as a class, so depth plus document order
+is a parent link — one stack-walk at start-up reconstructs the whole tree.
+The consequences:
+
+- **The tree costs 61 bytes of markup**, the empty container. Not one symbol
+  is on the page twice, which on a real profile is the difference between a
+  30 KB page and a 60 KB one.
+- Rows are built when their parent first opens (hooked on the `toggle`
+  event), so a 20,000-frame profile builds the rows someone actually looked
+  at. This is async-profiler's `expandTree` behaviour.
+- A frame with **exactly one child opens all the way through**, theirs does
+  the same, and it is not a nicety here: this profile's CPU path is a
+  corridor fourteen frames long with no doors off it, and clicking fourteen
+  times down it is not navigation. `_start` opens to sixteen rows in one
+  click.
+- Children are sorted by value descending — the tree's question is "what is
+  under this", and the answer wants the big things first. The *markup* stays
+  sorted by name, so the page is still byte-identical between renders.
+
+The tree is rooted at the current zoom target, so the two views agree about
+what you are looking at. Pressing `T` after zooming into `_start` gives a
+tree of `_start`.
+
+`title` on the row carries name, value, share, **self time**, module and the
+inference notes — the native tooltip is right here, where #75's objection to
+`<title>` (a second tooltip behind the cursor tooltip) does not apply,
+because the tree has no cursor tooltip. Self time is new and is also now in
+the flame graph's tooltip.
+
+Colour: the swatch takes its fill, hatch and outline from the same rules the
+frames use. That required dropping the `.frame` prefix from the eleven
+`[data-domain="…"]` rules — a domain is a domain wherever it is drawn — which
+**saved 84 bytes** and means an unsymbolized frame's swatch is hatched
+without a second rule saying so. A test asserts none of those rules is
+frame-scoped any more, so a tree swatch can never lose its colour to a
+selector tightening.
+
+## Search
+
+Kept: `Ctrl+F` to reveal and focus, live incremental matching, `Esc` to clear.
+
+Added:
+
+- **A share of the total**, beside the count and the value:
+  `3 matched · 5.99 ms · 100.00%`.
+- **`N` / `Shift+N`** to step, with `(k of n)` appended to the counter, the
+  status bar naming the frame, and — in the flame view — a zoom onto the
+  match plus a scroll to its row, which is how you reach a 3-px sliver. In
+  the tree view, `N` expands the path to the match and scrolls to it.
+  Because the field swallows `N`, **Enter and Shift+Enter step from inside
+  it**, which is the find-bar idiom.
+- **A colour reserved to search.** A match is filled magenta, non-matches
+  dim, and the one match `N` is standing on gets the ink outline that used to
+  be on every match. (Every match outlined was wrong once matches are also
+  filled: at 1.8 px inset on a 3-px frame the outline *is* the frame, and it
+  would have painted a matched sliver black rather than magenta.)
+
+**The share is a share.** Only the *outermost* matches are accumulated: a
+match inside a match is highlighted, but its value is not added twice, so the
+percentage cannot exceed 100. This is async-profiler's `totalMarked()`
+dedupe, done as a single pre-order sweep because our items are already in
+pre-order. `nav` is that same set, so `N` never walks you to a frame nested
+inside the frame you are already looking at. The count `n` is every matching
+frame and the value `v` is the outermost ones — two different questions, both
+answered.
+
+**The count is over the profile, not over the visible graph.** A count and a
+share that changed when you zoomed would be answering a different question
+from the one the reader asked. This also simplified `zoom()` and `reset()`,
+which no longer re-run the search.
+
+### The colour, and the contrast floor
+
+async-profiler uses `#ee00ee`. **I did not**, because it fails the floor this
+branch is required to hold. `#ee00ee` is `hsl(300 100% 46.7%)`; against
+`--frame-ink` it is 4.99:1 bare, but **3.13:1 once the hatch is composited at
+full coverage**, and a matched frame that is unsymbolized still carries its
+hatch — losing it would be losing an honesty signal to a search highlight.
+
+So the search fill is the same hue at the lightness the floor allows:
+
+```css
+--fill-match: hsl(300 100% 71%);
+```
+
+| | contrast vs `--frame-ink` |
+|---|---|
+| bare | **7.49:1** |
+| hatched, light theme (α .26) | **4.56:1** |
+| hatched, dark theme (α .20) | **5.15:1** |
+
+70% gives 4.46:1 and fails; 71% is the first rung that passes. It is
+**not exempt** and `TestTheSearchColourIsLegibleAndReservedToSearch` walks it
+in both themes at both hatch alphas.
+
+It is deliberately **outside** the themed `--fill-*` family — no `--fill-dl`,
+no `--fill-ds` — for the same reason `--frame-ink` is: it is a signal, not a
+layer, and a signal that shifted with the page would have to be re-proved
+twice. The dark-theme block is asserted not to mention it. It is also off the
+jitter ladder: `.frame.match` sets `background-color` directly, so a reserved
+colour is exactly one colour. And it is in the legend, named as
+"Not a domain", so the page says out loud that one of its colours means
+something else.
+
+The jitter guarantee is untouched — `worst(all rungs) == worst(rung 0)` still
+passes, because nothing about the ladder or the fills moved.
+
+## The keyboard map
+
+| key | action |
+|---|---|
+| `I` | invert: root at top |
+| `T` | tree view |
+| `Ctrl+F` / `Cmd+F` | reveal and focus the search field |
+| `N` / `Shift+N` | next / previous match (Enter / Shift+Enter inside the field) |
+| `0` | reset zoom |
+| `Esc` | close the panel, else clear and hide search, else reset zoom |
+| `D` | light / dark |
+| `?` | info panel |
+| click a frame / the background | zoom / reset |
+
+`I` was ours for the info panel and is theirs for invert. **Theirs wins**; the
+panel is `?` alone and is also two clicks away on the ⓘ button, which is how
+async-profiler reaches its legend. The panel's own Keys list is regenerated
+from the same table, and a test asserts every key in that list is a key the
+script actually handles — the panel is the only place these are discoverable,
+so a map that drifted from the code would be worse than no map.
+
+Two buttons joined the top bar, ⇅ (invert) and ☰ (tree), with `title`s naming
+their keys, next to the existing ⓘ and ◐.
+
+## The byte cost
+
+Rendered from `/home/diego/gpu-cuda-45.pb.gz` (RTX 3090, 4,000 samples, 3
+stacks, 20 frames, 17 depths). **23,369 B → 29,304 B, +5,935 (+25.4%).**
+
+| block | before | after | delta | what arrived |
+|---|---:|---:|---:|---|
+| the graph | 4,304 | 4,304 | **+0** | the tree is built from these frames, so not one byte of the new views is per-frame markup |
+| `<style>` | 7,823 | 8,937 | **+1,114** | treeCSS 1,062; the two icicle rules +76; `--fill-match`, `.frame.match`, `.frame.cur`, `.sw[data-domain]` +91. Against that, the depth ladder got 21 B shorter and dropping `.frame` from eleven domain selectors saved 84 |
+| `<script>` | 4,867 | 8,964 | **+4,097** | the tree builder and its lazy/chain expansion (~2,050), reveal-in-tree and the nav/step machinery (~1,050), the parent-link and self-time pass (~450), invert (~180), the search rework (~370) |
+| info panel | 5,499 | 5,918 | **+419** | three more key rows, one more legend row |
+| chrome | 876 | 1,181 | **+305** | two buttons (244) and the tree container (61) |
+
+**The script more than doubled and that is where the whole cost is.** A tree
+view is a second renderer; it does not get cheaper than that while the brief
+says keep the DOM. The one thing I would not trade for bytes is where the
+tree's data comes from: emitting rows from Go instead would have been maybe
+600 B of simpler script and **+3,900 B of markup on this profile alone**,
+scaling with frame count, since every symbol would be on the page twice.
+
+**The degenerate page is byte-identical, 6,805 B before and after** — `diff`
+clean. That is why treeCSS is its own constant emitted beside `paletteCSS`
+rather than living in `styleSheet`: a profile with nothing to draw has no
+tree to press `T` for and should not carry 1,062 bytes of rules for one.
+There is a test for it.
+
+## Nothing regressed — checked, not assumed
+
+- **Percentage geometry.** Chrome, `.chart` measures 776 / 1,256 / 1,966 px at
+  800 / 1,280 / 1,990 px windows (window minus the 24 px body padding), and
+  `documentElement.scrollWidth == clientWidth` at all three. `font-size`
+  11 px, frame height 17 px, row pitch 18 px, **identical at all three widths
+  and identical inverted**. The script still contains no `resize`,
+  `clientWidth`, `offsetWidth` or `getBoundingClientRect().width`; the tests
+  that assert this are unchanged and pass.
+- **The no-JS baseline.** With the `<script>` element deleted, PNG
+  screenshots are **byte-identical** (sha256) to the scripted page at 800,
+  1,280 and 1,990 px. The default view is still the unscripted one: no `inv`
+  class in the markup, chart not hidden, `#tree` empty and `hidden`. A new
+  test pins all of that, and the existing no-JS tests pass untouched.
+- **Accessibility.** Frames keep `role="img"` + `aria-label`; the chart keeps
+  `role="group"`. The tree container gets `role="group"` and a name for the
+  same reason. New semantics are argued above.
+- **Jitter's lighten-only guarantee.** `worst(all rungs) == worst(rung 0)`
+  still passes, unchanged.
+- **The rest.** The one-line `gpu_sample_period` note, the status bar, the
+  degenerate page, self-containment (no CDN, no external font — that test is
+  unchanged), and `html.EscapeString` on symbol names are all as they were.
+  The tree writes every string with `textContent`, never `innerHTML`.
+- `go build ./... && go vet ./... && go test ./... -count=1` — all packages
+  ok. `golangci-lint run --timeout=5m` — 0 issues.
+
+One rule I broke and then fixed: my first draft put explanatory comments
+*inside* the `script` constant, which assets.go's own header forbids —
+"a comment inside one of these constants is shipped to every reader of every
+page perf-agent writes". Moving them to Go comments saved **1,624 B**, and
+`TestTheShippedAssetsCarryNoProseComments` now enforces the rule that was
+previously only written down.
+
+## Verification actually performed
+
+Driven in headless Chrome 1280×900 over a hand-written CDP client
+(`Input.dispatchKeyEvent`), so the keys below were **really pressed**, not
+simulated with synthetic `KeyboardEvent`s:
+
+- `data-total="5987854"` and the synthetic root at `data-value="5987854"`,
+  before and after everything.
+- `I` → root moves from the bottom row to the top, hatching, jitter and
+  labels intact, `aria-label` updated. `I` again → every frame's `left` and
+  `width` string identical to the start. **Lossless.**
+- `T` → 3 rows, then 20 after expanding, matching the 20 frames exactly;
+  chart hidden, tree shown; `T` again → geometry identical to before.
+  Zoomed into `_start` then `T` → the tree is rooted at `_start`, 16 rows,
+  the whole corridor auto-opened.
+- `Ctrl+F`, typed `cuda` → `1 matched · 397.13 µs · 6.63%`, one magenta
+  frame at `rgb(255,107,255)`, 19 dimmed. `gpu:kernel` → 3 matched, and
+  `N` walked 1→2→3→1 and `Shift+N` walked back, zooming to each.
+- The share cannot exceed 100: searching `a` (which matches the root)
+  reports `15 matched · 5.99 ms · 100.00%`, not 700%.
+- `N` in the tree view expands the path and marks the row; a match outside
+  the tree's current root drops the tree back to the whole profile rather
+  than silently doing nothing (this was a bug I found this way and fixed).
+- `Esc` clears the field, hides it, clears the counter and drops every match
+  class. `?` opens the panel, `Esc` closes it, and `I` **does not** open it
+  any more — it inverts.
+- Both themes: `D`, then all three views screenshotted. Tree swatches follow
+  the dark knobs (`root` 210,207,203 → 189,184,178); the magenta and its ink
+  do not move, by design.
+- Firefox 150 headless: flame graph, icicle and tree + search all render
+  correctly, including `calc(var(--d)*18px)`, the hatches and the magenta.
+
+## What I could not verify
+
+- **No Safari or WebKit, at all.** Chrome 1xx and Firefox 150, both headless,
+  both on this machine. No Windows, no mobile. `hsl(from …)` and
+  `calc(var(--d)*18px)` are both old enough that I expect Safari fine, but I
+  did not see it.
+- **Firefox was screenshotted, not driven.** I have no marionette client, so
+  the Firefox icicle and tree were produced by pre-setting the state in the
+  markup and by an appended bootstrap script — which exercises the CSS (the
+  part that differs by engine) but **not one Firefox keypress**. `I`, `T`,
+  `N` and `?` have only ever been pressed in Chrome.
+- **No screen reader.** The tree's semantics are argued from the HTML-AAM
+  mapping and from `<details>` being spec behaviour, not from listening to
+  it. Nobody has run NVDA, JAWS, VoiceOver or Orca over this page. In
+  particular I have not confirmed that a nested `<ul>` of `<details>` is
+  navigable in practice at fourteen levels of nesting, which is what this
+  profile produces — deep nesting is exactly where my "a list is honest
+  enough" argument is weakest, and it is untested.
+- **No real pointer and no real window.** Clicking a tree row to expand it,
+  dragging a window edge to watch the icicle reflow, and scrolling a tree
+  taller than the viewport were all verified by reading the code, by
+  measuring at fixed widths, or by dispatching events — not by using them.
+  `scrollIntoView` in particular has never been watched.
+- **Only one profile.** 20 frames, 17 depths, 3 stacks. The tree's lazy
+  build, the chain-expansion and the `N`-through-many-matches path are all
+  designed for a 20,000-frame system-wide profile and **none of them has seen
+  one**. I did not render one. The performance claim ("builds the rows
+  someone looked at") is a property of the code, not a measurement.
+- **The tree has no keyboard navigation of its own** beyond Tab. That is the
+  deliberate consequence of not claiming `role="tree"`, but it means a
+  keyboard user tabs through every visible row to reach the bottom of a deep
+  tree. `N` is the only fast way down, and only when a search is active.
+- **Icon glyphs depend on the reader's fonts.** ⇅ (U+21C5) and ☰ (U+2630)
+  rendered correctly in Chrome and Firefox here; I cannot promise them on a
+  machine without a font that covers them. Both buttons carry `aria-label`
+  and `title`, so the meaning survives a missing glyph even if the picture
+  does not.
+- **Two dead buttons with JavaScript off.** ⇅ and ☰ do nothing on an
+  unscripted page, as ◐ already did. Screenshots stay byte-identical because
+  a button renders the same either way, so the pinned property holds, but it
+  is a wart and I am naming it rather than hiding it.
+- **Theme is still not persisted**, and the tree's expansion state is lost on
+  `T`-off/`T`-on if the zoom root changed.

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -98,6 +98,37 @@ th{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--mu
 .lv{display:inline-block;margin:0 8px 2px 0;white-space:nowrap}
 `
 
+// treeCSS is the tree view's own rules, kept out of styleSheet because a
+// degenerate profile has no tree to press T for and should not carry 1.1 KB
+// of rules for one. Same reasoning as reportCSS, which the graph page does
+// not carry either.
+//
+// A row is a native <summary> inside a <details>, so the triangle is CSS on
+// ::before rather than an aria-expanded the script has to keep in sync, and
+// the marker the UA would draw is suppressed. The percentage and the value
+// are fixed-width columns so the numbers line up down the page; the swatch
+// takes its colour from the same [data-domain] rules the frames use, which
+// is why those rules are not scoped to .frame.
+const treeCSS = `
+#tree{margin:8px 0 0;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px}
+#tree ul{list-style:none;margin:0;padding:0 0 0 15px}
+#tree>ul{padding-left:0}
+#tree li{white-space:nowrap}
+#tree summary,#tree .leaf{display:block;padding:1px 3px;border-radius:3px;list-style:none}
+#tree summary{cursor:pointer}
+#tree .leaf{padding-left:16px}
+#tree summary::-webkit-details-marker{display:none}
+#tree summary::before{content:"\25B8";display:inline-block;width:13px;color:var(--muted)}
+#tree details[open]>summary::before{content:"\25BE"}
+#tree summary:hover,#tree .leaf:hover{background:var(--line)}
+#tree summary:focus-visible{outline:2px solid var(--accent)}
+#tree .p{display:inline-block;width:5em;text-align:right;color:var(--muted)}
+#tree .v{display:inline-block;width:8.5em;text-align:right;color:var(--muted);padding-right:9px}
+#tree .sw{width:10px;height:10px;margin-right:5px}
+#tree .m{background:var(--fill-match);color:var(--frame-ink);border-radius:2px;padding:0 2px}
+#tree .cur{outline:2px solid var(--accent);outline-offset:-2px}
+`
+
 // reportCSS styles the page a degenerate profile gets: no graph, no status
 // bar, no info panel — a written report about why there is nothing to draw.
 // It is emitted only on that page, so the 99% case does not carry it.
@@ -212,26 +243,29 @@ const paletteCSS = `
   --edge-shim:         hsl(215 24% calc(46% + var(--fill-dl)));
 
   --frame-ink: hsl(30 12% 9%);
+  --fill-match: hsl(300 100% 71%);
 }
 @media (prefers-color-scheme: dark){:root:not([data-theme="light"]){` + darkKnobs + `}}
 :root[data-theme="dark"]{` + darkKnobs + `}
 
 .frame{color:var(--frame-ink);background-color:var(--fill-x);background-color:hsl(from var(--fill-x) h s calc(l + var(--fill-j)));box-shadow:inset 0 0 0 .5px var(--edge-frame)}
-.frame[data-domain="root"]{--fill-x:var(--fill-root)}
-.frame[data-domain="app"]{--fill-x:var(--fill-app)}
-.frame[data-domain="system"]{--fill-x:var(--fill-system)}
-.frame[data-domain="kernel"]{--fill-x:var(--fill-kernel)}
-.frame[data-domain="vendor"]{--fill-x:var(--fill-vendor)}
-.frame[data-domain="unsym"]{--fill-x:var(--fill-unsym);background-image:var(--hatch-gap)}
-.frame[data-domain="gpu-kernel"]{--fill-x:var(--fill-gpu-kernel)}
-.frame[data-domain="shim"]{--fill-x:var(--fill-shim);box-shadow:inset 0 0 0 1px var(--edge-shim)}
-.frame[data-domain="boundary"]{--fill-x:var(--fill-boundary);box-shadow:inset 0 0 0 1px var(--edge-boundary)}
-.frame[data-domain="boundary-unattributed"]{--fill-x:var(--fill-boundary-unattributed);background-image:var(--hatch-gap);box-shadow:none;outline:1px dashed var(--edge-unattributed);outline-offset:-1px}
+[data-domain="root"]{--fill-x:var(--fill-root)}
+[data-domain="app"]{--fill-x:var(--fill-app)}
+[data-domain="system"]{--fill-x:var(--fill-system)}
+[data-domain="kernel"]{--fill-x:var(--fill-kernel)}
+[data-domain="vendor"]{--fill-x:var(--fill-vendor)}
+[data-domain="unsym"]{--fill-x:var(--fill-unsym);background-image:var(--hatch-gap)}
+[data-domain="gpu-kernel"]{--fill-x:var(--fill-gpu-kernel)}
+[data-domain="shim"]{--fill-x:var(--fill-shim);box-shadow:inset 0 0 0 1px var(--edge-shim)}
+[data-domain="boundary"]{--fill-x:var(--fill-boundary);box-shadow:inset 0 0 0 1px var(--edge-boundary)}
+[data-domain="boundary-unattributed"]{--fill-x:var(--fill-boundary-unattributed);background-image:var(--hatch-gap);box-shadow:none;outline:1px dashed var(--edge-unattributed);outline-offset:-1px}
 .frame.inexact{background-image:var(--hatch-inf)}
 .frame.inexact[data-domain="unsym"],.frame.inexact[data-domain="boundary-unattributed"]{background-image:var(--hatch-gap),var(--hatch-inf)}
 
 .frame:hover{box-shadow:inset 0 0 0 1.4px var(--frame-ink);outline:none}
-.frame.match{box-shadow:inset 0 0 0 1.8px var(--frame-ink);outline:none}
+.frame.match{background-color:var(--fill-match)}
+.frame.cur{box-shadow:inset 0 0 0 1.8px var(--frame-ink);outline:none}
+.sw[data-domain]{background-color:var(--fill-x)}
 `
 
 // The jitter ladder. jitterSteps shades per domain, evenly spaced from 0 to
@@ -266,19 +300,25 @@ func buildJitterCSS() string {
 	return b.String()
 }
 
-// rowCSS is the vertical half of the geometry: one rule per depth, offset
-// from the bottom of the chart because a flame graph grows upward from its
-// root. It is a rule per depth rather than an inline top on every frame
-// because a profile has far more frames than it has depths — 20 frames over
-// 17 depths here, but 20,000 over 60 in anything real.
+// rowCSS is the vertical half of the geometry: one rule per depth, and the
+// two rules that turn a depth into an offset.
 //
-// Measured from the bottom, so a depth means the same number of pixels
-// whatever the profile's height; measured from the top it would depend on
-// maxDepth, and the same class would mean two different things in two pages.
+// A depth class carries a NUMBER, not an offset — .d3{--d:3} — and the frame
+// multiplies it by the row pitch. That indirection is what buys the icicle:
+// the flame graph offsets from the bottom because it grows upward from its
+// root, the icicle offsets from the top because it grows downward from it,
+// and the difference is one extra rule rather than a second ladder of
+// per-depth offsets. It is also shorter than the offsets were — ".d59{--d:59}"
+// against ".d59{bottom:1062px}" — and a profile has far more frames than
+// depths, which is why the depth is a class at all and not an inline style.
+//
+// Both rules are in px and neither mentions the window, so the row pitch is
+// the same number of pixels at 800px and at 1990px, in either direction.
 func rowCSS(maxDepth int) string {
 	var b strings.Builder
+	fmt.Fprintf(&b, ".frame{bottom:calc(var(--d)*%dpx)}\n.inv .frame{bottom:auto;top:calc(var(--d)*%dpx)}\n", frameHeight, frameHeight)
 	for d := range maxDepth {
-		fmt.Fprintf(&b, ".d%d{bottom:%dpx}", d, d*frameHeight)
+		fmt.Fprintf(&b, ".d%d{--d:%d}", d, d)
 	}
 	b.WriteByte('\n')
 	return b.String()
@@ -298,6 +338,36 @@ func rowCSS(maxDepth int) string {
 //     resize because nothing in it was ever in pixels.
 //   - fmt() mirrors flamegraph.FormatValue exactly: never invent a unit the
 //     profile did not give, and never call nanoseconds "samples".
+//
+// The three views it adds to that:
+//
+// toggleInvert is async-profiler's I, and theirs is a visual flip: the same
+// tree, drawn from the top down. It merges nothing and aggregates nothing —
+// the callee-centric reverse merge is their converter's --reverse flag,
+// which builds a different tree before the page exists. So inverting here is
+// one class on the chart, which swaps every frame's offset from bottom to
+// top (see rowCSS); no width, no value and no zoom is touched, and inverting
+// twice is the page it started as.
+//
+// buildTree reconstructs the call tree from the frames already in the
+// document. A frame carries its depth as a class and writeNode emits frames
+// in pre-order, so depth plus document order is a parent link — which means
+// the tree view costs no markup at all until someone presses T, and no
+// symbol is ever on the page twice. Rows are made when their parent first
+// opens, so a 20,000-frame profile builds the rows someone looked at; a
+// frame with exactly one child opens all the way through, because this
+// profile's CPU path is a corridor fourteen frames long with no doors off
+// it and clicking fourteen times down it is not navigation.
+//
+// applySearch counts over the whole profile, not over what the zoom happens
+// to show: a count and a share that changed when you zoomed would answer a
+// different question from the one the reader asked. nav holds only the
+// OUTERMOST matches — a match inside a match is highlighted but not walked
+// to, and its value is not added a second time, so the share can never
+// exceed 100%. Stepping (N, Shift+N, and Enter from inside the field, which
+// swallows N) zooms the flame view to the match or reveals it in the tree.
+// A match outside the tree's current root has no row to scroll to, so the
+// tree drops back to the whole profile rather than doing nothing.
 const script = `
 (function(){
 "use strict";
@@ -307,15 +377,33 @@ if(!chart){return;}
 var info=doc.getElementById("info");
 var st=doc.getElementById("st"),mc=doc.getElementById("mc");
 var q=doc.getElementById("q"),tip=doc.getElementById("tip");
+var tree=doc.getElementById("tree");
 var unit=chart.dataset.unit||"",total=+chart.dataset.total||0;
 var idle=st.textContent,zoomTarget=null;
+var axis=chart.getAttribute("aria-label");
+var inverted=false,treeOn=false,treeRoot=null;
+var nav=[],navIdx=-1,cur=null,tally="";
 
 var items=[].map.call(chart.querySelectorAll(".frame"),function(el){
   var name=el.textContent;
   return {el:el,name:name,lower:name.toLowerCase(),
+    d:+/(?:^| )d(\d+)(?: |$)/.exec(el.className)[1],
     value:+el.dataset.value||0,inexact:+el.dataset.inexact||0,
-    x:parseFloat(el.style.left),w:parseFloat(el.style.width),shown:true};
+    x:parseFloat(el.style.left),w:parseFloat(el.style.width),shown:true,kids:[]};
 });
+(function(){
+  var stack=[];
+  items.forEach(function(it){
+    stack.length=it.d;
+    if(it.d>0){it.up=stack[it.d-1];it.up.kids.push(it);}
+    stack.push(it);
+  });
+  items.forEach(function(it){
+    it.kids.sort(function(a,b){return b.value-a.value;});
+    it.self=it.value;
+    it.kids.forEach(function(c){it.self-=c.value;});
+  });
+})();
 
 function grouped(n){
   var s=String(Math.round(n)),out="",i;
@@ -347,6 +435,7 @@ function place(it,x,w,vis){
 function line(it){return it.name+"  ·  "+fmt(it.value)+"  ·  "+pct(it.value)+" of total";}
 function detail(it){
   var s=line(it),d=it.el.dataset;
+  if(it.kids.length&&it.self>0){s+="\nself: "+fmt(it.self);}
   if(d.module){s+="\nmodule: "+d.module;}
   if(it.inexact>0){s+="\n"+fmt(it.inexact)+" of this is attributed by inference, not measurement";}
   if(d.domain==="unsym"){s+="\nno symbol: the unwind found this frame, nothing could name it";}
@@ -367,7 +456,6 @@ function showTip(evt,it){
 function reset(){
   zoomTarget=null;
   items.forEach(function(it){place(it,it.x,it.w,true);});
-  applySearch(q.value);
   status(null);
 }
 function zoom(target){
@@ -380,26 +468,144 @@ function zoom(target){
     if(it.x>=target.x&&end<=tEnd){place(it,(it.x-target.x)*ratio,it.w*ratio,true);return;}
     place(it,it.x,it.w,false);
   });
-  applySearch(q.value);
   status(null);
 }
-function applySearch(query){
-  var s=(query||"").trim().toLowerCase(),n=0,v=0;
+
+function applySearch(){
+  var s=q.value.trim().toLowerCase(),n=0,v=0,end=-1,keep=cur;
+  nav=[];
   items.forEach(function(it){
     var hit=s!==""&&it.lower.indexOf(s)!==-1;
-    it.el.classList.toggle("match",hit&&it.shown);
-    it.el.classList.toggle("dim",s!==""&&it.shown&&!hit);
-    if(hit&&it.shown){n++;v+=it.value;}
+    it.hit=hit;
+    it.el.classList.toggle("match",hit);
+    it.el.classList.toggle("dim",s!==""&&!hit);
+    it.el.classList.remove("cur");
+    if(it.nm){it.nm.classList.toggle("m",hit);}
+    if(it.head){it.head.classList.remove("cur");}
+    if(hit){
+      n++;
+      if(it.x>=end){nav.push(it);v+=it.value;end=it.x+it.w;}
+    }
   });
-  mc.textContent=s===""?"":(n===0?"no match":grouped(n)+" matched · "+fmt(v)+" · "+pct(v));
+  tally=s===""?"":(n===0?"no match":grouped(n)+" matched · "+fmt(v)+" · "+pct(v));
+  navIdx=keep?nav.indexOf(keep):-1;
+  cur=navIdx<0?null:keep;
+  if(cur){markCur();}
+  showTally();
 }
+function showTally(){
+  mc.textContent=tally+(cur?" ("+(navIdx+1)+" of "+nav.length+")":"");
+}
+function markCur(){
+  cur.el.classList.add("cur");
+  if(cur.head){cur.head.classList.add("cur");}
+}
+function stepMatch(dir){
+  if(nav.length===0){return;}
+  if(cur){cur.el.classList.remove("cur");if(cur.head){cur.head.classList.remove("cur");}}
+  navIdx=(navIdx+dir+nav.length)%nav.length;
+  cur=nav[navIdx];
+  if(treeOn){revealInTree(cur);}else{zoom(cur);cur.el.scrollIntoView({block:"center"});}
+  markCur();
+  status(cur);
+  showTally();
+}
+function openSearch(){q.hidden=false;q.focus();q.select();}
+function closeSearch(){q.value="";cur=null;applySearch();q.hidden=true;q.blur();}
+
 function toggleInfo(){info.open=!info.open;}
 function toggleTheme(){
   var dark=root.dataset.theme?root.dataset.theme==="dark":matchMedia("(prefers-color-scheme: dark)").matches;
   root.dataset.theme=dark?"light":"dark";
 }
-function openSearch(){q.hidden=false;q.focus();q.select();}
-function closeSearch(){q.value="";applySearch("");q.hidden=true;q.blur();}
+
+function toggleInvert(){
+  inverted=!inverted;
+  chart.classList.toggle("inv",inverted);
+  chart.setAttribute("aria-label",inverted?axis+", inverted: root at top":axis);
+  tip.hidden=true;
+}
+
+function toggleTree(){
+  treeOn=!treeOn;
+  if(treeOn){buildTree();}
+  tip.hidden=true;
+  tree.hidden=!treeOn;
+  chart.hidden=treeOn;
+}
+function buildTree(){
+  var r=zoomTarget||items[0];
+  if(treeRoot===r){return;}
+  treeRoot=r;
+  items.forEach(function(it){it.det=it.head=it.nm=it.filled=null;});
+  tree.textContent="";
+  var ul=doc.createElement("ul");
+  ul.appendChild(makeRow(r));
+  tree.appendChild(ul);
+  expand(r);
+}
+function makeRow(it){
+  var li=doc.createElement("li"),head;
+  if(it.kids.length){
+    var det=doc.createElement("details");
+    head=doc.createElement("summary");
+    det.appendChild(head);
+    det.addEventListener("toggle",function(){if(det.open){expand(it);}});
+    li.appendChild(det);
+    it.det=det;
+  }else{
+    head=doc.createElement("div");
+    head.className="leaf";
+    li.appendChild(head);
+  }
+  var sw=doc.createElement("span");
+  sw.className="sw";
+  sw.dataset.domain=it.el.dataset.domain||"";
+  sw.setAttribute("aria-hidden","true");
+  var p=doc.createElement("span");
+  p.className="p";
+  p.textContent=pct(it.value);
+  var v=doc.createElement("span");
+  v.className="v";
+  v.textContent=fmt(it.value);
+  var nm=doc.createElement("span");
+  nm.textContent=it.name;
+  if(it.hit){nm.className="m";}
+  head.appendChild(p);
+  head.appendChild(v);
+  head.appendChild(sw);
+  head.appendChild(nm);
+  head.title=detail(it);
+  it.head=head;
+  it.nm=nm;
+  if(cur===it){head.classList.add("cur");}
+  return li;
+}
+function expand(it){
+  if(!it.kids.length){return;}
+  if(!it.filled){
+    it.filled=true;
+    var ul=doc.createElement("ul");
+    it.kids.forEach(function(c){ul.appendChild(makeRow(c));});
+    it.det.appendChild(ul);
+  }
+  it.det.open=true;
+  if(it.kids.length===1){expand(it.kids[0]);}
+}
+function revealInTree(it){
+  var chain=[],p=it;
+  while(p&&p!==treeRoot){chain.push(p);p=p.up;}
+  if(p!==treeRoot){
+    treeRoot=null;
+    zoomTarget=null;
+    buildTree();
+    return revealInTree(it);
+  }
+  chain.push(treeRoot);
+  chain.reverse();
+  chain.forEach(function(o,i){if(i<chain.length-1){expand(o);}});
+  if(it.head){it.head.scrollIntoView({block:"center"});}
+}
 
 items.forEach(function(it){
   it.el.addEventListener("click",function(e){e.stopPropagation();zoom(it);});
@@ -408,8 +614,10 @@ items.forEach(function(it){
   it.el.addEventListener("mouseleave",function(){tip.hidden=true;status(null);});
 });
 chart.addEventListener("click",function(e){if(e.target===chart){reset();}});
-q.addEventListener("input",function(e){applySearch(e.target.value);});
+q.addEventListener("input",function(){cur=null;applySearch();});
 doc.getElementById("theme-btn").addEventListener("click",toggleTheme);
+doc.getElementById("inv-btn").addEventListener("click",toggleInvert);
+doc.getElementById("tree-btn").addEventListener("click",toggleTree);
 doc.getElementById("close").addEventListener("click",function(){info.open=false;});
 doc.addEventListener("click",function(e){
   if(info.open&&!info.contains(e.target)){info.open=false;}
@@ -422,10 +630,18 @@ doc.addEventListener("keydown",function(e){
     else{reset();}
     return;
   }
-  if(e.ctrlKey||e.metaKey||e.altKey||doc.activeElement===q){return;}
+  if(doc.activeElement===q){
+    if(e.key==="Enter"){e.preventDefault();stepMatch(e.shiftKey?-1:1);}
+    return;
+  }
+  if(e.ctrlKey||e.metaKey||e.altKey){return;}
   if(e.key==="0"){reset();}
   else if(e.key==="d"||e.key==="D"){toggleTheme();}
-  else if(e.key==="?"||e.key==="i"||e.key==="I"){toggleInfo();}
+  else if(e.key==="i"||e.key==="I"){toggleInvert();}
+  else if(e.key==="t"||e.key==="T"){toggleTree();}
+  else if(e.key==="n"){stepMatch(1);}
+  else if(e.key==="N"){stepMatch(-1);}
+  else if(e.key==="?"){toggleInfo();}
 });
 reset();
 })();

--- a/internal/flamegraph/palette_test.go
+++ b/internal/flamegraph/palette_test.go
@@ -169,7 +169,7 @@ func TestPaletteDeclaresATokenForEveryDomain(t *testing.T) {
 func TestEveryDomainKeyIsSelectedByARule(t *testing.T) {
 	for d := Domain(0); d < numDomains; d++ {
 		info := d.Info()
-		sel := fmt.Sprintf(`.frame[data-domain="%s"]{--fill-x:%s`, info.Key, info.Fill)
+		sel := fmt.Sprintf(`[data-domain="%s"]{--fill-x:%s`, info.Key, info.Fill)
 		assert.Contains(t, paletteCSS, sel, "no rule paints domain %q", info.Key)
 	}
 }
@@ -265,9 +265,9 @@ func TestTheTwoBoundariesStayTellableApart(t *testing.T) {
 	assert.Greater(t, tokens["fill-boundary-unattributed"].l, tokens["fill-boundary"].l+5,
 		"the unattributed boundary must be visibly paler")
 	assert.NotEmpty(t, DomainBoundaryUnattributed.Info().Overlay, "and hatched")
-	assert.Contains(t, paletteCSS, `.frame[data-domain="boundary-unattributed"]{--fill-x:var(--fill-boundary-unattributed);background-image:var(--hatch-gap);box-shadow:none;outline:1px dashed var(--edge-unattributed);outline-offset:-1px}`,
+	assert.Contains(t, paletteCSS, `[data-domain="boundary-unattributed"]{--fill-x:var(--fill-boundary-unattributed);background-image:var(--hatch-gap);box-shadow:none;outline:1px dashed var(--edge-unattributed);outline-offset:-1px}`,
 		"and dashed, because there is nothing behind it")
-	assert.NotContains(t, paletteCSS, `.frame[data-domain="boundary"]{--fill-x:var(--fill-boundary);box-shadow:inset 0 0 0 1px var(--edge-boundary);outline`)
+	assert.NotContains(t, paletteCSS, `[data-domain="boundary"]{--fill-x:var(--fill-boundary);box-shadow:inset 0 0 0 1px var(--edge-boundary);outline`)
 }
 
 // Frame labels are drawn on the fills. Gregg's palette was designed for a
@@ -358,7 +358,7 @@ func TestInkAndFrameOutlinesDoNotFollowThePageTheme(t *testing.T) {
 		"the page's ink inverts with the page; a frame's does not")
 	assert.Contains(t, paletteCSS, ".frame{color:var(--frame-ink)")
 	assert.Contains(t, paletteCSS, ".frame:hover{box-shadow:inset 0 0 0 1.4px var(--frame-ink)")
-	assert.Contains(t, paletteCSS, ".frame.match{box-shadow:inset 0 0 0 1.8px var(--frame-ink)")
+	assert.Contains(t, paletteCSS, ".frame.cur{box-shadow:inset 0 0 0 1.8px var(--frame-ink)")
 }
 
 // A hatch used to be an SVG <pattern> painted by a second <rect> per frame.
@@ -371,7 +371,7 @@ func TestEveryHatchedDomainIsActuallyHatchedByARule(t *testing.T) {
 		if info.Overlay == "" {
 			continue
 		}
-		assert.Contains(t, paletteCSS, fmt.Sprintf(`.frame[data-domain="%s"]{--fill-x:%s;background-image:%s`, info.Key, info.Fill, info.Overlay),
+		assert.Contains(t, paletteCSS, fmt.Sprintf(`[data-domain="%s"]{--fill-x:%s;background-image:%s`, info.Key, info.Fill, info.Overlay),
 			"domain %q says it is hatched but no rule hatches it", info.Key)
 		assert.Contains(t, paletteCSS, strings.TrimSuffix(strings.TrimPrefix(info.Overlay, "var("), ")")+":",
 			"domain %q names a hatch token the stylesheet does not declare", info.Key)
@@ -399,4 +399,54 @@ func TestFrameOutlinesAreNeverLaidOut(t *testing.T) {
 	}
 	assert.Contains(t, paletteCSS, "outline:1px dashed var(--edge-unattributed);outline-offset:-1px",
 		"the one dashed outline needs outline, which box-shadow cannot do — but it still must not be laid out")
+}
+
+// Magenta is the only colour on the page that does not mean "domain", and it
+// has to clear the same floor as the ones that do: a matched frame still has
+// a label on it, and a matched frame that is unsymbolized still has a hatch
+// over it. It is deliberately outside the themed --fill-* family — it is a
+// signal, not a layer, so it must not shift when the page does — which means
+// the light theme's heavier hatch is the binding case for both themes.
+func TestTheSearchColourIsLegibleAndReservedToSearch(t *testing.T) {
+	const matchH, matchS, matchL = 300, 100, 71
+	require.Contains(t, paletteCSS,
+		fmt.Sprintf("--fill-match: hsl(%d %d%% %d%%)", matchH, matchS, matchL),
+		"this test's magenta must be the magenta the page uses")
+
+	ink := hsl{frameInkH, frameInkS, frameInkL}
+	match := hsl{matchH, matchS, matchL}
+	assert.GreaterOrEqual(t, contrast(ink, match), 4.5,
+		"label ink on the search fill is %.2f:1", contrast(ink, match))
+	for _, alpha := range []float64{lightHatch, darkHatch} {
+		got := contrast(ink, overHatch(match, alpha))
+		assert.GreaterOrEqual(t, got, 4.5,
+			"label ink on a hatched search fill at hatch alpha %.2f is %.2f:1", alpha, got)
+	}
+
+	// It does not move with the theme, and no domain may spend it.
+	assert.NotContains(t, paletteCSS, "--fill-match: hsl(300 calc(",
+		"the search colour is a signal, not a palette member; the theme knobs must not touch it")
+	m := darkBlockRe.FindStringSubmatch(paletteCSS)
+	require.Len(t, m, 2)
+	assert.NotContains(t, m[1], "--fill-match")
+	assert.NotContains(t, paletteCSS, "]{--fill-x:var(--fill-match)")
+	for d := Domain(0); d < numDomains; d++ {
+		assert.NotEqual(t, "var(--fill-match)", d.Info().Fill, "domain %q took the search colour", d.Info().Key)
+	}
+	// Search paints the fill; only the one match N is standing on is outlined.
+	assert.Contains(t, paletteCSS, ".frame.match{background-color:var(--fill-match)}")
+	assert.NotContains(t, paletteCSS, ".frame.match{box-shadow")
+}
+
+// A domain is a domain wherever it is drawn. The tree view's swatches carry
+// data-domain and take their colour, their hatch and their outline from the
+// same rules the frames do, so a domain cannot come out one colour in the
+// graph and another in the tree.
+func TestDomainRulesAreNotFrameOnly(t *testing.T) {
+	for d := Domain(0); d < numDomains; d++ {
+		info := d.Info()
+		assert.NotContains(t, paletteCSS, fmt.Sprintf(`.frame[data-domain="%s"]{--fill-x:`, info.Key),
+			"domain %q paints only frames, so a tree swatch would have no colour", info.Key)
+	}
+	assert.Contains(t, paletteCSS, ".sw[data-domain]{background-color:var(--fill-x)}")
 }

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -127,6 +127,7 @@ func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
 		ew.s(paletteCSS)
 		ew.s(jitterCSS)
 		ew.s(rowCSS(maxDepth))
+		ew.s(treeCSS)
 	}
 	ew.s("</style>\n</head>\n<body>\n")
 
@@ -141,6 +142,7 @@ func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
 	if err := writeChart(ew, root, maxDepth, res); err != nil {
 		return err
 	}
+	writeTreeContainer(ew, res)
 	writeStatusBar(ew, res)
 	ew.s("<div id=\"tip\" hidden></div>\n")
 
@@ -519,6 +521,8 @@ func writeTopBar(ew *errWriter, opts Options, res *foldedstacks.Result, root *no
 	ew.esc(opts.Title)
 	ew.s("</h1>\n")
 	writeInfoPanel(ew, root, res, opts)
+	ew.s("<button id=\"inv-btn\" type=\"button\" title=\"Invert: root at top (I)\" aria-label=\"Invert the graph\">&#8645;</button>\n")
+	ew.s("<button id=\"tree-btn\" type=\"button\" title=\"Tree view (T)\" aria-label=\"Toggle the tree view\">&#9776;</button>\n")
 	ew.s("<button id=\"theme-btn\" type=\"button\" title=\"Light / dark (D)\" aria-label=\"Toggle light or dark\">&#9680;</button>\n")
 	ew.s("</div>\n")
 }
@@ -549,6 +553,24 @@ func samplePeriod(res *foldedstacks.Result) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// writeTreeContainer emits the empty box the tree view is built into.
+//
+// Empty, and hidden, because the tree is the same data the chart already
+// carries: the script reconstructs it from the frames' depth classes and
+// their document order, which is a pre-order walk. Emitting the rows from Go
+// as well would put every symbol on the page twice — the tree is the one
+// view here that is genuinely scripted, so it costs 61 bytes of markup and
+// nothing at all to a reader who never presses T.
+//
+// role="group" for the same reason the chart has it rather than role="img":
+// it takes an accessible name and leaves its children — a nested <ul> of
+// native <details> disclosures — exposed. See the report for why the tree is
+// a list of disclosures and not role="tree".
+func writeTreeContainer(ew *errWriter, res *foldedstacks.Result) {
+	ew.f("<div id=\"tree\" role=\"group\" aria-label=\"Call tree, %s\" hidden></div>\n",
+		html.EscapeString(res.SampleTypeName+"/"+res.Unit))
 }
 
 // writeStatusBar emits the single permanent line of text on the page. Its
@@ -587,11 +609,14 @@ func writeInfoPanel(ew *errWriter, root *node, res *foldedstacks.Result, opts Op
 
 	ew.s("<h2>Keys</h2>\n<ul class=\"keys\">\n")
 	for _, k := range [][2]string{
+		{"I", "invert: root at top"},
+		{"T", "tree view"},
 		{"Ctrl+F", "search frames"},
+		{"N / Shift+N", "next / previous match (Enter in the field)"},
 		{"0", "reset zoom"},
 		{"Esc", "close this, then clear search, then reset zoom"},
 		{"D", "light / dark"},
-		{"? or I", "this panel"},
+		{"?", "this panel"},
 	} {
 		ew.s("<li><kbd>")
 		ew.esc(k[0])
@@ -651,6 +676,7 @@ func writeLegend(ew *errWriter, root *node) {
 	} else {
 		ew.s("<li><span class=\"sw hatch\"></span><b>diagonal hatching</b> The frame has no symbol, or no CPU stack stands behind it. Hover the frame for which.</li>\n")
 	}
+	ew.s("<li><span class=\"sw\" style=\"background-color:var(--fill-match)\"></span><b>magenta</b> Not a domain: a frame matching the current search. It is the only colour on the page that means something other than which layer a frame belongs to, which is why nothing else uses it.</li>\n")
 	ew.s("</ul>\n")
 	if present[DomainGPUKernel] {
 		ew.s("<p class=\"muted\">A <code>[gpu:kernel:&hellip;]</code> frame is one kernel and its duration.</p>\n")

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -49,7 +49,8 @@ func TestRenderHTMLProducesAStandalonePage(t *testing.T) {
 		"<!DOCTYPE html>", "<html lang=\"en\">", "<title>GPU flame graph</title>",
 		"<div class=\"chart\"", ">main</div>", ">work</div>",
 		`id="status"`, `id="tip"`, `id="info"`, `id="q"`, `id="info-btn"`, `id="theme-btn"`,
-		"function zoom(target)", "function applySearch(query)",
+		`id="tree"`, `id="inv-btn"`, `id="tree-btn"`,
+		"function zoom(target)", "function applySearch()", "function buildTree()", "function toggleInvert()",
 	} {
 		assert.Contains(t, got, want)
 	}
@@ -549,11 +550,16 @@ func TestTypographyAndRowPitchAreFixedPixelsAtEveryWindowWidth(t *testing.T) {
 	assert.Contains(t, styleSheet, "font-size:11px")
 	assert.Contains(t, styleSheet, "height:17px")
 	assert.Contains(t, styleSheet, "line-height:17px")
-	// One rule per depth, offset from the floor: a depth is the same number
-	// of pixels up whatever the profile and whatever the window.
-	for d, top := range map[int]int{0: 0, 1: frameHeight, 3: 3 * frameHeight} {
-		assert.Contains(t, got, fmt.Sprintf(".d%d{bottom:%dpx}", d, top))
+	// One rule per depth, and one rule that turns a depth into an offset
+	// from the floor: a depth is the same number of pixels up whatever the
+	// profile and whatever the window. The pitch is a px literal in a
+	// stylesheet, so there is nothing in it for a window width to change.
+	for d := range 4 {
+		assert.Contains(t, got, fmt.Sprintf(".d%d{--d:%d}", d, d))
 	}
+	assert.Contains(t, got, fmt.Sprintf(".frame{bottom:calc(var(--d)*%dpx)}", frameHeight))
+	assert.Contains(t, got, fmt.Sprintf(".inv .frame{bottom:auto;top:calc(var(--d)*%dpx)}", frameHeight),
+		"the icicle is the same ladder measured from the other end")
 	assert.Contains(t, got, `class="frame d3 `, "the leaf sits three rows up")
 	assert.NotContains(t, got, ".d4{", "and there is no fourth row to sit on")
 }
@@ -620,11 +626,133 @@ func TestRenderFragmentCarriesTheGraphAndItsColoursAndNothingElse(t *testing.T) 
 	assert.Contains(t, got, `<div class="chart"`)
 	assert.Contains(t, got, `style="left:25%;width:75%"`, "the same percentage geometry as the page")
 	assert.Contains(t, got, "--fill-app:", "and its own palette, since a host page has none")
-	assert.Contains(t, got, ".d2{bottom:36px}")
+	assert.Contains(t, got, ".d2{--d:2}")
+	assert.Contains(t, got, fmt.Sprintf(".frame{bottom:calc(var(--d)*%dpx)}", frameHeight))
 	assert.Contains(t, got, "text-overflow:ellipsis", "including the rule that does the truncating")
 
 	// None of the page's chrome, and none of its interactivity.
 	for _, gone := range []string{"<script", "<!DOCTYPE", "id=\"status\"", "id=\"info\"", "Colour means domain"} {
 		assert.NotContains(t, got, gone)
+	}
+}
+
+// The three new views are scripted, and the page must not become one of them
+// by default: with the <script> deleted, a reader still gets the flame graph
+// — right way up, chart visible, tree box empty and hidden.
+func TestTheDefaultViewIsTheUnscriptedOne(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"main", "work"}, Value: 3000},
+		foldedstacks.Stack{Frames: []string{"main", "idle"}, Value: 1000},
+	), Options{})
+	body := got[strings.Index(got, "<body>"):strings.Index(got, "<script>")]
+
+	assert.Contains(t, body, `<div class="chart"`)
+	assert.NotContains(t, body, `class="chart inv`, "the icicle is a class the script adds, never the markup")
+	assert.NotContains(t, body, `<div class="chart" hidden`)
+	assert.Contains(t, body, `<div id="tree" role="group" aria-label="Call tree, gpu/nanoseconds`)
+	assert.Contains(t, body, `hidden></div>`, "the tree box is empty and hidden until T")
+	// Empty: the tree's rows are the frames the chart already carries, so
+	// nothing on the page is a second copy of a symbol.
+	assert.Equal(t, 1, strings.Count(got, ">work</div>"))
+	assert.Equal(t, 1, strings.Count(got, ">idle</div>"))
+	// Both directions of the ladder ship, so inverting needs no re-render.
+	assert.Contains(t, got, ".inv .frame{bottom:auto;top:")
+}
+
+// async-profiler's I is a visual flip: the same tree, drawn downward. It is
+// not a callee-centric reverse merge — that is their converter's --reverse
+// flag, which builds a different tree before the page exists. Ours matches,
+// which means the client must not be aggregating anything: inverting is a
+// class on the chart and the widths are untouched, so I and I again is the
+// page it started as.
+func TestInvertIsAVisualFlipAndMergesNothing(t *testing.T) {
+	assert.Contains(t, script, `chart.classList.toggle("inv",inverted)`)
+	// No second aggregation, no rebuilding of spans: the only writes to a
+	// frame's geometry are place(), which zoom and reset drive.
+	assert.Equal(t, 1, strings.Count(script, "it.el.style.left="),
+		"one place to write a frame's span, or inverting has grown a second layout")
+	assert.NotContains(t, script, "it.x=")
+	assert.NotContains(t, script, "it.w=")
+	assert.NotContains(t, script, "it.value=")
+	// The row ladder does the flip, and it is the same ladder both ways.
+	assert.Contains(t, rowCSS(4), ".frame{bottom:calc(var(--d)*18px)}")
+	assert.Contains(t, rowCSS(4), ".inv .frame{bottom:auto;top:calc(var(--d)*18px)}")
+}
+
+// The tree is the same data, so it is built from the frames rather than
+// emitted beside them: depth class plus document order is a pre-order walk,
+// and writeNode already emits one.
+func TestTheFramesCarryEnoughToRebuildTheTree(t *testing.T) {
+	got := renderString(t, result(
+		foldedstacks.Stack{Frames: []string{"main", "a", "deep"}, Value: 3000},
+		foldedstacks.Stack{Frames: []string{"main", "b"}, Value: 1000},
+	), Options{})
+
+	// Document order is the pre-order walk the script assumes.
+	order := regexp.MustCompile(`class="frame d(\d+)[^"]*"[^>]*>([^<]*)</div>`).FindAllStringSubmatch(got, -1)
+	require.Len(t, order, 5)
+	var seen []string
+	for _, m := range order {
+		seen = append(seen, m[1]+":"+m[2])
+	}
+	assert.Equal(t, []string{"0:all", "1:main", "2:a", "3:deep", "2:b"}, seen)
+
+	// And the value every row needs is already on the frame.
+	assert.Contains(t, got, `data-value="3000"`)
+	assert.Contains(t, script, "function buildTree()")
+	assert.Contains(t, script, "doc.createElement(\"details\")", "the tree's disclosure is native, not an aria-expanded we keep in sync")
+	assert.Contains(t, script, "doc.createElement(\"summary\")")
+
+	// The tree's rules ship with the graph page and only with it: a
+	// degenerate profile has no tree to press T for.
+	assert.Contains(t, got, "#tree summary::before")
+	var b strings.Builder
+	require.NoError(t, RenderHTML(&b, &foldedstacks.Result{SampleTypeName: "gpu", Unit: "nanoseconds"}, Options{}))
+	assert.NotContains(t, b.String(), "#tree", "the degenerate page must not carry the tree's stylesheet")
+}
+
+// Search grew a match count, a share of the total and N/Shift+N stepping.
+// The share must be a share: a match nested inside a match is highlighted,
+// but its value is not added a second time, or the page can report 140% of
+// the profile matching one word.
+func TestSearchCountsTheOutermostMatchesOnce(t *testing.T) {
+	assert.Contains(t, script, "if(it.x>=end){nav.push(it);v+=it.value;end=it.x+it.w;}")
+	assert.Contains(t, script, `grouped(n)+" matched · "+fmt(v)+" · "+pct(v)`)
+	assert.Contains(t, script, "function stepMatch(dir)")
+	assert.Contains(t, script, `" ("+(navIdx+1)+" of "+nav.length+")"`)
+	// The count is over the profile, not over what the zoom happens to show,
+	// so it answers the same question at every zoom level.
+	assert.NotContains(t, script, "if(hit&&it.shown)")
+}
+
+// The keyboard map is only discoverable from the panel, so the panel must
+// carry the map the script actually implements.
+func TestTheInfoPanelListsTheKeysTheScriptImplements(t *testing.T) {
+	got := renderString(t, result(foldedstacks.Stack{Frames: []string{"main"}, Value: 1}), Options{})
+	for _, k := range []string{"I", "T", "Ctrl+F", "N / Shift+N", "0", "Esc", "D", "?"} {
+		assert.Contains(t, got, "<kbd>"+html.EscapeString(k)+"</kbd>")
+	}
+	// I moved to invert, so the panel must no longer promise it opens this.
+	assert.NotContains(t, got, "<kbd>? or I</kbd>")
+	assert.NotContains(t, script, `e.key==="?"||e.key==="i"`)
+	assert.Contains(t, script, `e.key==="i"||e.key==="I"){toggleInvert()`)
+	assert.Contains(t, script, `e.key==="t"||e.key==="T"){toggleTree()`)
+	assert.Contains(t, script, `e.key==="?"){toggleInfo()`)
+}
+
+// Every byte of these constants is shipped to every reader of every page
+// perf-agent writes, so the prose that explains them lives in Go comments
+// beside them, not inside them. The rule is stated at the top of assets.go;
+// this is what keeps it true.
+func TestTheShippedAssetsCarryNoProseComments(t *testing.T) {
+	for name, asset := range map[string]string{
+		"script": script, "styleSheet": styleSheet, "paletteCSS": paletteCSS,
+		"reportCSS": reportCSS, "embedCSS": embedCSS, "jitterCSS": jitterCSS,
+	} {
+		for i, l := range strings.Split(asset, "\n") {
+			line := strings.TrimSpace(l)
+			assert.False(t, strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*"),
+				"%s line %d is a comment shipped to every reader; explain it in a Go comment instead: %s", name, i+1, line)
+		}
 	}
 }


### PR DESCRIPTION
Adds the three views from [async-profiler](https://github.com/async-profiler/async-profiler): invert/icicle, tree, and search brought up to their standard.

### What their Invert actually is — I checked rather than assumed

**A visual flip, not a reverse merge.** Their `I` handler sets `inverted = !inverted; render()`, and `inverted` reaches exactly one thing in the file: `const y = inverted ? h*16 : canvasHeight - (h+1)*16`. `levels[]` is never rebuilt.

The callee-centric merge does exist there, but as a **build-time** flag — `--reverse` in `FlameGraph.java`, which walks each stack backwards at insert time so leaves become roots. The two meet in one line: `out.print(args.reverse ^ args.inverted)`. So `--reverse` picks the tree and `I` picks which way up.

Implemented the flip, per matching their semantics. Where reverse-merge would belong here is noted in the report: `internal/foldedstacks`, not the client.

### The three views

**Icicle (`I`).** Depth classes now carry a number (`.d3{--d:3}`) and the frame multiplies by the pitch, so the flip is one extra CSS rule rather than a second ladder — *21 B shorter* than the old offsets on this profile, and negative cost past ~24 depths. Verified lossless: every frame's `left`/`width` string is identical after `I`, `I`.

**Tree (`T`).** Nested `&lt;ul&gt;` of native `&lt;details&gt;`/`&lt;summary&gt;` — deliberately **not `role="tree"`**, because a tree role promises roving focus and arrow keys, and one without them is worse than a list of buttons that genuinely announce expanded/collapsed. Built client-side from the frames already in the document (depth class + document order = pre-order), so it costs **61 B of markup and +0 B on the graph**: no symbol is on the page twice. Lazy rows, single-child chain expansion, rooted at the current zoom.

**Search.** Share-of-total, `N`/`Shift+N` (and Enter in the field, which swallows `N`), magenta fill. The share counts only outermost matches, so it cannot exceed 100%.

**Their `#ee00ee` was not used.** Hatched, it reads 3.13:1 against our frame ink — under the floor the palette work established. `hsl(300 100% 71%)` is the first lightness that clears it: 4.56:1 hatched light, 5.15:1 hatched dark, 7.49:1 bare. Theme-invariant, off the jitter ladder, with a test.

### Keys

`I` invert, `T` tree, `N`/`Shift+N` next/previous match, `Ctrl+F` search, `0` reset zoom, `Esc` cancel, `D` dark. Info moved off `I` to `?`. The panel's list is updated, and **a test asserts every listed key is one the script actually handles**.

### Cost

**23,369 → 29,304 B (+5,935, +25.4%)**: script +4,097, stylesheet +1,114, panel +419, chrome +305, **graph +0**. The degenerate page is byte-identical at 6,805 B — the tree CSS is emitted only where there is a tree.

### Constraints re-checked, not assumed

Chart fills 776/1256/1966 px at 800/1280/1990; font-size 11 px and row pitch 18 px identical at all three **and while inverted**; no-JS screenshots **byte-identical by sha256** at all three widths; jitter's `worst(all rungs) == worst(rung 0)` unchanged.

Two bugs found by driving the page with a hand-written CDP client and real key events: tree chain-expansion did not fire on the initial build, and `N` silently no-op'd for matches outside the zoom root. Both fixed. Also caught prose comments shipping inside the JS constant against `assets.go`'s own rule — moved to Go, saving 1,624 B, with a test enforcing it.

### Cannot verify

No Safari/WebKit at all. Firefox was screenshotted, never keyboard-driven. No screen reader — deep nesting is where the "a list is honest enough" argument is weakest, and it is untested. Only this 20-frame profile, so the lazy tree build has never met the 20k-frame case it is designed for. The tree has no arrow-key navigation, by design. And ⇅/☰ are dead buttons with JS off, as ◐ already was.