### PR TITLE
gpu: join correlation-less PC samples through the module, and mark how

### DIFF
--- a/.superpowers/sdd/task-8b-join-report.md
+++ b/.superpowers/sdd/task-8b-join-report.md
@@ -1,0 +1,458 @@
+# Task 8b — the `Snapshot` join, and `gpu_pc_attrib`
+
+Branch `feat/pc-snapshot-join`, one commit on top of Task 8a
+(`feat/pc-pending-module-index`, PR #80, itself one commit off `main`).
+
+Scope: attach correlation-less (Tier B / `CONTINUOUS`) PC samples to the
+executions they belong to, through the module, and decide the
+`gpu_pc_attrib` value for every PC-bearing execution. **Task 9 emits the
+label; this task only decides it** — `gpu/projection.go` is untouched.
+
+Five files: `gpu/timeline.go`, `gpu/modulestore.go`, `gpu/joinhealth.go` and
+the new `gpu/pcattrib.go`, plus tests in `gpu/pcjoin_test.go`,
+`gpu/modulestore_test.go` and `gpu/conformance_test.go`.
+
+---
+
+## 1. The join order
+
+`Snapshot`, per execution:
+
+1. **Exact-correlation index first, unchanged.** The existing
+   `t.pending[exec.Correlation]` pass runs exactly as it did. Tier A keeps
+   taking it and nothing in that path was modified — no new branch, no new
+   condition, no reordering. The only addition is an `exactServed []bool`
+   recording which executions it served.
+2. **Module-keyed join second, over what the first pass left unserved.**
+   `joinPendingModuleLocked` walks the `pendingModule` groups, resolves each
+   `{PID, CubinCRC, FunctionIndex}` to a device function name through
+   `ModuleStore.FunctionName`, and hands the group to an execution of that
+   kernel in the same process.
+
+Both passes run inside one hold of `t.mu`, so nothing can be created or
+evicted between them, which is what makes the group identity in §5 an
+identity rather than an approximation.
+
+An execution served by the exact index is **not** a candidate for the module
+join. `TestExactPathKeepsFirstClaim` pins it: a correlation-less group for
+the same kernel does not pile onto an exactly-joined execution, it waits for
+one of its own.
+
+**"In the horizon" means "in this snapshot."** The candidate set is the
+executions this `Snapshot` call drained. There is deliberately no time
+filter between a sample and an execution's `[StartNs, EndNs]`: CUPTI PC
+records carry no timestamp of their own, so `GPUPCSample.TimeNs` is the
+drain time the producer stamped, and filtering executions by it would be
+filtering on the wrong clock. The sample-side horizon
+(`PendingSampleHorizonNs`) is what bounds how stale a group may get, and it
+is unchanged.
+
+Where more than one execution qualifies, the group goes **whole** to the
+earliest by `StartNs` — not the first in ring order, which is drain order and
+not run order (`TestTierBAmbiguousGoesToTheEarliestExecution` emits them
+late-first to prove the difference). Splitting a group across candidates
+would manufacture a distribution the data does not contain and would make
+each resulting execution look individually more certain than the group is.
+The label carries the doubt instead.
+
+---
+
+## 2. The name-match rule, and what happens when it fails
+
+Kernel identity comes from the module. `ModuleStore` holds
+`functionIndex → function name`, read out of the cubin's `.symtab`; the
+execution carries `KernelName` from `gpu_kernel_name_v1`. The join is a
+**plain, exact string comparison** of those two, inside a map key that also
+carries the PID:
+
+```go
+type execKernelKey struct {
+	pid        uint32
+	kernelName string
+}
+```
+
+No demangling. No prefix or suffix trimming. No normalization of any kind.
+Every relaxation of this comparison is a way to attach a sample to a kernel
+that merely looks related, and the plan's rule is that identity comes from
+the module and never from guessing on the name string.
+
+**When the names do not match, the group stays pending.** It is not attached
+to a neighbour, not attached to the only execution in the snapshot, not
+attached to anything. It remains in `pendingModule`, is counted in
+`PCJoin.GroupsNoExecution`, and is eligible for a later `Snapshot` — the
+execution may simply not have arrived yet. If it never becomes joinable it
+ages out on the shared horizon into
+`Dropped.EvictedPendingModuleSamples`, which is where the loss is counted.
+
+`TestTierBKernelNameMismatchStaysPending` uses a name differing by one
+character, in the same process, on the same queue, at a time any windowed
+heuristic would have accepted — everything a "close enough" match would have
+taken. Relaxing the comparison to a prefix match fails it (mutation M2).
+
+**The PID is a field of the key, not a check beside it.** Two processes
+running the identical binary produce the identical cubin CRC and the
+identical function index; only the pid separates them, and issue #52's
+discipline says the refusal must be structural rather than a guard someone
+can edit out. `TestTierBJoinStaysWithinTheProcess` pins it; deleting the pid
+from either side of the key fails it (M3).
+
+A group whose PID is **zero** — the producer named no process — is refused
+outright and counted in `GroupsNoProcess`. Every such group from every
+process shares one key, so attaching one to an execution would attribute one
+process's GPU samples to another's call stack on nothing but a kernel name.
+
+---
+
+## 3. `gpu_pc_attrib`, and the de-overloading
+
+New type in `gpu/pcattrib.go`, new field `ExecutionView.PCAttrib`. Empty
+exactly when `PCSamples` is empty (there is nothing to describe); one of the
+four otherwise.
+
+| value | set when |
+| --- | --- |
+| `exact` | the sample carried a correlation value and joined through the correlation index |
+| `kernel` | joined through the module, exactly one execution of that kernel in the snapshot |
+| `kernel-ambiguous` | joined through the module, **more than one** execution of that kernel in the snapshot |
+| `kernel-multidevice` | joined through the module in a process observed running kernels on more than one device |
+
+Ambiguity is counted over **every** execution of that kernel in the
+snapshot, not only the ones the join was allowed to use: "how many
+invocations could these samples have come from" is a question about the
+horizon, not about which of them the exact pass happened to leave free.
+
+Precedence is `multidevice > ambiguous > kernel > exact` (`worsePCAttrib`),
+so an execution served by two groups of differing quality reports the worse
+of the two rather than whichever was processed last. Attribution quality is
+only ever revised downward.
+
+### The test that pins it
+
+`TestTierBAmbiguityIsMarkedWithoutTouchingAmbiguous`. Two executions of one
+kernel, one Tier B group. It asserts:
+
+- the receiving execution carries `PCAttribKernelAmbiguous`;
+- `view.Ambiguous` is **false** on every execution;
+- `projectionLabels(view)` contains **no** `gpu_ambiguous` key — asserted
+  through the projection, not only the struct field, because the struct
+  field is not what a consumer reads;
+- `JoinStats.AmbiguousHeuristicMatchCount` is **zero**.
+
+`ExecutionView.Ambiguous` is still set in exactly one place, the heuristic
+launch-join branch, and still counted only by
+`AmbiguousHeuristicMatchCount`. Making PC ambiguity also set it (mutation
+M5) fails this test.
+
+`PCAttrib` is set in `Snapshot`'s view loop in a `switch` that reads
+`exactServed[i]` and `len(view.PCSamples)` and nothing else — it never reads
+or writes `view.Join`, `view.Heuristic` or `view.Ambiguous`, and none of
+them reads it. An execution can be joined to its launch by vendor
+correlation, exactly, and still carry inferred PC samples; that is precisely
+the pair of facts one boolean could not carry.
+
+`PCAttrib.MarshalJSON` refuses anything that is not one of the four,
+**including the empty value**, matching `SrcStatus`, `ClockDomain` and
+`GPUCapability`. The field is `omitempty`, so a view with no PC samples never
+reaches that path. `PCAttribs()` returns the four in stable order (a copy) so
+Task 9's switch can be tested for exhaustiveness against the enum.
+
+### Multi-device detection
+
+`gpu_pc_sample_batch_v1` carries no device id and one binary has one cubin
+CRC on both devices, so the samples are indistinguishable on the wire. There
+is no way to make the join right; there is only a way to stop it from
+looking right.
+
+Detection is on **executions**, which do carry a device id
+(`Execution.DeviceID`, falling back to `Queue.Device.DeviceID`). `EmitExec`
+feeds `Timeline.devicesByPID`, which holds per process the first device id
+seen and whether a different one has since arrived — a decision, not an
+inventory.
+
+It is **cumulative, not per-snapshot**: the condition is a property of the
+process, and per-snapshot detection would clear the mark on exactly the
+snapshots where only one device happened to report, which is this project's
+recurring failure shape. It is **bounded** at
+`maxTrackedDeviceProcesses = 4096`, because a system-wide profile has no
+a-priori bound on distinct pids. Past the cap a new process is not admitted
+and is therefore treated as single-device — the right guess, and still a
+guess, so the refusal is counted in `PCJoin.DeviceTrackingCapped` and raised
+as a `joinhealth` anomaly rather than absorbed.
+`TestDeviceTrackingCapIsCountedNotSilent` drives it past the bound.
+
+An untracked process answers "not multi-device". Turning every unknown into
+a multidevice mark would bury the real ones.
+
+---
+
+## 4. `ModuleStore.FunctionName(crc, functionIndex) (string, bool)`
+
+Added with its tests, as Task 4's report asked.
+
+```go
+func (s *ModuleStore) FunctionName(crc uint64, functionIndex uint32) (string, bool)
+```
+
+**Why `Resolve` cannot answer this.** `Resolution` carries a function name
+only under `SrcResolved`, which is the four-valued status doing its job — a
+name paired with `no-lineinfo` would invite a caller to emit `gpu_src_func`
+for a module with no source information. But the continuous-mode chain is
+`cubin_crc → module → function → KERNEL`, and it needs the name whether or
+not `-lineinfo` was passed: a kernel built without it still has a name,
+still runs, and still owns its PC samples. Routing attribution through
+`Resolve` would make it depend on a build flag it has nothing to do with.
+`TestFunctionNameWorksWithoutLineInfo` asserts both halves — the name is
+returned, and the same module's `Resolve` still answers `no-lineinfo` with
+no location.
+
+`ok` is false when the CRC is not held (never arrived, or evicted), when the
+bytes did not parse, or when the index is not in the symbol table. A
+**damaged `.debug_line` does not make it false**: the symbol table is intact
+and the kernel's identity does not come from DWARF, so attribution survives
+a line table this reader cannot read even though source resolution does not
+(`TestFunctionNameSurvivesADamagedLineTable`). There is never a
+nearest-index guess.
+
+It refreshes LRU recency, for `Resolve`'s reason: a module whose functions
+are being joined is a module in use, and letting it age out under a burst of
+unrelated loads would silently stop attribution for a live kernel
+(`TestFunctionNameRefreshesRecency`).
+
+It increments **none** of the four `Resolve*` counters. Those partition calls
+to `Resolve` exactly and that identity is the store's main self-check;
+folding a second entry point into it would break the identity while looking
+like better instrumentation. `TestFunctionNameDoesNotDisturbTheResolveIdentity`
+makes ten `FunctionName` calls, asserts `ResolveTotal() == 0`, then makes
+three `Resolve` calls and asserts the identity still holds. What
+`FunctionName`'s failures cost is counted at the join, in
+`GroupsUnresolvedName`.
+
+Seven tests, including `TestFunctionNameBindsTheIndexToTheRightKernel` over
+the two-kernel fixture (an accessor returning a neighbouring function would
+still look healthy on a single-kernel module) and
+`TestFunctionNameAfterEvictionIsRefusedNotStale` (the store's no-memo
+guarantee: an answer must never outlive the bytes it came from).
+
+---
+
+## 5. The extended reconciliation
+
+Every PC sample the sink accepted lands in exactly one of: attributed-exact,
+attributed-kernel, still-pending (in either store), or evicted (from either
+store). 8a had already extended `assertPCSampleLossesAccounted` to cover both
+pending stores; this task built on that rather than adding a third path.
+
+Three identities, all in `assertPCSampleLossesAccounted` (so they run for
+**every** conformance scenario) and re-asserted by
+`assertPCJoinIdentities` in the new tests:
+
+```
+accepted == AttributedPCSamples
+          + PendingSamples       + EvictedPendingSamples
+          + PendingModuleSamples + EvictedPendingModuleSamples     (8a's, unchanged)
+
+AttributedPCSamples == PCJoin.AttributedExact + PCJoin.AttributedKernel
+
+PCJoin.GroupsExamined() == PCJoin.GroupsJoined + PendingModuleGroups
+```
+
+The second closes a hole the first cannot see: a module join that attached
+samples while forgetting to count them would still satisfy the first
+identity (the samples left the pending store and arrived on an execution)
+while reporting a per-tier split that was quietly wrong.
+
+The third is the group-level partition. Because the whole join runs under one
+lock hold, every group it examined was either consumed or is still in the
+store, and the three not-joined reasons — `GroupsUnresolvedName`,
+`GroupsNoExecution`, `GroupsNoProcess` — partition the remainder exactly. A
+refusal path that returned without incrementing any counter is the easiest
+and most invisible mistake available in that function, and this is what
+catches it (mutation M6).
+
+Plus one presence invariant, `assertPCAttribAccompaniesSamples`, run over
+every conformance scenario: every view holding PC samples carries one of
+`PCAttribs()`, every view holding none carries the empty value. `gpu_pc_attrib`
+is emitted unconditionally for `gpu_join`'s reason — an absent label must
+never be readable as "exact" by a consumer that does not know to check for
+its absence — and `MarshalJSON` refusing the empty value only catches that at
+the serialization boundary, which not every consumer crosses.
+
+### `TestConformancePCSampleReconciliationCoversPendingAndEvicted` grew
+
+The existing test now also asserts its continuous-mode terms are
+structurally zero (every sample there carries a correlation), which is what
+keeps the two halves of the identity from being read as each other. Its
+non-dead counterpart is the new
+**`TestConformancePCSampleReconciliationCoversAttributedByKernel`**, which
+runs the full invariant suite over `drivePCSampleMixedFateContinuous` — a
+scenario with all three new buckets non-zero in one run: two samples
+attributed by kernel, one still pending in an unnameable group, two evicted
+by the per-group cap. `newConformanceHarnessWithTimeline` was added so a
+harness can be given a module store; without one, no group can be named and
+the attributed-by-kernel bucket would be a structurally unreachable dead
+term.
+
+### Counters
+
+`Snapshot.PCJoin PCJoinStats` — nine fields, each assertable, none of which
+can read green when things are worst:
+
+- `AttributedExact` / `AttributedKernel` — the split of `AttributedPCSamples`.
+- `GroupsJoined` / `GroupsUnresolvedName` / `GroupsNoExecution` /
+  `GroupsNoProcess` — the partition above.
+- `AmbiguousAttributions` / `MultiDeviceAttributions` — counts of
+  **executions** carrying those `gpu_pc_attrib` values (the unit the label
+  rides on), computed after the walk so two groups landing on one execution
+  count once. `AmbiguousAttributions` is emphatically **not**
+  `AmbiguousHeuristicMatchCount` and must never be merged with it.
+- `MultiDeviceProcesses` — cumulative, and `DeviceTrackingCapped` beside it
+  so "we found none" and "we stopped looking" stay distinguishable.
+
+`joinhealth` gained one summary refinement (the exact/by-kernel split,
+printed only when both are actually in play) and five anomalies: PC
+ambiguity, multi-device processes, the device-tracker cap, unnameable
+groups, and groups naming no process. `GroupsNoExecution` deliberately does
+**not** raise one — a group whose execution has not landed yet is the normal
+state at a snapshot boundary, exactly as `UnmatchedLaunchCount` is, and
+raising it would devalue the word for the counters that mean something.
+`TestJoinHealthHealthyRunIsOneShortLine` is unchanged and passes.
+
+One drive-by fix in `joinhealth.go`: 8a's correlation-less summary clause
+rendered `"1 1 kernel group"` (a `%d %s` against `plural`, which already
+carries the number) and pluralized "samples" for a count of one. Corrected;
+it is one line and the output is asserted by the new tests.
+
+---
+
+## 6. Not touched
+
+`gpu/projection.go` — Task 9 emits the labels. `LaunchCache`. The #52
+heuristic guard and `findLaunchHeuristic`. The exact-correlation pending
+path in `EmitPCSample` and `Snapshot`. `ExecutionView.Ambiguous`,
+`JoinStats.AmbiguousHeuristicMatchCount`, and every existing `JoinStats`
+field. `internal/cubin`. The ABI.
+
+`TimelineConfig.Modules` is nil for both shipping drivers
+(`cmd/gpu-stub-profile`, `cmd/gpu-cuda-profile`) and for every backend that
+does not do PC sampling. Nil is supported and **accounted for, not skipped**:
+with no store nothing can be named, so every group is counted in
+`GroupsUnresolvedName` and left pending — the same accounting as "the cubin
+never arrived", because for the profile it is the same fact. Skipping
+silently would make a missing store look identical to a healthy run with no
+PC samples (`TestTierBWithoutAModuleStoreLeavesEverythingPending`).
+
+---
+
+## 7. Verification
+
+`CapEff: 0`, no GPU, no capabilities. From the worktree with the plan's build
+environment.
+
+```
+go build ./...                                     ok
+go vet ./...                                       ok
+go test ./gpu/ ./gpuprobe/ ./internal/... -count=1 ok (12 packages)
+go test ./... -count=1                             ok (whole repo, no regressions)
+go test ./gpu/ -race -count=4                      ok  20.5s
+~/go/bin/golangci-lint run --timeout=5m            0 issues.
+```
+
+The plan's four offline checks for this task, and the test that is each one:
+
+| the plan asks | test |
+| --- | --- |
+| a Tier B sample reaches its execution | `TestTierBSampleReachesItsExecution` |
+| two executions of one kernel yield `kernel-ambiguous` **and leave `gpu_ambiguous` unset** | `TestTierBAmbiguityIsMarkedWithoutTouchingAmbiguous` |
+| a sample whose module is unknown stays pending, is evicted, and is counted | `TestTierBUnknownModuleStaysPendingAndIsEvicted` |
+| a multi-device process yields `kernel-multidevice` | `TestTierBMultiDeviceProcessIsMarked` |
+
+New tests, `gpu/pcjoin_test.go` (20): the four above, plus
+`TestTierBJoinIsConsumingLikeTheExactPath`,
+`TestTierBAmbiguousGoesToTheEarliestExecution`,
+`TestMultiDeviceOutranksAmbiguity`,
+`TestSingleDeviceProcessIsNotMarkedMultiDevice`,
+`TestDeviceTrackingCapIsCountedNotSilent`,
+`TestTierBKernelNameMismatchStaysPending`,
+`TestTierBJoinStaysWithinTheProcess`,
+`TestTierBGroupWithNoProcessIsRefused`,
+`TestTierBWithoutAModuleStoreLeavesEverythingPending`,
+`TestTierBUnknownFunctionIndexStaysPending`,
+`TestExactCorrelationJoinIsUnchangedAndLabelledExact`,
+`TestExactPathKeepsFirstClaim`,
+`TestTierBJoinAccountsForEveryGroup`,
+`TestTierBReconciliationCoversAttributedAndPending`,
+`TestPCAttribsAreExhaustiveAndStable`,
+`TestPCAttribRefusesValuesNobodyDecided`. Plus seven in
+`modulestore_test.go` and one new conformance test.
+
+### Mutation checks — the tests bite
+
+Each applied alone to the finished code, `go test ./gpu/ -count=1`:
+
+| mutation | result |
+| --- | --- |
+| M1 — ambiguity never marked (`candidates > 1` branch deleted) | `TestTierBAmbiguityIsMarkedWithoutTouchingAmbiguous`, `TestTierBAmbiguousGoesToTheEarliestExecution` |
+| M2 — name match relaxed to a prefix match | `TestTierBKernelNameMismatchStaysPending` |
+| M3 — pid dropped from `execKernelKey` | `TestTierBJoinStaysWithinTheProcess`, `TestTierBJoinAccountsForEveryGroup` |
+| M4 — multi-device never checked | `TestTierBMultiDeviceProcessIsMarked`, `TestMultiDeviceOutranksAmbiguity` |
+| M5 — PC ambiguity also sets `ExecutionView.Ambiguous` (the overload this label exists to prevent) | `TestTierBAmbiguityIsMarkedWithoutTouchingAmbiguous` |
+| M6 — a refusal path returns without its counter | 4 failures, including both group-identity assertions |
+| M7 — the module join runs over exactly-served executions too | `TestExactPathKeepsFirstClaim` |
+
+A test that cannot fail is not a test.
+
+---
+
+## 8. Cannot verify
+
+**Nothing here has been run against a GPU, and no claim in this report is
+about hardware.** This machine has `CapEff: 0` and no NVIDIA device; no BPF
+program, no CUPTI call and no shim was executed. Every sample this join has
+ever seen is synthetic, and every module it has ever resolved is one of Task
+1's four `sm_86` / CUDA 13.3 fixtures.
+
+The plan defers two things about this task to the RTX 3090, and both are
+open:
+
+- **What fraction of real PC samples attribute versus stay pending.**
+  Unknown. `PCJoin.GroupsJoined` against `GroupsUnresolvedName +
+  GroupsNoExecution`, and `AttributedKernel` against `PendingModuleSamples`,
+  are the instruments; both are in every `Snapshot` and one is in
+  `joinhealth`. The dominant risk is the name comparison in §2: `KernelName`
+  arrives from `gpu_kernel_name_v1` (what CUPTI's activity record reports)
+  and the function name comes from the cubin's `.symtab`. Whether those two
+  spellings are byte-identical for C++ kernels — mangled on one side and not
+  the other, or mangled differently — **is not established anywhere in this
+  repository**. The fixtures are `extern "C"`, so they cannot settle it. If
+  the spellings differ, this join attributes nothing on real workloads and
+  the symptom is `GroupsNoExecution` climbing to match the group count, with
+  every sample aging out. That is the honest failure and it is visible, but
+  it is a failure, and it is the first thing to measure.
+- **Whether the eviction horizon is long enough given the drain period.**
+  Unknown. `PendingSampleHorizonNs` is shared with the correlation-keyed
+  store and defaults to zero (disabled) — a caller must set it. Whether the
+  gap between a PC sample's drain-stamped `TimeNs` and its execution's
+  arrival fits inside any particular horizon at the shim's 100 ms drain
+  period has not been measured. `Dropped.EvictedPendingModuleSamples` with
+  a low `AttributedKernel` is the reading that says it is too short.
+
+Also unestablished, carried forward from Tasks 4 and 8a and load-bearing
+here:
+
+- **That `functionIndex` is the cubin's `.symtab` index.** Task 6 measures
+  it. This join groups and names on whatever the store keys on, so a
+  negative answer changes `indexFunctions` and nothing in this file — but it
+  changes whether the names this join compares are the right names at all.
+- **That real Tier B samples arrive with a usable `cubin_crc`.** If `CRC` and
+  `FunctionIndex` both arrive zero, every sample from a process lands in one
+  group whose CRC no module matches, and every one of them counts as
+  `GroupsUnresolvedName`.
+- **That `pcOffset` is function-relative in the sense the line table is.**
+  Not this task's business — it is Task 9's — but it is the other half of
+  what makes a PC sample useful once it has reached its execution.
+
+The device-tracking cap (4,096) is reasoned, not measured. Reaching it needs
+thousands of concurrently profiled processes that each run GPU kernels; the
+counter and the anomaly exist so that if it ever is reached, that is visible
+rather than inferred from a suspiciously clean profile.

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -161,10 +161,19 @@ type conformanceHarness struct {
 // set. The clock is always frozen, for the same reason newConformanceHarness
 // freezes it.
 func newConformanceHarnessWithConfig(cacheCfg LaunchCacheConfig, sinkBurst int) *conformanceHarness {
-	tl := NewTimeline(TimelineConfig{LaunchCache: cacheCfg})
+	return newConformanceHarnessWithTimeline(TimelineConfig{LaunchCache: cacheCfg}, sinkBurst)
+}
+
+// newConformanceHarnessWithTimeline is the same generalized over the whole
+// TimelineConfig, for the continuous-mode scenarios that need a module store
+// wired in - without one no correlation-less group can ever be named, so the
+// attributed-by-kernel bucket of the reconciliation identity would be
+// structurally unreachable and the term would be dead.
+func newConformanceHarnessWithTimeline(cfg TimelineConfig, sinkBurst int) *conformanceHarness {
+	tl := NewTimeline(cfg)
 	clock := newFakeClock(time.Unix(0, 0))
 	sink := NewCountingSinkWithRate(tl, sinkBurst, 0, clock.Now)
-	return &conformanceHarness{tl: tl, sink: sink, attempt: newAttemptSink(sink), cacheCapacity: cacheCfg.Capacity}
+	return &conformanceHarness{tl: tl, sink: sink, attempt: newAttemptSink(sink), cacheCapacity: cfg.LaunchCache.Capacity}
 }
 
 func newConformanceHarness() *conformanceHarness {
@@ -243,8 +252,40 @@ func assertConformanceInvariants(t *testing.T, h *conformanceHarness) Snapshot {
 	// this-call gauges, not cumulative, so a second Snapshot call would need
 	// its own reconciliation, not this one.
 	assertPCSampleLossesAccounted(t, snap, sinkStats, h.attempt.pcAttempts)
+	assertPCAttribAccompaniesSamples(t, snap)
 
 	return snap
+}
+
+// assertPCAttribAccompaniesSamples is the gpu_pc_attrib presence invariant:
+// every ExecutionView holding at least one PC sample carries one of
+// PCAttribs(), and every view holding none carries the empty value.
+//
+// It matters because gpu_pc_attrib is emitted unconditionally on PC-derived
+// samples, for the same reason gpu_join is: an ABSENT label must never be
+// readable as "exact" by a consumer that does not know to check for its
+// absence. A view that reached the profile with samples and no attribution
+// would produce exactly that, and PCAttrib.MarshalJSON refusing the empty
+// value only catches it at the serialization boundary, which not every
+// consumer crosses.
+func assertPCAttribAccompaniesSamples(t *testing.T, snap Snapshot) {
+	t.Helper()
+	valid := make(map[PCAttrib]struct{}, len(PCAttribs()))
+	for _, a := range PCAttribs() {
+		valid[a] = struct{}{}
+	}
+	for _, view := range snap.Executions {
+		if len(view.PCSamples) == 0 {
+			assert.Empty(t, string(view.PCAttrib),
+				"execution %+v holds no PC samples, so there is nothing for gpu_pc_attrib to describe",
+				view.Exec.Correlation)
+			continue
+		}
+		_, ok := valid[view.PCAttrib]
+		assert.Truef(t, ok,
+			"execution %+v holds %d PC samples with gpu_pc_attrib %q, which is not one of %v",
+			view.Exec.Correlation, len(view.PCSamples), view.PCAttrib, PCAttribs())
+	}
 }
 
 // assertNoFabricatedLaunch is invariant 3: every non-nil view.Launch must
@@ -401,6 +442,26 @@ func assertPCSampleLossesAccounted(t *testing.T, snap Snapshot, sinkStats SinkSt
 			uint64(snap.PendingSamples)+snap.Dropped.EvictedPendingSamples+
 			uint64(snap.PendingModuleSamples)+snap.Dropped.EvictedPendingModuleSamples,
 		"every PC sample the sink accepted must be attributed, still pending in one of the two pending stores, or evicted from one of them - never unaccounted for")
+
+	// The attributed term now has two sources - the exact-correlation index
+	// and the module-keyed join - and the breakdown must account for all of
+	// it. Without this, a module join that attached samples while forgetting
+	// to count them would still satisfy the identity above (the samples left
+	// the pending store and arrived on an execution) while reporting a
+	// per-tier split that was quietly wrong.
+	assert.Equal(t, snap.AttributedPCSamples, snap.PCJoin.AttributedTotal(),
+		"AttributedExact + AttributedKernel must account for every attributed PC sample: %+v", snap.PCJoin)
+
+	// The group-level identity. Snapshot's join runs entirely under the lock,
+	// so no group can be created or evicted between the walk and the gauge:
+	// every group the join examined was either consumed (GroupsJoined) or is
+	// still in the store, and the three not-joined reasons partition the
+	// latter exactly. A refusal path that returned without incrementing any
+	// counter - the easiest mistake to make here, and an invisible one -
+	// breaks this.
+	assert.Equal(t, snap.PCJoin.GroupsExamined(),
+		snap.PCJoin.GroupsJoined+uint64(snap.PendingModuleGroups),
+		"every pending module group must be joined or left pending for exactly one counted reason: %+v", snap.PCJoin)
 }
 
 // TestConformance runs the producer-scenario table against every invariant.
@@ -845,6 +906,96 @@ func TestConformancePCSampleReconciliationCoversPendingAndEvicted(t *testing.T) 
 	assert.Equal(t, 1, snap.PendingCorrelations)
 	assert.Equal(t, uint64(2), snap.Dropped.EvictedPendingSamples,
 		"evict-a and evict-b (1 sample each) must have been evicted from pending entirely by the cardinality bound")
+
+	// The continuous-mode terms are structurally zero in this scenario -
+	// every sample here carries a correlation - and asserting so is what
+	// keeps the two halves of the identity from being confused for each
+	// other. Their non-dead counterpart is
+	// TestConformancePCSampleReconciliationCoversAttributedByKernel below.
+	assert.Zero(t, snap.PendingModuleSamples)
+	assert.Zero(t, snap.Dropped.EvictedPendingModuleSamples)
+	assert.Equal(t, snap.AttributedPCSamples, snap.PCJoin.AttributedExact,
+		"a scenario in which every sample carried a correlation must attribute all of them exactly")
+}
+
+// drivePCSampleMixedFateContinuous is drivePCSampleMixedFate's continuous-mode
+// twin: it forces the buckets the module-keyed join added - attributed by
+// kernel, still pending in the module store, and evicted from it - non-zero in
+// one run, so none of them is a dead term where the reconciliation actually
+// runs.
+//
+// Every sample here carries NO correlation value, which is what continuous
+// collection produces on every record. Attribution therefore runs entirely
+// through the module: the "joined" group's (CRC, functionIndex) names a device
+// function the execution below carries as its KernelName, and the "unnameable"
+// group's CRC is one no cubin ever arrived for.
+//
+// The harness this runs under sets MaxPendingSamplesPerCorrelation to 2, which
+// is what makes the eviction bucket reachable: the joined group is offered
+// four samples and may hold two.
+func drivePCSampleMixedFateContinuous(sink EventSink, crc uint64, fnIndex uint32, kernel string) error {
+	const pid = 4242
+
+	// Joined, with two of its four samples evicted by the per-group cap.
+	for i := range 4 {
+		if err := sink.EmitPCSample(tierBSample(pid, crc, fnIndex, uint64(10+i))); err != nil {
+			return err
+		}
+	}
+	// Unnameable: no cubin for this CRC ever reached the agent, so nothing can
+	// turn its function index into a name. It stays pending rather than being
+	// attached to the execution below, whose kernel name would have matched.
+	if err := sink.EmitPCSample(tierBSample(pid, 0xBAD0BAD0, fnIndex, 20)); err != nil {
+		return err
+	}
+	return sink.EmitExec(pcExec(pid, kernel, "0", 30, 40))
+}
+
+// TestConformancePCSampleReconciliationCoversAttributedByKernel is
+// TestConformancePCSampleReconciliationCoversPendingAndEvicted for the
+// continuous-mode half of the identity. It runs the full invariant suite -
+// including assertPCSampleLossesAccounted and both PC-join identities - over a
+// scenario whose samples reach their execution through the module and nothing
+// else, then asserts each new term is genuinely non-zero.
+//
+// Mutations this catches: dropping AttributedKernel from the attributed
+// breakdown; a join that consumed a group without counting it in GroupsJoined;
+// and a refusal path that left a group pending without incrementing any of the
+// three not-joined counters, which is the easiest and most invisible mistake
+// available in that function.
+func TestConformancePCSampleReconciliationCoversAttributedByKernel(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	store := NewModuleStore(ModuleStoreConfig{})
+	require.NoError(t, store.Put(pcJoinCRC, b))
+	fnIndex := symIndexOf(t, b, "addOne")
+
+	h := newConformanceHarnessWithTimeline(TimelineConfig{
+		LaunchCache:                     LaunchCacheConfig{Capacity: conformanceCacheCapacity},
+		MaxPendingSamplesPerCorrelation: 2,
+		Modules:                         store,
+	}, conformanceSinkBurst)
+
+	snap := runConformanceWithHarness(t, "pc-sample-mixed-fate-continuous", h,
+		func(sink EventSink) error {
+			return drivePCSampleMixedFateContinuous(sink, pcJoinCRC, fnIndex, "addOne")
+		})
+
+	assert.Equal(t, uint64(2), snap.AttributedPCSamples,
+		"the joined group's two held samples must reach their execution")
+	assert.Equal(t, uint64(2), snap.PCJoin.AttributedKernel)
+	assert.Zero(t, snap.PCJoin.AttributedExact, "not one of these samples carried a correlation")
+	assert.Equal(t, 1, snap.PendingModuleSamples, "the unnameable group's sample stays pending")
+	assert.Equal(t, uint64(2), snap.Dropped.EvictedPendingModuleSamples,
+		"the per-group cap's two refusals are counted, and on the continuous-mode counter")
+	assert.Zero(t, snap.Dropped.EvictedPendingSamples,
+		"never on the correlation-keyed counter, or a Tier B storm reads as a Tier A one")
+
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsJoined)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsUnresolvedName)
+	assert.Equal(t, uint64(2), snap.PCJoin.GroupsExamined())
+
+	require.Len(t, snap.Executions, 1)
+	assert.Equal(t, PCAttribKernel, snap.Executions[0].PCAttrib)
 }
 
 // BenchmarkSnapshotAtScale is the Phase 2 gate: a million launches through a

--- a/gpu/joinhealth.go
+++ b/gpu/joinhealth.go
@@ -107,6 +107,17 @@ func joinSummary(snap Snapshot, anomalies int) string {
 	if snap.AttributedPCSamples > 0 || snap.PendingSamples > 0 {
 		fmt.Fprintf(&b, "; pc samples %d attributed, %d pending",
 			snap.AttributedPCSamples, snap.PendingSamples)
+		// The split by index is printed only when both are actually in play.
+		// A pure Tier A run (every sample exact) and a pure Tier B run (every
+		// sample through the module) each need one number, not two, and
+		// printing "0 by kernel" on every CUPTI run is the zero-valued noise
+		// this format exists to avoid.
+		if snap.PCJoin.AttributedExact > 0 && snap.PCJoin.AttributedKernel > 0 {
+			fmt.Fprintf(&b, " (%d exact, %d by kernel)",
+				snap.PCJoin.AttributedExact, snap.PCJoin.AttributedKernel)
+		} else if snap.PCJoin.AttributedKernel > 0 {
+			b.WriteString(" by kernel")
+		}
 	}
 
 	// Its own clause rather than folded into the one above, for the same
@@ -116,8 +127,8 @@ func joinSummary(snap Snapshot, anomalies int) string {
 	// collection is optional and off by default, so the clause is absent
 	// entirely when nothing produced such samples.
 	if snap.PendingModuleSamples > 0 {
-		fmt.Fprintf(&b, "; %d correlation-less pc samples pending over %d %s",
-			snap.PendingModuleSamples, snap.PendingModuleGroups,
+		fmt.Fprintf(&b, "; %s pending over %s",
+			plural(uint64(snap.PendingModuleSamples), "correlation-less pc sample", "correlation-less pc samples"),
 			plural(uint64(snap.PendingModuleGroups), "kernel group", "kernel groups"))
 	}
 
@@ -229,6 +240,42 @@ func joinAnomalies(snap Snapshot) []string {
 		add("%s carried an out-of-range timestamp — the producer's clock is suspect and "+
 			"horizon eviction is running against a clamped anchor",
 			plural(lc.AnomalousTimestamp, "launch", "launches"))
+	}
+	// PC-attribution quality, kept strictly apart from the heuristic-launch
+	// clauses above. An execution can appear in both sets - joined to its
+	// launch by vendor correlation and still carrying inferred PC samples -
+	// and the two lines say different things about different joins.
+	if pj := snap.PCJoin; pj.AmbiguousAttributions > 0 {
+		add("%s carrying PC samples attributed by kernel with more than one execution of that "+
+			"kernel in the snapshot — the stall detail is on the right kernel but not provably on "+
+			"the right invocation; these samples are marked %s, which is NOT the same flag as an "+
+			"ambiguous heuristic launch join",
+			plural(pj.AmbiguousAttributions, "execution", "executions"), PCAttribKernelAmbiguous)
+	}
+	if pj := snap.PCJoin; pj.MultiDeviceProcesses > 0 {
+		add("%s ran kernels on more than one device — PC samples carry no device id and one binary "+
+			"has one cubin CRC on both, so their samples cannot be told apart; %s are marked %s. "+
+			"PC sampling is single-GPU in this phase",
+			plural(pj.MultiDeviceProcesses, "process", "processes"),
+			plural(pj.MultiDeviceAttributions, "execution", "executions"),
+			PCAttribKernelMultiDevice)
+	}
+	if pj := snap.PCJoin; pj.DeviceTrackingCapped > 0 {
+		add("%s could not be admitted to the multi-device guard (it is full) and are being treated "+
+			"as single-device — a second device in one of them would go unmarked",
+			plural(pj.DeviceTrackingCapped, "process", "processes"))
+	}
+	if pj := snap.PCJoin; pj.GroupsUnresolvedName > 0 {
+		add("%s could not be resolved to a device function — no cubin for that CRC reached the "+
+			"agent, it was evicted, or the function index is not in its symbol table; those samples "+
+			"stay pending and will age out unattributed rather than be attached to a nearby kernel",
+			plural(pj.GroupsUnresolvedName, "correlation-less PC group", "correlation-less PC groups"))
+	}
+	if pj := snap.PCJoin; pj.GroupsNoProcess > 0 {
+		add("%s arrived naming no process — every process that names none shares one key, so they "+
+			"cannot be joined to any execution without risking another process's kernel; have the "+
+			"producer set CorrelationID.PID",
+			plural(pj.GroupsNoProcess, "correlation-less PC group", "correlation-less PC groups"))
 	}
 	if dr.EvictedPendingSamples > 0 {
 		add("%s evicted while waiting for their execution — never attributed, so the "+

--- a/gpu/modulestore.go
+++ b/gpu/modulestore.go
@@ -604,3 +604,53 @@ func (s *ModuleStore) evictOldestLocked() bool {
 	s.stats.ModulesEvicted++
 	return true
 }
+
+// FunctionName returns the device function a PC record's functionIndex names
+// inside the module with this CRC, and ok reporting whether the store could
+// answer at all.
+//
+// It exists because Resolve deliberately cannot answer this question. Resolve
+// carries a function name only under SrcResolved - that is the four-valued
+// status doing its job, since a name paired with no-lineinfo would invite a
+// caller to emit gpu_src_func for a module that has no source information.
+// But the continuous-mode attribution chain is cubin_crc -> module ->
+// function -> KERNEL, and it needs the name whether or not the module was
+// built with -lineinfo: a kernel compiled without -lineinfo still has a name,
+// still executes, and its PC samples still belong to it. Routing that need
+// through Resolve would either leak a name out of a non-resolved status or
+// make attribution depend on a build flag it has nothing to do with.
+//
+// ok is false when the CRC is not held (never arrived, or evicted), when the
+// bytes did not parse, or when functionIndex is not in the module's symbol
+// table. A damaged .debug_line does NOT make it false: the symbol table is
+// intact in that case and the function's identity does not come from DWARF.
+// There is never a nearest-index guess - an index this store cannot map is
+// reported as unmappable, and the caller's business is then to leave the
+// samples unattributed rather than to attach them to a plausible neighbour.
+//
+// Like Resolve, it refreshes LRU recency: a module whose functions are being
+// joined is a module in use, and letting it age out under a burst of
+// unrelated loads would silently stop attribution for a live kernel.
+//
+// It deliberately increments none of the Resolve* counters. Those four
+// partition calls to Resolve exactly, and that identity is the store's main
+// self-check; folding a second entry point into it would break the identity
+// while looking like an improvement. What this call's failures cost is
+// counted where the loss actually happens - at the join, which reports the
+// groups it could not name.
+func (s *ModuleStore) FunctionName(crc uint64, functionIndex uint32) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.byCRC[crc]
+	if !ok {
+		return "", false
+	}
+	s.lru.MoveToFront(e.elem)
+	if e.byIndex == nil {
+		// parseErr != nil: we hold bytes we cannot read. Nothing to name.
+		return "", false
+	}
+	name, ok := e.byIndex[functionIndex]
+	return name, ok
+}

--- a/gpu/modulestore_test.go
+++ b/gpu/modulestore_test.go
@@ -693,3 +693,171 @@ func TestModuleStoreConcurrentPutAndResolve(t *testing.T) {
 	assert.Equal(t, s.ModulesStored-uint64(s.Live), s.ModulesEvicted,
 		"every stored module is either live or evicted")
 }
+
+// ---------------------------------------------------------------------------
+// FunctionName - the accessor the continuous-mode join needs
+// ---------------------------------------------------------------------------
+
+// TestFunctionNameWorksWithoutLineInfo is the reason this accessor exists at
+// all. Resolve carries a function name only under SrcResolved, which is
+// correct for source labels and wrong for attribution: the continuous-mode
+// chain is cubin_crc -> module -> function -> KERNEL, and a kernel built
+// without -lineinfo still has a name, still runs, and still owns its PC
+// samples. If attribution went through Resolve, a missing build flag would
+// silently cost the whole join rather than just the source lines.
+func TestFunctionNameWorksWithoutLineInfo(t *testing.T) {
+	withInfo := fixture(t, "single_lineinfo.cubin")
+	noInfo := fixture(t, "single_nolineinfo.cubin")
+
+	st := NewModuleStore(ModuleStoreConfig{})
+	require.NoError(t, st.Put(1, withInfo))
+	require.NoError(t, st.Put(2, noInfo))
+
+	name, ok := st.FunctionName(1, symIndexOf(t, withInfo, "addOne"))
+	require.True(t, ok)
+	assert.Equal(t, "addOne", name)
+
+	name, ok = st.FunctionName(2, symIndexOf(t, noInfo, "addOne"))
+	require.True(t, ok, "a module with no line table still has a symbol table")
+	assert.Equal(t, "addOne", name)
+
+	// And the contrast that makes the point: the same module answers
+	// no-lineinfo for source, with no name at all.
+	res := st.Resolve(2, symIndexOf(t, noInfo, "addOne"), 0)
+	assert.Equal(t, SrcNoLineInfo, res.Status())
+	_, _, _, hasSource := res.Source()
+	assert.False(t, hasSource, "no-lineinfo carries no location, and that is unchanged")
+}
+
+// TestFunctionNameBindsTheIndexToTheRightKernel uses the two-kernel fixture:
+// an accessor that returned a neighbouring function would still look healthy
+// on a single-kernel module. Attribution built on a swapped index puts a
+// kernel's stalls on a different kernel, confidently.
+func TestFunctionNameBindsTheIndexToTheRightKernel(t *testing.T) {
+	b := fixture(t, "two_kernels_lineinfo.cubin")
+	st := NewModuleStore(ModuleStoreConfig{})
+	require.NoError(t, st.Put(7, b))
+
+	for _, kernel := range []string{"scale", "offset"} {
+		name, ok := st.FunctionName(7, symIndexOf(t, b, kernel))
+		require.Truef(t, ok, "kernel %s", kernel)
+		assert.Equal(t, kernel, name)
+	}
+}
+
+// TestFunctionNameRefusesRatherThanGuesses covers every way the answer is
+// unavailable. Each returns ok=false and an empty name; none returns a
+// neighbouring function, and none is a partial answer a caller could mistake
+// for a real one.
+func TestFunctionNameRefusesRatherThanGuesses(t *testing.T) {
+	withInfo := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, withInfo, "addOne")
+
+	st := NewModuleStore(ModuleStoreConfig{})
+	require.NoError(t, st.Put(1, withInfo))
+	require.Error(t, st.Put(2, []byte("not an ELF at all")))
+
+	cases := []struct {
+		name    string
+		crc     uint64
+		fnIndex uint32
+	}{
+		{"a CRC nothing was ever offered for", 99, idx},
+		{"a module whose bytes did not parse", 2, idx},
+		{"an index that is not in the symbol table", 1, idx + 9999},
+		{"index zero, which is the ELF null symbol", 1, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name, ok := st.FunctionName(tc.crc, tc.fnIndex)
+			assert.False(t, ok)
+			assert.Empty(t, name, "a refusal must carry no name at all, not a plausible one")
+		})
+	}
+}
+
+// TestFunctionNameSurvivesADamagedLineTable pins the one case where
+// FunctionName and Resolve deliberately disagree. A cubin whose .debug_line
+// cannot be read resolves as no-module - we hold bytes we cannot use for
+// source - but its symbol table is intact and the kernel's identity does not
+// come from DWARF. Attribution must not be lost to a broken line table.
+func TestFunctionNameSurvivesADamagedLineTable(t *testing.T) {
+	damaged := damagedLineInfo(t)
+	idx := symIndexOf(t, damaged, "addOne")
+
+	st := NewModuleStore(ModuleStoreConfig{})
+	require.NoError(t, st.Put(1, damaged))
+
+	assert.Equal(t, SrcNoModule, st.Resolve(1, idx, 0).Status(),
+		"source resolution is correctly lost")
+	name, ok := st.FunctionName(1, idx)
+	require.True(t, ok, "attribution is not")
+	assert.Equal(t, "addOne", name)
+}
+
+// TestFunctionNameAfterEvictionIsRefusedNotStale is the store's central
+// no-memo guarantee applied to this accessor: an answer must never outlive the
+// bytes it came from.
+func TestFunctionNameAfterEvictionIsRefusedNotStale(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 1})
+	require.NoError(t, st.Put(1, b))
+	name, ok := st.FunctionName(1, idx)
+	require.True(t, ok)
+	require.Equal(t, "addOne", name)
+
+	require.NoError(t, st.Put(2, b)) // evicts CRC 1
+
+	name, ok = st.FunctionName(1, idx)
+	assert.False(t, ok, "an evicted module must answer nothing, not its last known name")
+	assert.Empty(t, name)
+}
+
+// TestFunctionNameRefreshesRecency: a module whose functions are being joined
+// is a module in use. Without the touch, a burst of unrelated module loads
+// would silently stop attribution for a live kernel while the store still had
+// room for it.
+func TestFunctionNameRefreshesRecency(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	st := NewModuleStore(ModuleStoreConfig{Capacity: 2})
+	require.NoError(t, st.Put(1, b))
+	require.NoError(t, st.Put(2, b))
+
+	// Touch 1 through FunctionName only, then push a third module in.
+	_, ok := st.FunctionName(1, idx)
+	require.True(t, ok)
+	require.NoError(t, st.Put(3, b))
+
+	_, ok = st.FunctionName(1, idx)
+	assert.True(t, ok, "the module FunctionName just used must not be the one evicted")
+	_, ok = st.FunctionName(2, idx)
+	assert.False(t, ok, "the untouched module is the one that goes")
+}
+
+// TestFunctionNameDoesNotDisturbTheResolveIdentity pins the deliberate
+// omission: FunctionName increments none of the four Resolve* counters,
+// because those four partition calls to Resolve exactly and that identity is
+// the store's main self-check. Folding a second entry point into it would
+// break the identity while looking like better instrumentation.
+func TestFunctionNameDoesNotDisturbTheResolveIdentity(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	c := &counting{ModuleStore: NewModuleStore(ModuleStoreConfig{})}
+	require.NoError(t, c.Put(1, b))
+
+	for range 5 {
+		_, _ = c.FunctionName(1, idx)
+		_, _ = c.FunctionName(99, idx)
+	}
+	require.Zero(t, c.Stats().ResolveTotal(), "no Resolve call has been made yet")
+
+	for range 3 {
+		c.Resolve(1, idx, 0x10)
+	}
+	requireSumIdentity(t, c)
+}

--- a/gpu/pcattrib.go
+++ b/gpu/pcattrib.go
@@ -1,0 +1,214 @@
+package gpu
+
+import "fmt"
+
+// PCAttrib is gpu_pc_attrib: HOW a PC sample reached the execution it is
+// attached to, and therefore how much the attachment can be trusted.
+//
+// # Why this is its own label and not ExecutionView.Ambiguous
+//
+// ExecutionView.Ambiguous means one thing and only one thing: the heuristic
+// LAUNCH join found more than one candidate launch for a correlation-less
+// execution and picked one (see findLaunchHeuristic, and
+// JoinStats.AmbiguousHeuristicMatchCount, which counts exactly that). PC
+// attribution is a different join, over different inputs, with a different
+// failure mode. Reusing that boolean would put two unrelated facts on one bit
+// and would emit gpu_join="exact" gpu_ambiguous="true" on a single sample - an
+// execution whose launch was joined by vendor correlation, exactly, while its
+// PC samples were inferred. A reader has no way to tell which of the two the
+// flag is about, and AmbiguousHeuristicMatchCount stops counting what its name
+// says. So the two stay entirely separate: Ambiguous keeps its meaning
+// untouched, and PC-attribution quality lives here.
+//
+// # The four values
+//
+//	exact               the sample carried a vendor correlation and joined
+//	                    through it. Kernel-serialized collection only; this is
+//	                    vendor-provided truth, not an inference.
+//	kernel              joined through the module: the sample's
+//	                    (cubin CRC, functionIndex) named a device function,
+//	                    and exactly one execution of that kernel was in the
+//	                    horizon. The sample is on the right kernel; which
+//	                    invocation of it is not in question because there was
+//	                    only one.
+//	kernel-ambiguous    the same join, with MORE than one execution of that
+//	                    kernel in the horizon. The samples were attached to
+//	                    one of them. This is an inference and it is marked as
+//	                    one - spec §10 requires the marking rather than
+//	                    guessing it away.
+//	kernel-multidevice  the same join, in a process observed running kernels
+//	                    on more than one device. gpu_pc_sample_batch_v1
+//	                    carries no device id and two devices running one
+//	                    binary produce one cubin CRC, so the samples are
+//	                    indistinguishable on the wire. PC sampling is
+//	                    single-GPU in this phase; this value is the refusal,
+//	                    made visible rather than silent.
+//
+// The empty value is not one of the four and is not a fifth outcome: it is
+// what an ExecutionView with no PC samples at all carries, because there is
+// nothing to describe. Every ExecutionView holding at least one PC sample
+// carries one of the four.
+type PCAttrib string
+
+const (
+	// PCAttribExact is the correlation-keyed join, unchanged by the module
+	// path. It is the only value that is not an inference.
+	PCAttribExact PCAttrib = "exact"
+
+	// PCAttribKernel is the module join with one candidate execution.
+	PCAttribKernel PCAttrib = "kernel"
+
+	// PCAttribKernelAmbiguous is the module join with several candidate
+	// executions of the same kernel in the horizon.
+	PCAttribKernelAmbiguous PCAttrib = "kernel-ambiguous"
+
+	// PCAttribKernelMultiDevice is the module join in a multi-device process,
+	// where cubin_crc cannot distinguish the devices.
+	PCAttribKernelMultiDevice PCAttrib = "kernel-multidevice"
+)
+
+// pcAttribs lists the four in stable order, worst-caveat last. The order is
+// also the precedence order used by worsePCAttrib.
+var pcAttribs = []PCAttrib{
+	PCAttribExact,
+	PCAttribKernel,
+	PCAttribKernelAmbiguous,
+	PCAttribKernelMultiDevice,
+}
+
+// PCAttribs returns the four gpu_pc_attrib values in stable order.
+//
+// It exists for the same reason SrcStatuses does: a consumer switching on the
+// value can be tested for exhaustiveness against the enum itself rather than
+// against a hand-copied list that a fifth value would escape.
+func PCAttribs() []PCAttrib {
+	out := make([]PCAttrib, len(pcAttribs))
+	copy(out, pcAttribs)
+	return out
+}
+
+// pcAttribRank orders the four by how much doubt they carry, so that an
+// execution served by two pending groups of differing quality reports the
+// worse of the two rather than whichever happened to be processed last. A
+// value not in the table ranks below everything, which is what makes the empty
+// value lose to any real one.
+func pcAttribRank(a PCAttrib) int {
+	for i, v := range pcAttribs {
+		if v == a {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+// worsePCAttrib returns whichever of the two carries more doubt. Attribution
+// quality can only ever be revised downward as more evidence arrives, never
+// up: an execution that took ambiguous samples does not become unambiguous
+// because a second, unambiguous group also landed on it.
+func worsePCAttrib(a, b PCAttrib) PCAttrib {
+	if pcAttribRank(b) > pcAttribRank(a) {
+		return b
+	}
+	return a
+}
+
+// MarshalJSON refuses any value that is not one of the four, matching
+// SrcStatus, ClockDomain and GPUCapability in this package. The empty value is
+// refused too: an ExecutionView that holds PC samples and no attribution is a
+// bug in the join, and it must fail at the serialization boundary rather than
+// ship as a string a consumer would read as meaningful. ExecutionView tags the
+// field omitempty, so a view with no PC samples never reaches here.
+func (a PCAttrib) MarshalJSON() ([]byte, error) {
+	if pcAttribRank(a) == 0 {
+		return nil, fmt.Errorf("invalid gpu_pc_attrib %q", string(a))
+	}
+	return []byte(`"` + string(a) + `"`), nil
+}
+
+// PCJoinStats accounts for the module-keyed PC join that Snapshot performs on
+// correlation-less samples - the continuous-mode path. Every field is
+// per-Snapshot except MultiDeviceProcesses, which is a cumulative gauge of the
+// Timeline's observations (see Timeline.devicesByPID).
+//
+// The four Groups* counters partition every pending group the join examined,
+// which is the identity that makes this set checkable rather than merely
+// reported: a group is joined, or it is left pending for exactly one stated
+// reason. A group left pending is not lost - it stays in the store and is
+// eligible for a later Snapshot, and if it never becomes joinable it ages out
+// into Dropped.EvictedPendingModuleSamples, which is where the loss is
+// finally counted.
+type PCJoinStats struct {
+	// AttributedExact and AttributedKernel split Snapshot.AttributedPCSamples
+	// by which index served the sample. They always sum to it.
+	AttributedExact  uint64 `json:"attributed_exact,omitempty"`
+	AttributedKernel uint64 `json:"attributed_kernel,omitempty"`
+
+	// GroupsJoined counts pending module groups consumed into an execution by
+	// this Snapshot.
+	GroupsJoined uint64 `json:"groups_joined,omitempty"`
+
+	// GroupsUnresolvedName counts groups whose (cubin CRC, functionIndex)
+	// could not be turned into a device function name: no module store is
+	// configured, the cubin never reached the agent, it was evicted, its
+	// bytes did not parse, or the index is not in its symbol table. Without a
+	// name there is nothing to match an execution's KernelName against, and
+	// the samples stay pending rather than being attached to a plausible
+	// neighbour.
+	GroupsUnresolvedName uint64 `json:"groups_unresolved_name,omitempty"`
+
+	// GroupsNoExecution counts groups that DID resolve to a device function
+	// but found no execution to attach to: no execution in this snapshot came
+	// from the same process carrying that kernel name, or every one that did
+	// had already been served by the exact-correlation index. This is the
+	// ordinary state at a snapshot boundary - the execution may simply not
+	// have arrived yet - and is not on its own an anomaly.
+	GroupsNoExecution uint64 `json:"groups_no_execution,omitempty"`
+
+	// GroupsNoProcess counts groups whose PID is zero: the producer named no
+	// process. Such a group cannot be joined at all, because every process
+	// that names no process shares the key, so attaching it to an execution
+	// would be attributing one process's GPU samples to another's call stack
+	// on nothing but a kernel name. Issue #52's refusal, applied to PC
+	// samples.
+	GroupsNoProcess uint64 `json:"groups_no_process,omitempty"`
+
+	// AmbiguousAttributions and MultiDeviceAttributions count EXECUTIONS in
+	// this snapshot whose final gpu_pc_attrib is kernel-ambiguous and
+	// kernel-multidevice respectively. They are counts of executions, not of
+	// groups, because that is the unit the label is carried on.
+	//
+	// AmbiguousAttributions is emphatically NOT
+	// JoinStats.AmbiguousHeuristicMatchCount and must never be merged with
+	// it. That one counts heuristic LAUNCH joins; this one counts PC
+	// attributions. See PCAttrib.
+	AmbiguousAttributions   uint64 `json:"ambiguous_attributions,omitempty"`
+	MultiDeviceAttributions uint64 `json:"multi_device_attributions,omitempty"`
+
+	// MultiDeviceProcesses counts distinct processes the Timeline has ever
+	// seen execute kernels on more than one device. Cumulative, not
+	// per-snapshot: the condition is a property of the process, and a process
+	// does not stop having used two devices because this snapshot only saw
+	// one.
+	MultiDeviceProcesses uint64 `json:"multi_device_processes,omitempty"`
+
+	// DeviceTrackingCapped counts processes the multi-device tracker refused
+	// to admit because it was already at maxTrackedDeviceProcesses. It exists
+	// so that "no multi-device process was found" and "we stopped looking"
+	// are distinguishable: past the cap a new process is treated as
+	// single-device, which is the right guess and still a guess. Zero on
+	// anything short of thousands of concurrently profiled GPU processes.
+	DeviceTrackingCapped uint64 `json:"device_tracking_capped,omitempty"`
+}
+
+// GroupsExamined returns the number of pending module groups the four Groups*
+// counters account for, which must equal the number of groups the join
+// actually walked.
+func (s PCJoinStats) GroupsExamined() uint64 {
+	return s.GroupsJoined + s.GroupsUnresolvedName + s.GroupsNoExecution + s.GroupsNoProcess
+}
+
+// AttributedTotal returns the number of PC samples the two Attributed*
+// counters account for, which must equal Snapshot.AttributedPCSamples.
+func (s PCJoinStats) AttributedTotal() uint64 {
+	return s.AttributedExact + s.AttributedKernel
+}

--- a/gpu/pcjoin_test.go
+++ b/gpu/pcjoin_test.go
@@ -1,0 +1,641 @@
+package gpu
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures for the module join
+// ---------------------------------------------------------------------------
+
+// pcJoinFixture is a Timeline wired to a module store holding one real cubin,
+// plus the symbol index that cubin's kernel actually occupies. The index is
+// read out of the fixture rather than hard-coded: whether CUPTI's
+// functionIndex IS the .symtab index is measured on hardware, and these tests
+// assert only that the join uses whatever the store uses, consistently.
+type pcJoinFixture struct {
+	tl      *Timeline
+	store   *ModuleStore
+	crc     uint64
+	fnIndex uint32
+	kernel  string
+}
+
+const pcJoinCRC = 0xC0FFEE
+
+func newPCJoinFixture(t *testing.T, cfg TimelineConfig) *pcJoinFixture {
+	t.Helper()
+	return newPCJoinFixtureFrom(t, cfg, "single_lineinfo.cubin", "addOne")
+}
+
+func newPCJoinFixtureFrom(t *testing.T, cfg TimelineConfig, cubinName, kernel string) *pcJoinFixture {
+	t.Helper()
+	b := fixture(t, cubinName)
+	store := NewModuleStore(ModuleStoreConfig{})
+	require.NoError(t, store.Put(pcJoinCRC, b))
+
+	cfg.Modules = store
+	return &pcJoinFixture{
+		tl:      NewTimeline(cfg),
+		store:   store,
+		crc:     pcJoinCRC,
+		fnIndex: symIndexOf(t, b, kernel),
+		kernel:  kernel,
+	}
+}
+
+// sample emits one Tier B PC sample for the fixture's kernel.
+func (f *pcJoinFixture) sample(t *testing.T, pid uint32, timeNs uint64) {
+	t.Helper()
+	require.NoError(t, f.tl.EmitPCSample(tierBSample(pid, f.crc, f.fnIndex, timeNs)))
+}
+
+// pcExec is an execution of a named kernel on a named device, in a process,
+// with no vendor correlation value - the Tier B shape, where the exec's
+// correlation is not what the PC samples join on.
+func pcExec(pid uint32, kernel, device string, startNs, endNs uint64) GPUKernelExec {
+	return GPUKernelExec{
+		Execution:   GPUExecutionRef{Backend: BackendCUPTI, DeviceID: device},
+		Correlation: CorrelationID{Backend: BackendCUPTI, PID: pid},
+		Queue:       GPUQueueRef{Backend: BackendCUPTI, QueueID: "s0"},
+		KernelName:  kernel,
+		StartNs:     startNs,
+		EndNs:       endNs,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The join works
+// ---------------------------------------------------------------------------
+
+// TestTierBSampleReachesItsExecution is the deliverable: a continuous-mode PC
+// sample, which carries no correlation at all, arrives at the execution of the
+// kernel it was sampled in - through the module and nothing else.
+//
+// Nothing in the inputs connects the sample to the execution directly. The
+// sample knows a cubin CRC and a function index; the execution knows a kernel
+// name. The module is the only thing that turns the first into the second.
+func TestTierBSampleReachesItsExecution(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, pid, 10)
+	f.sample(t, pid, 11)
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 20, 30)))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	view := snap.Executions[0]
+
+	require.Len(t, view.PCSamples, 2, "both samples must reach the execution of their kernel")
+	assert.Equal(t, PCAttribKernel, view.PCAttrib,
+		"one execution of this kernel was in the horizon, so the attribution is not an inference about which invocation")
+	assert.Equal(t, uint64(2), snap.AttributedPCSamples)
+	assert.Equal(t, uint64(2), snap.PCJoin.AttributedKernel)
+	assert.Zero(t, snap.PCJoin.AttributedExact, "no sample here carried a correlation")
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsJoined)
+	assert.Zero(t, snap.PendingModuleSamples, "a joined group is consumed, not left behind")
+	assert.Zero(t, snap.PendingModuleGroups)
+	assert.Zero(t, snap.Dropped.EvictedPendingModuleSamples)
+
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestTierBJoinIsConsumingLikeTheExactPath pins the lifecycle: a group handed
+// to an execution is gone, so a second Snapshot cannot hand the same samples
+// to a second execution of the same kernel. Re-reporting them would
+// double-count stall time across snapshots exactly as the pre-fix exec bug
+// double-counted GPU time.
+func TestTierBJoinIsConsumingLikeTheExactPath(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, pid, 10)
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 20, 30)))
+	first := f.tl.Snapshot()
+	require.Len(t, first.Executions[0].PCSamples, 1)
+
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 40, 50)))
+	second := f.tl.Snapshot()
+	require.Len(t, second.Executions, 1)
+	assert.Empty(t, second.Executions[0].PCSamples,
+		"the group was consumed by the first snapshot; the second must not receive it again")
+	assert.Empty(t, string(second.Executions[0].PCAttrib),
+		"an execution with no PC samples has nothing for gpu_pc_attrib to describe")
+	assert.Zero(t, second.AttributedPCSamples)
+}
+
+// ---------------------------------------------------------------------------
+// kernel-ambiguous, and the de-overloading it exists for
+// ---------------------------------------------------------------------------
+
+// TestTierBAmbiguityIsMarkedWithoutTouchingAmbiguous is the assertion that
+// pins the whole reason gpu_pc_attrib is a separate label.
+//
+// Two executions of one kernel are in the horizon, so which invocation the
+// samples came from is an inference. That inference is marked - and
+// ExecutionView.Ambiguous, which means "the heuristic LAUNCH join picked one
+// of several candidate launches" and feeds AmbiguousHeuristicMatchCount, is
+// left alone. Reusing it would emit gpu_ambiguous="true" on this sample
+// alongside whatever gpu_join says, putting two unrelated facts on one boolean
+// and making AmbiguousHeuristicMatchCount stop counting heuristic launch
+// joins.
+//
+// The projection is asserted directly rather than only the struct field,
+// because the struct field is not what a consumer reads.
+func TestTierBAmbiguityIsMarkedWithoutTouchingAmbiguous(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, pid, 10)
+	f.sample(t, pid, 11)
+	f.sample(t, pid, 12)
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 20, 30)))
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 40, 50)))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 2)
+
+	var carrying int
+	for _, view := range snap.Executions {
+		labels := projectionLabels(view)
+		_, hasAmbiguous := labels["gpu_ambiguous"]
+		assert.False(t, hasAmbiguous,
+			"gpu_ambiguous means a heuristic LAUNCH join chose between candidate launches; "+
+				"PC ambiguity must never set it, or one boolean carries two unrelated facts")
+		assert.False(t, view.Ambiguous, "and the field it comes from must be untouched too")
+
+		if len(view.PCSamples) == 0 {
+			continue
+		}
+		carrying++
+		assert.Equal(t, PCAttribKernelAmbiguous, view.PCAttrib,
+			"two executions of this kernel were in the horizon, so which invocation is an inference and must say so")
+	}
+	assert.Equal(t, 1, carrying,
+		"the group goes to one execution whole; splitting it would manufacture a distribution the data does not contain")
+
+	assert.Equal(t, uint64(1), snap.PCJoin.AmbiguousAttributions)
+	assert.Zero(t, snap.JoinStats.AmbiguousHeuristicMatchCount,
+		"AmbiguousHeuristicMatchCount counts heuristic launch joins and there were none; "+
+			"a PC-ambiguity increment here would corrupt what that counter's name promises")
+	assert.Equal(t, uint64(3), snap.PCJoin.AttributedKernel)
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestTierBAmbiguousGoesToTheEarliestExecution pins which invocation receives
+// the samples, so the choice is a stated rule rather than whatever order the
+// producer's drain happened to deliver executions in.
+func TestTierBAmbiguousGoesToTheEarliestExecution(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, pid, 10)
+	// Emitted late-first: ring order and StartNs order disagree deliberately.
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 900, 950)))
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 100, 150)))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 2)
+	require.Equal(t, uint64(900), snap.Executions[0].Exec.StartNs, "ring order is emission order")
+
+	assert.Empty(t, snap.Executions[0].PCSamples)
+	require.Len(t, snap.Executions[1].PCSamples, 1,
+		"the earliest execution by StartNs takes the group, whatever order the producer drained them in")
+	assert.Equal(t, PCAttribKernelAmbiguous, snap.Executions[1].PCAttrib)
+}
+
+// ---------------------------------------------------------------------------
+// kernel-multidevice
+// ---------------------------------------------------------------------------
+
+// TestTierBMultiDeviceProcessIsMarked drives the out-of-scope condition the
+// design names: gpu_pc_sample_batch_v1 carries no device id, and one binary on
+// two devices has one cubin CRC, so their samples are indistinguishable on the
+// wire. There is no way to make this join right; there is only a way to stop
+// it looking right.
+func TestTierBMultiDeviceProcessIsMarked(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, pid, 10)
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 20, 30)))
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, "other_kernel", "1", 25, 35)))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 2)
+	require.Len(t, snap.Executions[0].PCSamples, 1)
+
+	assert.Equal(t, PCAttribKernelMultiDevice, snap.Executions[0].PCAttrib,
+		"only one execution of this kernel was in the horizon, but the process ran on two devices, "+
+			"so the samples cannot be shown to have come from this device at all")
+	assert.Equal(t, uint64(1), snap.PCJoin.MultiDeviceProcesses)
+	assert.Equal(t, uint64(1), snap.PCJoin.MultiDeviceAttributions)
+	assert.Zero(t, snap.PCJoin.AmbiguousAttributions,
+		"multidevice is the reported caveat; it must not also be counted as ambiguity")
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestMultiDeviceOutranksAmbiguity pins the precedence: an execution whose
+// attribution is doubtful on two axes reports the one that says the samples
+// might be from another device entirely, which is the larger doubt.
+func TestMultiDeviceOutranksAmbiguity(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, pid, 10)
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 20, 30)))
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "1", 40, 50)))
+
+	snap := f.tl.Snapshot()
+	var attribs []PCAttrib
+	for _, view := range snap.Executions {
+		if len(view.PCSamples) > 0 {
+			attribs = append(attribs, view.PCAttrib)
+		}
+	}
+	require.Len(t, attribs, 1)
+	assert.Equal(t, PCAttribKernelMultiDevice, attribs[0])
+}
+
+// TestSingleDeviceProcessIsNotMarkedMultiDevice is the negative half: the
+// guard must not fire on the ordinary case, or the mark it exists to raise
+// means nothing.
+func TestSingleDeviceProcessIsNotMarkedMultiDevice(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, pid, 10)
+	for i := range 20 {
+		require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", uint64(20+i), uint64(30+i))))
+	}
+	require.NoError(t, f.tl.EmitExec(pcExec(9999, "elsewhere", "1", 5, 6)))
+
+	snap := f.tl.Snapshot()
+	assert.Zero(t, snap.PCJoin.MultiDeviceProcesses,
+		"two processes on one device each is not one process on two devices")
+	assert.Zero(t, snap.PCJoin.MultiDeviceAttributions)
+	assert.Zero(t, snap.PCJoin.DeviceTrackingCapped)
+}
+
+// TestDeviceTrackingCapIsCountedNotSilent drives the multi-device guard past
+// its bound. Past the cap a new process is treated as single-device, which is
+// the right guess and still a guess - so the refusal is counted and raised,
+// rather than leaving "we found no multi-device process" and "we stopped
+// looking" indistinguishable.
+func TestDeviceTrackingCapIsCountedNotSilent(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{})
+	for i := range maxTrackedDeviceProcesses + 10 {
+		//nolint:gosec // the loop bound is a small constant.
+		require.NoError(t, tl.EmitExec(pcExec(uint32(i+1), "k", "0", 1, 2)))
+	}
+	snap := tl.Snapshot()
+	assert.Equal(t, uint64(10), snap.PCJoin.DeviceTrackingCapped)
+	assert.Contains(t, strings.Join(JoinHealth(snap), "\n"), "multi-device guard",
+		"a guard that stopped looking must say so")
+}
+
+// ---------------------------------------------------------------------------
+// Refusals: the four ways a group is left pending
+// ---------------------------------------------------------------------------
+
+// TestTierBUnknownModuleStaysPendingAndIsEvicted is the "when in doubt, leave
+// it pending" case, end to end. The cubin for this CRC never reached the
+// agent, so nothing can name the function; the samples are not attached to a
+// nearby kernel, they wait, and when they age out the loss is counted where
+// losses are counted.
+func TestTierBUnknownModuleStaysPendingAndIsEvicted(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{PendingSampleHorizonNs: 1_000})
+
+	// A CRC the store has never seen, against an execution whose kernel name
+	// would have matched had the module been in hand.
+	const unknownCRC = 0xDEADBEEF
+	require.NoError(t, f.tl.EmitPCSample(tierBSample(pid, unknownCRC, f.fnIndex, 10)))
+	require.NoError(t, f.tl.EmitPCSample(tierBSample(pid, unknownCRC, f.fnIndex, 11)))
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 20, 30)))
+
+	pendingSnap := f.tl.Snapshot()
+	require.Len(t, pendingSnap.Executions, 1)
+	assert.Empty(t, pendingSnap.Executions[0].PCSamples,
+		"an unnameable group must never be attached to an execution that merely looks plausible")
+	assert.Empty(t, string(pendingSnap.Executions[0].PCAttrib))
+	assert.Equal(t, uint64(1), pendingSnap.PCJoin.GroupsUnresolvedName)
+	assert.Zero(t, pendingSnap.PCJoin.GroupsJoined)
+	assert.Equal(t, 2, pendingSnap.PendingModuleSamples, "still pending, not lost")
+	assert.Zero(t, pendingSnap.Dropped.EvictedPendingModuleSamples)
+	assert.Contains(t, strings.Join(JoinHealth(pendingSnap), "\n"),
+		"could not be resolved to a device function",
+		"an operator must be told why these samples are not in the profile")
+	assertPCJoinIdentities(t, pendingSnap)
+
+	// Age it out. The horizon anchor advances on the next sample, which
+	// belongs to a different group.
+	require.NoError(t, f.tl.EmitPCSample(tierBSample(pid, f.crc, f.fnIndex, 500_000)))
+
+	evictedSnap := f.tl.Snapshot()
+	assert.Equal(t, uint64(2), evictedSnap.Dropped.EvictedPendingModuleSamples,
+		"the loss is counted at eviction, which is where it actually happens")
+	assert.Zero(t, evictedSnap.Dropped.EvictedPendingSamples,
+		"and never on the correlation-keyed counter")
+}
+
+// TestTierBKernelNameMismatchStaysPending is the rule the design states in so
+// many words: matching the module's function name against the execution's
+// KernelName is what links a PC group to an execution, and where they do not
+// match the samples stay pending rather than being attached to a plausible
+// neighbour.
+//
+// The comparison is exact. This test uses a name that differs by one
+// character, in the same process, on the same queue, at a time that would have
+// qualified under any windowed heuristic - everything a "close enough" match
+// would have taken.
+func TestTierBKernelNameMismatchStaysPending(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+	require.Equal(t, "addOne", f.kernel)
+
+	f.sample(t, pid, 10)
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, "addOnes", "0", 20, 30)))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Empty(t, snap.Executions[0].PCSamples,
+		"a one-character difference is a different kernel; the module, not the string, decides identity")
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsNoExecution)
+	assert.Equal(t, 1, snap.PendingModuleSamples)
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestTierBJoinStaysWithinTheProcess is issue #52's discipline at the join.
+// Two processes running the identical binary produce the identical cubin CRC
+// and the identical function index - only the pid separates them, and it is a
+// field of both keys rather than a check beside them.
+func TestTierBJoinStaysWithinTheProcess(t *testing.T) {
+	const (
+		pidA = 4242
+		pidB = 5353
+	)
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, pidA, 10)
+	f.sample(t, pidB, 11)
+	// Only process A has an execution.
+	require.NoError(t, f.tl.EmitExec(pcExec(pidA, f.kernel, "0", 20, 30)))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.Len(t, snap.Executions[0].PCSamples, 1,
+		"process A's execution takes process A's group and nothing else")
+	assert.Equal(t, uint32(pidA), snap.Executions[0].PCSamples[0].Correlation.PID)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsJoined)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsNoExecution,
+		"process B's identical group finds no execution of its own and waits")
+	assert.Equal(t, 1, snap.PendingModuleSamples)
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestTierBGroupWithNoProcessIsRefused covers the producer that names no
+// process at all. Every such group from every process shares one key, so
+// attaching one to an execution would be attributing one process's GPU samples
+// to another's call stack on nothing but a kernel name.
+func TestTierBGroupWithNoProcessIsRefused(t *testing.T) {
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, 0, 10)
+	require.NoError(t, f.tl.EmitExec(pcExec(0, f.kernel, "0", 20, 30)))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Empty(t, snap.Executions[0].PCSamples)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsNoProcess)
+	assert.Zero(t, snap.PCJoin.GroupsJoined)
+	assert.Equal(t, 1, snap.PendingModuleSamples)
+	assert.Contains(t, strings.Join(JoinHealth(snap), "\n"), "naming no process")
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestTierBWithoutAModuleStoreLeavesEverythingPending pins that a nil store is
+// accounted for rather than skipped. A Timeline with no module store cannot
+// name any group, which is the same fact for the profile as a cubin that never
+// arrived - and it must read that way in the counters, not as a healthy run
+// that happened to join nothing.
+func TestTierBWithoutAModuleStoreLeavesEverythingPending(t *testing.T) {
+	const pid = 4242
+	tl := NewTimeline(TimelineConfig{})
+
+	require.NoError(t, tl.EmitPCSample(tierBSample(pid, pcJoinCRC, 3, 10)))
+	require.NoError(t, tl.EmitExec(pcExec(pid, "addOne", "0", 20, 30)))
+
+	snap := tl.Snapshot()
+	assert.Empty(t, snap.Executions[0].PCSamples)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsUnresolvedName,
+		"no store is not 'nothing to do'; it is 'every group is unnameable'")
+	assert.Equal(t, 1, snap.PendingModuleSamples)
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestTierBUnknownFunctionIndexStaysPending is the other half of unnameable: the
+// module is in hand, and the index is not one of its functions. The store
+// refuses to pick a neighbouring function and the join refuses to invent an
+// execution for it.
+func TestTierBUnknownFunctionIndexStaysPending(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	require.NoError(t, f.tl.EmitPCSample(tierBSample(pid, f.crc, f.fnIndex+9999, 10)))
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 20, 30)))
+
+	snap := f.tl.Snapshot()
+	assert.Empty(t, snap.Executions[0].PCSamples)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsUnresolvedName)
+	assertPCJoinIdentities(t, snap)
+}
+
+// ---------------------------------------------------------------------------
+// The exact path is unchanged
+// ---------------------------------------------------------------------------
+
+// TestExactCorrelationJoinIsUnchangedAndLabelledExact is the non-regression
+// half. Tier A keeps taking the correlation index, first, and the samples it
+// delivers are labelled exact - vendor truth, not an inference - while the
+// module join is confined to what that pass left unserved.
+func TestExactCorrelationJoinIsUnchangedAndLabelledExact(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+	corr := CorrelationID{Backend: BackendCUPTI, PID: pid, Value: "77"}
+
+	require.NoError(t, f.tl.EmitPCSample(GPUPCSample{
+		Correlation:   corr,
+		Module:        ModuleRef{Backend: BackendCUPTI, CRC: f.crc},
+		FunctionIndex: f.fnIndex,
+		TimeNs:        10,
+		PCOffset:      0x10,
+		Count:         1,
+	}))
+	exec := pcExec(pid, f.kernel, "0", 20, 30)
+	exec.Correlation = corr
+	require.NoError(t, f.tl.EmitExec(exec))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	view := snap.Executions[0]
+	require.Len(t, view.PCSamples, 1)
+	assert.Equal(t, PCAttribExact, view.PCAttrib)
+	assert.Equal(t, uint64(1), snap.PCJoin.AttributedExact)
+	assert.Zero(t, snap.PCJoin.AttributedKernel)
+	assert.Zero(t, snap.PCJoin.GroupsExamined(), "the module store was never consulted; nothing was pending in it")
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestExactPathKeepsFirstClaim pins the ordering the design requires. An
+// execution served by the correlation index is not a candidate for the module
+// join, so a correlation-less group for the same kernel cannot pile onto it -
+// it waits for an execution of its own.
+func TestExactPathKeepsFirstClaim(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+	corr := CorrelationID{Backend: BackendCUPTI, PID: pid, Value: "77"}
+
+	require.NoError(t, f.tl.EmitPCSample(GPUPCSample{
+		Correlation: corr, Module: ModuleRef{Backend: BackendCUPTI, CRC: f.crc},
+		FunctionIndex: f.fnIndex, TimeNs: 10, Count: 1,
+	}))
+	f.sample(t, pid, 11)
+
+	exec := pcExec(pid, f.kernel, "0", 20, 30)
+	exec.Correlation = corr
+	require.NoError(t, f.tl.EmitExec(exec))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.Len(t, snap.Executions[0].PCSamples, 1, "only the exact sample lands here")
+	assert.Equal(t, PCAttribExact, snap.Executions[0].PCAttrib)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsNoExecution,
+		"the only execution of this kernel was already served exactly, so the module group waits")
+	assert.Equal(t, 1, snap.PendingModuleSamples)
+	assertPCJoinIdentities(t, snap)
+}
+
+// ---------------------------------------------------------------------------
+// Accounting
+// ---------------------------------------------------------------------------
+
+// TestTierBJoinAccountsForEveryGroup forces all four group outcomes in one
+// run. A refusal path that returned without incrementing a counter - the
+// easiest mistake here and an invisible one - breaks the partition.
+func TestTierBJoinAccountsForEveryGroup(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{})
+
+	f.sample(t, pid, 10)                                                          // joined
+	require.NoError(t, f.tl.EmitPCSample(tierBSample(pid, 0xBAD, f.fnIndex, 11))) // unnameable
+	f.sample(t, 5353, 12)                                                         // named, no execution (other process)
+	f.sample(t, 0, 13)                                                            // no process
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 20, 30)))
+
+	snap := f.tl.Snapshot()
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsJoined)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsUnresolvedName)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsNoExecution)
+	assert.Equal(t, uint64(1), snap.PCJoin.GroupsNoProcess)
+	assert.Equal(t, uint64(4), snap.PCJoin.GroupsExamined())
+	assert.Equal(t, 3, snap.PendingModuleGroups)
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestTierBReconciliationCoversAttributedAndPending is the reconciliation
+// identity with its new bucket forced non-zero: some samples attributed
+// through the module, some still pending, some evicted. Every sample emitted
+// lands in exactly one.
+func TestTierBReconciliationCoversAttributedAndPending(t *testing.T) {
+	const pid = 4242
+	f := newPCJoinFixture(t, TimelineConfig{
+		MaxPendingSamplesPerCorrelation: 2,
+	})
+
+	emitted := uint64(0)
+	// Four into the joinable group, which holds two: two attributed, two
+	// evicted by the per-group cap.
+	for i := range 4 {
+		f.sample(t, pid, uint64(10+i))
+		emitted++
+	}
+	// One into a group nothing can name: still pending at the end.
+	require.NoError(t, f.tl.EmitPCSample(tierBSample(pid, 0xBAD, f.fnIndex, 20)))
+	emitted++
+
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 30, 40)))
+
+	snap := f.tl.Snapshot()
+
+	assert.Equal(t, emitted,
+		snap.AttributedPCSamples+
+			uint64(snap.PendingSamples)+snap.Dropped.EvictedPendingSamples+
+			uint64(snap.PendingModuleSamples)+snap.Dropped.EvictedPendingModuleSamples,
+		"every emitted sample must be attributed, pending, or evicted - never unaccounted for")
+
+	assert.Equal(t, uint64(2), snap.AttributedPCSamples)
+	assert.Equal(t, uint64(2), snap.PCJoin.AttributedKernel)
+	assert.Equal(t, uint64(2), snap.Dropped.EvictedPendingModuleSamples)
+	assert.Equal(t, 1, snap.PendingModuleSamples)
+	assert.Zero(t, snap.Dropped.EvictedPendingSamples,
+		"the Tier A counter stays assertably zero through every Tier B outcome")
+	assertPCJoinIdentities(t, snap)
+}
+
+// assertPCJoinIdentities checks the two sums the PC join must satisfy in every
+// scenario, in the same shape the conformance suite checks them: the attributed
+// breakdown accounts for every attributed sample, and the four group outcomes
+// account for every group examined.
+func assertPCJoinIdentities(t *testing.T, snap Snapshot) {
+	t.Helper()
+	assert.Equal(t, snap.AttributedPCSamples, snap.PCJoin.AttributedTotal(),
+		"AttributedExact + AttributedKernel must account for every attributed sample: %+v", snap.PCJoin)
+	assert.Equal(t, snap.PCJoin.GroupsExamined(),
+		snap.PCJoin.GroupsJoined+uint64(snap.PendingModuleGroups),
+		"every group examined must be joined or left pending for one counted reason: %+v", snap.PCJoin)
+	assertPCAttribAccompaniesSamples(t, snap)
+}
+
+// ---------------------------------------------------------------------------
+// The enum itself
+// ---------------------------------------------------------------------------
+
+// TestPCAttribsAreExhaustiveAndStable pins the four wire strings. They are the
+// gpu_pc_attrib label values; rewording one silently changes the profile.
+func TestPCAttribsAreExhaustiveAndStable(t *testing.T) {
+	assert.Equal(t,
+		[]PCAttrib{"exact", "kernel", "kernel-ambiguous", "kernel-multidevice"},
+		PCAttribs())
+
+	PCAttribs()[0] = "mutated"
+	assert.Equal(t, PCAttribExact, PCAttribs()[0], "PCAttribs must return a copy")
+}
+
+// TestPCAttribRefusesValuesNobodyDecided is the SrcStatus discipline applied
+// here: a value the join did not choose - including the empty one, which is
+// what an ExecutionView carrying samples and no attribution would hold - must
+// fail at the serialization boundary rather than ship as a string a consumer
+// would read as meaningful.
+func TestPCAttribRefusesValuesNobodyDecided(t *testing.T) {
+	for _, a := range PCAttribs() {
+		b, err := json.Marshal(a)
+		require.NoError(t, err)
+		assert.JSONEq(t, `"`+string(a)+`"`, string(b))
+	}
+	for _, bad := range []PCAttrib{"", "kernel-probably", "heuristic"} {
+		_, err := json.Marshal(bad)
+		assert.Error(t, err, "gpu_pc_attrib %q is not one of the four and must not serialize", bad)
+	}
+
+	// omitempty is what keeps a view with no PC samples off that path.
+	b, err := json.Marshal(ExecutionView{})
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "pc_attrib")
+}

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -32,7 +32,17 @@ type ExecutionView struct {
 	PCSamples []GPUPCSample    `json:"pc_samples,omitempty"`
 	Join      JoinKind         `json:"join,omitempty"`
 	Heuristic bool             `json:"heuristic"`
-	Ambiguous bool             `json:"ambiguous,omitempty"`
+
+	// Ambiguous means the heuristic LAUNCH join picked one of several
+	// candidate launches. It says nothing about PC samples, and nothing about
+	// PC samples ever sets it - see PCAttrib for why the two are kept apart
+	// and what would break if they were not.
+	Ambiguous bool `json:"ambiguous,omitempty"`
+
+	// PCAttrib is gpu_pc_attrib: how the PC samples above reached this
+	// execution. Empty exactly when PCSamples is empty, since there is then
+	// nothing to describe; one of PCAttribs() otherwise.
+	PCAttrib PCAttrib `json:"pc_attrib,omitempty"`
 }
 
 // TimelineDropStats counts what Timeline's own bounded storage evicted.
@@ -119,14 +129,19 @@ type Snapshot struct {
 	// every PC sample the sink accepted is attributed, still pending in one
 	// of the two stores, or evicted from one of them.
 	//
-	// Nothing joins out of this store yet — that is the Snapshot join, and it
-	// is deliberately NOT part of this change. Until it lands, a continuous-
-	// mode run shows these two gauges rising and AttributedPCSamples flat,
-	// which is the honest reading of "collected, correctly grouped, not yet
-	// attributed" rather than the previous "collapsed onto one key and
-	// silently evicted".
+	// A group that this Snapshot's join could not place is left here rather
+	// than attached to a plausible neighbour, so a persistently high
+	// PendingModuleSamples alongside a low PCJoin.AttributedKernel means the
+	// join is not finding executions for these kernels - see PCJoin for which
+	// of the four reasons it was.
 	PendingModuleSamples int `json:"pending_module_samples,omitempty"`
 	PendingModuleGroups  int `json:"pending_module_groups,omitempty"`
+
+	// PCJoin accounts for the module-keyed PC join: how each pending group
+	// fared, how the attributed samples split between the two indexes, and how
+	// many executions ended up carrying an inferred gpu_pc_attrib. See
+	// PCJoinStats.
+	PCJoin PCJoinStats `json:"pc_join,omitempty"`
 }
 
 // TimelineConfig configures Timeline's storage bounds.
@@ -203,6 +218,23 @@ type TimelineConfig struct {
 	//
 	// Zero means defaultMaxPendingModuleGroups.
 	MaxPendingModuleGroups int
+
+	// Modules is the module store the Snapshot join resolves a pending
+	// group's (cubin CRC, functionIndex) through to a device function name.
+	// It is injected rather than owned because it is filled by the cubin
+	// transport, not by Timeline, and because the projection resolves source
+	// lines against the same store: one store, two readers, no second copy of
+	// the bytes.
+	//
+	// Nil is a supported configuration and is what every backend that does
+	// not do PC sampling passes. With no store, no correlation-less group can
+	// be named, so none is joined - every one of them is counted in
+	// PCJoinStats.GroupsUnresolvedName and left pending. That is deliberately
+	// the same accounting as "the cubin never arrived", because for the
+	// profile it is the same fact: there is nothing to resolve the group
+	// against. It is NOT silently skipped, which would make a missing store
+	// look identical to a healthy run with no PC samples.
+	Modules *ModuleStore
 }
 
 // Timeline is the indexed join point: it ingests launches, executions, PC
@@ -349,20 +381,75 @@ type Timeline struct {
 	// *read*, which orderedFIFO has no notion of. This store is pure FIFO by
 	// arrival like pending, so that reason does not apply.)
 	//
-	// Nothing joins out of this store yet. Getting samples into a correctly
-	// keyed index and getting them attached to an execution are separate
-	// changes on purpose; the second one is where the module store, the
-	// kernel-name match and the attribution-quality label live.
+	// Snapshot consumes from this store exactly as it consumes from pending,
+	// via joinPendingModuleLocked: a group whose (CRC, functionIndex) names a
+	// device function that an execution in the snapshot carries as its
+	// KernelName is handed over whole and deleted. A group that cannot be
+	// named, or that finds no execution, is left here untouched and stays
+	// eligible for a later Snapshot - never attached to a plausible
+	// neighbour.
 	pendingModule            map[pendingModuleKey]pendingSamples
 	pendingModuleOrder       *orderedFIFO[pendingModuleKey]
 	pendingModuleCap         int
 	pendingModuleSampleTotal uint64
+
+	// modstore resolves a pendingModule key's (CRC, functionIndex) to a
+	// device function name at Snapshot time. Nil is supported - see
+	// TimelineConfig.Modules. Named apart from the modules ring below, which
+	// records THAT a module loaded; this one holds what a module IS.
+	modstore *ModuleStore
+
+	// devicesByPID is the multi-GPU guard's whole state: for each process
+	// that has produced an execution naming a device, the first device id
+	// seen and whether a second, different one has since arrived.
+	//
+	// It exists because gpu_pc_sample_batch_v1 carries no device id and two
+	// devices running the same binary produce the same cubin CRC, so a
+	// process's PC samples are indistinguishable BETWEEN its devices on the
+	// wire. There is no way to make the join right in that case; there is
+	// only a way to stop it from looking right, which is what
+	// PCAttribKernelMultiDevice does. Detection is on executions, which do
+	// carry a device id.
+	//
+	// It is cumulative rather than per-snapshot on purpose. The condition is
+	// a property of the process, and a process that used two devices in an
+	// earlier snapshot has not stopped having done so; per-snapshot detection
+	// would clear the mark on exactly the snapshots where only one device
+	// happened to report, which is the reading-green-when-worst failure this
+	// project keeps hitting.
+	//
+	// It is bounded, because a system-wide profile has no a-priori bound on
+	// distinct pids. Past maxTrackedDeviceProcesses a new process is not
+	// admitted and is therefore treated as single-device - the right guess,
+	// and still a guess, which is why the refusal is counted in
+	// deviceTrackingCapped and raised in joinhealth rather than absorbed.
+	devicesByPID         map[uint32]processDevices
+	multiDeviceProcesses uint64
+	deviceTrackingCapped uint64
 
 	events  *ring[GPUTimelineEvent]
 	modules *ring[GPUModule]
 
 	dropped TimelineDropStats
 }
+
+// processDevices is one process's entry in Timeline.devicesByPID: the first
+// device id observed for it, and whether a different one has since been seen.
+// Only two states matter to the join (one device, or more than one), so the
+// set itself is never retained - the whole point is a decision, not an
+// inventory, and retaining the set would make the guard's memory a function of
+// the machine's GPU count for no gain.
+type processDevices struct {
+	first string
+	multi bool
+}
+
+// maxTrackedDeviceProcesses bounds Timeline.devicesByPID. One entry is a pid,
+// a short device id string and a bool; 4,096 of them is a few hundred
+// kilobytes at most, and reaching it needs thousands of concurrently profiled
+// processes that each run GPU kernels. See the devicesByPID doc comment for
+// what happens past it and why that is counted.
+const maxTrackedDeviceProcesses = 4096
 
 // pendingSamples is a pending correlation's accumulated samples, tagged with
 // the sequence number of its current (live) generation - see the pending
@@ -478,6 +565,9 @@ func NewTimeline(cfg TimelineConfig) *Timeline {
 		// mode sampling should not pay for a preallocated slice.
 		pendingModuleOrder: newOrderedFIFO[pendingModuleKey](0),
 		pendingModuleCap:   moduleGroupCap,
+		modstore:           cfg.Modules,
+
+		devicesByPID: make(map[uint32]processDevices),
 	}
 }
 
@@ -509,10 +599,63 @@ func (t *Timeline) EmitLaunch(l GPUKernelLaunch) error {
 func (t *Timeline) EmitExec(e GPUKernelExec) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.observeExecDeviceLocked(e)
 	if t.execs.push(e) {
 		t.dropped.EvictedExecutions++
 	}
 	return nil
+}
+
+// execDeviceID is the device an execution ran on. GPUExecutionRef is the
+// authoritative place (it is the execution's own identity); GPUQueueRef's
+// device is the fallback for a producer that fills in the queue and not the
+// execution ref. Empty means the producer named no device at all, which is not
+// evidence of one device or of two and is therefore not an observation.
+func execDeviceID(e GPUKernelExec) string {
+	if e.Execution.DeviceID != "" {
+		return e.Execution.DeviceID
+	}
+	return e.Queue.Device.DeviceID
+}
+
+// observeExecDeviceLocked feeds the multi-GPU guard. It runs on every
+// execution, not only when PC sampling is on: the executions that reveal a
+// second device are not necessarily the ones whose kernels get sampled, and a
+// guard that only watched while sampling was running would learn the fact too
+// late to mark anything. Caller holds t.mu.
+func (t *Timeline) observeExecDeviceLocked(e GPUKernelExec) {
+	device := execDeviceID(e)
+	if device == "" {
+		return
+	}
+	pid := e.Correlation.PID
+
+	cur, ok := t.devicesByPID[pid]
+	if !ok {
+		if len(t.devicesByPID) >= maxTrackedDeviceProcesses {
+			t.deviceTrackingCapped++
+			return
+		}
+		t.devicesByPID[pid] = processDevices{first: device}
+		return
+	}
+	if cur.multi || cur.first == device {
+		return
+	}
+	cur.multi = true
+	t.devicesByPID[pid] = cur
+	t.multiDeviceProcesses++
+}
+
+// isMultiDeviceLocked reports whether this process has been observed running
+// kernels on more than one device. An untracked process answers false: it has
+// produced no execution naming a device, or the tracker was full, and in both
+// cases there is no evidence of a second device. The absence of evidence is
+// reported honestly by deviceTrackingCapped rather than by turning every
+// unknown into a multidevice mark, which would bury the real ones. Caller
+// holds t.mu.
+func (t *Timeline) isMultiDeviceLocked(pid uint32) bool {
+	return t.devicesByPID[pid].multi
 }
 
 func (t *Timeline) EmitPCSample(p GPUPCSample) error {
@@ -703,6 +846,198 @@ func (t *Timeline) evictPendingModuleLocked() {
 	}
 }
 
+// pcModuleJoin is joinPendingModuleLocked's result: the per-execution
+// attribution it decided, the samples it moved, and the accounting for every
+// group it looked at.
+type pcModuleJoin struct {
+	// attrib is parallel to the execs slice the join was given, empty at every
+	// index the join did not attach samples to. It is nil when the join did no
+	// work at all, which attribAt handles so callers need no length check.
+	attrib  []PCAttrib
+	samples uint64
+	stats   PCJoinStats
+}
+
+func (r pcModuleJoin) attribAt(i int) PCAttrib {
+	if i < len(r.attrib) {
+		return r.attrib[i]
+	}
+	return ""
+}
+
+// execKernelKey is the identity the module join matches on: the process, and
+// the kernel's name. Both halves are load-bearing.
+//
+// The PROCESS is in the key for the reason issue #52 put it in
+// candidateGroupKey: two processes running the identical binary produce the
+// identical cubin CRC and the identical function index, so the module side of
+// this join cannot distinguish them at all, and only the pid can. It is a
+// field of the key rather than a check beside it so there is nothing to
+// forget.
+//
+// The NAME is a plain string comparison against the name the module store read
+// out of the cubin's symbol table, and it is deliberately exact. No
+// demangling, no prefix or suffix trimming, no "close enough" - the design's
+// rule is that kernel identity comes from the module and never from guessing
+// on the kernel-name string, and every relaxation of this comparison is a way
+// to attach a sample to a kernel that merely looks related. Where the two
+// spellings do not match, the group stays pending and is counted; a sample
+// left pending is recoverable, a sample on the wrong kernel is not.
+type execKernelKey struct {
+	pid        uint32
+	kernelName string
+}
+
+// joinPendingModuleLocked is the continuous-mode half of the Snapshot join:
+// for every correlation-less pending group, resolve (cubin CRC,
+// functionIndex) through the module store to a device function name, and hand
+// the group's samples to the execution of that kernel in this snapshot.
+//
+// It runs only after the exact-correlation pass, and only over executions that
+// pass left unserved - exactServed marks the rest. That ordering is the
+// design's: Tier A keeps taking the exact index, untouched, and the module
+// path is strictly what happens on a miss.
+//
+// Four outcomes per group, and they partition the groups examined:
+//
+//	no process        the producer named no pid; refused (see execKernelKey)
+//	unnameable        no module store, no module, or an unknown functionIndex
+//	no execution      named, but no eligible execution of that kernel is here
+//	joined            attached, with the attribution quality below
+//
+// The first three leave the group in the store, untouched and still eligible
+// for a later Snapshot; they are not losses, and the loss - if the group never
+// becomes joinable - is counted where it happens, at horizon eviction.
+//
+// Attribution quality:
+//
+//	one execution of that kernel in the snapshot     -> kernel
+//	more than one                                    -> kernel-ambiguous
+//	either, in a process observed on 2+ devices      -> kernel-multidevice
+//
+// Ambiguity is counted over EVERY execution of that kernel in the snapshot,
+// not only the eligible ones, because "how many invocations of this kernel
+// could these samples have come from" is a question about the horizon, not
+// about which of them the join happened to be allowed to use.
+//
+// Where more than one execution qualifies, the group's samples go to the
+// earliest of them by StartNs, whole. Splitting them across the candidates would
+// manufacture a distribution the data does not contain, and it would make each
+// resulting execution look individually more certain than the group is; the
+// label is what carries the doubt instead. Caller holds t.mu.
+func (t *Timeline) joinPendingModuleLocked(execs []GPUKernelExec, execSamples [][]GPUPCSample, exactServed []bool) pcModuleJoin {
+	res := pcModuleJoin{
+		stats: PCJoinStats{
+			MultiDeviceProcesses: t.multiDeviceProcesses,
+			DeviceTrackingCapped: t.deviceTrackingCapped,
+		},
+	}
+	if len(t.pendingModule) == 0 {
+		return res
+	}
+
+	// byKernel indexes every named execution of this snapshot. len(indices) is
+	// the ambiguity test; the first index whose exact pass came up empty is
+	// the target.
+	byKernel := make(map[execKernelKey][]int, len(execs))
+	for i, e := range execs {
+		if e.KernelName == "" || e.Correlation.PID == 0 {
+			continue
+		}
+		key := execKernelKey{pid: e.Correlation.PID, kernelName: e.KernelName}
+		byKernel[key] = append(byKernel[key], i)
+	}
+
+	res.attrib = make([]PCAttrib, len(execs))
+
+	// Map iteration order is randomized, and two groups can legitimately
+	// resolve to the same kernel name (the same device function in two cubin
+	// generations, after a JIT reload). Walking the keys in a fixed order
+	// makes the resulting sample order, and therefore the profile, the same
+	// for the same inputs.
+	keys := slices.SortedFunc(maps.Keys(t.pendingModule), comparePendingModuleKey)
+	for _, key := range keys {
+		if key.PID == 0 {
+			res.stats.GroupsNoProcess++
+			continue
+		}
+		name, ok := "", false
+		if t.modstore != nil {
+			name, ok = t.modstore.FunctionName(key.CubinCRC, key.FunctionIndex)
+		}
+		if !ok {
+			res.stats.GroupsUnresolvedName++
+			continue
+		}
+		candidates := byKernel[execKernelKey{pid: key.PID, kernelName: name}]
+		target := -1
+		for _, i := range candidates {
+			// Earliest by StartNs, not first in ring order: executions reach
+			// the ring in the order the producer drained them, which is not
+			// the order they ran, and "which invocation" must not depend on
+			// that. Ties break on the ring index, which is stable.
+			if exactServed[i] {
+				continue
+			}
+			if target < 0 || execs[i].StartNs < execs[target].StartNs {
+				target = i
+			}
+		}
+		if target < 0 {
+			res.stats.GroupsNoExecution++
+			continue
+		}
+
+		attrib := PCAttribKernel
+		if len(candidates) > 1 {
+			attrib = PCAttribKernelAmbiguous
+		}
+		if t.isMultiDeviceLocked(key.PID) {
+			attrib = PCAttribKernelMultiDevice
+		}
+
+		entry := t.pendingModule[key]
+		execSamples[target] = append(execSamples[target], entry.samples...)
+		res.attrib[target] = worsePCAttrib(res.attrib[target], attrib)
+		res.samples += uint64(len(entry.samples))
+		res.stats.GroupsJoined++
+
+		delete(t.pendingModule, key)
+		t.pendingModuleSampleTotal -= uint64(len(entry.samples))
+	}
+
+	// Counted over executions after the fact, not incremented per group: two
+	// groups landing on one execution are one execution carrying the label,
+	// and incrementing inline would double-count it.
+	for _, a := range res.attrib {
+		switch a {
+		case PCAttribKernelAmbiguous:
+			res.stats.AmbiguousAttributions++
+		case PCAttribKernelMultiDevice:
+			res.stats.MultiDeviceAttributions++
+		case PCAttribExact, PCAttribKernel:
+		}
+	}
+	res.stats.AttributedKernel = res.samples
+	return res
+}
+
+// comparePendingModuleKey orders the pending module store's keys for the
+// deterministic walk in joinPendingModuleLocked. The field order is
+// arbitrary; only its stability matters.
+func comparePendingModuleKey(a, b pendingModuleKey) int {
+	if c := cmp.Compare(a.PID, b.PID); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.CubinCRC, b.CubinCRC); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.FunctionIndex, b.FunctionIndex); c != 0 {
+		return c
+	}
+	return cmp.Compare(string(a.Backend), string(b.Backend))
+}
+
 func (t *Timeline) EmitModule(m GPUModule) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -746,7 +1081,8 @@ func cloneTimelineEvent(in GPUTimelineEvent) GPUTimelineEvent {
 // guards: execs, events and modules are drained from their rings (a second
 // consecutive Snapshot call returns none of them unless new ones arrived in
 // between), and PC samples matched to an execution in this call are removed
-// from the pending store the same way. This is a deliberate, uniform
+// from the pending stores - both of them, correlation-keyed and module-keyed -
+// the same way. This is a deliberate, uniform
 // lifecycle across all five stores - see review Critical 3: execs used to be
 // merely copied (re-reported in every Snapshot until the ring rotated, so a
 // polling caller double-, triple-, N-counted the same kernel time) while PC
@@ -792,23 +1128,31 @@ func (t *Timeline) Snapshot() Snapshot {
 	// actually use, rather than copying the whole map: a correlation with
 	// no live exec this round is left untouched (still eligible for a
 	// later snapshot, or eventual orphan eviction).
-	var attributedPCSamples uint64
+	var attributedExact uint64
 	t.mu.Lock()
 	execSamples := make([][]GPUPCSample, len(execs))
+	exactServed := make([]bool, len(execs))
 	for i, exec := range execs {
 		if entry, ok := t.pending[exec.Correlation]; ok {
 			execSamples[i] = entry.samples
+			exactServed[i] = true
 			delete(t.pending, exec.Correlation)
 			t.pendingSampleTotal -= uint64(len(entry.samples))
-			attributedPCSamples += uint64(len(entry.samples))
+			attributedExact += uint64(len(entry.samples))
 		}
 	}
+	// The module-keyed join runs strictly after the loop above and strictly
+	// over what it left unserved: the exact-correlation path is unchanged and
+	// keeps first claim. It consumes from the module store exactly as the loop
+	// above consumes from the correlation-keyed one - a group it can place is
+	// deleted, a group it cannot is left alone and stays eligible for a later
+	// Snapshot.
+	pcJoin := t.joinPendingModuleLocked(execs, execSamples, exactServed)
+	pcJoin.stats.AttributedExact = attributedExact
+	attributedPCSamples := attributedExact + pcJoin.samples
+
 	pendingCorrelations := len(t.pending)
 	pendingSamples := t.pendingSampleTotal
-	// Read, never drained: nothing joins out of the module-keyed store yet,
-	// so every group here survives this Snapshot. When the join lands it
-	// consumes from this store the same way the loop above consumes from the
-	// correlation-keyed one.
 	pendingModuleGroups := len(t.pendingModule)
 	pendingModuleSamples := t.pendingModuleSampleTotal
 	t.mu.Unlock()
@@ -865,6 +1209,18 @@ func (t *Timeline) Snapshot() Snapshot {
 	matched := make(map[CorrelationID]struct{})
 	for i, exec := range execs {
 		view := ExecutionView{Exec: exec, PCSamples: execSamples[i]}
+		// gpu_pc_attrib, decided entirely by which index served this
+		// execution. It is set independently of view.Join and view.Ambiguous
+		// below and never reads or writes either: an execution can be joined
+		// to its launch exactly and still have INFERRED PC samples, which is
+		// precisely the pair of facts one boolean could not carry. See
+		// PCAttrib.
+		switch {
+		case exactServed[i]:
+			view.PCAttrib = PCAttribExact
+		case len(view.PCSamples) > 0:
+			view.PCAttrib = pcJoin.attribAt(i)
+		}
 
 		if exec.Correlation.Present() {
 			if l, ok := t.cache.Get(exec.Correlation); ok {
@@ -972,6 +1328,7 @@ func (t *Timeline) Snapshot() Snapshot {
 
 		PendingModuleSamples: int(pendingModuleSamples),
 		PendingModuleGroups:  pendingModuleGroups,
+		PCJoin:               pcJoin.stats,
 	}
 }
 


### PR DESCRIPTION
**Task 8b of [the GPU PC sampling plan](docs/superpowers/plans/2026-08-25-gpu-pc-sampling.md).**

`Snapshot` runs the exact-correlation pass first, byte-for-byte unchanged — the only addition is an `exactServed []bool` recording which executions it served. A module-keyed pass then walks the `pendingModule` groups from 8a, resolves each `{PID, CubinCRC, FunctionIndex}` to a device function name via `ModuleStore.FunctionName`, and hands the group to an execution of that kernel in the same process. Both passes sit inside one hold of `t.mu`, which is what makes the group accounting an identity rather than an approximation.

### The name rule, and the risk it carried

Exact string comparison between the cubin's `.symtab` name and `exec.KernelName`, inside a key that also carries the PID (#52's structural refusal). No demangling, no prefix match, no normalization. On a mismatch the group **stays pending**, is counted, and remains eligible for a later snapshot rather than being attached to a plausible neighbour.

The implementer flagged this as the dominant unknown: `KernelName` comes from CUPTI's activity record and the function name from the cubin, and whether those spellings are byte-identical for C++ kernels was established nowhere — all our fixtures are `extern "C"`, so they could not settle it. If they differed, this join would attribute **nothing** on real workloads.

**Settled offline, and it holds.** The shipped `cuda_workload.cu` uses plain C++ `__global__` kernels; compiling it with `nvcc -arch=sm_86 -cubin` and reading `.symtab`, against the kernel names CUPTI actually reported in the RTX 3090 profile:

```
.symtab                        CUPTI (real 3090 capture)
_Z14perfagent_axpyfPKfPfi  ==  _Z14perfagent_axpyfPKfPfi
_Z15perfagent_scalePffi    ==  _Z15perfagent_scalePffi
```

Byte-identical, both mangled. Exact comparison is the right rule and now has evidence rather than being the leading suspect.

###  is its own type, and cannot borrow 

New type in `gpu/pcattrib.go`, new field `ExecutionView.PCAttrib`, four values, `PCAttribs()` for exhaustiveness, and `MarshalJSON` refusing anything else **including the empty value**. It is set in a `switch` reading only `exactServed[i]` and `len(PCSamples)`; it never touches `Join`, `Heuristic` or `Ambiguous`.

Reusing `ExecutionView.Ambiguous` would have emitted `gpu_join="exact" gpu_ambiguous="true"` on one sample — two unrelated facts on one boolean, and a counter that stops meaning what its name says. Seven mutations were applied and each caught, including *"PC ambiguity also sets `ExecutionView.Ambiguous`"* and *"name match relaxed to a prefix"*.

Ambiguity is counted over every execution of the kernel in the snapshot; ties go whole to the earliest by `StartNs`.

### 

The accessor Task 4 deliberately did not add ("an accessor with no caller is an accessor with no test"), now with 7 tests: works without `-lineinfo`, survives a damaged line table, refuses rather than guesses, refreshes LRU, and increments none of the `Resolve*` counters so their partition identity still holds.

### Reconciliation

Two identities added beside 8a's, both inside `assertPCSampleLossesAccounted` so they run for every conformance scenario: `AttributedExact + AttributedKernel == AttributedPCSamples`, and `GroupsExamined() == GroupsJoined + PendingModuleGroups`.

### Cannot verify

- **What fraction of real PC samples attribute versus stay pending.** The name risk above is now closed, so the remaining unknown is horizon-shaped, not identity-shaped.
- **Whether the eviction horizon is long enough given the 100 ms drain period.** `PendingSampleHorizonNs` defaults to zero (disabled), and the gap between a drain-stamped sample and its execution has never been measured.

One drive-by fix: 8a's joinhealth summary rendered `"1 1 kernel group"` — a `%d %s` against `plural`, which already carries the number.