### PR TITLE
gpu: feed received cubins to the ModuleStore

### DIFF
--- a/.superpowers/sdd/issue-93-wiring-report.md
+++ b/.superpowers/sdd/issue-93-wiring-report.md
@@ -1,0 +1,292 @@
+# Issue #93 — the cubin transport now feeds `gpu.ModuleStore`
+
+Branch `fix/wire-cubins-to-modulestore`, one commit, on top of `e09c073a` (merge of #92,
+`feat/phase6-gate`). Verified on this machine: `CapEff: 0`, no GPU, no passwordless sudo
+(`sudo -n true` → "a password is required"). What that costs is stated in "What ran and
+what only compiled" rather than glossed.
+
+Nothing in `shim/`, `bpf/` or `internal/` changed. The transport, its seal verification,
+its admission bucket and the enrolment isolation are byte-for-byte untouched:
+`git diff --stat` shows `gpuprobe/cubin.go` +66/-7, all of it new code beside the
+existing path, and no line of `handle` altered.
+
+---
+
+## 1. The wiring
+
+Four objects, one instance, three readers.
+
+| where | what it does with the store |
+| --- | --- |
+| `gpuprobe.Config.Modules` (new) | the store the cubin listener writes every accepted cubin into |
+| `gpu.TimelineConfig.Modules` (existing) | the Snapshot join resolves a pending PC group's `(crc, functionIndex)` to a device function name through it |
+| `gpu.ProjectionConfig.Modules` (existing) | `setSourceLabels` resolves `gpu_src_*` against it |
+| the driver (`cmd/gpu-cuda-profile`, `cmd/gpu-stub-profile`) | constructs it, hands the **same pointer** to all three |
+
+Three pieces of code:
+
+**`gpu.ModuleStore.Has(crc) bool`** — live membership, refreshing LRU recency. The
+transport asks before it maps a payload, so the answer decides whether a memfd is mapped,
+copied and parsed again for bytes already held. It refreshes recency for the same reason
+`Put`'s already-held path does (a re-offer is the producer saying the module is live), and
+it increments none of the `Resolve*` counters, so Task 4's "the four partition every
+`Resolve` call" identity is intact. That identity is asserted in the new test.
+
+**`gpuprobe.moduleStoreSink`** — the adapter, holding `*gpu.ModuleStore` and satisfying
+`cubinSink`. An adapter rather than methods on `gpu.ModuleStore` because the two contracts
+differ in one place (below) and because `gpu` should not grow a method named for this
+transport.
+
+**`gpuprobe.cubinSinkFor(cfg)`** — `Config.Modules` when the caller supplied one, the
+bounded `memCubinStore` when it did not. `Attach` still calls `newCubinListener(cfg, nil)`;
+the nil now means "the sink `cfg` asks for" rather than "the placeholder". An explicit sink
+remains a test seam and nothing else.
+
+`gpu.ModuleStore` itself is otherwise unchanged: no new branch in `Resolve`, no new status,
+no memoized resolution. A nil store still yields `no-module` by being answered by an empty
+store inside `ProjectExecutionsWith`, exactly as before — the projection still does not
+decide the enum.
+
+### The one place the two contracts disagree, and where it is resolved
+
+`gpu.ModuleStore.Put`'s error is **diagnostic**: unparseable bytes are still stored (so a
+re-offer is not re-parsed), counted in `ModulesUnparseable`, and resolve as `no-module`.
+`cubinSink.PutCubin`'s error means "the offer did not land", and the listener answers it
+with `reply('X')` and `CubinsRejectedMalformed++`.
+
+Propagating one as the other would have the transport report a rejection for a cubin the
+agent is holding: `CubinsRejectedMalformed` non-zero on a healthy run, `CubinsReceived` and
+`CubinBytesReceived` understating what is held (and the total-bytes ceiling with them), and
+the producer told `'X'` for an offer that landed and that `HasCubin` will answer `true` for
+a millisecond later. So `PutCubin` reports only a failure to *store*, and the two facts
+stay in the two counters where each is true — the transport counts what arrived, the store
+counts what it can read. `Put` has no other error today; if it grows one, the adapter
+returns it.
+
+This is pinned by `TestACubinTheStoreCannotParseStillLandsAndIsCountedApart`, and the
+mutation that propagates the error fails it by name.
+
+---
+
+## 2. What the drivers configure, and why
+
+Both drivers build the store with `gpu.NewModuleStore(gpu.ModuleStoreConfig{})` — the
+package defaults, **512 modules and 64 MiB** — taken rather than restated.
+
+- **512 modules** is already the JIT/template-explosion case rather than a normal
+  workload; a real process has one cubin per loaded module, tens to low hundreds.
+- **64 MiB** is the tighter of the two resident bounds in play. The transport's own
+  ceilings sit *outside* it: 8 MiB per cubin (`Config.CubinMaxBytes`) and 256 MiB total
+  offered (`Config.CubinTotalBytes`). So the store is what actually caps what this process
+  holds, and neither driver has a workload-specific reason to deviate.
+- Writing the numbers again at each call site would put a second copy of the sizing where
+  drift is invisible. The rationale is at the call site; the numbers are in one place.
+
+Both bounds evict least-recently-used, and eviction is honest — see §4.
+
+Both drivers also now log `store.Stats()` after `JoinHealthWith`. That line is the one that
+separates the two ways a profile full of `no-module` can happen: `modules_stored=0` means
+nothing arrived (look at the `Cubins*` counters), while `modules_stored>0` with
+`resolve_no_module` high means the CRCs the PC records join on are not the CRCs the cubins
+arrived under — which is hardware assertion 13, and the single most consequential thing the
+first GPU run has to check.
+
+`cmd/gpu-stub-profile` is wired identically. It selects no tier of its own, but the stub
+inherits `PERFAGENT_GPU_PC_SAMPLING` and `PERFAGENT_STUB_CUBINS` from the operator's
+environment, so a run configured that way now produces real source labels instead of
+`no-module`, and an unconfigured run holds an empty store.
+
+---
+
+## 3. The gate assertion: from pin to real
+
+Task 13 pinned this gap with `TestGateTheCubinTransportDoesNotYetFeedTheModuleStore`, which
+passed *because* the gap existed — it asserted that the listener's default sink was
+`*memCubinStore` and that no `gpuprobe.Config` field named a module store. Its own doc
+comment said what to do when the hop was wired: delete it.
+
+**It is deleted.** The gate slot it occupied now holds assertions, in
+`gpuprobe/gate_compose_test.go`'s `TestPhase6GateConsumerHalf`:
+
+| sub-test | what it asserts |
+| --- | --- |
+| `assertion-02-an-offered-cubin-becomes-a-source-line` | a cubin crosses the real socket as a real sealed memfd, the listener writes it into the store `Config.Modules` named (asserted `require.Same`, not merely "a store"), and a PC sample carrying that CRC comes out of `ProjectExecutionsWith` as `gpu_src_status="resolved"` with `gpu_src_file="single.cu"` and a line checked against `single.cu` itself, on a sample whose frames are the launching CPU call path |
+| `assertion-02-an-evicted-module-is-no-module-and-can-return` | §4 |
+| `assertion-02-an-unreadable-cubin-still-lands-and-is-counted-apart` | §1's contract seam |
+| `assertion-04-no-store-is-a-supported-no-module-state` | a store-less consumer still binds, admits and counts offers, keeps the bounded placeholder, and resolves `no-module` |
+
+and in `gpu/gate_test.go`'s `TestPhase6Gate`, under assertion 4:
+`assertion-04-an-evicted-module-is-no-module-not-stale` (Task 4's own test, now composed
+into the gate because eviction is reachable in production for the first time) and
+`assertion-04-membership-is-live-and-counts-as-use`.
+
+All of these **run unprivileged on this machine**. The producer in them is the test process
+itself, offering the checked-in fixture over the real abstract socket as a real sealed
+memfd — which is byte-for-byte what `shim/core/cubin.cc` does, pinned from the other side
+by `TestTheCppProducerAndTheGoCubinListenerAgreeOnTheWire`.
+
+### The privileged gate
+
+`TestStubDrivesPCSamplingToPprofWithoutAGPU` no longer builds the store's contents. It
+still constructs the store — as a driver does — but hands it to `gpuprobe.Config.Modules`
+and then **asserts what the product put in it**:
+
+```
+require.Equal(t, 2, store.Len(), "the cubin transport did not feed the module store ...")
+assert.Equal(t, uint64(1), ms.ModulesWithLineInfo)
+assert.Equal(t, uint64(1), ms.ModulesWithoutLineInfo)
+assert.Equal(t, gpu.SrcResolved,   store.Resolve(gateCRCLineInfo,  lineIdx,  0x10).Status())
+assert.Equal(t, gpu.SrcNoLineInfo, store.Resolve(gateCRCNoLineInfo, noLineIdx, 0x10).Status())
+```
+
+The two `store.Put(...)` calls that filled it are gone. The CRCs are still the ones the
+**producer** declared (parsed from its own report and independently recomputed in Go over
+the fixture bytes), so the identity the store is keyed on is still the identity that went
+on the wire — that has not been weakened, it has been moved from "the test puts it there"
+to "the test checks it arrived there".
+
+`TestStubDrivesThePipelineToPprofWithoutAGPU`, the baseline gate, is untouched.
+
+---
+
+## 4. Is assertion 2 now reachable through the producer?
+
+**Half of it is, and the missing half is a second hop that is not in this product.** Stated
+precisely, because "route around it" was not an option here.
+
+Assertion 2 is the conjunction of a real CPU stack and `gpu_src_status="resolved"` naming a
+real line of the fixture's source. It has two producer-side inputs:
+
+1. **the cubin, and the store it must reach.** This is what #93 was, and it is now driven
+   entirely through the shipping path: the producer sends, the transport receives, the
+   listener writes `Config.Modules`, the Timeline and the projection read that same
+   instance. Nothing in any test puts bytes into the store any more.
+2. **a PC record that reaches an execution.** This is **still injected** at
+   `Timeline.EmitPCSample` in the privileged gate, and it still has to be.
+
+The reason is Task 13's finding 1, unchanged by this commit and still pinned by
+`TestGateTheStubsPCRecordsCannotAttributeToAnything` (unprivileged, ran):
+
+- `shim/stub/stub.cc` keys its PC records on `kStubCubinCRC = {0xC0FFEE01, 0xC0FFEE02}`,
+  two compile-time constants, while the cubins the same run delivers are keyed by a
+  content hash of the fixture bytes. No cubin is ever stored under a `0xC0FFEE0n` key, so
+  the module lookup cannot fire whatever the store holds;
+- their `correlation` is 0 in every tier, so the exact-correlation path is unavailable;
+- Tier B attribution runs `crc → module → function name → the execution's KernelName`, and
+  the stub's kernel names are `kernel_1111`/`kernel_2222` while the fixtures' only function
+  is `addOne`. No name can match.
+
+So the wire path from a *stub* PC record to a source line is broken **in the stub**, one
+hop upstream of anything this issue touched. Fixing it is a change to `shim/stub/stub.cc`
+(record the CRC each capture computed; name the kernels after the fixtures' functions),
+which is finding 1's fix and a separate change — `shim/` is also live on another worktree
+right now. It is a finding, reported, not routed around.
+
+**What this means for the phase.** Gate assertion 14 — a flame graph reaching a real line
+of `cuda_workload.cu` from a CPU stack on the RTX 3090 — was blocked by #93 *and* is not
+blocked by finding 1: the real CUPTI adapter emits real CRCs and real kernel names, so on
+hardware the join has both halves. The stub's inability to drive it is a property of the
+stub, not of the product. What the unprivileged gate now proves is the whole chain minus
+the BPF decode of `KIND_PC` (asserted separately and exactly by the 64 wire records in the
+privileged gate): socket → seals → store → module join → projection → pprof labels.
+
+---
+
+## 5. The eviction guarantee, and why the wiring cannot bypass it
+
+Task 4's `TestResolveAfterEvictionIsNoModuleNotStale` pins that an evicted module answers
+`no-module` and never the line it used to have. The store has no memoized resolution, so
+that half is absolute.
+
+The wiring has exactly **one** way to break it, and it would look like an optimisation: the
+transport asks `HasCubin` before mapping and treats "yes" as a counted no-op, so a set of
+"CRCs seen once" kept anywhere on this path — in the adapter, in the listener — would make
+one eviction permanent. The module would never be re-admitted, every PC sample for it would
+read `no-module` forever, and `CubinsDuplicate` would climb while every store counter read
+healthy. That is this project's recurring defect class exactly.
+
+So `HasCubin` is `store.Has`, live membership and nothing else, and
+`TestAnEvictedModuleAnswersNoModuleAndIsOfferedAgainNotSuppressed` drives it over the real
+socket: offer, resolve, re-offer (counted duplicate, **nothing mapped**), evict under
+`Capacity: 1`, assert `no-module`, assert `HasCubin` is false, re-offer, assert it is stored
+again (`received` 2 → 3, `duplicate` still 1) and resolves to the **same line** it did
+before.
+
+### Mutation checks (each applied, run, reverted)
+
+| mutation | result |
+| --- | --- |
+| `cubinSinkFor` ignores `cfg.Modules` (the pre-#93 behaviour) | gate assertions 02-source-line, 02-evicted, 02-unreadable FAIL |
+| the adapter keeps a `sync.Map` of CRCs it has seen | assertion 02-evicted FAILS: "the wiring remembers a CRC the store has evicted; one eviction would then be permanent" |
+| `PutCubin` returns `Put`'s diagnostic error | assertion 02-unreadable FAILS: "the offer was refused; the bytes crossed and are held, so the transport must say so" |
+
+---
+
+## 6. A finding: the transport's total ceiling is now a lifetime budget, not a resident one
+
+Not fixed here, because fixing it means changing the transport, which this task was told not
+to do. Stated so it is on the record.
+
+`cubinListener.handle` charges the total-bytes ceiling against `l.stats.bytes`, which is a
+**cumulative** count of everything ever received. With the old placeholder store nothing was
+ever evicted, so cumulative and resident were the same number and `CubinTotalBytes` bounded
+both. With `gpu.ModuleStore` they diverge: the store evicts at 64 MiB resident while the
+listener keeps counting toward 256 MiB cumulative, and a re-offer after an eviction is
+charged again.
+
+The consequence for a process that loads more than 256 MiB of *distinct* cubin bytes over
+one run: the channel starts refusing every further offer with
+`CubinsRejectedTooLarge` ("total ceiling"), and modules loaded after that point resolve
+`no-module`. It is bounded, counted, and visible in the reason string — it is not silent —
+but the counter's meaning has shifted from "we are holding too much" to "we have been sent
+too much", and the two are no longer the same. The 512-module placeholder had a comparable
+cliff (offers past 512 were refused as store failures), so this is not a regression, but it
+is now the *only* cliff and it deserves its own issue: the listener should charge the
+ceiling against what the sink actually holds, or the two ceilings should be documented as
+lifetime-vs-resident.
+
+---
+
+## 7. What ran and what only compiled
+
+**Ran, unprivileged, on this machine:**
+
+```
+make -C shim && make -C shim test && make -C shim check-fpless \
+  && make -C shim check-cubin-defer && make -C shim nvidia     # all OK
+go build ./... && go vet ./...                                  # clean
+go test ./gpu/ ./gpuprobe/ ./internal/... -count=1              # ok
+go test ./... -count=1                                          # ok (whole repo)
+go test ./gpu/ ./gpuprobe/ -race -count=4                       # ok (26.5s / 20.3s)
+~/go/bin/golangci-lint run --timeout=5m                         # 0 issues
+```
+
+Every assertion in §3's table **ran**, including the full socket → store → Timeline →
+projection → pprof-label chain, plus `TestPhase6Gate` and `TestPhase6GateConsumerHalf` in
+their entirety.
+
+**Compiled only:** `TestStubDrivesPCSamplingToPprofWithoutAGPU` — the privileged end-to-end
+gate, including the new `store.Len() == 2` / `ModulesWithLineInfo == 1` /
+`Resolve(...) == SrcResolved` block that is issue #93's own assertion. It type-checks, vets
+and lints clean and skips here with the message naming its setcap line. `CapEff: 0` and
+`sudo -n true` refuses, so it cannot be setcap'd or run on this machine at all.
+
+**Cannot verify.** Explicitly, in the order of how much it would matter:
+
+1. **That the wiring works on hardware.** Nothing here has seen a cubin CUPTI produced.
+   Everything moved is a checked-in `sm_86` fixture over a socket in one process. The
+   privileged gate is the closest thing and it did not run.
+2. **That `cuptiGetCubinCrc()` over the received bytes equals the `cubinCrc` the PC records
+   carry** — Task 3's outstanding item, and now the *only* thing between this wiring and a
+   resolved source line on the RTX 3090. If the two numbers disagree on hardware, every PC
+   sample resolves `no-module` with every counter reading green, and the new
+   `module store: {...}` log line in both drivers is what tells the two cases apart
+   (`modules_stored=2, resolve_no_module` high).
+3. **That `functionIndex` is the cubin's `.symtab` index** — unchanged premise, Task 6
+   measures it. Every test here reads the index out of the fixture and asserts only that
+   the store and the sample use the same one.
+4. **Whether the store's defaults are the right size for a real workload.** 512 / 64 MiB
+   is reasoning, not measurement; no run has ever pressured them. `ModulesEvicted*` in the
+   new driver log line is what would say so.
+5. Finding 1 above: whether assertion 2 is drivable from the *stub* — it is not, and the
+   fix is in `shim/stub/stub.cc`, out of scope here.

--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -91,11 +91,33 @@ func main() {
 		log.Fatalf("adapter %s: %v (build it with: make -C shim nvidia)", shimPath, err)
 	}
 
+	// The module store, built HERE because it has three readers and no owner
+	// among them: the cubin listener writes every arriving cubin into it
+	// (gpuprobe.Config.Modules), the Timeline's join resolves a pending PC
+	// group's (cubin_crc, functionIndex) to a device function name through it
+	// (gpu.TimelineConfig.Modules), and the projection resolves the source
+	// location against it (gpu.ProjectionConfig.Modules). It is ONE instance
+	// in all three places on purpose: a second store would hold a second copy
+	// of every cubin and answer "no-module" for modules the first one holds.
+	//
+	// The bounds are gpu.ModuleStoreConfig's defaults - 512 modules and
+	// 64 MiB - and they are taken rather than restated. 512 distinct cubins is
+	// already the JIT/template-explosion case rather than a normal workload,
+	// and 64 MiB is a tighter resident bound than anything the transport
+	// enforces (8 MiB per cubin, 256 MiB total offered), so the store is what
+	// actually caps what this process holds. Writing the numbers again here
+	// would put a second copy of the sizing where drift is invisible.
+	//
+	// Both bounds evict least-recently-used, and eviction is honest: a PC
+	// sample for a module that was dropped resolves "no-module", never a stale
+	// line from a module that is no longer here.
+	store := gpu.NewModuleStore(gpu.ModuleStoreConfig{})
+
 	// The selected tier reaches the agent's own join here and the producer's
 	// environment below, from ONE variable. Two copies that could disagree
 	// about which tier ran is how a profile ends up disclosing one thing and
 	// doing another.
-	timeline := gpu.NewTimeline(gpu.TimelineConfig{PCSampling: tier})
+	timeline := gpu.NewTimeline(gpu.TimelineConfig{PCSampling: tier, Modules: store})
 	// Without a symbolizer the sampled launch stacks still arrive and are
 	// still accounted for, but every one of them degrades to no stack — the
 	// profile would then be honest and useless, all GPU time unattributed.
@@ -133,6 +155,10 @@ func main() {
 		Backend:    gpu.BackendCUPTI,
 		Sink:       timeline,
 		Symbolizer: sym,
+		// Where the cubins land. Without this the bytes cross the socket,
+		// are sealed, verified and stored where nothing reads them, and
+		// every PC sample in this profile says gpu_src_status="no-module".
+		Modules: store,
 	})
 	if err != nil {
 		log.Fatalf("attach: %v", err)
@@ -219,7 +245,7 @@ func main() {
 	// own losses reach the operator: gpu_pc labels dropped at the cardinality
 	// ceiling are invisible in the profile itself, and JoinHealthWith below is
 	// the only place they are reported.
-	samples, projStats := gpu.ProjectExecutionsWith(snap, gpu.ProjectionConfig{})
+	samples, projStats := gpu.ProjectExecutionsWith(snap, gpu.ProjectionConfig{Modules: store})
 	if len(samples) == 0 {
 		log.Fatal("no samples projected; the pipeline produced nothing")
 	}
@@ -253,4 +279,12 @@ func main() {
 	for _, line := range gpu.JoinHealthWith(snap, projStats) {
 		log.Print(line)
 	}
+	// And the store's own account, which is neither of the above: what
+	// arrived, what it could read, and what it evicted trying. A run where
+	// every sample says "no-module" is a different problem depending on
+	// whether this line reads modules_stored=0 (nothing arrived - look at the
+	// Cubins* counters above) or modules_stored>0 with resolve_no_module high
+	// (the CRCs the PC records join on are not the CRCs the cubins arrived
+	// under, which is hardware assertion 13).
+	log.Printf("module store: %+v", store.Stats())
 }

--- a/cmd/gpu-stub-profile/main.go
+++ b/cmd/gpu-stub-profile/main.go
@@ -20,7 +20,20 @@ import (
 func main() {
 	const stub = "./shim/perfagent-gpu-stub"
 
-	timeline := gpu.NewTimeline(gpu.TimelineConfig{})
+	// The module store. Same three readers as cmd/gpu-cuda-profile - the cubin
+	// listener writes it, the Timeline's join names device functions through
+	// it, the projection resolves source lines against it - and the same
+	// defaults (512 modules, 64 MiB), for the same reason: the transport's own
+	// ceilings sit outside them, so this is the bound that decides what the
+	// process holds.
+	//
+	// The stub offers cubins when PERFAGENT_STUB_CUBINS names them and emits
+	// PC records when PERFAGENT_GPU_PC_SAMPLING is on, both inherited from the
+	// operator's environment, so this driver produces real source labels for a
+	// run configured that way and an empty store for one that is not.
+	store := gpu.NewModuleStore(gpu.ModuleStoreConfig{})
+
+	timeline := gpu.NewTimeline(gpu.TimelineConfig{Modules: store})
 	// Without a symbolizer the sampled launch stacks still arrive and are
 	// still accounted for, but every one of them degrades to no stack — the
 	// profile would then be honest and useless, all GPU time unattributed.
@@ -44,6 +57,7 @@ func main() {
 		Backend:    gpu.GPUBackendID("stub"),
 		Sink:       timeline,
 		Symbolizer: sym,
+		Modules:    store,
 	})
 	if err != nil {
 		log.Fatalf("attach: %v", err)
@@ -128,7 +142,7 @@ func main() {
 	// own losses reach the operator: gpu_pc labels dropped at the cardinality
 	// ceiling are invisible in the profile itself, and JoinHealthWith below is
 	// the only place they are reported.
-	samples, projStats := gpu.ProjectExecutionsWith(snap, gpu.ProjectionConfig{})
+	samples, projStats := gpu.ProjectExecutionsWith(snap, gpu.ProjectionConfig{Modules: store})
 	if len(samples) == 0 {
 		log.Fatal("no samples projected; the pipeline produced nothing")
 	}
@@ -160,4 +174,5 @@ func main() {
 	for _, line := range gpu.JoinHealthWith(snap, projStats) {
 		log.Print(line)
 	}
+	log.Printf("module store: %+v", store.Stats())
 }

--- a/gpu/gate_test.go
+++ b/gpu/gate_test.go
@@ -83,6 +83,14 @@ func TestPhase6Gate(t *testing.T) {
 	t.Run("assertion-04-four-statuses-in-the-labels", TestProjectionEmitsAllFourSrcStatuses)
 	t.Run("assertion-04-status-enum-is-exhaustive", TestSrcStatusesIsExhaustiveAndStable)
 	t.Run("assertion-04-zero-value-is-not-a-status", TestSrcStatusZeroValueIsNotAStatus)
+	// no-module has to stay reachable now that the cubin transport actually
+	// feeds this store (issue #93). The two ways it is reached are a CRC
+	// nothing was ever offered under, and a module the bounds evicted - and
+	// the second must never answer with the line it used to have.
+	t.Run("assertion-04-an-evicted-module-is-no-module-not-stale",
+		TestResolveAfterEvictionIsNoModuleNotStale)
+	t.Run("assertion-04-membership-is-live-and-counts-as-use",
+		TestHasIsLiveMembershipAndCountsAsUse)
 
 	// 5. Reconciliation: every emitted PC record lands in exactly one of
 	//    attributed-exact, attributed-kernel, pending, evicted.

--- a/gpu/modulestore.go
+++ b/gpu/modulestore.go
@@ -544,6 +544,45 @@ func (s *ModuleStore) Resolve(crc uint64, functionIndex uint32, pcOffset uint64)
 	return resolvedAt(fn, file, line)
 }
 
+// Has reports whether this CRC is held RIGHT NOW, and refreshes its recency
+// when it is.
+//
+// It exists for the cubin transport, which asks before it maps a payload: an
+// offer for a CRC already held is a counted no-op, so the answer decides
+// whether a memfd is mapped, copied and parsed again for bytes that are
+// already here. cubin_crc is content-addressed, so "the same CRC" is the same
+// bytes and re-reading them could only produce the same answer at the cost of
+// doing it again.
+//
+// It is deliberately LIVE membership and not a memory of everything ever
+// stored. A module the bounds evicted answers false, so the next offer for it
+// is admitted and stores it again - which is the only way a re-offered module
+// can come back. A "seen once" set kept anywhere on this path would turn one
+// eviction into permanent unresolvability, silently, with every counter on
+// both sides reading green.
+//
+// Recency is refreshed for the same reason Put's already-held path refreshes
+// it: a re-offer is the producer telling us this module is being loaded again,
+// which is use. Without that, a module offered repeatedly but sampled rarely
+// would age out under a burst of unrelated loads.
+//
+// It increments none of the Resolve* counters. Those four partition calls to
+// Resolve exactly, and that identity is this store's main self-check; folding
+// a second entry point into it would break the identity while looking like an
+// improvement. What an offer did is counted by the transport, which is where
+// it happened.
+func (s *ModuleStore) Has(crc uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	e, ok := s.byCRC[crc]
+	if !ok {
+		return false
+	}
+	s.lru.MoveToFront(e.elem)
+	return true
+}
+
 // Len reports how many modules are currently held.
 func (s *ModuleStore) Len() int {
 	s.mu.Lock()

--- a/gpu/modulestore_test.go
+++ b/gpu/modulestore_test.go
@@ -861,3 +861,48 @@ func TestFunctionNameDoesNotDisturbTheResolveIdentity(t *testing.T) {
 	}
 	requireSumIdentity(t, c)
 }
+
+// TestHasIsLiveMembershipAndCountsAsUse covers the accessor the cubin
+// transport asks before it maps a payload (gpuprobe.Config.Modules).
+//
+// Two properties, and the store is the only place either can be guaranteed:
+//
+//   - it answers about what is held NOW. An evicted module answers false, so
+//     the transport admits the next offer for it and the module comes back.
+//     Anything that remembered CRCs across an eviction would turn one eviction
+//     into permanent unresolvability, with every counter on both sides reading
+//     healthy;
+//   - it counts as use. A producer re-announcing a module is evidence the
+//     module is live, exactly as Put's already-held path treats it, so a
+//     module offered often but sampled rarely does not age out under a burst
+//     of unrelated loads.
+//
+// And it must not touch the Resolve* counters: those four partition calls to
+// Resolve exactly, and that identity is this store's main self-check.
+func TestHasIsLiveMembershipAndCountsAsUse(t *testing.T) {
+	b := fixture(t, "single_lineinfo.cubin")
+	idx := symIndexOf(t, b, "addOne")
+
+	st := &counting{ModuleStore: NewModuleStore(ModuleStoreConfig{Capacity: 2})}
+	require.NoError(t, st.Put(1, b))
+	require.NoError(t, st.Put(2, b))
+	assert.False(t, st.Has(3), "a CRC that was never offered is not held")
+
+	// Touch 1 through Has alone, making 2 the least recently used.
+	require.True(t, st.Has(1))
+	require.NoError(t, st.Put(3, b))
+	assert.True(t, st.Has(1), "Has did not count as use, so the module it asked about aged out")
+	assert.False(t, st.Has(2), "the untouched module is the one that goes")
+
+	// Live membership, not a memory: the evicted CRC answers false, and
+	// offering it again brings it back.
+	require.Equal(t, SrcNoModule, st.Resolve(2, idx, 0x10).Status())
+	require.NoError(t, st.Put(2, b))
+	assert.True(t, st.Has(2))
+	assert.Equal(t, SrcResolved, st.Resolve(2, idx, 0x10).Status(),
+		"a re-offered module did not become resolvable again")
+
+	// The identity still holds: Has is not a fifth Resolve.
+	assert.Equal(t, st.calls, st.Stats().ResolveTotal(),
+		"Has incremented a Resolve counter; the four no longer partition Resolve calls")
+}

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -336,6 +336,37 @@ type Config struct {
 	// table, which is the one failure worse than no line table.
 	CubinMaxBytes int
 
+	// Modules is the store every cubin that arrives over the cubin transport
+	// (cubin.go) is written into. It is the ONE hop between the bytes
+	// crossing the socket and gpu_src_status meaning anything: without it the
+	// cubins are received, sealed, verified, size-checked and stored where
+	// nothing reads them, and every PC sample in the profile reads
+	// "no-module" (issue #93).
+	//
+	// It is INJECTED rather than owned, and the caller must hand the SAME
+	// store to gpu.TimelineConfig.Modules (which resolves a pending PC group's
+	// (crc, functionIndex) to a device function name) and to
+	// gpu.ProjectionConfig.Modules (which resolves the source location). One
+	// store, three references, no second copy of the bytes - a store this
+	// package constructed for itself would be one the join and the projection
+	// cannot see, which is exactly the shape of the bug this field closes.
+	//
+	// Nil is supported and is what every backend that does not resolve source
+	// lines passes. With no store the channel still binds and offers are still
+	// admitted, authenticated and counted; they land in a bounded placeholder
+	// nothing reads, and every PC sample carries gpu_src_status="no-module".
+	// That is the same fact for the reader as a cubin that never arrived (see
+	// gpu.SrcNoModule), and it is deliberately not silent: a profile that says
+	// "no-module" on every sample points straight at the missing store, while
+	// one with the source labels absent is indistinguishable from a profile
+	// taken before this phase existed.
+	//
+	// The store's own bounds (gpu.ModuleStoreConfig.Capacity and MaxBytes) are
+	// the caller's, and they are enforced by eviction: a module the store drops
+	// answers "no-module" from then on, never a stale line. CubinMaxBytes and
+	// CubinTotalBytes below bound the TRANSPORT and are separate from them.
+	Modules *gpu.ModuleStore
+
 	// CubinTotalBytes bounds every cubin this consumer will hold. Zero means
 	// defaultCubinTotalBytes. This is the memory a JIT- or template-explosion
 	// workload can make the agent hold, so it is a ceiling rather than a dial;
@@ -1563,6 +1594,11 @@ func Attach(cfg Config) (c *Consumer, err error) {
 	// admission bucket. Best-effort in exactly the same way - a consumer
 	// that cannot bind it still profiles, still walks stacks, and simply
 	// resolves no source lines.
+	//
+	// The nil sink means "the one cfg asks for": cubinSinkFor writes accepted
+	// cubins into Config.Modules when the caller supplied a store, and into
+	// the bounded placeholder nothing reads when it did not. An explicit sink
+	// is a test seam and nothing else.
 	if cl, cerr := newCubinListener(cfg, nil); cerr != nil {
 		c.cubinErr = cerr.Error()
 	} else {

--- a/gpuprobe/cubin.go
+++ b/gpuprobe/cubin.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/dpsoft/perf-agent/gpu"
 )
 
 // The cubin transport: how a module's bytes get from the producer to this
@@ -182,10 +184,12 @@ const (
 	// make the agent hold, so it is a hard ceiling rather than a dial.
 	defaultCubinTotalBytes = 256 << 20
 	// defaultCubinStoreCapacity bounds the number of distinct CRCs the
-	// built-in store holds. Task 4 replaces this store with the LRU,
-	// line-table-backed gpu.ModuleStore; until then the bound still has to
-	// exist, because an unbounded map fed by a profiled application is the
-	// same defect whoever owns it.
+	// built-in store holds - the one a consumer with no Config.Modules gets,
+	// where the bytes land and nothing reads them. A consumer that resolves
+	// source lines supplies gpu.ModuleStore instead and is bounded by
+	// gpu.ModuleStoreConfig. The bound exists on both paths because an
+	// unbounded map fed by a profiled application is the same defect whoever
+	// owns it.
 	defaultCubinStoreCapacity = 512
 )
 
@@ -284,10 +288,11 @@ func newCubinAdmission(now func() time.Time) *enrollAdmission {
 	}
 }
 
-// cubinSink is what an accepted cubin is handed to. Task 4's
-// gpu.ModuleStore - bounded, LRU, line-table-backed - implements this; until
-// then memCubinStore does, so the transport is complete and testable on its
-// own rather than half-built behind a store that does not exist yet.
+// cubinSink is what an accepted cubin is handed to. gpu.ModuleStore - bounded,
+// LRU, line-table-backed - is the sink a consumer that resolves source lines
+// installs, through Config.Modules and moduleStoreSink below. memCubinStore is
+// what a consumer with no store gets, so the transport is complete and
+// testable on its own.
 type cubinSink interface {
 	// HasCubin reports whether this CRC is already held. Asked BEFORE the
 	// payload is touched, so a duplicate costs no mmap and no parse.
@@ -296,8 +301,64 @@ type cubinSink interface {
 	PutCubin(crc uint64, bytes []byte) error
 }
 
-// memCubinStore is the placeholder store: bounded by count, no line table, no
-// LRU. Task 4 replaces it.
+// moduleStoreSink is the one hop between the cubin transport and the store
+// that turns (cubin_crc, functionIndex, pcOffset) into a function, a file and
+// a line. It is the whole of issue #93: both ends were built and tested and
+// nothing connected them, so every PC sample in a real profile read
+// gpu_src_status="no-module".
+//
+// It is an adapter rather than a set of methods on gpu.ModuleStore because the
+// two contracts differ in one place that matters - see PutCubin - and because
+// gpu must not grow a method named for this transport.
+//
+// It holds the store the CALLER built (Config.Modules) and never one of its
+// own. gpu.TimelineConfig.Modules and gpu.ProjectionConfig.Modules read the
+// same instance: one store, three references, no second copy of the bytes. A
+// store constructed here would be a store the projection cannot see, which is
+// the shape of the bug this closes.
+type moduleStoreSink struct {
+	store *gpu.ModuleStore
+}
+
+// HasCubin asks the store for LIVE membership, which is what makes the
+// duplicate no-op safe against eviction: a module the store's bounds dropped
+// answers false, so the next offer for it is admitted and stores it again. No
+// set of "CRCs seen once" is kept anywhere on this path, deliberately - one
+// would turn a single eviction into permanent unresolvability while
+// CubinsReceived, CubinsDuplicate and every store counter still read healthy.
+func (m moduleStoreSink) HasCubin(crc uint64) bool { return m.store.Has(crc) }
+
+// PutCubin stores the bytes and reports only a failure to STORE them.
+//
+// gpu.ModuleStore.Put's error is diagnostic, not a rejection: bytes that do
+// not parse are still stored (so a re-offer is not re-parsed), counted in
+// ModuleStoreStats.ModulesUnparseable, and resolve as no-module. Propagating
+// it here would make the listener count a rejection for a cubin it is holding
+// - CubinsRejectedMalformed non-zero on a healthy run, CubinsReceived and
+// CubinBytesReceived understating what the agent actually holds, and the
+// producer told 'X' for an offer that landed. The two facts stay where each is
+// true: the transport counts what arrived, and the store counts what it can
+// read. Put has no other error, so nothing is being swallowed - if it grows
+// one, this returns it.
+func (m moduleStoreSink) PutCubin(crc uint64, b []byte) error {
+	_ = m.store.Put(crc, b)
+	return nil
+}
+
+// cubinSinkFor picks the sink for a consumer's configuration. A store supplied
+// by the caller is the sink; nothing is constructed here when one is missing,
+// because a store this package owned would be one the projection cannot read.
+func cubinSinkFor(cfg Config) cubinSink {
+	if cfg.Modules != nil {
+		return moduleStoreSink{store: cfg.Modules}
+	}
+	return newMemCubinStore(defaultCubinStoreCapacity)
+}
+
+// memCubinStore is what a consumer with no Config.Modules gets: bounded by
+// count, no line table, no LRU, and nothing reads it. Its PC samples resolve
+// gpu_src_status="no-module", which is the truth for them - there is no store
+// to resolve against. See Config.Modules.
 type memCubinStore struct {
 	mu   sync.Mutex
 	cap  int
@@ -432,7 +493,7 @@ func buildCubinListener(cfg Config, sink cubinSink) (*cubinListener, error) {
 		totalBytes = uint64(cfg.CubinTotalBytes)
 	}
 	if sink == nil {
-		sink = newMemCubinStore(defaultCubinStoreCapacity)
+		sink = cubinSinkFor(cfg)
 	}
 	return &cubinListener{
 		ln:         ln,

--- a/gpuprobe/cubin_modulestore_test.go
+++ b/gpuprobe/cubin_modulestore_test.go
@@ -1,0 +1,356 @@
+package gpuprobe
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dpsoft/perf-agent/gpu"
+	"github.com/dpsoft/perf-agent/internal/cubin"
+	pp "github.com/dpsoft/perf-agent/pprof"
+)
+
+// The hop issue #93 was about: a cubin that crosses the transport must end up
+// in the gpu.ModuleStore the join and the projection read, and it must end up
+// in THAT store rather than in a copy of it.
+//
+// These run without capabilities and without a GPU. The producer here is this
+// test process, offering a real checked-in cubin over the real abstract socket
+// as a real sealed memfd - which is byte-for-byte what shim/core/cubin.cc
+// does, pinned from the other side by
+// TestTheCppProducerAndTheGoCubinListenerAgreeOnTheWire. What is NOT exercised
+// here is the BPF decode of gpu_pc_sample_batch_v1; the privileged gate covers
+// that with 64 real records off a real uprobe_multi link.
+
+// storeFixturePath locates a Task 1 cubin fixture. Read from
+// internal/cubin/testdata rather than copied into this package: two copies of
+// a binary fixture drift, and the point is that this store answers about the
+// same bytes internal/cubin asserts its own claims against.
+func storeFixturePath(name string) string {
+	return filepath.Join("..", "internal", "cubin", "testdata", name)
+}
+
+func storeFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(storeFixturePath(name))
+	require.NoError(t, err, "cubin fixture %s", name)
+	require.NotEmpty(t, b)
+	return b
+}
+
+// storeFixtureSymIndex reads the .symtab index the module store keys its
+// functionIndex table on out of the fixture itself. Whether CUPTI's
+// functionIndex IS that index is the design's premise, measured on hardware;
+// nothing here depends on the answer, only on the store and the sample
+// agreeing.
+func storeFixtureSymIndex(t *testing.T, b []byte, fn string) uint32 {
+	t.Helper()
+	c, err := cubin.Parse(b)
+	require.NoError(t, err)
+	for _, f := range c.Functions() {
+		if f.Name == fn {
+			require.GreaterOrEqual(t, f.SymIndex, 0)
+			return uint32(f.SymIndex)
+		}
+	}
+	t.Fatalf("fixture has no function %q", fn)
+	return 0
+}
+
+// offerFixture puts one cubin on the wire the way the shim does and returns
+// the listener's reply byte.
+func offerFixture(t *testing.T, l *cubinListener, body []byte, crc uint64) byte {
+	t.Helper()
+	fd := sealedCubinFD(t, body, cubinRequiredSeals)
+	return offerCubin(t, l.address(), offerHeader(uint64(len(body)), crc), fd)
+}
+
+// The CRCs these tests offer under. Arbitrary, exactly as cubin_crc's value is
+// arbitrary to this end: what matters is that the number the bytes arrived
+// under is the number a later PC sample resolves against.
+const (
+	wiredCRCLineInfo   uint64 = 0x9317E0001
+	wiredCRCNoLineInfo uint64 = 0x9317E0002
+	wiredCRCAbsent     uint64 = 0x9317E0003
+)
+
+// TestACubinOfferedOverTheChannelBecomesASourceLine is gate assertion 2's
+// transport half, driven end to end through the SHIPPING path: a cubin crosses
+// the real socket, the listener writes it into the store the consumer's Config
+// named, and a PC sample carrying that CRC comes out of the projection as a
+// named line of the CUDA source the cubin was built from - on a sample whose
+// frames are the CPU call path that launched the kernel.
+//
+// Before issue #93 was closed this could not be written at all: the listener's
+// sink was a placeholder map with no line table and no Resolve, and
+// gpuprobe.Config had no field by which a caller could supply anything else.
+// The pin that recorded that gap - TestGateTheCubinTransportDoesNotYetFeedThe
+// ModuleStore - is deleted, and this is what replaced it.
+//
+// Mutations this catches: a sink that stores into a store of its own rather
+// than the caller's (the projection would then resolve nothing); a listener
+// that ignores Config.Modules; a Put that stores the header rather than the
+// payload; a resolution naming a line the fixture's table does not contain.
+func TestACubinOfferedOverTheChannelBecomesASourceLine(t *testing.T) {
+	const pid = 4242
+	lineInfo := storeFixture(t, "single_lineinfo.cubin")
+	noLineInfo := storeFixture(t, "single_nolineinfo.cubin")
+	fnIndex := storeFixtureSymIndex(t, lineInfo, "addOne")
+
+	// The store the DRIVER builds, exactly as cmd/gpu-cuda-profile does, and
+	// the one all three readers are handed.
+	store := gpu.NewModuleStore(gpu.ModuleStoreConfig{})
+	l := testCubinListener(t, Config{ShimPath: selfExe(t), Modules: store}, nil)
+
+	// Structurally the caller's store, not one this package made: a listener
+	// writing into a private store would satisfy every counter below and
+	// resolve nothing in the profile.
+	sink, ok := l.sink.(moduleStoreSink)
+	require.True(t, ok, "Config.Modules did not become the listener's sink (it is %T)", l.sink)
+	require.Same(t, store, sink.store, "the listener writes into a DIFFERENT store from the one the caller supplied")
+
+	require.Equal(t, byte(cubinReplyOK), offerFixture(t, l, lineInfo, wiredCRCLineInfo))
+	require.Equal(t, byte(cubinReplyOK), offerFixture(t, l, noLineInfo, wiredCRCNoLineInfo))
+
+	st := l.snapshot()
+	assertNoCubinRejections(t, st)
+	require.Equal(t, uint64(2), st.received)
+	require.Equal(t, uint64(len(lineInfo)+len(noLineInfo)), st.bytes)
+
+	// The store holds them, and holds them as MODULES rather than as bytes:
+	// one parsed with a line table, one parsed without.
+	ms := store.Stats()
+	assert.Equal(t, 2, store.Len())
+	assert.Equal(t, uint64(2), ms.ModulesStored)
+	assert.Equal(t, uint64(1), ms.ModulesWithLineInfo)
+	assert.Equal(t, uint64(1), ms.ModulesWithoutLineInfo)
+	assert.Zero(t, ms.ModulesUnparseable, "a cubin arrived that the store could not parse")
+	assert.Zero(t, ms.ModulesEvicted)
+
+	// --- and now the profile, against the same store instance.
+	tl := gpu.NewTimeline(gpu.TimelineConfig{Modules: store})
+	corr := gpu.CorrelationID{Backend: gpu.BackendCUPTI, PID: pid, Value: "17"}
+	require.NoError(t, tl.EmitLaunch(gpu.GPUKernelLaunch{
+		Correlation: corr,
+		KernelName:  "addOne",
+		TimeNs:      10,
+		Launch: gpu.LaunchContext{
+			PID:          pid,
+			TimeNs:       10,
+			CPUStack:     pp.FramesFromNames([]string{"main", "run_training_step", "cudaLaunchKernel"}),
+			SamplePeriod: 8,
+		},
+	}))
+	// Tier B: no correlation value. The sample reaches its execution through
+	// cubin_crc -> module -> function name, which is the store's other reader.
+	require.NoError(t, tl.EmitPCSample(gpu.GPUPCSample{
+		Correlation:   gpu.CorrelationID{Backend: gpu.BackendCUPTI, PID: pid},
+		Module:        gpu.ModuleRef{Backend: gpu.BackendCUPTI, CRC: wiredCRCLineInfo},
+		FunctionIndex: fnIndex,
+		TimeNs:        20,
+		PCOffset:      0x10,
+		StallReason:   "long_scoreboard",
+		Count:         1,
+	}))
+	require.NoError(t, tl.EmitExec(gpu.GPUKernelExec{
+		Correlation: corr,
+		KernelName:  "addOne",
+		StartNs:     30,
+		EndNs:       130,
+	}))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.Len(t, snap.Executions[0].PCSamples, 1,
+		"the sample never reached its execution through the store the transport filled")
+
+	samples, _ := gpu.ProjectExecutionsWith(snap, gpu.ProjectionConfig{Modules: store})
+	require.Len(t, samples, 1)
+	s := samples[0]
+
+	var names []string
+	for _, f := range s.Stack {
+		names = append(names, f.Name)
+	}
+	assert.Equal(t,
+		[]string{"main", "run_training_step", "cudaLaunchKernel", gpu.FrameLaunch, "[gpu:kernel:addOne]"},
+		names, "the frames must still be the launching CPU call path, the boundary marker and the kernel")
+
+	require.Equal(t, "resolved", s.Labels["gpu_src_status"],
+		"the cubin crossed the transport and the store still cannot resolve against it")
+	assert.Equal(t, "single.cu", s.Labels["gpu_src_file"], "the basename, never the build-host path")
+	assert.Equal(t, "addOne", s.Labels["gpu_src_func"])
+	require.Contains(t, s.Labels, "gpu_src_line")
+
+	// The line names a real, non-blank line of the fixture's own source, read
+	// from the .cu rather than pinned as a constant: a fixture rebuilt from
+	// edited source would otherwise keep this green while the label pointed
+	// somewhere else.
+	line, err := strconv.Atoi(s.Labels["gpu_src_line"])
+	require.NoError(t, err)
+	src := strings.Split(strings.TrimRight(string(storeFixture(t, "single.cu")), "\n"), "\n")
+	require.Positive(t, line)
+	require.LessOrEqual(t, line, len(src),
+		"gpu_src_line=%d is past the end of single.cu (%d lines)", line, len(src))
+	body := strings.TrimSpace(src[line-1])
+	assert.NotEmpty(t, body, "gpu_src_line names a blank line of single.cu")
+	t.Logf("wire -> store -> profile: %s -> %s:%s  %q",
+		strings.Join(names, " -> "), s.Labels["gpu_src_file"], s.Labels["gpu_src_line"], body)
+
+	// The other fixture, through the store's own reader, so that "the
+	// transport fed the store" is not one lucky module: the no-lineinfo cubin
+	// arrived too, and it answers the status that names its build rather than
+	// the status that names a missing module.
+	assert.Equal(t, gpu.SrcNoLineInfo,
+		store.Resolve(wiredCRCNoLineInfo, storeFixtureSymIndex(t, noLineInfo, "addOne"), 0x10).Status())
+	// And a CRC nothing was offered under still answers no-module, which is
+	// what keeps that status reachable after this wiring (gate assertion 4).
+	assert.Equal(t, gpu.SrcNoModule, store.Resolve(wiredCRCAbsent, fnIndex, 0x10).Status())
+}
+
+// TestAnEvictedModuleAnswersNoModuleAndIsOfferedAgainNotSuppressed is the
+// bound half of the same wiring, and it is the one that decides whether the
+// hop can lie.
+//
+// gpu.ModuleStore is bounded and evicts least-recently-used; Task 4's
+// TestResolveAfterEvictionIsNoModuleNotStale pins that an evicted module
+// answers no-module rather than a stale line. The transport asks HasCubin
+// BEFORE it maps a payload and treats "yes" as a counted no-op, so the wiring
+// has exactly one way to break that guarantee: remember CRCs somewhere other
+// than the store. It would look like an optimisation - the same bytes, why map
+// them twice - and it would make one eviction permanent, with CubinsDuplicate
+// climbing and every store counter reading healthy while every PC sample for
+// that module said no-module forever.
+//
+// So: evict, and require that the module comes BACK when it is offered again.
+func TestAnEvictedModuleAnswersNoModuleAndIsOfferedAgainNotSuppressed(t *testing.T) {
+	lineInfo := storeFixture(t, "single_lineinfo.cubin")
+	noLineInfo := storeFixture(t, "single_nolineinfo.cubin")
+	fnIndex := storeFixtureSymIndex(t, lineInfo, "addOne")
+
+	// One module at a time, so the second offer evicts the first.
+	store := gpu.NewModuleStore(gpu.ModuleStoreConfig{Capacity: 1})
+	l := testCubinListener(t, Config{ShimPath: selfExe(t), Modules: store}, nil)
+
+	require.Equal(t, byte(cubinReplyOK), offerFixture(t, l, lineInfo, wiredCRCLineInfo))
+	before := store.Resolve(wiredCRCLineInfo, fnIndex, 0x10)
+	require.Equal(t, gpu.SrcResolved, before.Status())
+	_, _, wantLine, ok := before.Source()
+	require.True(t, ok)
+
+	// A second offer while the first is still held is the counted no-op, and
+	// it costs no mapping: that is the property HasCubin exists for.
+	mappedBefore := l.snapshot().mapped
+	require.Equal(t, byte(cubinReplyOK), offerFixture(t, l, lineInfo, wiredCRCLineInfo))
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.duplicate, "a re-offer of a HELD crc must be the counted no-op")
+	assert.Equal(t, mappedBefore, st.mapped, "a duplicate offer mapped the payload anyway")
+	assert.Equal(t, uint64(1), st.received)
+
+	// Now push it out.
+	require.Equal(t, byte(cubinReplyOK), offerFixture(t, l, noLineInfo, wiredCRCNoLineInfo))
+	require.Equal(t, uint64(1), store.Stats().ModulesEvicted, "the bound did not bite, so this proves nothing")
+
+	assert.Equal(t, gpu.SrcNoModule, store.Resolve(wiredCRCLineInfo, fnIndex, 0x10).Status(),
+		"an evicted module answered something other than no-module: the wiring is serving a stale answer")
+
+	// And the recovery: the store no longer holds it, so the transport must
+	// admit it again rather than suppressing it as a duplicate.
+	require.False(t, l.sink.HasCubin(wiredCRCLineInfo),
+		"the wiring remembers a CRC the store has evicted; one eviction would then be permanent")
+	require.Equal(t, byte(cubinReplyOK), offerFixture(t, l, lineInfo, wiredCRCLineInfo))
+	st = l.snapshot()
+	assert.Equal(t, uint64(3), st.received,
+		"the re-offer of an evicted module was not stored (offers that stored: the first, the no-lineinfo one, and this)")
+	assert.Equal(t, uint64(1), st.duplicate, "the re-offer of an EVICTED module was miscounted as a duplicate")
+
+	after := store.Resolve(wiredCRCLineInfo, fnIndex, 0x10)
+	require.Equal(t, gpu.SrcResolved, after.Status(), "a re-offered module did not become resolvable again")
+	_, _, gotLine, ok := after.Source()
+	require.True(t, ok)
+	assert.Equal(t, wantLine, gotLine, "the same PC resolved to a different line after a round trip through eviction")
+}
+
+// TestACubinTheStoreCannotParseStillLandsAndIsCountedApart pins the one place
+// the two contracts the adapter joins disagree.
+//
+// gpu.ModuleStore.Put returns the parse error as a DIAGNOSTIC: unparseable
+// bytes are still stored (so a re-offer is not re-parsed), counted in
+// ModulesUnparseable, and resolve as no-module. cubinSink.PutCubin's error
+// means "the offer did not land", and the listener answers it with a refusal
+// counted in CubinsRejectedMalformed.
+//
+// Propagating one as the other would make the transport report a rejection for
+// a cubin the agent is holding: CubinsReceived and CubinBytesReceived would
+// understate what is held (and the total-bytes ceiling with them), a healthy
+// run would show a non-zero rejection counter, and the producer would be told
+// 'X' for an offer that landed. The two facts belong in different counters
+// because they are different facts - what arrived, and what could be read.
+func TestACubinTheStoreCannotParseStillLandsAndIsCountedApart(t *testing.T) {
+	store := gpu.NewModuleStore(gpu.ModuleStoreConfig{})
+	l := testCubinListener(t, Config{ShimPath: selfExe(t), Modules: store}, nil)
+
+	// Well-formed on the wire, not a cubin underneath: exactly what a
+	// truncated or garbled module would look like to this end, since the
+	// transport deliberately does not parse.
+	body := cubinFixture(4096)
+	require.Equal(t, byte(cubinReplyOK), offerFixture(t, l, body, wiredCRCLineInfo),
+		"the offer was refused; the bytes crossed and are held, so the transport must say so")
+
+	st := l.snapshot()
+	assertNoCubinRejections(t, st)
+	assert.Equal(t, uint64(1), st.received)
+	assert.Equal(t, uint64(len(body)), st.bytes)
+
+	ms := store.Stats()
+	assert.Equal(t, uint64(1), ms.ModulesStored)
+	assert.Equal(t, uint64(1), ms.ModulesUnparseable,
+		"the store did not count the module it cannot read; the loss would then be invisible")
+	assert.Zero(t, ms.ModulesWithLineInfo)
+
+	assert.Equal(t, gpu.SrcNoModule, store.Resolve(wiredCRCLineInfo, 0, 0x10).Status(),
+		"bytes we hold and cannot read are no-module - we have nothing to resolve against")
+	// And it is not re-parsed on every offer: the store holds it, so the
+	// transport's duplicate path takes over.
+	require.Equal(t, byte(cubinReplyOK), offerFixture(t, l, body, wiredCRCLineInfo))
+	assert.Equal(t, uint64(1), l.snapshot().duplicate)
+}
+
+// TestAConsumerWithNoModuleStoreKeepsTheBoundedPlaceholder pins the nil case
+// as a supported configuration rather than an accident.
+//
+// A backend that does not resolve source lines passes no store. The channel
+// still binds, offers are still authenticated, admitted and counted, and the
+// bytes land in a bounded map nothing reads - so every PC sample carries
+// gpu_src_status="no-module", which is the truth for it: there is no store to
+// resolve against, and for the reader that is the same fact as a cubin that
+// never arrived.
+//
+// Nothing here constructs a store on the caller's behalf, deliberately. A
+// store gpuprobe owned would be one gpu.ProjectionConfig cannot see, which is
+// the bug issue #93 filed - a store with bytes in it and no reader.
+func TestAConsumerWithNoModuleStoreKeepsTheBoundedPlaceholder(t *testing.T) {
+	sink := cubinSinkFor(Config{})
+	mem, ok := sink.(*memCubinStore)
+	require.True(t, ok, "a consumer with no Config.Modules got a %T", sink)
+	assert.Equal(t, defaultCubinStoreCapacity, mem.cap, "the placeholder must still be bounded")
+
+	l := testCubinListener(t, Config{ShimPath: selfExe(t)}, nil)
+	_, ok = l.sink.(*memCubinStore)
+	assert.True(t, ok, "Attach's default sink for a store-less consumer is %T", l.sink)
+
+	body := storeFixture(t, "single_lineinfo.cubin")
+	require.Equal(t, byte(cubinReplyOK), offerFixture(t, l, body, wiredCRCLineInfo),
+		"a store-less consumer must still accept and account for an offer")
+	assert.Equal(t, uint64(1), l.snapshot().received)
+
+	// The reader's side of the same fact: with no store the projection
+	// resolves an empty one, and says no-module rather than saying nothing.
+	assert.Equal(t, gpu.SrcNoModule,
+		gpu.NewModuleStore(gpu.ModuleStoreConfig{}).Resolve(wiredCRCLineInfo, 0, 0x10).Status())
+}

--- a/gpuprobe/cubin_test.go
+++ b/gpuprobe/cubin_test.go
@@ -1013,9 +1013,10 @@ func TestClosingTheCubinListenerIsSafeAndReleasesPeers(t *testing.T) {
 	}
 }
 
-// The built-in store is bounded. Task 4 replaces it with the LRU,
-// line-table-backed gpu.ModuleStore, but an unbounded map fed by a profiled
-// application is the same defect whoever owns it, so the bound exists now.
+// The built-in store is bounded. It is what a consumer with no Config.Modules
+// gets - see TestAConsumerWithNoModuleStoreKeepsTheBoundedPlaceholder - and an
+// unbounded map fed by a profiled application is the same defect whoever owns
+// it, so the bound is asserted on that path too.
 func TestTheBuiltInCubinStoreIsBounded(t *testing.T) {
 	s := newMemCubinStore(2)
 	require.NoError(t, s.PutCubin(1, []byte("a")))

--- a/gpuprobe/gate_compose_test.go
+++ b/gpuprobe/gate_compose_test.go
@@ -3,7 +3,6 @@ package gpuprobe
 import (
 	"os"
 	"os/exec"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -14,7 +13,9 @@ import (
 )
 
 // TestPhase6GateConsumerHalf is the consumer-side quarter of the Phase 6 phase
-// gate: assertions 10, 10a, 11 and 12 of Task 13.
+// gate: assertions 10, 10a, 11 and 12 of Task 13, plus the half of assertion 2
+// this package owns - the hop from the cubin transport into gpu.ModuleStore
+// (issue #93), which used to be a pin here and is now an assertion.
 //
 // It is a SECOND gate entry point, in package gpuprobe rather than
 // gpuprobe_test, and both halves of that are load-bearing:
@@ -87,11 +88,32 @@ func TestPhase6GateConsumerHalf(t *testing.T) {
 	t.Run("assertion-12-kindmax-matches-the-bpf-object", TestEmbeddedProgramIsUprobeMulti)
 	t.Run("assertion-12-every-cookie-has-a-sized-kind", TestBPFSizesEveryKindCookieForInstalls)
 
-	// Not one of the twelve: the wiring gap that stops assertion 2 from being
-	// reachable by the shipping product. Pinned here so it fails the moment it
-	// is closed, rather than being remembered only in a report.
-	t.Run("outstanding-cubin-transport-does-not-feed-the-module-store",
-		TestGateTheCubinTransportDoesNotYetFeedTheModuleStore)
+	// 2, at the level this package owns: the hop from the cubin transport to
+	// gpu.ModuleStore. Until issue #93 was closed this slot held a PIN - a
+	// test that passed BECAUSE the hop was missing - because assertion 2 was
+	// not reachable through the shipping path at all: Attach installed a
+	// placeholder store with no line table, and gpuprobe.Config had no field
+	// by which a caller could supply the real one. It is now the real thing: a
+	// cubin crosses the socket and comes out of the projection as a named line
+	// of the CUDA source it was built from.
+	//
+	// Catches: a sink that writes into a store the projection cannot see (the
+	// bug #93 filed, in its subtler form); a wiring that remembers CRCs
+	// outside the store, which would make one eviction permanent while every
+	// counter read healthy; a Put error translated into a transport rejection,
+	// which would have the transport report a refusal for a cubin the agent is
+	// holding.
+	t.Run("assertion-02-an-offered-cubin-becomes-a-source-line",
+		TestACubinOfferedOverTheChannelBecomesASourceLine)
+	t.Run("assertion-02-an-evicted-module-is-no-module-and-can-return",
+		TestAnEvictedModuleAnswersNoModuleAndIsOfferedAgainNotSuppressed)
+	t.Run("assertion-02-an-unreadable-cubin-still-lands-and-is-counted-apart",
+		TestACubinTheStoreCannotParseStillLandsAndIsCountedApart)
+	// And assertion 4's floor: no-module stays reachable after the wiring,
+	// both from a consumer that configured no store at all and from a CRC
+	// nothing was ever offered under.
+	t.Run("assertion-04-no-store-is-a-supported-no-module-state",
+		TestAConsumerWithNoModuleStoreKeepsTheBoundedPlaceholder)
 }
 
 // TestPhase6GateBinaryDoesNotAskForCapSysAdmin is gate assertion 11, the
@@ -207,70 +229,4 @@ func TestGetcapAgreesWithTheLibraryReading(t *testing.T) {
 	t.Logf("getcap %s -> %q", self, strings.TrimSpace(text))
 	assert.NotContains(t, strings.ToLower(text), "cap_sys_admin",
 		"getcap names cap_sys_admin on the gate binary")
-}
-
-// TestGateTheCubinTransportDoesNotYetFeedTheModuleStore pins the gap that
-// stops the Phase 6 exit condition from being reachable by the shipping
-// product, so that it is a named, self-invalidating fact rather than prose in
-// a report nobody re-reads.
-//
-// # The gap
-//
-// Task 3 built the cubin channel and Task 4 built gpu.ModuleStore - the store
-// that turns (cubin_crc, functionIndex, pcOffset) into a source line and is
-// "the single place gpu_src_status is decided". Nothing connects them:
-//
-//   - Attach calls newCubinListener(cfg, nil), and a nil sink becomes
-//     memCubinStore - a bounded map of CRC to bytes with no line table, no LRU
-//     and no Resolve. Its own comment says "Task 4 replaces it";
-//   - gpuprobe.Config has no field by which a caller could supply one, and
-//     gpu.ModuleStore does not implement cubinSink (Put/HasCubin versus
-//     PutCubin/HasCubin) even if it had;
-//   - cmd/gpu-cuda-profile builds neither: it calls ProjectExecutionsWith with
-//     a zero ProjectionConfig and NewTimeline without Modules.
-//
-// So on hardware today, every cubin is received, sealed, verified, size- and
-// identity-checked, stored - and then never read. Every PC sample in a real
-// profile reads gpu_src_status="no-module", and gate assertion 2 (a source
-// line reached from a CPU stack) cannot be satisfied end to end by the product
-// as shipped. TestStubDrivesPCSamplingToPprofWithoutAGPU therefore builds the
-// store itself, from the CRCs the producer declared, and says so.
-//
-// This is the ONE hop between the transport and the labels, and both ends of
-// it are built and tested. It is a wiring task, not a design gap.
-//
-// # Why a passing test rather than a failing one
-//
-// Same reason as gpu's TestGateGraphExecutionRefusalIsNotAssertableYet: the
-// gate must not ship red, and it must not ship silently short of an assertion
-// either. When the hop is wired, this test fails - by name, in the gate's own
-// file - and the person wiring it deletes it and drops the injection from the
-// end-to-end gate.
-func TestGateTheCubinTransportDoesNotYetFeedTheModuleStore(t *testing.T) {
-	// The default sink a real Attach installs.
-	l, err := newCubinListener(Config{ShimPath: selfExe(t)}, nil)
-	require.NoError(t, err)
-	defer func() { _ = l.close() }()
-
-	_, isPlaceholder := l.sink.(*memCubinStore)
-	assert.True(t, isPlaceholder,
-		"the cubin listener's default sink is no longer the placeholder memCubinStore (it is %T). "+
-			"If that is gpu.ModuleStore, gate assertion 2 is now reachable end to end: delete this "+
-			"test and drop the PC-sample injection from TestStubDrivesPCSamplingToPprofWithoutAGPU.",
-		l.sink)
-
-	// And no caller can supply one, which is why the default is the whole
-	// story rather than merely a default.
-	typ := reflect.TypeOf(Config{})
-	for i := range typ.NumField() {
-		name := strings.ToLower(typ.Field(i).Name)
-		assert.NotContains(t, name, "module",
-			"gpuprobe.Config grew a field naming a module store (%s); the hop may now be wired - see this test's doc comment",
-			typ.Field(i).Name)
-		assert.NotContains(t, name, "store",
-			"gpuprobe.Config grew a store field (%s); the hop may now be wired - see this test's doc comment",
-			typ.Field(i).Name)
-	}
-	t.Log("cubin transport -> gpu.ModuleStore: OUTSTANDING - the bytes arrive and stop at " +
-		"memCubinStore; see .superpowers/sdd/task-13-gate-report.md")
 }

--- a/gpuprobe/gate_test.go
+++ b/gpuprobe/gate_test.go
@@ -1302,6 +1302,13 @@ const gateCRCAbsent uint64 = 0x6A7E0003
 // is the consumer's decode arm for KIND_PC, and that is asserted separately and
 // exactly by the 64 records above.
 //
+// The MODULES those injected samples resolve against are no longer supplied by
+// the gate. Issue #93 - the cubin transport never feeding gpu.ModuleStore - is
+// closed, so the store below is handed to gpuprobe.Config.Modules and FILLED BY
+// THE PRODUCT from the bytes the producer sent, and this test asserts what it
+// holds rather than putting it there. Only the PC records are still injected,
+// and only for the reason above.
+//
 // # Assertion 11 is not here
 //
 // getcap on the gate binary is asserted in gate_compose_test.go, where it runs
@@ -1321,20 +1328,19 @@ func TestStubDrivesPCSamplingToPprofWithoutAGPU(t *testing.T) {
 	requireFPLess(t, built)
 	stub := privateStubCopy(t, built)
 
-	// The module store. It is built HERE, and filled after the run from the
-	// CRCs the PRODUCER declared, rather than by the consumer - and that is
-	// the second finding this gate records rather than papers over:
+	// The module store, built here exactly as cmd/gpu-cuda-profile builds it:
+	// one instance, handed to gpuprobe.Config.Modules (where the cubin
+	// listener writes it), to gpu.TimelineConfig.Modules (where the join reads
+	// device function names out of it) and to gpu.ProjectionConfig.Modules
+	// (where the source labels are resolved). The defaults are taken rather
+	// than restated - 512 modules and 64 MiB - because the sizing belongs in
+	// one place.
 	//
-	//	The cubin listener's sink is gpuprobe's own bounded memCubinStore
-	//	(gpuprobe/cubin.go). Nothing in gpuprobe, in gpu, or in
-	//	cmd/gpu-cuda-profile ever hands a gpu.ModuleStore to gpuprobe.Config
-	//	or to gpu.ProjectionConfig. The bytes cross the socket, are sealed,
-	//	verified and stored - and stop there. As shipped, every PC sample in a
-	//	real profile therefore reads gpu_src_status="no-module".
-	//
-	// CubinsReceived and snap.Modules are asserted below so the transport half
-	// is still proven end to end on this run, and the missing hop is one named
-	// gap rather than an invisible one.
+	// Nothing in this test PUTS anything into it. It is filled by the product,
+	// over the cubin channel, from the bytes the producer sends, and what it
+	// ends up holding is asserted below against the CRCs the producer itself
+	// declared. That is the hop issue #93 was about, and it is why this gate
+	// no longer says "as shipped every PC sample reads no-module".
 	lineInfo := readFixture(t, "single_lineinfo.cubin")
 	noLineInfo := readFixture(t, "single_nolineinfo.cubin")
 	store := gpu.NewModuleStore(gpu.ModuleStoreConfig{})
@@ -1359,6 +1365,11 @@ func TestStubDrivesPCSamplingToPprofWithoutAGPU(t *testing.T) {
 		Backend:    gpu.GPUBackendID("stub"),
 		Sink:       timeline,
 		Symbolizer: sym,
+		// The same store the Timeline above and the projection below read.
+		// Without this the cubins still arrive, are still sealed, verified
+		// and counted - and land where nothing reads them, which is what
+		// issue #93 was.
+		Modules: store,
 	})
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
@@ -1445,8 +1456,31 @@ func TestStubDrivesPCSamplingToPprofWithoutAGPU(t *testing.T) {
 		"same, for single_nolineinfo.cubin")
 	assert.NotEqual(t, gateCRCLineInfo, gateCRCNoLineInfo,
 		"two different cubins collided on one CRC, which would make them indistinguishable to the store")
-	require.NoError(t, store.Put(gateCRCLineInfo, lineInfo))
-	require.NoError(t, store.Put(gateCRCNoLineInfo, noLineInfo))
+
+	// And the hop: the store the consumer was handed holds both modules, under
+	// those CRCs, because the cubin listener wrote them there. This test put
+	// nothing in it.
+	//
+	// This is issue #93's assertion. Before it was closed the listener's sink
+	// was a bounded map with no line table, gpuprobe.Config had no field for a
+	// store, and this block could not be written at all - the gate filled the
+	// store itself and recorded the gap as a finding.
+	ms := store.Stats()
+	require.Equal(t, 2, store.Len(),
+		"the cubin transport did not feed the module store: %d modules held after %d cubins were received. "+
+			"Every PC sample in a real profile would read gpu_src_status=\"no-module\" (issue #93)",
+		store.Len(), c.Stats().CubinsReceived)
+	assert.Equal(t, uint64(1), ms.ModulesWithLineInfo,
+		"the -lineinfo fixture did not arrive as a module with a usable line table: %+v", ms)
+	assert.Equal(t, uint64(1), ms.ModulesWithoutLineInfo,
+		"the no-lineinfo fixture did not arrive as a module without one: %+v", ms)
+	assert.Zero(t, ms.ModulesUnparseable,
+		"a cubin crossed the transport and did not survive as an ELF: %+v", ms)
+	assert.Zero(t, ms.ModulesEvicted, "two modules cannot pressure a 512-module, 64 MiB store")
+	assert.Equal(t, gpu.SrcResolved, store.Resolve(gateCRCLineInfo, lineIdx, 0x10).Status(),
+		"the module the PRODUCER declared under %#x does not resolve a source line in the store the product filled",
+		gateCRCLineInfo)
+	assert.Equal(t, gpu.SrcNoLineInfo, store.Resolve(gateCRCNoLineInfo, noLineIdx, 0x10).Status())
 
 	// The tail: PC batches, the stall map, the config record, the windows and
 	// the drop records are all flushed after the last launch, so they are the


### PR DESCRIPTION
Closes #93. **Phase-blocking**: every cubin was received over the Task 3 channel, seal-verified, size-checked and stored — and never read, so every PC sample resolved `gpu_src_status="no-module"` and Phase 6's exit condition was unsatisfiable by the shipping product regardless of what the GPU reported.

The transport did not fail. Both ends were built and one hop was missing.

### The wiring

- **`gpu.ModuleStore.Has(crc) bool`** — live membership, refreshes LRU recency, increments none of the `Resolve*` counters so Task 4's partition identity still holds. Live and deliberately *not* remembered: an evicted module answers false so the next offer re-admits it.
- **`gpuprobe.moduleStoreSink`** adapts the caller's store to `cubinSink`. `PutCubin` reports only a failure to *store*: `Put`'s error is diagnostic (unparseable bytes are still held, counted in `ModulesUnparseable`, and resolve `no-module`), so propagating it would make the transport count a rejection for a cubin the agent is holding, and answer `'X'` to a producer whose offer landed.
- **`gpuprobe.Config.Modules`** plus `cubinSinkFor(cfg)`. Nil `Modules` keeps the bounded placeholder and `no-module` — **nothing is constructed inside gpuprobe**, because a store this package owned would be one the projection cannot see.

`gpu.ModuleStore`'s decision logic is untouched: no new `Resolve` branch, no new status, no memoization, and a nil store still reaches `no-module` through an empty store in the projection. Transport, seals, admission bucket and enrolment isolation are unchanged — every new line sits *beside* `handle`, none inside it.

**Drivers**: both build one store at the package defaults (512 modules / 64 MiB) and hand the **same instance** to `Config.Modules`, `TimelineConfig.Modules` and `ProjectionConfig.Modules` — Task 4's "one store, two readers, no second copy of the bytes". Both now log `store.Stats()`, which separates *"no cubin arrived"* from *"the CRCs don't match"* — hardware assertion 13.

### The gate assertion converted from pin to real

`TestGateTheCubinTransportDoesNotYetFeedTheModuleStore` is deleted. Its slot now holds four real, **unprivileged** assertions — chief among them a cubin crossing the real socket as a sealed memfd and emerging from `ProjectExecutionsWith` as `gpu_src_status=resolved`, `single.cu:6`, on a sample carrying the launching CPU stack. **Phase 6's exit condition, proven with no GPU and no privilege.**

The privileged gate no longer `Put`s the fixtures itself; it asserts what the *product* put there. `no-module` stays reachable three ways (absent CRC, evicted module, store-less consumer) so assertion 4's four values all survive.

Three mutations checked and reverted: ignoring `Config.Modules`, memoizing CRCs outside the store, propagating `Put`'s error — each fails a named assertion.

### Assertion 2 reachability — the honest answer

The **cubin half is now fully producer-driven**. The **PC-record half is still injected**, and must be, for Task 13's *finding 1* rather than this issue: `shim/stub/stub.cc` keys PC records on `kStubCubinCRC = {0xC0FFEE01, 0xC0FFEE02}` and names kernels `kernel_NNNN`, so no stub PC record can join to any cubin whatever the store holds. That is a `shim/` fix and a separate change.

The real CUPTI adapter emits real CRCs and real kernel names, **so hardware assertion 14 is no longer blocked by #93.**

### Ran vs compiled

Ran green, including the full socket → store → Timeline → projection → pprof-label chain: shim build/test/check-fpless/check-cubin-defer/nvidia, `go build`/`vet`, `go test ./... -count=1`, `-race -count=4`, golangci-lint 0 issues.

Compiled only: `TestStubDrivesPCSamplingToPprofWithoutAGPU` — `CapEff: 0` and `sudo -n` refuses, so it cannot even be setcap'd here.

### One finding, filed separately

The transport charges `CubinTotalBytes` against a **cumulative** byte count, not resident bytes. With the non-evicting placeholder those were the same; with the LRU store they are not. A process loading >256 MiB of distinct cubins across one run will start refusing offers — counted as `"total ceiling"`, not silent — while the store holds only 64 MiB. Not a regression, but it is now the only such cliff.