### PR TITLE
gpu: make Tier A actually refuse where CUDA graphs have been observed

### DIFF
--- a/.superpowers/sdd/issue-94-graph-refusal-report.md
+++ b/.superpowers/sdd/issue-94-graph-refusal-report.md
@@ -1,0 +1,377 @@
+# Issue #94 — Tier A now actually refuses where CUDA graph executions have been observed
+
+Branch `fix/tier-a-refuses-graphs`, one commit on `origin/main` (`e09c073a`, the Task 13 gate
+merge). Verified on this machine: `CapEff: 0`, **no GPU**. What that means for each claim below
+is stated where the claim is made, not once at the bottom.
+
+The scope is the **refusal**. Making graphs actually *work* under Tier A needs `gpu_exec_v2`
+carrying `graphId` plus a one-launch-to-many-executions join shape — "a phase, not a field" —
+and none of it is attempted here.
+
+---
+
+## What consumes `DropClassGraphExec` now
+
+Before this commit: nothing. The consumer decoded `gpu_dropped_v1` into `batch.Drops`, the
+batch fell through `applyBatch`'s `default:` arm and was counted as `Stats.Undecoded`, and no
+counter, no `Snapshot` field, no `joinhealth` line and no gate existed anywhere downstream.
+Tier A ran happily in a graph-using process and produced `gpu_join="exact"`,
+`gpu_pc_attrib="exact"`, every counter green, N kernels billed to one call site.
+
+The chain now, wire to profile:
+
+| hop | where | what |
+| --- | --- | --- |
+| decode | `gpuprobe/consumer.go` — new `case kindDropped:` + `noteDropLocked` | one record per class, dispatched by class |
+| count | `Stats.GraphExecutions` / `GraphExecReports` / `DropsDecoded` / `DropsUnconsumed` | arrival, on the producer side of the sink |
+| normalize | `gpu.GPUGraphExecutions{Backend, PID, Count}` (`gpu/types.go`) | a first-class event, not a string-parsed attribute |
+| transport | `EventSink.EmitGraphExecutions` (new method), `CountingSink` pass-through | **unconditionally admitted** — see below |
+| latch | `Timeline.EmitGraphExecutions`, `graphExecsByPID` + `isGraphRefusedLocked` | per process, cumulative |
+| mark | `ExecutionView.GraphRefused`, `PCAttribGraphRefused` | applied in `Snapshot` |
+| count | `Snapshot.GraphExecutions`, `GraphExecProcesses`, `GraphExecUnscoped`, `GraphExecTrackingCapped`, `ExecutionsGraphRefused`, `PCJoinStats.GraphRefusedAttributions` | |
+| disclose | `gpu/joinhealth.go` — one summary clause, two anomaly lines | |
+| label | `gpu_graph_refused="true"`, `gpu_pc_attrib="graph-refused"` (`gpu/projection.go`) | |
+| refuse to start | `PCSamplingRequest.GraphExecutionsObserved` → `ErrPCSamplingGraphExecutions` (`gpu/tier.go`) | |
+
+### The one deliberate exception to this package's own rules
+
+`CountingSink.EmitGraphExecutions` has **no admission control at all**: no capacity check, no
+token bucket, no clock-domain check, no path on which it can be refused. Every other method
+there is bounded, because every other event is a *measurement* and dropping one costs a slice
+of the profile. This one is a *refusal*, and dropping it does not cost a slice of the profile —
+it restores the entire defect the refusal exists to prevent, precisely under the load that
+makes a bucket bite. A bounded refusal is not a refusal. It is also cheap enough that the bound
+buys nothing: the producer emits deltas at most once per drain tick.
+
+Consequently there is no `SinkStats` row for it (a row whose three drop counters can never move
+is a row of zeros that trains the reader to skip the table). The arrival count lives in
+`gpuprobe.Stats.GraphExecutions` and can be compared against `Snapshot.GraphExecutions`; the
+privileged gate asserts them equal.
+
+### `Stats.Undecoded` changed meaning, and assertion 12 with it
+
+Adding a `case kindDropped:` arm means `Undecoded` is now zero for **every** kind the ABI
+defines. That is a stronger contract than before — it now means only "a kind neither side of
+the wire knows", i.e. ABI drift — and it required editing the privileged gate's assertion 12
+from `Undecoded == 4` to `Undecoded == 0` plus an exact partition of the four class records.
+
+Scope discipline on the other three classes: `pc-dropped-hw`, `pc-buffer-full` and
+`pc-non-user-kernel` are **decoded and counted, not acted on**. Turning each into an
+operator-visible number is the separate task the Task 13 report deferred; `DropsUnconsumed` is
+what keeps them from being silent in the meantime, exactly as `Undecoded` did before. The
+identity `DropsDecoded == GraphExecReports + DropsUnconsumed` is asserted, so a class that
+reaches the decoder and then vanishes shows up as a shortfall.
+
+The asymmetry is written at `noteDropLocked`: the other three describe **loss**, which
+under-reports a profile and is visible as a shortfall; the graph class describes a claim that
+is **false while looking like the strongest answer available**, which cannot wait for the
+general treatment because its whole purpose is to stop a tier.
+
+---
+
+## The refusal's shape and its loudness
+
+### Two halves, because a graph can arrive at any time
+
+**It never starts.** `PCSamplingRequest.Select` refuses `"serialized"` with
+`ErrPCSamplingGraphExecutions`, resolving to `PCSamplingOff` — never to `"continuous"`. Off
+means the producer's environment carries `PERFAGENT_GPU_PC_SAMPLING=off`, so the burst
+controller is never constructed, no burst is ever opened and no kernel is ever serialized. The
+check runs **before** the perturbation acknowledgement and no flag buys past it: an operator
+who acknowledges the perturbation has agreed to pay a cost for exact attribution, and in a
+graph-using process they would pay the cost and receive attribution that is exact-looking and
+many-to-one, which is not the trade they agreed to.
+
+The refusal is a refusal and not a downgrade because the plan says so and the reason is
+load-bearing: a silent fall back to Tier B is *indistinguishable from Tier A working*.
+
+**It is withdrawn mid-run.** A process's first graph launch can be minutes into a run that
+began legitimately. Two mechanisms, neither of which is `Select`:
+
+- the producer stops bursting. `BurstController::poll` latches on the first graph execution,
+  returns `kStop` so an open burst closes honestly rather than being abandoned, and never
+  returns `kStart` again (`shim/core/burst.h`, Task 10). **This already existed** and is
+  untouched by this commit;
+- the agent withdraws the claim. `Timeline` marks every execution of that process
+  `GraphRefused`, turns `gpu_pc_attrib` from `"exact"` to `"graph-refused"`, counts both, and
+  `JoinHealth` raises a standing anomaly.
+
+### Loudness, in the exact words an operator sees
+
+On the **summary line every run prints**, so a reader who stops after one line cannot come away
+believing the attribution held:
+
+```
+gpu join: 3 executions, all exact; 3 launches, all matched; cache 3 live; pc samples 3
+attributed, 0 pending; 512 executions from CUDA graphs — TIER A EXACT ATTRIBUTION WITHDRAWN on
+3 executions; pc sampling serialized; serialization 3 true, 0 false, 0 unknown over 1 burst;
+4 standing warning lines; 3 anomalies
+```
+
+And as an anomaly:
+
+```
+gpu join ANOMALY: 512 kernel executions launched from CUDA GRAPHS in 1 process, and Tier A
+("serialized") PC sampling was selected — ONE graph launch fires ONE runtime callback for N
+kernels and gpu_exec_v1 carries no graph id, so those executions share one correlation and one
+CPU stack. Tier A's exact-launch attribution is FALSE here while still looking exact. It is
+withdrawn rather than downgraded: 3 of 3 executions in this snapshot carry
+gpu_graph_refused="true", and 3 executions had gpu_pc_attrib turned from "exact" to
+"graph-refused". Their durations and sample weights are real measurements and are kept; only
+the attribution claim is gone. The producer has also stopped opening bursts in that process.
+Re-run with --gpu-pc-sampling=continuous, which joins through the module rather than through
+the launch and is unaffected by graphs
+```
+
+It is raised **immediately after the serialization identity and before every other attribution
+clause**, because it is the one condition on that list that makes the counters below it read
+green while being wrong.
+
+Both drivers already log `JoinHealthWith` line by line, so **no change to `cmd/` was needed**
+for the mid-run refusal to reach an operator — which also kept this branch clear of
+`.worktrees/wire-modulestore`.
+
+### The counter is assertable in both directions
+
+`Snapshot.GraphExecutions` and `gpuprobe.Stats.GraphExecutions` read **exactly zero** on any run
+of a workload that launches no CUDA graph, and are non-zero the instant one is reported. Both
+directions are asserted (`TestGraphCountersAreZeroOnAHealthyRunAndNonZeroImmediately`), the
+zero half additionally runs on **every** conformance scenario in `gpu/conformance_test.go` via
+the new `assertGraphRefusalAccounted`, and `TestHealthyTierBRunLeavesEveryNewLossCounterAtZero`
+asserts the four new consumer counters at zero.
+
+`TierAGraphRefused()` is a **method, not a field**. A stored bool that a copy, a hand-built
+`Snapshot` or a forgotten assignment could leave false while `GraphExecutions` was non-zero
+would be a silent downgrade wearing the shape of the refusal.
+
+### Scope, and the direction it fails in
+
+The mark is **per process**, because PC-sampling collection mode is a property of the profiled
+process — the burst controller lives inside it — so one graph-using process in a system-wide
+profile must not withdraw the exact attribution of every other one.
+
+Two ways that scope is lost, and both **widen** rather than narrow: a report naming no process
+(`PID 0`), and the per-process tracker being full. That is the **opposite** resolution to the
+multi-device tracker's cap, deliberately: there, absence of evidence for a second device is not
+evidence of one, so an untracked process is treated as single-device. Here the evidence already
+exists and only its scope is missing, so discarding it would throw away a proven refusal. Both
+causes are counted (`GraphExecUnscoped`, `GraphExecTrackingCapped`) and raise their own
+`joinhealth` line, so an operator looking at a profile where *everything* is marked can tell
+"they all used graphs" from "we stopped being able to say which one did".
+
+---
+
+## What happens to samples from the pre-refusal window, and why
+
+**They are KEPT, and MARKED.** Not discarded, and not left unmarked.
+
+The window is real and was measured by Task 10 (its item 13): `g_exec_from_graph` is set from
+`CUpti_ActivityKernel12.graphId` on the **activity** path, which reaches the producer's drain
+tick — up to 100 ms, and one or two bursts, after the first graph kernel actually ran. So
+executions **arrive before the report that condemns them**.
+
+The three options are not equally honest:
+
+- **Discarding them** is the silent-downgrade shape wearing different clothes. A profile with
+  the graph process's GPU time removed is indistinguishable from a profile of a process that
+  did no GPU work. Worse, it would destroy the `gpu_serialized="true"` disclosure for kernels
+  that really were serialized: the profiler perturbed that workload, and deleting the evidence
+  does not un-perturb it, it only hides that the damage was done.
+- **Keeping them unmarked** is the defect the issue is about.
+- **Keeping them marked** keeps every measurement and takes away exactly one thing: the claim
+  about *which launch* they belong to.
+
+So the durations, the sample weights, the stall reasons, the source labels and the whole
+serialization disclosure survive untouched, and `gpu_pc_attrib` stops saying `"exact"`.
+`TestGraphRefusalKeepsTheMeasurementsItRefusesToAttribute` asserts each of those, including
+that the sample keeps its full share of the execution's duration.
+
+### The mark is retroactive within a snapshot, and not across one
+
+The condition is a property of the process, so it is applied at `Snapshot`, not at ingest:
+**every execution the Timeline still holds is marked however late the report came**. Both
+drivers in this tree snapshot exactly once, at the end of the run, so on those drivers **no
+execution escapes the mark at all** — the pre-refusal window costs nothing.
+
+A driver that snapshots *periodically* is different: a snapshot already emitted before the first
+report carries executions this one would have refused. That residue is real, it is unmeasured on
+hardware, and it is **reported rather than left to be discovered** — it has its own `joinhealth`
+line, quoted here in full because it is the honest statement of the remaining gap:
+
+```
+gpu join ANOMALY: the graph refusal is RETROACTIVE within a snapshot but not across one — the
+producer learns an execution came from a graph on its activity drain, up to a drain interval
+after the kernel ran, so every execution this Timeline still held is marked above, but any
+snapshot already EMITTED before the first graph report arrived carries executions labelled
+gpu_pc_attrib="exact" that this one would have refused. A run that snapshots once, at the end,
+has no such executions
+```
+
+Closing that residue would need the mark to travel with already-emitted pprof samples, which it
+cannot; the alternative is for a periodic driver to hold its output until the run ends, which is
+a driver decision and not this one.
+
+---
+
+## Tier B is untouched, and the asymmetry is now in the code
+
+Tier B joins a PC sample through the **module** — cubin CRC and function index to a device
+function name — and never through the launch, so a graph-launched kernel resolves to its own
+kernel exactly as any other does. Nothing about Tier B is false in a graph-using process, and
+marking it would be a false alarm that devalues the real one.
+
+That is enforced in four places rather than assumed:
+
+- `Timeline.isGraphRefusedLocked` returns false unless the tier is `PCSamplingSerialized`, and
+  the tier check lives **there** rather than at the call sites so a future caller cannot forget
+  it;
+- `Snapshot` replaces **`PCAttribExact` and only `PCAttribExact`**. `kernel`,
+  `kernel-ambiguous` and `kernel-multidevice` are left exactly as they are;
+- `PCAttribGraphRefused` is deliberately **not** reachable through `worsePCAttrib`. It sits last
+  in `pcAttribs` so `MarshalJSON` accepts it and `PCAttribs()` stays exhaustive, and its doc
+  comment says no path ranks its way there. Implementing the refusal with `worsePCAttrib` is a
+  mutation the gate catches;
+- `joinhealth` raises the anomaly only under Tier A. The count still rides on the `Snapshot` in
+  every tier — ingest is never gated, only the consequence — and the summary line says
+  *"(this tier joins through the module, not the launch, and is unaffected)"* once, so an
+  operator learns not to look for the refusal there.
+
+`TestGraphExecutionsDoNotWeakenTierB` drives Tier B and off; 
+`TestGraphRefusalLeavesModuleKeyedAttributionAloneThroughTheJoin` drives a **module-keyed join
+under Tier A with the refusal armed** and asserts the attribution survives — that second test
+exists because the first one, which builds views by hand, does not exercise `Snapshot` and
+therefore cannot catch a `Snapshot` that marks too widely.
+
+The cubin capture, the `CubinView` guard (`make -C shim check-cubin-defer`: OK, all 5 deferrals
+still refuse to compile), the `MODULE_UNLOAD_STARTING` drain and tier selection are unchanged.
+**No file under `shim/` or `bpf/` changed**; no `.o` churn.
+
+---
+
+## The gate assertion's conversion
+
+`TestGateGraphExecutionRefusalIsNotAssertableYet` was the #44 idiom: a passing test that pinned
+the gap by reflecting over `Snapshot`, `TimelineDropStats`, `PCJoinStats`, `TimelineConfig` and
+`PCSamplingRequest` and failing the moment any of them grew a field naming graph executions.
+
+It failed, by name, in the gate's own file, on the first run after `Snapshot` grew
+`GraphExecutions`. It is **deleted and replaced** by `TestGateGraphExecutionRefusalIsReal`,
+which composes rather than restates — the eight behaviours live in `gpu/graphrefusal_test.go`
+beside the code, and deleting or weakening any of them now fails *the gate*, by assertion
+number:
+
+```
+TestPhase6Gate/assertion-10b-graph-execution-makes-tier-a-refuse/
+    refuses-to-start
+    no-acknowledgement-buys-past-it
+    withdraws-exact-mid-run
+    is-loud-and-counted
+    counters-are-zero-when-healthy
+    keeps-the-measurements
+    does-not-weaken-tier-b
+    does-not-touch-module-keyed-attribution
+    does-not-touch-module-keyed-attribution-through-the-join
+```
+
+It also keeps the half that was always true: the acknowledgement refusal and the standing
+warning must go on naming CUDA graphs, since those are the only places the limitation reaches
+an operator who never hits the condition.
+
+The gate's assertion 10b comment no longer says the first clause is asserted "at the level the
+product implements it". It is asserted at the level the plan specified.
+
+**The privileged end-to-end gate now drives the refusal for real.** The stub emits
+`{count: 2, GPU_DROP_CLASS_GRAPH_EXEC}` whenever PC sampling is on, and
+`TestStubDrivesPCSamplingToPprofWithoutAGPU` runs Tier A, so on that run the class crosses a
+real uprobe, is decoded by the consumer's own arm, is scoped to the producer's pid from the
+batch header and reaches the Timeline through the ordinary sink. It asserts
+`Stats.GraphExecutions == 2`, `Stats.GraphExecutions == Snapshot.GraphExecutions` (loss between
+the wire and the join), one graph process, nothing unscoped, every execution marked, **no
+sample left claiming `gpu_pc_attrib="exact"`**, `gpu_graph_refused="true"` on every projected
+sample, and the two `joinhealth` strings. That test **compiles, vets and lints** here and
+**cannot run** — see below.
+
+Assertion 12's `Undecoded == 4` became `Undecoded == 0` plus the exact four-record partition,
+for the reason given above.
+
+### Mutation checks (each applied, run, reverted)
+
+| mutation | result |
+| --- | --- |
+| `isGraphRefusedLocked` always returns false | 4 gate sub-assertions FAIL |
+| `Select` returns `PCSamplingContinuous` instead of refusing (the silent downgrade) | 2 gate sub-assertions FAIL |
+| `Snapshot` guard relaxed from `== PCAttribExact` to `!= ""` (ranks over Tier B) | `does-not-touch-module-keyed-attribution-through-the-join` FAILS |
+| the `joinhealth` anomaly suppressed | 2 gate sub-assertions FAIL |
+| `noteDropLocked` treats every class as unconsumed | 3 consumer tests FAIL |
+
+---
+
+## Cannot verify
+
+**Everything below has not been executed. `CapEff: 0`, no GPU, no passwordless sudo, and no
+`CUpti_` code path in this repository has ever run on this machine.**
+
+1. **The size of the pre-refusal window on real hardware — the item this issue explicitly leaves
+   outstanding for the RTX 3090.** Task 10 item 13 established the mechanism (the activity path,
+   drained on a ≤100 ms tick) but not the magnitude: how many kernels, how many bursts and how
+   much wall time elapse between a graph-using process's first graph kernel and the agent's
+   first `gpu_dropped_v1 / GRAPH_EXEC` record. On this tree the answer is "it costs nothing for
+   a driver that snapshots once", which is both drivers here — but that is an argument, not a
+   measurement, and it says nothing about a periodic driver. **The measurement to take:** run
+   `cmd/gpu-cuda-profile` under Tier A against a graph-using workload, and compare
+   `Snapshot.GraphExecutions` against the count of executions whose `StartNs` precedes the first
+   graph report's arrival. Nothing here can produce that number.
+2. **`TestStubDrivesPCSamplingToPprofWithoutAGPU`** — compiles, vets and lints; skips here for
+   want of `cap_bpf,cap_perfmon,cap_checkpoint_restore`. The new end-to-end graph assertions in
+   it have never executed. What *has* executed, unprivileged, is every product hop they cover
+   except the BPF attach and the ringbuf: the decode arm (`gpuprobe/consumer_test.go`, against
+   synthetic `kindDropped` wire bytes built to the same ABI), the sink, the Timeline latch, the
+   `Snapshot` marking, the labels and `joinhealth`.
+3. **Whether the CUPTI adapter's `g_graph_exec_reported` delta actually reaches the wire at the
+   rate assumed.** `CountingSink.EmitGraphExecutions` is unbounded partly on the argument that
+   the volume is a handful of records per second per process; an adapter that emitted per
+   execution would make that argument false. The code says it emits deltas
+   (`shim/nvidia/cupti_adapter.cc`), and no run has confirmed it.
+4. **Whether `CUpti_ActivityKernel12.graphId` is non-zero for every graph-launched execution**,
+   or only for some — e.g. whether it survives graph instantiation and update. A partial signal
+   would still arm the refusal (one report is enough) but would make `GraphExecutions` an
+   undercount rather than a count.
+5. **Whether the producer's burst controller and this agent's withdrawal agree on hardware.**
+   Both refuse independently and neither reads the other; a disagreement (the producer still
+   bursting while the agent has withdrawn, or the reverse) would show up as
+   `ExecutionsSerialized > 0` alongside `ExecutionsGraphRefused > 0` for windows that opened
+   *after* the first report. Nothing here can produce that combination.
+
+**Not verifiable at all:** whether a workload's graph usage is representative. Inference serving
+uses graphs pervasively, which is precisely why the plan's risk section says this refusal
+shrinks Tier A's addressable market to nearly nothing in the workloads that most want it. That
+is a product fact this commit makes *visible*; it does not change it.
+
+### Outstanding, and named rather than hidden
+
+`PCSamplingRequest.GraphExecutionsObserved` **has no in-tree writer**. No driver here can know,
+on a first run against an unknown process, that it uses graphs — the knowledge arrives only
+after the run that discovers it. The field is kept for the same reason `TimelineConfig.Modules`
+is (finding 2 of the Task 13 report): a known, named hop with both ends built, awaiting a caller
+that has the information — a supervisor, a second profiling round, or an operator acting on the
+previous run's anomaly, for whom `Snapshot.GraphExecutions > 0` is the value to pass. Its doc
+comment says exactly this. The mid-run half needs no such caller and is fully live.
+
+---
+
+## Verification actually run
+
+```
+make -C shim                    OK
+make -C shim test               OK
+make -C shim check-fpless       OK
+make -C shim check-cubin-defer  OK - all 5 deferrals still refuse to compile
+make -C shim nvidia             OK (CUDA 13.3, real libcupti)
+go build ./... && go vet ./...  clean
+go test ./gpu/ ./gpuprobe/ ./internal/... -count=1     all pass
+go test ./gpu/ ./gpuprobe/ -race -count=4              ok gpu 23.0s, gpuprobe 19.6s
+~/go/bin/golangci-lint run --timeout=5m                0 issues
+```
+
+`git diff --stat`: 17 files changed plus the new `gpu/graphrefusal_test.go`. No file under
+`shim/`, `bpf/` or `cmd/` changed.

--- a/gpu/conformance_test.go
+++ b/gpu/conformance_test.go
@@ -101,6 +101,7 @@ type attemptSink struct {
 	moduleAttempts uint64
 	eventAttempts  uint64
 	windowAttempts uint64
+	graphAttempts  uint64
 }
 
 func newAttemptSink(inner EventSink) *attemptSink {
@@ -139,6 +140,11 @@ func (a *attemptSink) EmitEvent(e GPUTimelineEvent) error {
 func (a *attemptSink) EmitSamplingWindow(w GPUSamplingWindow) error {
 	a.windowAttempts++
 	return a.inner.EmitSamplingWindow(w)
+}
+
+func (a *attemptSink) EmitGraphExecutions(g GPUGraphExecutions) error {
+	a.graphAttempts++
+	return a.inner.EmitGraphExecutions(g)
 }
 
 // conformanceHarness is a fresh Timeline + CountingSink pair, wired the way a
@@ -267,6 +273,7 @@ func assertConformanceInvariants(t *testing.T, h *conformanceHarness) Snapshot {
 	// them, and an execution that reached the profile carrying no disclosure
 	// would otherwise be invisible.
 	assertSerializationOutcomesAccounted(t, snap)
+	assertGraphRefusalAccounted(t, snap)
 
 	return snap
 }
@@ -324,6 +331,32 @@ func assertSerializationOutcomesAccounted(t *testing.T, snap Snapshot) {
 	for _, v := range snap.Executions {
 		assert.Equal(t, SerializationNotSerialized, v.Serialized,
 			"execution %+v", v.Exec.Correlation)
+	}
+}
+
+// assertGraphRefusalAccounted runs on EVERY conformance scenario, and asserts
+// the negative: no scenario here reports a CUDA-graph execution, so the
+// refusal must be entirely unarmed. A run that started withdrawing attribution
+// nobody's graph caused would be as wrong as one that stopped withdrawing it
+// when a graph did.
+//
+// The two containment relations are the identity that keeps the counters
+// checkable rather than merely reported: an execution cannot be
+// graph-refused-and-not-in-the-snapshot, and an attribution cannot have been
+// withdrawn from an execution that was not marked.
+func assertGraphRefusalAccounted(t *testing.T, snap Snapshot) {
+	t.Helper()
+	assert.Zero(t, snap.GraphExecutions, "no scenario here reports a CUDA-graph execution")
+	assert.Zero(t, snap.ExecutionsGraphRefused)
+	assert.Zero(t, snap.PCJoin.GraphRefusedAttributions)
+	assert.False(t, snap.TierAGraphRefused())
+	assert.LessOrEqual(t, snap.ExecutionsGraphRefused, uint64(len(snap.Executions)),
+		"more executions were marked graph-refused than the snapshot holds")
+	assert.LessOrEqual(t, snap.PCJoin.GraphRefusedAttributions, snap.ExecutionsGraphRefused,
+		"an attribution was withdrawn from an execution that was never marked")
+	for _, v := range snap.Executions {
+		assert.False(t, v.GraphRefused, "execution %+v", v.Exec.Correlation)
+		assert.NotEqual(t, PCAttribGraphRefused, v.PCAttrib)
 	}
 }
 

--- a/gpu/gate_test.go
+++ b/gpu/gate_test.go
@@ -2,7 +2,6 @@ package gpu
 
 import (
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -143,8 +142,8 @@ func TestPhase6Gate(t *testing.T) {
 		TestProjectionCapSuppressesGpuPCAndOnlyGpuPC)
 	t.Run("assertion-09-suppression-is-surfaced", TestProjectionCapIsSurfacedInJoinHealth)
 
-	// 10b. Out-of-scope conditions refuse rather than guess. The graph clause
-	//      is asserted at the level the product implements it - see the test.
+	// 10b. Out-of-scope conditions refuse rather than guess: two devices, an
+	//      open window, and a CUDA graph.
 	t.Run("assertion-10b-two-devices-are-marked", TestTierBMultiDeviceProcessIsMarked)
 	t.Run("assertion-10b-multidevice-outranks-ambiguity", TestMultiDeviceOutranksAmbiguity)
 	t.Run("assertion-10b-open-window-is-unknown-never-false",
@@ -152,11 +151,11 @@ func TestPhase6Gate(t *testing.T) {
 	t.Run("assertion-10b-tier-a-refusal-names-cuda-graphs",
 		TestSerializedIsRefusedWithoutAnExplicitAcknowledgement)
 	// The first clause of 10b - "a graph execution makes Tier A refuse to
-	// start" - is NOT implemented by the product. This pins that, and fails
-	// when it becomes implementable so the gate is updated rather than left
-	// claiming an assertion it never made.
-	t.Run("assertion-10b-graph-refusal-is-outstanding",
-		TestGateGraphExecutionRefusalIsNotAssertableYet)
+	// start". Asserted for real since issue #94; it used to be PINNED here as
+	// an outstanding gap by TestGateGraphExecutionRefusalIsNotAssertableYet,
+	// which failed by name the moment the product grew the refusal.
+	t.Run("assertion-10b-graph-execution-makes-tier-a-refuse",
+		TestGateGraphExecutionRefusalIsReal)
 }
 
 // gateCubinCRCs are the CRCs this file stores its fixtures under. The values
@@ -352,86 +351,70 @@ func TestGateResolvedAndNoLineinfoAggregateAtTheSameKernel(t *testing.T) {
 	assert.Equal(t, []string{"main", FrameLaunch, "[gpu:kernel:addOne]"}, frameNames(samples[0].Stack))
 }
 
-// TestGateGraphExecutionRefusalIsNotAssertableYet is gate assertion 10b's
-// FIRST clause - "a graph execution makes Tier A refuse to start" - pinned as
-// an outstanding gap rather than asserted, because the product does not
-// implement it.
+// TestGateGraphExecutionRefusalIsReal is gate assertion 10b's FIRST clause:
+// "a graph execution makes Tier A refuse to start".
 //
-// # What exists and what does not
+// It replaces TestGateGraphExecutionRefusalIsNotAssertableYet, which pinned
+// this as an outstanding gap because the product did not implement it — the
+// #44 idiom, a passing test that fails when the gap closes. Issue #94 closed
+// it, that test failed by name in this file exactly as its doc comment said it
+// would, and this is the real assertion it demanded.
 //
-// The wire signal exists: the plan's Task 6 gave the adapter a
-// classGraphExec drop class, `internal/gpuabi.DropClassGraphExec` decodes it
-// and spells it "graph-exec", and the stub emits one such record so the class
-// is reachable from a test. The operator warning names CUDA graphs, and the
-// Tier A acknowledgement refusal names them too.
+// # What the clause is about
 //
-// What does not exist is the REFUSAL the plan specifies:
+// A CUDA graph launch fires ONE runtime callback for N kernels, and
+// gpu_exec_v1 carries no graph id, so all N executions arrive under one
+// correlation. Tier A's ENTIRE claim is exact launch attribution, so in such a
+// process that claim is false — and false in the worst available way, because
+// nothing about it looks wrong: gpu_join reads "exact", gpu_pc_attrib reads
+// "exact", every join counter reads green, and N kernels' time and samples are
+// billed to a single CPU call site. The plan requires the refusal be "loud and
+// counted, not a silent downgrade to Tier B", precisely because a downgrade is
+// indistinguishable from working.
 //
-//	Tier A refuses to start in a process where graph executions have been
-//	observed, because Tier A's whole claim is exact launch attribution and a
-//	graph makes that claim false. The refusal is loud and counted, not a
-//	silent downgrade to Tier B.
+// # What is asserted, and where
 //
-// Nothing in gpu/, gpuprobe/ or cmd/ consumes DropClassGraphExec. The
-// consumer decodes gpu_dropped_v1 into batch.Drops and stops there (see
-// Stats.Undecoded's own comment, which says normalizing a drop class is the
-// task after Task 7). So there is no counter for graph executions, nothing on
-// the Snapshot that names them, no joinhealth anomaly, and no input by which
-// PCSamplingRequest could be told about them. Tier A therefore starts happily
-// in a graph-using process and produces confident, exact-LOOKING attribution
-// of N kernels to one call site - which is finding 4 of the plan, and the
-// condition it says must be visible rather than merely out of scope.
+// Both halves of the refusal, because a process's first graph launch can be
+// minutes into a run that started legitimately:
 //
-// # Why this is a passing test rather than a failing one
+//   - it never STARTS — PCSamplingRequest.Select refuses "serialized" outright,
+//     resolving to OFF rather than to "continuous", and no acknowledgement flag
+//     buys past it. Refusing to start is what stops the producer's burst
+//     controller ever being built: the tier reaches the producer through
+//     PCSamplingEnvVar, and an OFF tier makes no PC-sampling call at all;
+//   - it is WITHDRAWN mid-run — Timeline marks every execution of that process,
+//     turns gpu_pc_attrib from "exact" to "graph-refused", counts both, and
+//     JoinHealth raises a standing anomaly.
 //
-// It is the shape issue #44 used and #45 inverted: an assertion that pins the
-// CURRENT state, with the note that fixing the defect must fail it. Writing
-// the real assertion now would leave the gate red on a branch that is not
-// allowed to change product behaviour; leaving nothing at all would let the
-// gate ship claiming twelve assertions while one of them was never written.
+// Plus the two things the refusal must not do: weaken Tier B, which joins
+// through the module rather than through the launch and is genuinely
+// unaffected; and discard the measurements it refuses to attribute.
 //
-// When Task 10's refusal lands, this test fails - by name, in the gate's own
-// file - and the person landing it replaces it with the real assertion:
-// a stub reporting a graph execution makes Tier A refuse to start, loudly and
-// counted.
-func TestGateGraphExecutionRefusalIsNotAssertableYet(t *testing.T) {
-	mentionsGraph := func(v any) []string {
-		var out []string
-		typ := reflect.TypeOf(v)
-		for i := range typ.NumField() {
-			if name := typ.Field(i).Name; strings.Contains(strings.ToLower(name), "graph") {
-				out = append(out, name)
-			}
-		}
-		return out
-	}
-	for _, tc := range []struct {
-		name string
-		v    any
-	}{
-		{"Snapshot", Snapshot{}},
-		{"TimelineDropStats", TimelineDropStats{}},
-		{"PCJoinStats", PCJoinStats{}},
-		{"TimelineConfig", TimelineConfig{}},
-		{"PCSamplingRequest", PCSamplingRequest{}},
-	} {
-		assert.Empty(t, mentionsGraph(tc.v),
-			"%s now names graph executions (%v). Gate assertion 10b's first clause has become "+
-				"assertable: replace this test with the real one - a stub reporting a graph "+
-				"execution makes Tier A refuse to start, loudly and counted.",
-			tc.name, mentionsGraph(tc.v))
-	}
+// Composed rather than restated, like every other assertion in this gate: the
+// tests live in gpu/graphrefusal_test.go beside the behaviour, and deleting or
+// weakening any of them now fails THE GATE, by assertion number.
+func TestGateGraphExecutionRefusalIsReal(t *testing.T) {
+	t.Run("refuses-to-start", TestGraphExecutionsMakeTierARefuseToStart)
+	t.Run("no-acknowledgement-buys-past-it", TestTheGraphRefusalIsNotOverridableByTheAcknowledgement)
+	t.Run("withdraws-exact-mid-run", TestGraphExecutionWithdrawsTierAExactAttribution)
+	t.Run("is-loud-and-counted", TestGraphRefusalIsLoudInJoinHealth)
+	t.Run("counters-are-zero-when-healthy", TestGraphCountersAreZeroOnAHealthyRunAndNonZeroImmediately)
+	t.Run("keeps-the-measurements", TestGraphRefusalKeepsTheMeasurementsItRefusesToAttribute)
+	t.Run("does-not-weaken-tier-b", TestGraphExecutionsDoNotWeakenTierB)
+	t.Run("does-not-touch-module-keyed-attribution", TestGraphRefusalDoesNotTouchModuleKeyedAttribution)
+	t.Run("does-not-touch-module-keyed-attribution-through-the-join",
+		TestGraphRefusalLeavesModuleKeyedAttributionAloneThroughTheJoin)
 
-	// The half that IS true today, so this test is not purely negative: the
-	// operator is told, in the refusal they must read before Tier A can run at
-	// all, that the tier is unavailable where graphs are in use.
+	// The half that was always true, kept: the operator is told about CUDA
+	// graphs in the acknowledgement refusal they must read before Tier A can
+	// run at all, and in the standing warning that stands for the whole run.
+	// Those are the only places the limitation reaches an operator who never
+	// hits the condition.
 	_, err := PCSamplingRequest{Flag: "serialized"}.Select()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "CUDA graphs",
-		"the only place the graph limitation is stated to an operator is the Tier A acknowledgement refusal; if that text loses it, nothing anywhere names the condition")
+		"the acknowledgement refusal must keep naming the graph limitation")
 	warning := strings.Join(PCSamplingStandingWarning(PCSamplingSerialized), "\n")
 	assert.Contains(t, warning, "CUDA GRAPHS",
 		"the standing warning must keep naming the third perturbation")
-	t.Log("gate assertion 10b, first clause: OUTSTANDING - see this test's doc comment and " +
-		".superpowers/sdd/task-13-gate-report.md")
 }

--- a/gpu/graphrefusal_test.go
+++ b/gpu/graphrefusal_test.go
@@ -1,0 +1,542 @@
+package gpu
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The CUDA-graph refusal — issue #94.
+//
+// A CUDA graph launch fires ONE runtime callback for N kernels and gpu_exec_v1
+// carries no graph id, so all N executions arrive under one correlation. Tier
+// A's entire claim is exact launch attribution, so in such a process that claim
+// is false — and false in the worst available way, because nothing about it
+// looks wrong: gpu_join reads "exact", gpu_pc_attrib reads "exact", every join
+// counter reads green, and N kernels' time and samples are billed to one CPU
+// call site.
+//
+// The tests below assert the refusal in both of its halves (it never starts;
+// once started it is withdrawn), its LOUDNESS (counted, in the snapshot, in
+// joinhealth, on the labels), and the two things it must NOT do: weaken Tier B,
+// which joins through the module rather than through the launch and is
+// genuinely unaffected, and discard the measurements it refuses to attribute.
+
+const graphPID = uint32(9001)
+
+// graphTimeline is a Tier A timeline; graphTimelineIn is one in any tier, so a
+// test can assert the same input produces opposite behaviour in Tier B.
+func graphTimeline() *Timeline { return graphTimelineIn(PCSamplingSerialized) }
+
+func graphTimelineIn(tier PCSamplingTier) *Timeline {
+	return NewTimeline(TimelineConfig{PCSampling: tier})
+}
+
+// graphExec drives one launch, one exact-correlation PC sample and one
+// execution through a Timeline the way the consumer does, so the resulting view
+// carries PCAttribExact — the claim the refusal exists to withdraw.
+func graphExec(t *testing.T, tl *Timeline, pid uint32, value string, startNs uint64) {
+	t.Helper()
+	corr := CorrelationID{Backend: BackendCUPTI, PID: pid, Value: value}
+	require.NoError(t, tl.EmitLaunch(GPUKernelLaunch{
+		Correlation: corr,
+		ClockDomain: ClockDomainCPUMonotonic,
+		TimeNs:      startNs,
+		Launch:      LaunchContext{PID: pid, TimeNs: startNs},
+	}))
+	require.NoError(t, tl.EmitPCSample(GPUPCSample{
+		Correlation: corr,
+		Module:      ModuleRef{Backend: BackendCUPTI, CRC: 0xC0DE},
+		ClockDomain: ClockDomainCPUMonotonic,
+		TimeNs:      startNs + 10,
+		PCOffset:    0x40,
+		StallReason: "long_scoreboard",
+		Count:       1,
+	}))
+	require.NoError(t, tl.EmitExec(GPUKernelExec{
+		Correlation: corr,
+		ClockDomain: ClockDomainCPUMonotonic,
+		StartNs:     startNs,
+		EndNs:       startNs + 100,
+		KernelName:  "addOne",
+	}))
+}
+
+func graphReport(pid uint32, count uint64) GPUGraphExecutions {
+	return GPUGraphExecutions{Backend: BackendCUPTI, PID: pid, Count: count}
+}
+
+// ---------------------------------------------------------------------------
+// The START half: Tier A never runs at all
+// ---------------------------------------------------------------------------
+
+// TestGraphExecutionsMakeTierARefuseToStart is the plan's Task 10 sentence,
+// asserted: "Tier A refuses to start in a process where graph executions have
+// been observed."
+//
+// It is a REFUSAL and not a downgrade, and that is the half worth pinning. A
+// silent fall back to "continuous" would leave the operator reading an inferred
+// profile while believing they had asked for and received an exact one, and
+// nothing in the output would say which they got — indistinguishable from Tier
+// A working, which is the specific failure the plan calls out.
+func TestGraphExecutionsMakeTierARefuseToStart(t *testing.T) {
+	tier, err := PCSamplingRequest{
+		Flag:                    PCSamplingNameSerialized,
+		AcknowledgePerturbation: true,
+		GraphExecutionsObserved: true,
+	}.Select()
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPCSamplingGraphExecutions)
+	assert.Equal(t, PCSamplingOff, tier,
+		"a refused Tier A must resolve to OFF, never to continuous: a downgrade the operator "+
+			"did not choose is indistinguishable from Tier A working")
+	assert.NotErrorIs(t, err, ErrPCSamplingNotAcknowledged,
+		"the graph refusal must be its own sentinel, so a driver can tell 'acknowledge it' from "+
+			"'this tier cannot work here' — the first has a remedy the operator can apply")
+	for _, want := range []string{"CUDA graph", "exact", "continuous"} {
+		assert.Contains(t, err.Error(), want,
+			"the refusal must name the condition, the claim it breaks and the tier that still works")
+	}
+}
+
+// TestTheGraphRefusalIsNotOverridableByTheAcknowledgement pins the ORDER of the
+// two Tier A gates.
+//
+// The perturbation acknowledgement is a trade: the operator agrees to have
+// their kernels serialized in exchange for exact attribution. In a graph-using
+// process they would pay that cost and receive attribution that is
+// exact-looking and many-to-one, which is not the trade they agreed to. So the
+// graph refusal is checked FIRST and there is no flag that turns it off.
+func TestTheGraphRefusalIsNotOverridableByTheAcknowledgement(t *testing.T) {
+	for _, ack := range []bool{false, true} {
+		_, err := PCSamplingRequest{
+			Flag:                    PCSamplingNameSerialized,
+			AcknowledgePerturbation: ack,
+			GraphExecutionsObserved: true,
+		}.Select()
+		require.ErrorIs(t, err, ErrPCSamplingGraphExecutions,
+			"acknowledging the perturbation must not buy past the graph refusal (ack=%v)", ack)
+	}
+}
+
+// The refusal gates Tier A and NOTHING else. Tier B is unaffected by graphs
+// because it joins through the module rather than through the launch, and "off"
+// has no claim to withdraw; refusing either would be a false alarm that makes
+// the real one easier to ignore.
+func TestTheGraphRefusalGatesTierAAndNoOtherTier(t *testing.T) {
+	for _, tc := range []struct {
+		flag string
+		want PCSamplingTier
+	}{
+		{PCSamplingNameOff, PCSamplingOff},
+		{PCSamplingNameContinuous, PCSamplingContinuous},
+	} {
+		tier, err := PCSamplingRequest{Flag: tc.flag, GraphExecutionsObserved: true}.Select()
+		require.NoError(t, err, "%s must not be refused for CUDA graphs", tc.flag)
+		assert.Equal(t, tc.want, tier)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The MID-RUN half: the claim is withdrawn
+// ---------------------------------------------------------------------------
+
+// TestGraphExecutionWithdrawsTierAExactAttribution is the mid-run refusal: a
+// process's first graph launch can be minutes into a run that started
+// legitimately, so Select cannot be the whole answer.
+//
+// The same Timeline is driven twice with identical events, differing only in
+// whether a graph execution was reported, and the two snapshots are compared.
+// That shape is the point: a refusal asserted only in its own scenario cannot
+// show that the CONTROL run is green, and "green when healthy, loud when not"
+// is the whole property.
+func TestGraphExecutionWithdrawsTierAExactAttribution(t *testing.T) {
+	clean := graphTimeline()
+	graphExec(t, clean, graphPID, "1", 1_000)
+	cleanSnap := clean.Snapshot()
+
+	require.Len(t, cleanSnap.Executions, 1)
+	require.Equal(t, PCAttribExact, cleanSnap.Executions[0].PCAttrib,
+		"the control run must actually reach the exact claim, or this test proves nothing")
+	assert.Zero(t, cleanSnap.GraphExecutions,
+		"a run with no CUDA graph must read EXACTLY zero here")
+	assert.Zero(t, cleanSnap.ExecutionsGraphRefused)
+	assert.Zero(t, cleanSnap.PCJoin.GraphRefusedAttributions)
+	assert.False(t, cleanSnap.Executions[0].GraphRefused)
+	assert.False(t, cleanSnap.TierAGraphRefused())
+
+	refused := graphTimeline()
+	require.NoError(t, refused.EmitGraphExecutions(graphReport(graphPID, 7)))
+	graphExec(t, refused, graphPID, "1", 1_000)
+	snap := refused.Snapshot()
+
+	require.Len(t, snap.Executions, 1)
+	assert.Equal(t, PCAttribGraphRefused, snap.Executions[0].PCAttrib,
+		"gpu_pc_attrib must stop saying \"exact\" the moment a graph makes it false")
+	assert.True(t, snap.Executions[0].GraphRefused)
+	assert.True(t, snap.TierAGraphRefused())
+	assert.Equal(t, uint64(7), snap.GraphExecutions)
+	assert.Equal(t, uint64(1), snap.GraphExecProcesses)
+	assert.Equal(t, uint64(1), snap.ExecutionsGraphRefused)
+	assert.Equal(t, uint64(1), snap.PCJoin.GraphRefusedAttributions)
+	assert.Zero(t, snap.GraphExecUnscoped)
+	assert.Zero(t, snap.GraphExecTrackingCapped)
+}
+
+// TestGraphRefusalKeepsTheMeasurementsItRefusesToAttribute is the explicit
+// answer to "what happens to the samples collected before the refusal fired".
+//
+// KEPT, AND MARKED. Not discarded, and not left unmarked.
+//
+//   - Discarding them is the silent-downgrade shape wearing different clothes:
+//     a profile with the graph process's GPU time removed is indistinguishable
+//     from a profile of a process that did no GPU work. It would also destroy
+//     the gpu_serialized="true" disclosure for kernels that really were
+//     serialized — the profiler perturbed that workload, and deleting the
+//     evidence does not un-perturb it, it only hides that the damage was done.
+//   - Leaving them unmarked is the defect itself.
+//
+// So the durations, the sample weights, the stall reasons and the serialization
+// disclosure all survive untouched. Exactly one thing is taken away: the claim
+// about WHICH LAUNCH they belong to.
+func TestGraphRefusalKeepsTheMeasurementsItRefusesToAttribute(t *testing.T) {
+	tl := graphTimeline()
+	emitBurst(t, tl, uint64(graphPID), 900, 1_500)
+	graphExec(t, tl, graphPID, "1", 1_000)
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(graphPID, 3)))
+	snap := tl.Snapshot()
+
+	require.Len(t, snap.Executions, 1)
+	view := snap.Executions[0]
+	require.Len(t, view.PCSamples, 1, "the PC samples must be KEPT, not dropped with the claim")
+	assert.Equal(t, uint64(1_000), view.Exec.StartNs)
+	assert.Equal(t, uint64(1_100), view.Exec.EndNs, "the measured duration is a measurement and survives")
+	assert.Equal(t, uint64(1), snap.AttributedPCSamples)
+	assert.Equal(t, SerializationSerialized, view.Serialized,
+		"the perturbation disclosure survives the refusal: those kernels really did run serialized, "+
+			"and dropping the mark would hide damage the profiler actually did")
+	assert.Equal(t, uint64(1), snap.ExecutionsSerialized)
+
+	samples := ProjectExecutions(snap)
+	require.Len(t, samples, 1)
+	assert.Equal(t, "true", samples[0].Labels["gpu_serialized"])
+	assert.Equal(t, "true", samples[0].Labels["gpu_graph_refused"])
+	assert.Equal(t, string(PCAttribGraphRefused), samples[0].Labels["gpu_pc_attrib"])
+	assert.Equal(t, "long_scoreboard", samples[0].Labels["gpu_stall"])
+	assert.Positive(t, samples[0].Value, "the sample keeps its full share of the execution's duration")
+}
+
+// TestGraphRefusalIsRetroactiveOverEverythingTheTimelineStillHolds covers the
+// measured wrinkle from the Task 10 report: g_exec_from_graph is set from
+// CUpti_ActivityKernel12.graphId on the ACTIVITY path, which reaches the agent
+// on the producer's drain tick — up to 100 ms, and one or two bursts, after the
+// first graph kernel ran.
+//
+// So executions ARRIVE BEFORE the report that condemns them. The mark is a
+// property of the process and is applied at Snapshot, not at ingest, so every
+// execution the Timeline still holds is marked however late the report came. A
+// driver that snapshots once at the end of a run — which both drivers in this
+// tree do — therefore has no unmarked executions at all.
+//
+// What is NOT covered, and cannot be from here, is a driver that snapshots
+// periodically: a snapshot already emitted before the first report carries
+// executions this one would have refused. joinhealth says so in its own line.
+func TestGraphRefusalIsRetroactiveOverEverythingTheTimelineStillHolds(t *testing.T) {
+	tl := graphTimeline()
+	for _, v := range []string{"1", "2", "3"} {
+		graphExec(t, tl, graphPID, v, 1_000)
+	}
+	// The report arrives LAST, after every execution it condemns.
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(graphPID, 3)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 3)
+	for i, v := range snap.Executions {
+		assert.True(t, v.GraphRefused, "execution %d arrived before the report and must still be marked", i)
+		assert.Equal(t, PCAttribGraphRefused, v.PCAttrib)
+	}
+	assert.Equal(t, uint64(3), snap.ExecutionsGraphRefused)
+}
+
+// ---------------------------------------------------------------------------
+// What the refusal must NOT do
+// ---------------------------------------------------------------------------
+
+// TestGraphExecutionsDoNotWeakenTierB is the asymmetry, and it is deliberate
+// rather than lucky: Tier B reaches a PC sample's kernel through the cubin CRC
+// and the function index, never through the launch, so a graph-launched kernel
+// resolves to its own kernel exactly as any other does.
+//
+// Nothing about Tier B is false in a graph-using process. Marking it would be a
+// false alarm on a healthy run, and a false alarm is how the real one stops
+// being read.
+func TestGraphExecutionsDoNotWeakenTierB(t *testing.T) {
+	for _, tier := range []PCSamplingTier{PCSamplingOff, PCSamplingContinuous} {
+		t.Run(tier.String(), func(t *testing.T) {
+			tl := graphTimelineIn(tier)
+			require.NoError(t, tl.EmitGraphExecutions(graphReport(graphPID, 11)))
+			graphExec(t, tl, graphPID, "1", 1_000)
+			snap := tl.Snapshot()
+
+			require.Len(t, snap.Executions, 1)
+			assert.Equal(t, PCAttribExact, snap.Executions[0].PCAttrib,
+				"a graph does not make THIS tier's attribution false; downgrading it would weaken "+
+					"the tier that ships toward always-on for a condition that does not affect it")
+			assert.False(t, snap.Executions[0].GraphRefused)
+			assert.Zero(t, snap.ExecutionsGraphRefused)
+			assert.Zero(t, snap.PCJoin.GraphRefusedAttributions)
+			assert.False(t, snap.TierAGraphRefused())
+
+			// The fact is still RECORDED, in every tier. Ingest is not gated;
+			// only the consequence is.
+			assert.Equal(t, uint64(11), snap.GraphExecutions,
+				"the report must still be counted: a producer emitting it and an agent silently "+
+					"discarding it leaves the two ends out of step")
+
+			lines := JoinHealth(snap)
+			assert.NotContains(t, strings.Join(lines, "\n"), joinAnomalyPrefix+": 11 kernel executions",
+				"a graph is not an anomaly in this tier")
+			for _, l := range lines[1:] {
+				assert.NotContains(t, l, "WITHDRAWN")
+			}
+			assert.Contains(t, lines[0], "unaffected",
+				"the summary should say so once, so an operator learns not to look for the refusal here")
+
+			samples := ProjectExecutions(snap)
+			require.Len(t, samples, 1)
+			assert.NotContains(t, samples[0].Labels, "gpu_graph_refused")
+			assert.Equal(t, string(PCAttribExact), samples[0].Labels["gpu_pc_attrib"])
+		})
+	}
+}
+
+// TestGraphRefusalDoesNotTouchModuleKeyedAttribution is the Tier B asymmetry at
+// the level of one label, under Tier A itself: even where the refusal IS armed,
+// a sample that reached its execution through the module rather than through
+// the launch keeps its own attribution. Only "exact" is withdrawn.
+//
+// Mutation this catches: implementing the refusal with worsePCAttrib, which
+// would rank "graph-refused" over every module-keyed value and bury the
+// executions whose claim really did become false among ones whose did not.
+func TestGraphRefusalDoesNotTouchModuleKeyedAttribution(t *testing.T) {
+	for _, keep := range []PCAttrib{PCAttribKernel, PCAttribKernelAmbiguous, PCAttribKernelMultiDevice} {
+		view := pcView(keep, pcSampleAt(0xC0DE, 7, 0x10))
+		view.GraphRefused = true
+		samples := ProjectExecutions(Snapshot{Executions: []ExecutionView{view}})
+		require.Len(t, samples, 1)
+		assert.Equal(t, string(keep), samples[0].Labels["gpu_pc_attrib"],
+			"%s reached its execution through the module, which a CUDA graph does not damage", keep)
+		assert.Equal(t, "true", samples[0].Labels["gpu_graph_refused"],
+			"the process-level fact still rides, because gpu_join is still many-to-one there")
+	}
+}
+
+// TestGraphRefusalLeavesModuleKeyedAttributionAloneThroughTheJoin is the same
+// asymmetry as the test above, but driven through Timeline.Snapshot rather
+// than through a hand-built view — because the refusal is APPLIED in Snapshot,
+// and a test that only exercises the projection cannot catch a Snapshot that
+// applies it too widely.
+//
+// Mutation this catches, and the one above does not: relaxing Snapshot's
+// `view.PCAttrib == PCAttribExact` guard to `view.PCAttrib != ""`, which would
+// turn every Tier B attribution in a graph-using process into "graph-refused"
+// — weakening the tier that is genuinely unaffected, and burying the
+// executions whose claim really did become false among ones whose did not.
+func TestGraphRefusalLeavesModuleKeyedAttributionAloneThroughTheJoin(t *testing.T) {
+	const pid = uint32(4242)
+	// Tier A selected, so the refusal IS armed - but these samples carry no
+	// correlation and reach their execution through the module, exactly as
+	// they would in Tier B.
+	f := newPCJoinFixture(t, TimelineConfig{PCSampling: PCSamplingSerialized})
+	require.NoError(t, f.tl.EmitGraphExecutions(graphReport(pid, 4)))
+	f.sample(t, pid, 10)
+	require.NoError(t, f.tl.EmitExec(pcExec(pid, f.kernel, "0", 20, 30)))
+
+	snap := f.tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	view := snap.Executions[0]
+	require.Len(t, view.PCSamples, 1)
+	assert.Equal(t, PCAttribKernel, view.PCAttrib,
+		"a module-keyed attribution is not damaged by a CUDA graph and must survive the refusal intact")
+	assert.Zero(t, snap.PCJoin.GraphRefusedAttributions,
+		"nothing here claimed exact attribution, so nothing was withdrawn")
+
+	// The process-level fact still rides, because gpu_join on this execution
+	// is still describing a launch join a graph makes many-to-one.
+	assert.True(t, view.GraphRefused)
+	assert.Equal(t, uint64(1), snap.ExecutionsGraphRefused)
+	assertPCJoinIdentities(t, snap)
+}
+
+// TestGraphRefusalIsScopedToItsOwnProcess. PC-sampling collection mode is a
+// property of the profiled process — the burst controller lives inside it — so
+// one graph-using process in a system-wide profile must not withdraw the exact
+// attribution of every other process being profiled beside it.
+func TestGraphRefusalIsScopedToItsOwnProcess(t *testing.T) {
+	const otherPID = uint32(9002)
+	tl := graphTimeline()
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(graphPID, 5)))
+	graphExec(t, tl, graphPID, "1", 1_000)
+	graphExec(t, tl, otherPID, "2", 2_000)
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 2)
+	byPID := map[uint32]ExecutionView{}
+	for _, v := range snap.Executions {
+		byPID[v.Exec.Correlation.PID] = v
+	}
+	assert.True(t, byPID[graphPID].GraphRefused)
+	assert.Equal(t, PCAttribGraphRefused, byPID[graphPID].PCAttrib)
+	assert.False(t, byPID[otherPID].GraphRefused,
+		"a neighbour's CUDA graph must not withdraw this process's exact attribution")
+	assert.Equal(t, PCAttribExact, byPID[otherPID].PCAttrib)
+	assert.Equal(t, uint64(1), snap.ExecutionsGraphRefused)
+	assert.Equal(t, uint64(1), snap.GraphExecProcesses)
+}
+
+// TestAnUnscopedGraphReportWidensRatherThanVanishes. A report that names no
+// process is evidence whose SCOPE is missing, not missing evidence. Discarding
+// it would throw away a proven refusal; widening it over-marks, which is the
+// safe direction and is counted so a reader can tell it apart from "every
+// process really did use graphs".
+//
+// This is the OPPOSITE resolution to the multi-device tracker's cap, where an
+// untracked process is treated as single-device — there, absence of evidence
+// for a second device is not evidence of one.
+func TestAnUnscopedGraphReportWidensRatherThanVanishes(t *testing.T) {
+	tl := graphTimeline()
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(0, 4)))
+	graphExec(t, tl, graphPID, "1", 1_000)
+	graphExec(t, tl, 9002, "2", 2_000)
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 2)
+	for i, v := range snap.Executions {
+		assert.True(t, v.GraphRefused, "execution %d must be marked when the scope is unknown", i)
+	}
+	assert.Equal(t, uint64(4), snap.GraphExecutions)
+	assert.Equal(t, uint64(4), snap.GraphExecUnscoped)
+	assert.Zero(t, snap.GraphExecProcesses, "no process was named, so none was tracked")
+	assert.Equal(t, uint64(2), snap.ExecutionsGraphRefused)
+
+	health := strings.Join(JoinHealth(snap), "\n")
+	assert.Contains(t, health, "lost its per-process scope",
+		"an operator looking at a profile where everything is marked must be able to tell "+
+			"'they all used graphs' from 'we stopped being able to say which one did'")
+}
+
+// A report carrying zero arms nothing. The producer emits DELTAS, and a zero
+// delta is not evidence; latching on a record's mere arrival would make "no
+// graphs yet" indistinguishable from "graphs".
+func TestAZeroGraphReportArmsNothing(t *testing.T) {
+	tl := graphTimeline()
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(graphPID, 0)))
+	graphExec(t, tl, graphPID, "1", 1_000)
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	assert.Zero(t, snap.GraphExecutions)
+	assert.False(t, snap.TierAGraphRefused())
+	assert.Equal(t, PCAttribExact, snap.Executions[0].PCAttrib)
+}
+
+// The counts ACCUMULATE. The producer reports only what it has not reported
+// before, so a consumer that replaced rather than summed would under-report the
+// condition by every report but the last.
+func TestGraphExecutionReportsAccumulate(t *testing.T) {
+	tl := graphTimeline()
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(graphPID, 2)))
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(graphPID, 3)))
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(9002, 1)))
+
+	snap := tl.Snapshot()
+	assert.Equal(t, uint64(6), snap.GraphExecutions)
+	assert.Equal(t, uint64(2), snap.GraphExecProcesses)
+}
+
+// ---------------------------------------------------------------------------
+// Loudness
+// ---------------------------------------------------------------------------
+
+// TestGraphRefusalIsLoudInJoinHealth. "Loud and counted, not a silent downgrade
+// to Tier B" is the plan's wording, and joinhealth is where an operator meets
+// it. The anomaly must name the mechanism (one callback, N kernels), say what
+// was done about it, and point at the tier that still works.
+func TestGraphRefusalIsLoudInJoinHealth(t *testing.T) {
+	tl := graphTimeline()
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(graphPID, 12)))
+	graphExec(t, tl, graphPID, "1", 1_000)
+	snap := tl.Snapshot()
+
+	lines := JoinHealth(snap)
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"launched from CUDA GRAPHS",
+		"ONE graph launch fires ONE runtime callback for N kernels",
+		"FALSE here while still looking",
+		"gpu_graph_refused",
+		string(PCAttribGraphRefused),
+		"--gpu-pc-sampling=continuous",
+	} {
+		assert.Contains(t, joined, want, "the anomaly must say this")
+	}
+	assert.Contains(t, lines[0], "WITHDRAWN",
+		"the one line printed on every run must carry it too; an operator who reads only the "+
+			"summary must not come away believing the attribution held")
+	assert.NotContains(t, lines[0], "no anomalies")
+
+	// And the pre-refusal window, stated rather than left to be discovered.
+	assert.Contains(t, joined, "RETROACTIVE within a snapshot but not across one")
+}
+
+// The counter is assertable at ZERO on a healthy run and NON-ZERO the moment a
+// graph execution appears. Nineteen defects on this project have been counters
+// reading green exactly when things were worst; a counter that cannot be
+// asserted in both directions is not a counter.
+func TestGraphCountersAreZeroOnAHealthyRunAndNonZeroImmediately(t *testing.T) {
+	tl := graphTimeline()
+	graphExec(t, tl, graphPID, "1", 1_000)
+	before := tl.Snapshot()
+	assert.Zero(t, before.GraphExecutions)
+	assert.Zero(t, before.GraphExecProcesses)
+	assert.Zero(t, before.ExecutionsGraphRefused)
+	assert.Zero(t, before.PCJoin.GraphRefusedAttributions)
+	assert.Zero(t, before.GraphExecUnscoped)
+	assert.Zero(t, before.GraphExecTrackingCapped)
+	// The healthy run raises the ordinary Tier A "no window covered these
+	// executions" anomaly and NOT the graph one, which is the distinction that
+	// matters: the graph line must appear exactly when a graph appears.
+	// "launched from CUDA GRAPHS" and not merely "CUDA GRAPHS": the standing
+	// Tier A warning names them too, on every render, and matching that would
+	// make this assertion pass for the wrong reason.
+	assert.NotContains(t, strings.Join(JoinHealth(before), "\n"), "launched from CUDA GRAPHS")
+	assert.NotContains(t, JoinHealth(before)[0], "WITHDRAWN")
+
+	require.NoError(t, tl.EmitGraphExecutions(graphReport(graphPID, 1)))
+	graphExec(t, tl, graphPID, "2", 2_000)
+	after := tl.Snapshot()
+	assert.Equal(t, uint64(1), after.GraphExecutions)
+	assert.Equal(t, uint64(1), after.ExecutionsGraphRefused)
+	assert.Contains(t, strings.Join(JoinHealth(after), "\n"), "launched from CUDA GRAPHS")
+	assert.Contains(t, JoinHealth(after)[0], "WITHDRAWN")
+}
+
+// TierAGraphRefused is a METHOD and not a stored bool, so it cannot disagree
+// with the two facts it is derived from. A hand-built Snapshot, a copy, or a
+// forgotten assignment would otherwise be able to leave it false while
+// GraphExecutions was non-zero — a silent downgrade wearing the shape of the
+// refusal.
+func TestTierAGraphRefusedIsDerivedNotStored(t *testing.T) {
+	assert.True(t, Snapshot{PCSampling: PCSamplingSerialized, GraphExecutions: 1}.TierAGraphRefused())
+	assert.False(t, Snapshot{PCSampling: PCSamplingSerialized}.TierAGraphRefused())
+	assert.False(t, Snapshot{PCSampling: PCSamplingContinuous, GraphExecutions: 99}.TierAGraphRefused())
+	assert.False(t, Snapshot{GraphExecutions: 99}.TierAGraphRefused())
+
+	// It is not settable, which is the property. A field named for it would
+	// be; a method is not.
+	assert.False(t, errors.Is(nil, ErrPCSamplingGraphExecutions))
+}

--- a/gpu/joinhealth.go
+++ b/gpu/joinhealth.go
@@ -166,6 +166,22 @@ func joinSummary(snap Snapshot, warnings, anomalies int) string {
 			plural(uint64(snap.PendingModuleGroups), "kernel group", "kernel groups"))
 	}
 
+	// The CUDA-graph refusal, in the summary as well as in the anomaly,
+	// because it changes what every other figure on this line means. Printed
+	// whenever any graph execution was reported — including in Tier B, where
+	// it is not an anomaly and the clause says so, since an operator reading
+	// "Tier B is unaffected" once is how they learn not to look for the
+	// refusal on the next run.
+	if snap.GraphExecutions > 0 {
+		if snap.TierAGraphRefused() {
+			fmt.Fprintf(&b, "; %s from CUDA graphs — TIER A EXACT ATTRIBUTION WITHDRAWN on %d executions",
+				plural(snap.GraphExecutions, "execution", "executions"), snap.ExecutionsGraphRefused)
+		} else {
+			fmt.Fprintf(&b, "; %s from CUDA graphs (this tier joins through the module, not the launch, and is unaffected)",
+				plural(snap.GraphExecutions, "execution", "executions"))
+		}
+	}
+
 	// Which tier this run selected, and only when one was. "off" is the
 	// default and printing it on every run is the zero-valued noise this
 	// format exists to avoid; "continuous" and "serialized" are both facts a
@@ -290,6 +306,62 @@ func joinAnomalies(snap Snapshot, proj ProjectionStats) []string {
 			"covers them (%s). They are marked gpu_serialized=\"unknown\" and MUST NOT be read "+
 			"as \"false\"",
 			snap.ExecutionsSerializationUnknown, execs, cause)
+	}
+	// THE CUDA-GRAPH REFUSAL. Raised immediately after the serialization
+	// identity and before every other attribution clause, because it is the
+	// one condition on this list that makes the counters BELOW it read green
+	// while being wrong: a graph-using process joins exactly, attributes
+	// exactly, evicts nothing, and bills N kernels to one call site.
+	//
+	// Only under Tier A. Tier B reaches a PC sample's kernel through the
+	// cubin and the function index, never through the launch, so a
+	// graph-launched kernel resolves to its own kernel exactly as any other
+	// does and nothing about that tier is false in a graph-using process.
+	// Raising it there would be a false alarm on a healthy run, which is how
+	// the word "anomaly" stops being read. The count still rides on the
+	// Snapshot (GraphExecutions) where a reader can find it.
+	if snap.TierAGraphRefused() {
+		add("%s launched from CUDA GRAPHS in %s, and Tier A (\"serialized\") PC sampling was "+
+			"selected — ONE graph launch fires ONE runtime callback for N kernels and "+
+			"gpu_exec_v1 carries no graph id, so those executions share one correlation and one "+
+			"CPU stack. Tier A's exact-launch attribution is FALSE here while still looking "+
+			"exact. It is withdrawn rather than downgraded: %d of %d executions in this "+
+			"snapshot carry gpu_graph_refused=\"true\", and %s had gpu_pc_attrib turned from "+
+			"\"exact\" to %q. Their durations and sample weights are real measurements and are "+
+			"kept; only the attribution claim is gone. The producer has also stopped opening "+
+			"bursts in that process. Re-run with --gpu-pc-sampling=continuous, which joins "+
+			"through the module rather than through the launch and is unaffected by graphs",
+			plural(snap.GraphExecutions, "kernel execution", "kernel executions"),
+			plural(snap.GraphExecProcesses, "process", "processes"),
+			snap.ExecutionsGraphRefused, execs,
+			plural(snap.PCJoin.GraphRefusedAttributions, "execution", "executions"),
+			PCAttribGraphRefused)
+		// The pre-refusal window, reported rather than left to be inferred.
+		// g_exec_from_graph is set from CUpti_ActivityKernel12.graphId on the
+		// ACTIVITY path, which arrives on the producer's drain tick — up to
+		// 100 ms, and one or two bursts, after the first graph kernel actually
+		// ran. Executions from that window are in this snapshot and ARE marked
+		// (the mark is a property of the process and applies to everything the
+		// Timeline holds for it, retroactively), so a caller that snapshots
+		// once at the end of a run loses nothing. A caller that snapshots
+		// PERIODICALLY has already emitted the earlier snapshots, and those
+		// executions left carrying gpu_pc_attrib="exact".
+		if snap.ExecutionsGraphRefused > 0 {
+			add("the graph refusal is RETROACTIVE within a snapshot but not across one — the " +
+				"producer learns an execution came from a graph on its activity drain, up to a " +
+				"drain interval after the kernel ran, so every execution this Timeline still " +
+				"held is marked above, but any snapshot already EMITTED before the first graph " +
+				"report arrived carries executions labelled gpu_pc_attrib=\"exact\" that this " +
+				"one would have refused. A run that snapshots once, at the end, has no such " +
+				"executions")
+		}
+	}
+	if snap.GraphExecUnscoped > 0 || snap.GraphExecTrackingCapped > 0 {
+		add("the CUDA-graph refusal lost its per-process scope (%d executions reported with no "+
+			"pid, %d processes past the tracker's bound) and now applies to EVERY execution in "+
+			"this snapshot — the safe direction, and a wider mark than the evidence supports; "+
+			"have the producer set the pid on gpu_dropped_v1, or profile fewer processes at once",
+			snap.GraphExecUnscoped, snap.GraphExecTrackingCapped)
 	}
 	if snap.SamplingWindowsOpen > 0 {
 		add("%s still open — the producer stopped reporting mid-burst (a hard exit), so the "+

--- a/gpu/pcattrib.go
+++ b/gpu/pcattrib.go
@@ -20,7 +20,7 @@ import "fmt"
 // says. So the two stay entirely separate: Ambiguous keeps its meaning
 // untouched, and PC-attribution quality lives here.
 //
-// # The four values
+// # The five values
 //
 //	exact               the sample carried a vendor correlation and joined
 //	                    through it. Kernel-serialized collection only; this is
@@ -43,11 +43,19 @@ import "fmt"
 //	                    indistinguishable on the wire. PC sampling is
 //	                    single-GPU in this phase; this value is the refusal,
 //	                    made visible rather than silent.
+//	graph-refused       what "exact" becomes in a process the producer
+//	                    reported launching kernels from a CUDA graph, when
+//	                    Tier A was selected. A graph launch fires ONE runtime
+//	                    callback for N kernels, so the correlation those
+//	                    samples joined through is shared by N executions and
+//	                    "exact" is false while looking like the strongest
+//	                    answer available. It is the refusal Tier A owes,
+//	                    made visible rather than silent.
 //
-// The empty value is not one of the four and is not a fifth outcome: it is
+// The empty value is not one of the five and is not a sixth outcome: it is
 // what an ExecutionView with no PC samples at all carries, because there is
 // nothing to describe. Every ExecutionView holding at least one PC sample
-// carries one of the four.
+// carries one of the five.
 type PCAttrib string
 
 const (
@@ -65,18 +73,38 @@ const (
 	// PCAttribKernelMultiDevice is the module join in a multi-device process,
 	// where cubin_crc cannot distinguish the devices.
 	PCAttribKernelMultiDevice PCAttrib = "kernel-multidevice"
+
+	// PCAttribGraphRefused is the correlation-keyed join in a process that
+	// launched kernels from a CUDA graph, under Tier A.
+	//
+	// It is reached ONLY by replacing PCAttribExact and never by ranking (see
+	// worsePCAttrib and Timeline.Snapshot). The module-keyed values are not
+	// downgraded to it, however many graph executions were reported: Tier B
+	// reaches its execution through the cubin and the function index rather
+	// than through the launch, so a graph does not make its attribution any
+	// less true. Ranking it above them would weaken Tier B for a condition
+	// that does not affect it, and would bury the executions where the claim
+	// really did become false among ones where it did not.
+	PCAttribGraphRefused PCAttrib = "graph-refused"
 )
 
-// pcAttribs lists the four in stable order, worst-caveat last. The order is
+// pcAttribs lists the five in stable order, worst-caveat last. The order is
 // also the precedence order used by worsePCAttrib.
+//
+// PCAttribGraphRefused sits at the end so that MarshalJSON accepts it and
+// PCAttribs() is exhaustive, NOT because anything ranks its way there: no code
+// path reaches it through worsePCAttrib. It describes a claim that was
+// withdrawn rather than a join whose quality was measured, and the two are
+// only comparable by accident.
 var pcAttribs = []PCAttrib{
 	PCAttribExact,
 	PCAttribKernel,
 	PCAttribKernelAmbiguous,
 	PCAttribKernelMultiDevice,
+	PCAttribGraphRefused,
 }
 
-// PCAttribs returns the four gpu_pc_attrib values in stable order.
+// PCAttribs returns the five gpu_pc_attrib values in stable order.
 //
 // It exists for the same reason SrcStatuses does: a consumer switching on the
 // value can be tested for exhaustiveness against the enum itself rather than
@@ -87,7 +115,7 @@ func PCAttribs() []PCAttrib {
 	return out
 }
 
-// pcAttribRank orders the four by how much doubt they carry, so that an
+// pcAttribRank orders them by how much doubt they carry, so that an
 // execution served by two pending groups of differing quality reports the
 // worse of the two rather than whichever happened to be processed last. A
 // value not in the table ranks below everything, which is what makes the empty
@@ -112,7 +140,7 @@ func worsePCAttrib(a, b PCAttrib) PCAttrib {
 	return a
 }
 
-// MarshalJSON refuses any value that is not one of the four, matching
+// MarshalJSON refuses any value that is not one of the five, matching
 // SrcStatus, ClockDomain and GPUCapability in this package. The empty value is
 // refused too: an ExecutionView that holds PC samples and no attribution is a
 // bug in the join, and it must fail at the serialization boundary rather than
@@ -183,6 +211,20 @@ type PCJoinStats struct {
 	// attributions. See PCAttrib.
 	AmbiguousAttributions   uint64 `json:"ambiguous_attributions,omitempty"`
 	MultiDeviceAttributions uint64 `json:"multi_device_attributions,omitempty"`
+
+	// GraphRefusedAttributions counts EXECUTIONS in this snapshot whose
+	// gpu_pc_attrib was withdrawn from "exact" to "graph-refused" because
+	// their process launched kernels from a CUDA graph under Tier A.
+	//
+	// It is a strict subset of Snapshot.ExecutionsGraphRefused: that counts
+	// every execution of an affected process, this counts only the ones that
+	// were actually carrying an exact PC attribution to withdraw. The gap
+	// between them is executions whose launch attribution is equally damaged
+	// but which carried no PC samples, and it is normally most of them.
+	//
+	// Zero on any run with no graph executions, and zero in Tier B however
+	// many there were.
+	GraphRefusedAttributions uint64 `json:"graph_refused_attributions,omitempty"`
 
 	// MultiDeviceProcesses counts distinct processes the Timeline has ever
 	// seen execute kernels on more than one device. Cumulative, not

--- a/gpu/pcjoin_test.go
+++ b/gpu/pcjoin_test.go
@@ -607,11 +607,15 @@ func assertPCJoinIdentities(t *testing.T, snap Snapshot) {
 // The enum itself
 // ---------------------------------------------------------------------------
 
-// TestPCAttribsAreExhaustiveAndStable pins the four wire strings. They are the
+// TestPCAttribsAreExhaustiveAndStable pins the five wire strings. They are the
 // gpu_pc_attrib label values; rewording one silently changes the profile.
+//
+// "graph-refused" is last and is the one value no join ever chooses: it
+// REPLACES "exact" in a process the producer reported launching kernels from a
+// CUDA graph, under Tier A. See PCAttribGraphRefused, and issue #94.
 func TestPCAttribsAreExhaustiveAndStable(t *testing.T) {
 	assert.Equal(t,
-		[]PCAttrib{"exact", "kernel", "kernel-ambiguous", "kernel-multidevice"},
+		[]PCAttrib{"exact", "kernel", "kernel-ambiguous", "kernel-multidevice", "graph-refused"},
 		PCAttribs())
 
 	PCAttribs()[0] = "mutated"
@@ -631,7 +635,7 @@ func TestPCAttribRefusesValuesNobodyDecided(t *testing.T) {
 	}
 	for _, bad := range []PCAttrib{"", "kernel-probably", "heuristic"} {
 		_, err := json.Marshal(bad)
-		assert.Error(t, err, "gpu_pc_attrib %q is not one of the four and must not serialize", bad)
+		assert.Error(t, err, "gpu_pc_attrib %q is not one of the five and must not serialize", bad)
 	}
 
 	// omitempty is what keeps a view with no PC samples off that path.

--- a/gpu/projection.go
+++ b/gpu/projection.go
@@ -66,7 +66,8 @@ const (
 //	gpu_stall       the instruction's stall reason, when the producer named one
 //	gpu_pc          the instruction's offset within its module, subject to the
 //	                cardinality budget - see pcLabelBudget
-//	gpu_pc_attrib   how the sample reached this execution - unconditional
+//	gpu_pc_attrib   how the sample reached this execution - unconditional,
+//	                and "graph-refused" where a CUDA graph made "exact" false
 //	gpu_src_status  why the sample does or does not have a source location -
 //	                unconditional
 //	gpu_src_file    the source file's BASENAME, only under "resolved"
@@ -622,6 +623,32 @@ func projectionLabels(view ExecutionView) map[string]string {
 	}
 	if view.Ambiguous {
 		labels["gpu_ambiguous"] = "true"
+	}
+	// gpu_graph_refused is the CUDA-graph refusal, and it rides on EVERY
+	// execution of an affected process rather than only on the PC-bearing
+	// ones — the same scope gpu_join has, because it says the same kind of
+	// thing about the same join. One graph launch fires one runtime callback
+	// for N kernels, so gpu_join="exact" on those executions is exact-looking
+	// and many-to-one: N kernels' time and N kernels' samples are billed to
+	// one CPU call site. gpu_pc_attrib="graph-refused" says it for the sampled
+	// subset; this says it for all of them.
+	//
+	// It is deleted before it is set, which the other conditional labels here
+	// are not, because it is the only one whose ABSENCE is what a reader acts
+	// on: a producer-supplied tag literally named "gpu_graph_refused" would
+	// otherwise survive on an execution this package did not refuse, and a
+	// forged refusal is a way to make a healthy Tier A profile look
+	// untrustworthy. It is set only when true because "no graph was reported"
+	// is the ordinary state of every profile; the loud, counted, unconditional
+	// form of this fact is the joinhealth anomaly and
+	// Snapshot.ExecutionsGraphRefused, not a label on every sample ever
+	// projected.
+	//
+	// It is never set in Tier B or with sampling off, however many graph
+	// executions were reported — see ExecutionView.GraphRefused.
+	delete(labels, "gpu_graph_refused")
+	if view.GraphRefused {
+		labels["gpu_graph_refused"] = "true"
 	}
 	// gpu_serialized is set UNCONDITIONALLY on every execution, exactly as
 	// gpu_join is and for exactly the same reason: an absent label would read

--- a/gpu/projection_test.go
+++ b/gpu/projection_test.go
@@ -661,12 +661,12 @@ func TestSrcFileBaseRejectsWhatIsNotAName(t *testing.T) {
 	}
 }
 
-// TestProjectionEmitsAllFourPCAttribValues walks the enum itself rather than a
-// hand-copied list, so a fifth value added to PCAttribs() without a projection
-// case fails here rather than shipping as a label nobody rendered.
-func TestProjectionEmitsAllFourPCAttribValues(t *testing.T) {
+// TestProjectionEmitsEveryPCAttribValue walks the enum itself rather than a
+// hand-copied list, so a value added to PCAttribs() without a projection case
+// fails here rather than shipping as a label nobody rendered.
+func TestProjectionEmitsEveryPCAttribValue(t *testing.T) {
 	attribs := PCAttribs()
-	require.Len(t, attribs, 4)
+	require.Len(t, attribs, 5)
 
 	views := make([]ExecutionView, 0, len(attribs))
 	for _, a := range attribs {
@@ -686,7 +686,7 @@ func TestProjectionEmitsAllFourPCAttribValues(t *testing.T) {
 // TestProjectionPCAttribIsNeverSilentlyAbsent is the honesty half of the
 // label. A view carrying PC samples with no attribution is a join bug; the
 // projection must make that visible rather than omit the label, because an
-// absent gpu_pc_attrib is readable as "exact" - the only one of the four that
+// absent gpu_pc_attrib is readable as "exact" - the only one of the five that
 // claims vendor-provided truth - by a consumer who does not know to check.
 //
 // Mutation this catches: `if view.PCAttrib != "" { labels[...] = ... }`.

--- a/gpu/sink.go
+++ b/gpu/sink.go
@@ -415,6 +415,37 @@ func (s *CountingSink) EmitSamplingWindow(w GPUSamplingWindow) error {
 	return nil
 }
 
+// EmitGraphExecutions is admitted UNCONDITIONALLY: no capacity check, no
+// token bucket, no clock-domain check, and no path on which it can be
+// refused by this sink.
+//
+// That is a deliberate exception to the rule every other method here follows,
+// and the reason is what the record carries. Every other event is a
+// measurement, and dropping one under pressure costs a slice of the profile
+// — which is why they are counted and bounded. This one is a REFUSAL: it says
+// Tier A's exact-launch attribution is false in a process. Dropping it does
+// not cost a slice of the profile, it restores the entire defect the refusal
+// exists to prevent — N kernels attributed to one call site with
+// gpu_pc_attrib="exact" and every counter green — and it would do so
+// precisely under the load that makes a token bucket bite. A bounded refusal
+// is not a refusal.
+//
+// It is also cheap enough that the bound buys nothing: the producer reports
+// only the DELTA since its last report, at most once per drain tick
+// (shim/nvidia/cupti_adapter.cc, g_graph_exec_reported), so the volume is a
+// handful of records per second per process regardless of how many graph
+// kernels ran.
+//
+// There is consequently no SinkStats entry for it. A per-kind EventKindStats
+// whose DroppedFull, DroppedInvalid and DroppedDownstream can never move is a
+// row of zeros that trains the reader to skip the table; the arrival count
+// lives on the producer side, in gpuprobe.Stats.GraphExecutions, where it can
+// be compared against Snapshot.GraphExecutions to size any loss upstream of
+// here.
+func (s *CountingSink) EmitGraphExecutions(g GPUGraphExecutions) error {
+	return s.inner.EmitGraphExecutions(g)
+}
+
 // SnapshotWith calls tl.Snapshot() and embeds s's own SinkStats into the
 // result - review Important 2: Timeline has no reference to the
 // CountingSink wrapping it (EventSink is the only contract between them),

--- a/gpu/sink_test.go
+++ b/gpu/sink_test.go
@@ -18,6 +18,10 @@ type recordingSink struct {
 	modules   int
 	events    int
 	windows   int
+	// graphReports counts EmitGraphExecutions calls. It exists so the
+	// unconditional-admission property of that method is assertable: the call
+	// must reach the inner sink even when every bucket is empty.
+	graphReports int
 }
 
 func (r *recordingSink) EmitLaunch(GPUKernelLaunch) error { r.launches++; return nil }
@@ -30,18 +34,24 @@ func (r *recordingSink) EmitSamplingWindow(GPUSamplingWindow) error {
 	return nil
 }
 
+func (r *recordingSink) EmitGraphExecutions(GPUGraphExecutions) error {
+	r.graphReports++
+	return nil
+}
+
 // erroringSink lets a test control exactly what the downstream sink returns,
 // to exercise the reserve/delegate/settle path when delivery fails.
 type erroringSink struct {
 	err error
 }
 
-func (e *erroringSink) EmitLaunch(GPUKernelLaunch) error           { return e.err }
-func (e *erroringSink) EmitExec(GPUKernelExec) error               { return e.err }
-func (e *erroringSink) EmitPCSample(GPUPCSample) error             { return e.err }
-func (e *erroringSink) EmitModule(GPUModule) error                 { return e.err }
-func (e *erroringSink) EmitEvent(GPUTimelineEvent) error           { return e.err }
-func (e *erroringSink) EmitSamplingWindow(GPUSamplingWindow) error { return e.err }
+func (e *erroringSink) EmitLaunch(GPUKernelLaunch) error             { return e.err }
+func (e *erroringSink) EmitExec(GPUKernelExec) error                 { return e.err }
+func (e *erroringSink) EmitPCSample(GPUPCSample) error               { return e.err }
+func (e *erroringSink) EmitModule(GPUModule) error                   { return e.err }
+func (e *erroringSink) EmitEvent(GPUTimelineEvent) error             { return e.err }
+func (e *erroringSink) EmitSamplingWindow(GPUSamplingWindow) error   { return e.err }
+func (e *erroringSink) EmitGraphExecutions(GPUGraphExecutions) error { return e.err }
 
 // atomicSink is a genuinely concurrency-safe EventSink, used only by the
 // concurrent-access test so a data race in the test double itself can never
@@ -50,12 +60,13 @@ type atomicSink struct {
 	launches atomic.Int64
 }
 
-func (a *atomicSink) EmitLaunch(GPUKernelLaunch) error           { a.launches.Add(1); return nil }
-func (a *atomicSink) EmitExec(GPUKernelExec) error               { return nil }
-func (a *atomicSink) EmitPCSample(GPUPCSample) error             { return nil }
-func (a *atomicSink) EmitModule(GPUModule) error                 { return nil }
-func (a *atomicSink) EmitEvent(GPUTimelineEvent) error           { return nil }
-func (a *atomicSink) EmitSamplingWindow(GPUSamplingWindow) error { return nil }
+func (a *atomicSink) EmitLaunch(GPUKernelLaunch) error             { a.launches.Add(1); return nil }
+func (a *atomicSink) EmitExec(GPUKernelExec) error                 { return nil }
+func (a *atomicSink) EmitPCSample(GPUPCSample) error               { return nil }
+func (a *atomicSink) EmitModule(GPUModule) error                   { return nil }
+func (a *atomicSink) EmitEvent(GPUTimelineEvent) error             { return nil }
+func (a *atomicSink) EmitSamplingWindow(GPUSamplingWindow) error   { return nil }
+func (a *atomicSink) EmitGraphExecutions(GPUGraphExecutions) error { return nil }
 
 // fakeClock is an injectable, manually-advanced clock so the token-bucket
 // refill can be tested deterministically instead of racing the wall clock.
@@ -242,6 +253,37 @@ func TestCountingSinkEmitModuleForwardsCountsAndEnforcesCapacity(t *testing.T) {
 // busy workload could starve the disclosure out of the sink — turning every
 // execution in the run gpu_serialized="unknown" while the profile still looked
 // full.
+// TestCountingSinkNeverRefusesAGraphReport pins the one method here that has no
+// admission control, against a sink whose every budget is exhausted.
+//
+// Every other event is a measurement, and dropping one under pressure costs a
+// slice of the profile. This one is a REFUSAL - Tier A's exact-launch
+// attribution is false in that process - and dropping it does not cost a slice
+// of the profile, it restores the entire defect the refusal exists to prevent,
+// precisely under the load that makes a token bucket bite.
+//
+// Mutation this catches: routing EmitGraphExecutions through admitCapacity for
+// consistency with its neighbours.
+func TestCountingSinkNeverRefusesAGraphReport(t *testing.T) {
+	inner := &recordingSink{}
+	s := NewCountingSink(inner, 1)
+
+	// Exhaust both budgets: the anchor class and the data class.
+	require.NoError(t, s.EmitLaunch(GPUKernelLaunch{
+		Correlation: CorrelationID{Backend: BackendCUPTI, Value: "1"},
+		ClockDomain: ClockDomainCPUMonotonic,
+	}))
+	require.Error(t, s.EmitSamplingWindow(GPUSamplingWindow{Backend: BackendCUPTI, StartNs: 1, EndNs: 2}),
+		"the anchor budget must actually be full, or this test proves nothing")
+
+	for range 100 {
+		require.NoError(t, s.EmitGraphExecutions(GPUGraphExecutions{
+			Backend: BackendCUPTI, PID: 7, Count: 1,
+		}), "a graph report must never be refused; a bounded refusal is not a refusal")
+	}
+	assert.Equal(t, 100, inner.graphReports)
+}
+
 func TestCountingSinkEmitSamplingWindowDrawsOnTheAnchorBudget(t *testing.T) {
 	inner := &recordingSink{}
 	s := NewCountingSink(inner, 2)

--- a/gpu/tier.go
+++ b/gpu/tier.go
@@ -114,6 +114,20 @@ var (
 	// destructive flag in the ordinary sense -- it changes the thing being
 	// measured -- so it takes the same shape as one.
 	ErrPCSamplingNotAcknowledged = errors.New("GPU PC-sampling tier \"serialized\" perturbs the workload and was not acknowledged")
+
+	// ErrPCSamplingGraphExecutions: "serialized" was selected for a process
+	// already known to launch kernels from CUDA graphs.
+	//
+	// This is the refusal, and it is a REFUSAL rather than a downgrade to
+	// "continuous" on purpose. Tier A's entire claim is exact launch
+	// attribution; a graph launch fires one runtime callback for N kernels, so
+	// in such a process that claim is false while every counter reads green
+	// and every label reads "exact". Silently running Tier B instead would be
+	// indistinguishable from Tier A working — the operator asked for exact
+	// attribution, would be handed inferred attribution, and nothing in the
+	// profile or the logs would say which they got. So the run refuses to
+	// start in that tier and the operator picks the next one deliberately.
+	ErrPCSamplingGraphExecutions = errors.New("GPU PC-sampling tier \"serialized\" cannot attribute CUDA graph launches and graph executions were observed")
 )
 
 // String renders the tier as the value an operator types. An out-of-range
@@ -256,16 +270,48 @@ type PCSamplingRequest struct {
 	// that Tier A perturbs the workload it measures. It gates nothing else:
 	// off and continuous do not need it and are not affected by it.
 	AcknowledgePerturbation bool
+
+	// GraphExecutionsObserved says that kernel executions launched from a
+	// CUDA graph have already been seen in the process this run will profile.
+	// It makes Select refuse "serialized" with ErrPCSamplingGraphExecutions —
+	// Tier A never starts, so the producer's burst controller is never built,
+	// no burst is ever opened and no kernel is ever serialized.
+	//
+	// This is the START half of the refusal. The MID-RUN half cannot live
+	// here and does not: a process's first graph launch may be minutes into a
+	// run that began legitimately, long after this decision was taken. Two
+	// mechanisms cover that, and neither is this one:
+	//
+	//   - the producer stops bursting. BurstController::poll latches its
+	//     refusal on the first graph execution it sees, returns kStop so an
+	//     open burst closes honestly rather than being abandoned, and never
+	//     returns kStart again (shim/core/burst.h). It does not know how to
+	//     become Tier B, which is the point;
+	//   - the agent withdraws the claim. Timeline marks every execution of
+	//     that process GraphRefused, turns gpu_pc_attrib="exact" into
+	//     "graph-refused", counts both, and JoinHealth raises a standing
+	//     anomaly (Snapshot.GraphExecutions, ExecutionsGraphRefused,
+	//     PCJoinStats.GraphRefusedAttributions).
+	//
+	// What feeds this field is a caller that already knows: a driver
+	// re-selecting the tier for a second profiling round over the same
+	// process, or one attaching to a process a previous round found using
+	// graphs. Snapshot.GraphExecutions > 0 is the value to pass. There is no
+	// way for the FIRST round against an unknown process to know, and that
+	// gap is real and stated rather than papered over — see
+	// .superpowers/sdd/issue-94-graph-refusal-report.md.
+	GraphExecutionsObserved bool
 }
 
 // Select resolves the request to a tier, or refuses.
 //
-// It refuses in exactly three ways, and every one of them is a startup error
+// It refuses in exactly four ways, and every one of them is a startup error
 // rather than a downgrade:
 //
 //   - an unknown value in either source;
 //   - both sources naming different tiers, or one source naming two;
-//   - "serialized" without AcknowledgePerturbation.
+//   - "serialized" without AcknowledgePerturbation;
+//   - "serialized" with GraphExecutionsObserved.
 //
 // On any error the returned tier is PCSamplingOff, so a caller that logs and
 // exits and a caller that logs and continues both end up not sampling, rather
@@ -290,6 +336,23 @@ func (r PCSamplingRequest) Select() (PCSamplingTier, error) {
 			ErrPCSamplingTiersExclusive, fromFlag, PCSamplingEnvVar, fromEnv)
 	case r.Flag != "":
 		tier = fromFlag
+	}
+
+	// Before the acknowledgement, because it is not overridable by one. An
+	// operator who acknowledges the perturbation has agreed to pay a cost for
+	// exact attribution; in a graph-using process they would pay the cost and
+	// receive attribution that is exact-looking and many-to-one, which is not
+	// the trade they agreed to. There is no flag that turns this off.
+	if tier == PCSamplingSerialized && r.GraphExecutionsObserved {
+		return PCSamplingOff, fmt.Errorf("%w. A CUDA graph launch fires ONE runtime callback "+
+			"for N kernels and gpu_exec_v1 carries no graph id, so all N executions share one "+
+			"correlation: Tier A would report gpu_join=\"exact\" and gpu_pc_attrib=\"exact\" "+
+			"while billing N kernels' time and samples to a single call site, with every join "+
+			"counter reading green. This refuses rather than downgrading to \"continuous\", "+
+			"because a silent downgrade is indistinguishable from Tier A working. Use "+
+			"--gpu-pc-sampling=continuous, which joins through the module rather than through "+
+			"the launch and is unaffected by graphs",
+			ErrPCSamplingGraphExecutions)
 	}
 
 	if tier == PCSamplingSerialized && !r.AcknowledgePerturbation {
@@ -347,8 +410,11 @@ func PCSamplingStandingWarning(tier PCSamplingTier) []string {
 			"it is, with nothing in that profile saying why.",
 		p + "(3) TIER A IS UNAVAILABLE WHERE CUDA GRAPHS ARE IN USE. A graph launch fires one " +
 			"runtime callback for N kernels, so Tier A's exact-launch attribution would be false " +
-			"while still looking exact; the producer refuses to open bursts in such a process " +
-			"rather than downgrading silently to Tier B, and this profile then carries no Tier A " +
-			"PC samples at all.",
+			"while still looking exact. Both ends refuse rather than downgrading silently to " +
+			"Tier B: the producer stops opening bursts in such a process, so the profile carries " +
+			"no further Tier A PC samples, and this agent withdraws the claim on what did " +
+			"arrive — those executions are marked gpu_graph_refused=\"true\" and their " +
+			"gpu_pc_attrib becomes \"graph-refused\" rather than \"exact\". If that happens " +
+			"you will see it as an anomaly below, not as a quiet absence.",
 	}
 }

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -55,6 +55,29 @@ type ExecutionView struct {
 	// unconditional label exists to prevent. The type's zero value is
 	// "unknown" for the same reason (see SerializationState).
 	Serialized SerializationState `json:"serialized"`
+
+	// GraphRefused is the CUDA-graph refusal: this execution came from a
+	// process the producer reported launching kernels from a CUDA graph, and
+	// Tier A ("serialized") PC sampling was selected for the run. Tier A's
+	// whole claim is exact launch attribution, and one graph launch fires one
+	// runtime callback for N kernels, so that claim is false here — while
+	// looking exactly like the strongest answer the pipeline can give.
+	//
+	// It is FALSE in Tier B and with PC sampling off, always, however many
+	// graph executions were reported. Tier B joins through the module and not
+	// through the launch, so nothing about it is false in a graph-using
+	// process; marking it would be a false alarm that devalues the real one.
+	// See Timeline.isGraphRefusedLocked.
+	//
+	// It is `omitempty` where Serialized deliberately is not, and the
+	// difference is which way absence reads. An absent gpu_serialized would
+	// read as "not perturbed", a positive claim nobody made. An absent
+	// GraphRefused reads as "no graph was reported", which is the ordinary and
+	// overwhelmingly common state and is what the field's zero value means.
+	// The loudness lives where it can be counted rather than inferred:
+	// Snapshot.ExecutionsGraphRefused, PCJoinStats.GraphRefusedAttributions
+	// and the standing joinhealth anomaly.
+	GraphRefused bool `json:"graph_refused,omitempty"`
 }
 
 // TimelineDropStats counts what Timeline's own bounded storage evicted.
@@ -207,6 +230,68 @@ type Snapshot struct {
 	ExecutionsSerialized           uint64 `json:"executions_serialized,omitempty"`
 	ExecutionsNotSerialized        uint64 `json:"executions_not_serialized,omitempty"`
 	ExecutionsSerializationUnknown uint64 `json:"executions_serialization_unknown,omitempty"`
+
+	// ---- The CUDA-graph refusal (Tier A).
+
+	// GraphExecutions is the CUMULATIVE number of kernel executions the
+	// producer has reported as launched from a CUDA graph — the agent's side
+	// of GPU_DROP_CLASS_GRAPH_EXEC. See GPUGraphExecutions for why one graph
+	// launch makes Tier A's exact attribution false for N kernels at once.
+	//
+	// It is populated in EVERY tier, and it is only an ANOMALY under Tier A.
+	// On a Tier B run it is information: Tier B joins through the module
+	// rather than through the launch and is unaffected, so a non-zero value
+	// there says the workload uses graphs and nothing more. joinhealth raises
+	// it only when the tier makes it matter, which is what keeps the word
+	// "anomaly" worth reading.
+	//
+	// ZERO on any run of a process that launches no CUDA graph. Non-zero the
+	// moment one is reported. TierAGraphRefused() is the derived question.
+	GraphExecutions uint64 `json:"graph_executions,omitempty"`
+
+	// GraphExecProcesses counts distinct processes that reported any. It is
+	// the denominator an operator needs before deciding whether the refusal is
+	// about the workload they care about or about a neighbour in a
+	// system-wide profile.
+	GraphExecProcesses uint64 `json:"graph_exec_processes,omitempty"`
+
+	// GraphExecUnscoped and GraphExecTrackingCapped are the two ways the
+	// refusal loses its per-process scope and widens to every execution the
+	// Timeline holds: a report that named no process (PID 0), and the
+	// per-process tracker being full.
+	//
+	// Both widen rather than narrow, which is the opposite of how the
+	// multi-device tracker resolves its own cap and is deliberate: there,
+	// absence of evidence for a second device is not evidence of one; here the
+	// evidence already exists and only its scope is missing, so discarding it
+	// would throw away a proven refusal. They are counted because an operator
+	// looking at a profile where every process is marked graph-refused needs
+	// to be able to tell "they all used graphs" from "we stopped being able to
+	// say which one did". Zero on any ordinary run.
+	GraphExecUnscoped       uint64 `json:"graph_exec_unscoped,omitempty"`
+	GraphExecTrackingCapped uint64 `json:"graph_exec_tracking_capped,omitempty"`
+
+	// ExecutionsGraphRefused counts executions in THIS snapshot whose
+	// ExecutionView.GraphRefused is set — every execution of a graph-affected
+	// process, PC-bearing or not, because one graph launch damages the launch
+	// attribution of N kernels whether or not any of them was sampled.
+	//
+	// It is zero in Tier B and with sampling off however large GraphExecutions
+	// is. PCJoinStats.GraphRefusedAttributions is the strictly smaller subset
+	// whose gpu_pc_attrib was withdrawn from "exact".
+	ExecutionsGraphRefused uint64 `json:"executions_graph_refused,omitempty"`
+}
+
+// TierAGraphRefused reports whether Tier A's exact-launch attribution has been
+// withdrawn for this run: the "serialized" tier was selected AND at least one
+// CUDA-graph execution was reported.
+//
+// It is a method rather than a field so it cannot disagree with the two facts
+// it is derived from — a stored bool that a copy, a hand-built Snapshot or a
+// forgotten assignment could leave false while GraphExecutions was non-zero
+// would be a silent downgrade wearing the shape of the refusal.
+func (s Snapshot) TierAGraphRefused() bool {
+	return s.PCSampling == PCSamplingSerialized && s.GraphExecutions > 0
 }
 
 // TimelineConfig configures Timeline's storage bounds.
@@ -537,6 +622,42 @@ type Timeline struct {
 	windows    *windowStore
 	pcSampling PCSamplingTier
 
+	// ---- The CUDA-graph refusal (Tier A).
+	//
+	// graphExecsByPID records, per process, how many kernel executions the
+	// producer has reported as launched from a CUDA graph (GPUGraphExecutions,
+	// the agent's side of GPU_DROP_CLASS_GRAPH_EXEC). A process with a
+	// non-zero entry has had Tier A's exact-launch claim WITHDRAWN: see
+	// isGraphRefusedLocked.
+	//
+	// Per process, and cumulative, for the same two reasons devicesByPID is
+	// both. Per process because PC-sampling collection mode is a property of
+	// the profiled process — one graph-using process in a system-wide profile
+	// must not withdraw the exact attribution of every other one. Cumulative
+	// because the condition is a property of the process and does not stop
+	// holding: a process that ran a graph in an earlier snapshot has not
+	// un-run it, and a per-snapshot latch would clear the mark on exactly the
+	// snapshots where no graph report happened to arrive, which is the
+	// reading-green-when-worst failure this project keeps hitting.
+	//
+	// graphExecAllPIDs is the overflow and the unattributable case, and it
+	// resolves in the OPPOSITE direction to the device tracker's cap. There,
+	// an untracked process is treated as single-device, because absence of
+	// evidence for a second device is not evidence of one. Here, evidence
+	// exists and only its scope is unknown, so treating it as "no process"
+	// would discard a refusal that has already been proven — the one outcome
+	// that must never be reachable. It is set when a report names no process
+	// (PID 0) and when the map is full, and it makes every execution in the
+	// Timeline graph-refused under Tier A. Both causes are counted, in
+	// graphExecUnscoped and graphExecTrackingCapped, so an operator reading a
+	// profile where everything is marked can tell which happened.
+	graphExecsByPID         map[uint32]uint64
+	graphExecTotal          uint64
+	graphExecProcesses      uint64
+	graphExecUnscoped       uint64
+	graphExecTrackingCapped uint64
+	graphExecAllPIDs        bool
+
 	dropped TimelineDropStats
 }
 
@@ -678,6 +799,8 @@ func NewTimeline(cfg TimelineConfig) *Timeline {
 
 		windows:    newWindowStore(cfg.MaxSamplingWindowsPerPID, cfg.MaxSamplingWindowPIDs),
 		pcSampling: cfg.PCSampling,
+
+		graphExecsByPID: make(map[uint32]uint64),
 	}
 }
 
@@ -696,6 +819,78 @@ func (t *Timeline) EmitSamplingWindow(w GPUSamplingWindow) error {
 	t.dropped.EvictedSamplingWindows += t.windows.evicted - before
 	return nil
 }
+
+// EmitGraphExecutions records the producer's report that N executions in a
+// process were launched from a CUDA graph — the event that arms Tier A's
+// refusal.
+//
+// Accepted in EVERY tier, exactly as EmitSamplingWindow is, and for the same
+// reason: a producer that is reporting graph executions is reporting a fact
+// about the workload, and dropping the evidence because this agent's own
+// configuration disagrees would leave the two ends silently out of step. What
+// TimelineConfig.PCSampling gates is the CONSEQUENCE — only Tier A's claim is
+// false — not the ingest. So Snapshot.GraphExecutions is populated on a Tier B
+// run too, where it is information and not an anomaly.
+//
+// A report carrying Count == 0 arms nothing. The producer emits deltas and a
+// zero delta is not evidence; latching on the record's mere arrival would make
+// a producer that says "no graphs yet" indistinguishable from one that says
+// "graphs".
+func (t *Timeline) EmitGraphExecutions(g GPUGraphExecutions) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if g.Count == 0 {
+		return nil
+	}
+	t.graphExecTotal += g.Count
+
+	// PID 0: the producer saw graph executions but could not say whose. The
+	// evidence is real and only its scope is missing, so it widens to every
+	// process rather than being discarded. See the graphExecAllPIDs comment.
+	if g.PID == 0 {
+		t.graphExecUnscoped += g.Count
+		t.graphExecAllPIDs = true
+		return nil
+	}
+	if _, ok := t.graphExecsByPID[g.PID]; !ok {
+		if len(t.graphExecsByPID) >= maxTrackedGraphProcesses {
+			t.graphExecTrackingCapped++
+			t.graphExecAllPIDs = true
+			return nil
+		}
+		t.graphExecProcesses++
+	}
+	t.graphExecsByPID[g.PID] += g.Count
+	return nil
+}
+
+// isGraphRefusedLocked reports whether Tier A's exact-launch attribution must
+// be withdrawn for this process's executions.
+//
+// The tier check is the whole of the Tier A / Tier B asymmetry and it belongs
+// here rather than at the call sites, so that a future caller cannot forget
+// it. Tier B (PCSamplingContinuous) joins a PC sample through the module —
+// cubin CRC and function index to a device function name — and never through
+// the launch, so a graph-launched kernel resolves to its own kernel exactly as
+// any other does. Nothing about Tier B is false in a graph-using process, and
+// marking it would be a false alarm that devalues the real one. With PC
+// sampling off there is no attribution claim to withdraw at all.
+//
+// Caller holds t.mu.
+func (t *Timeline) isGraphRefusedLocked(pid uint32) bool {
+	if t.pcSampling != PCSamplingSerialized {
+		return false
+	}
+	return t.graphExecAllPIDs || t.graphExecsByPID[pid] > 0
+}
+
+// maxTrackedGraphProcesses bounds Timeline.graphExecsByPID. It is the same
+// number as maxTrackedDeviceProcesses and for the same reason (a system-wide
+// profile has no a-priori bound on distinct pids), but it is its own constant
+// because the two maps overflow in OPPOSITE directions — see the
+// graphExecAllPIDs comment — and a shared constant would invite a reader to
+// assume shared behaviour.
+const maxTrackedGraphProcesses = 4096
 
 // isPendingLiveLocked answers orderedFIFO's isLive callback for pendingOrder:
 // a position is live only if t.pending still holds an entry for id stamped
@@ -1141,7 +1336,11 @@ func (t *Timeline) joinPendingModuleLocked(execs []GPUKernelExec, execSamples []
 			res.stats.AmbiguousAttributions++
 		case PCAttribKernelMultiDevice:
 			res.stats.MultiDeviceAttributions++
-		case PCAttribExact, PCAttribKernel:
+		// PCAttribGraphRefused cannot appear here and must not be produced
+		// here. This is the module-keyed join, which is exactly the path a
+		// CUDA graph does not damage; the refusal replaces PCAttribExact in
+		// Snapshot, over the correlation-keyed population only.
+		case PCAttribExact, PCAttribKernel, PCAttribGraphRefused:
 		}
 	}
 	res.stats.AttributedKernel = res.samples
@@ -1302,6 +1501,25 @@ func (t *Timeline) Snapshot() Snapshot {
 	windowsReceived := t.windows.received
 	windowsHeld, windowsOpen := t.windows.windows()
 	pcSampling := t.pcSampling
+
+	// The CUDA-graph refusal, classified under the same lock and by the same
+	// rule as the serialization disclosure above: a per-execution answer, read
+	// from cumulative per-process evidence, taken once here so the join loop
+	// below cannot forget to ask.
+	//
+	// isGraphRefusedLocked returns false for every execution in Tier B and
+	// with sampling off, so this slice is all-false there and nothing
+	// downstream is marked. That is the asymmetry, not an optimisation: Tier B
+	// attributes through the module rather than through the launch and is
+	// genuinely unaffected by graphs.
+	graphRefused := make([]bool, len(execs))
+	for i, exec := range execs {
+		graphRefused[i] = t.isGraphRefusedLocked(exec.Correlation.PID)
+	}
+	graphExecTotal := t.graphExecTotal
+	graphExecProcesses := t.graphExecProcesses
+	graphExecUnscoped := t.graphExecUnscoped
+	graphExecTrackingCapped := t.graphExecTrackingCapped
 	t.mu.Unlock()
 
 	// The heuristic's candidate set is built lazily - only once the loop
@@ -1360,8 +1578,21 @@ func (t *Timeline) Snapshot() Snapshot {
 	// identity (the three equal len(Executions)) hold by construction rather
 	// than by remembering to count in each branch.
 	var serializedCount, notSerializedCount, serializationUnknownCount uint64
+	// executionsGraphRefused is counted over EVERY execution of a
+	// graph-affected process, PC-bearing or not — the same scope gpu_join and
+	// gpu_serialized ride on. PCJoinStats.GraphRefusedAttributions is the
+	// strictly smaller subset whose gpu_pc_attrib was withdrawn from "exact".
+	// One graph launch damages the launch attribution of N kernels whether or
+	// not any of them happened to be sampled, so a count restricted to the
+	// sampled ones would understate the condition by the sampling factor.
+	var executionsGraphRefused uint64
 	for i, exec := range execs {
-		view := ExecutionView{Exec: exec, PCSamples: execSamples[i], Serialized: serialization[i]}
+		view := ExecutionView{
+			Exec:         exec,
+			PCSamples:    execSamples[i],
+			Serialized:   serialization[i],
+			GraphRefused: graphRefused[i],
+		}
 		// gpu_pc_attrib, decided entirely by which index served this
 		// execution. It is set independently of view.Join and view.Ambiguous
 		// below and never reads or writes either: an execution can be joined
@@ -1373,6 +1604,36 @@ func (t *Timeline) Snapshot() Snapshot {
 			view.PCAttrib = PCAttribExact
 		case len(view.PCSamples) > 0:
 			view.PCAttrib = pcJoin.attribAt(i)
+		}
+		// The CUDA-graph refusal, applied to gpu_pc_attrib. It replaces
+		// PCAttribExact and ONLY PCAttribExact.
+		//
+		// "exact" means the sample carried a vendor correlation and joined
+		// through it — one launch, one execution, vendor-provided truth. A
+		// graph launch fires one callback for N kernels, so in a graph-using
+		// process that correlation is shared by N executions and the word is
+		// false while still looking like the strongest answer available. It is
+		// withdrawn.
+		//
+		// The module-keyed values (kernel, kernel-ambiguous,
+		// kernel-multidevice) are left exactly as they are, which is the Tier
+		// B asymmetry made concrete at the label: those samples reached this
+		// execution through the cubin and the function index, never through
+		// the launch, so a graph changed nothing about how much they can be
+		// trusted. Downgrading them would weaken Tier B for a condition that
+		// does not affect it — and would bury the executions where the claim
+		// really did become false among ones where it did not.
+		//
+		// This is not worsePCAttrib's rank order. Rank exists to reconcile two
+		// pending groups of differing quality landing on one execution; this
+		// is a targeted replacement of one specific claim, which is why
+		// PCAttribGraphRefused is never reached by ranking.
+		if view.GraphRefused && view.PCAttrib == PCAttribExact {
+			view.PCAttrib = PCAttribGraphRefused
+			pcJoin.stats.GraphRefusedAttributions++
+		}
+		if view.GraphRefused {
+			executionsGraphRefused++
 		}
 		switch view.Serialized {
 		case SerializationSerialized:
@@ -1500,6 +1761,12 @@ func (t *Timeline) Snapshot() Snapshot {
 		ExecutionsSerialized:           serializedCount,
 		ExecutionsNotSerialized:        notSerializedCount,
 		ExecutionsSerializationUnknown: serializationUnknownCount,
+
+		GraphExecutions:         graphExecTotal,
+		GraphExecProcesses:      graphExecProcesses,
+		GraphExecUnscoped:       graphExecUnscoped,
+		GraphExecTrackingCapped: graphExecTrackingCapped,
+		ExecutionsGraphRefused:  executionsGraphRefused,
 	}
 }
 

--- a/gpu/types.go
+++ b/gpu/types.go
@@ -429,6 +429,50 @@ type GPUSamplingWindow struct {
 // serialized".
 func (w GPUSamplingWindow) Open() bool { return w.EndNs == 0 }
 
+// GPUGraphExecutions is the producer's report that kernel executions in a
+// process were launched from a CUDA graph.
+//
+// It is the agent's side of GPU_DROP_CLASS_GRAPH_EXEC (internal/gpuabi's
+// DropClassGraphExec), and it exists because a CUDA graph breaks the ONE thing
+// Tier A claims: exact launch attribution.
+//
+// A graph launch fires ONE runtime callback for N kernels. gpu_exec_v1 has no
+// field for graphId, so all N executions arrive carrying the SAME correlation
+// value — and the exact-correlation join, which is vendor-provided truth
+// everywhere else, quietly becomes one launch to many executions. Nothing
+// downstream can tell that apart from a correct exact join: gpu_join reads
+// "exact", gpu_pc_attrib reads "exact", every join counter reads green, and N
+// kernels' samples land on one call site. That is attribution which is
+// exact-LOOKING and many-to-one, and it is the reason this record is a first-
+// class event rather than a number in a drop table nobody reads.
+//
+// TIER B IS UNAFFECTED, and the asymmetry is deliberate rather than lucky:
+// Tier B joins a PC sample through the MODULE (cubin CRC and function index)
+// to a kernel name, never through the launch, so a graph-launched kernel
+// resolves to its own kernel exactly as any other does. Only Tier A's claim is
+// false. Timeline therefore withdraws Tier A's claim and leaves Tier B's
+// alone; see Timeline.isGraphRefusedLocked.
+//
+// Count is a DELTA, not a running total: the producer reports only what it has
+// not reported before (shim/nvidia/cupti_adapter.cc keeps g_graph_exec_reported
+// for exactly this), so a consumer accumulates rather than replaces.
+type GPUGraphExecutions struct {
+	Backend GPUBackendID `json:"backend"`
+	// PID is the process whose executions came from a graph. It is the whole
+	// of the refusal's scope: PC-sampling collection mode is per-process (the
+	// producer's burst controller lives in the profiled process), so one
+	// graph-using process must not withdraw another process's exact
+	// attribution in a system-wide profile.
+	//
+	// Zero means the producer named no process. That cannot be scoped, so it
+	// is treated as "every process" rather than as "no process" — the safe
+	// direction, and it is counted; see Timeline.EmitGraphExecutions.
+	PID uint32 `json:"pid,omitempty"`
+	// Count is how many graph-launched executions this report adds. A report
+	// carrying zero is not evidence of anything and does not arm the refusal.
+	Count uint64 `json:"count"`
+}
+
 // SerializationState is the gpu_serialized disclosure: whether an execution's
 // measured duration was perturbed by kernel serialization.
 //
@@ -610,6 +654,14 @@ type EventSink interface {
 	// is marked perturbed from these intervals, and a window that failed to
 	// be recognised would silently downgrade "unknown" to "false".
 	EmitSamplingWindow(GPUSamplingWindow) error
+	// EmitGraphExecutions delivers the producer's report that N executions in
+	// a process were launched from a CUDA graph. Like EmitSamplingWindow it is
+	// a method of its own rather than a GPUTimelineEvent with attributes, and
+	// for a stronger version of the same reason: what rides on it is not a
+	// measurement but a REFUSAL — Tier A's exact-launch attribution is false
+	// in that process — and a refusal that depended on string parsing would
+	// fail silently into the confident answer it exists to prevent.
+	EmitGraphExecutions(GPUGraphExecutions) error
 }
 
 // Backend produces normalized GPU events into an EventSink.

--- a/gpuprobe/attach_test.go
+++ b/gpuprobe/attach_test.go
@@ -16,12 +16,13 @@ import (
 // nothing here is ever called on these error paths.
 type nopSink struct{}
 
-func (nopSink) EmitLaunch(gpu.GPUKernelLaunch) error           { return nil }
-func (nopSink) EmitExec(gpu.GPUKernelExec) error               { return nil }
-func (nopSink) EmitPCSample(gpu.GPUPCSample) error             { return nil }
-func (nopSink) EmitModule(gpu.GPUModule) error                 { return nil }
-func (nopSink) EmitEvent(gpu.GPUTimelineEvent) error           { return nil }
-func (nopSink) EmitSamplingWindow(gpu.GPUSamplingWindow) error { return nil }
+func (nopSink) EmitLaunch(gpu.GPUKernelLaunch) error             { return nil }
+func (nopSink) EmitExec(gpu.GPUKernelExec) error                 { return nil }
+func (nopSink) EmitPCSample(gpu.GPUPCSample) error               { return nil }
+func (nopSink) EmitModule(gpu.GPUModule) error                   { return nil }
+func (nopSink) EmitEvent(gpu.GPUTimelineEvent) error             { return nil }
+func (nopSink) EmitSamplingWindow(gpu.GPUSamplingWindow) error   { return nil }
+func (nopSink) EmitGraphExecutions(gpu.GPUGraphExecutions) error { return nil }
 
 // Attach must return an error, never panic, when there is no such file.
 func TestAttachNonexistentShimReturnsError(t *testing.T) {

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -438,20 +438,23 @@ type Stats struct {
 	// SinkRejected counts events the sink refused (full, or invalid).
 	SinkRejected uint64
 	// Undecoded counts records of a kind this phase carries on the wire but
-	// does not yet normalize. Launches, executions, sampled launches, kernel
-	// names, module loads, PC samples, the stall-reason map, sampling windows
-	// and the config record all have an applyBatch arm. gpu_dropped_v1
-	// (kindDropped) is the one kind the ABI defines that is still in the
-	// original class: it is decoded into batch.Drops and carried, and
-	// normalizing a drop class into an operator-visible number is the
-	// consumer task that follows this one. Everything else that reaches here
-	// is a kind the producer invented, or a KIND_* added on one side of the
-	// wire and not the other - both of which are silent loss unless counted.
+	// does not decode at all. EVERY kind the ABI defines now has an applyBatch
+	// arm: launches, executions, sampled launches, kernel names, module loads,
+	// PC samples, the stall-reason map, sampling windows, the config record
+	// and - since issue #94 gave the CUDA-graph refusal something to consume -
+	// gpu_dropped_v1. So anything that reaches here is a kind the producer
+	// invented, or a KIND_* added on one side of the wire and not the other,
+	// both of which are silent loss unless counted.
 	//
-	// Healthy: zero, and gate_test.go asserts it - the gate runs the stub
-	// without PERFAGENT_STUB_PC_SAMPLES, so no dropped batch is fired.
-	// Worst: equal to the record count of every batch of some kind the
-	// consumer cannot read, which is the ABI having drifted.
+	// The successor for the one kind that used to land here is
+	// DropsUnconsumed: a drop class this side decodes but does not yet act on
+	// is counted there rather than left to look like an unknown kind, because
+	// the two call for completely different responses.
+	//
+	// Healthy: zero, in every tier and on every producer, and gate_test.go
+	// asserts it as an equality. Worst: equal to the record count of every
+	// batch of some kind the consumer cannot read, which is the ABI having
+	// drifted.
 	Undecoded uint64
 	// Malformed counts ringbuf samples that did not decode: a short header,
 	// a payload shorter than the header claims, or a truncated record.
@@ -1200,6 +1203,56 @@ type Stats struct {
 	ConfigSamplingFactor uint32
 	ConfigSMCount        uint32
 	ConfigClockHz        uint64
+	// DropsDecoded counts gpu_dropped_v1 records read off the wire, of every
+	// class. It is the denominator for the two counters below: they partition
+	// it, so DropsDecoded == GraphExecReports + DropsUnconsumed exactly, and a
+	// class that reached the decoder and then vanished shows up as a
+	// shortfall rather than as nothing at all.
+	DropsDecoded uint64
+	// GraphExecReports counts gpu_dropped_v1 records carrying
+	// GPU_DROP_CLASS_GRAPH_EXEC, and GraphExecutions sums their counts: how
+	// many kernel executions the producer has reported as launched from a
+	// CUDA graph.
+	//
+	// GraphExecutions is the one to read, and it is the counter that makes
+	// Tier A's refusal auditable. A CUDA graph launch fires ONE runtime
+	// callback for N kernels and gpu_exec_v1 carries no graph id, so those N
+	// executions share one correlation — and Tier A's entire claim is exact
+	// launch attribution. Left unconsumed (which it was, until issue #94) the
+	// result is attribution that is exact-LOOKING and many-to-one, with every
+	// counter on this struct reading green.
+	//
+	// Healthy: EXACTLY ZERO, on any run of a workload that launches no CUDA
+	// graph. Non-zero the instant one is reported, which is the property that
+	// makes it assertable in both directions. Both counters are cumulative and
+	// neither is ever reset: the condition is a property of the process and
+	// does not stop holding.
+	//
+	// The records are also forwarded to the sink as gpu.GPUGraphExecutions,
+	// where Timeline withdraws Tier A's exact attribution for that process.
+	// Counting without forwarding would be a number in a struct nobody reads;
+	// forwarding without counting would make loss between here and the
+	// Timeline invisible. Both, so the two can be compared.
+	GraphExecReports uint64
+	GraphExecutions  uint64
+	// DropsUnconsumed counts gpu_dropped_v1 records whose drop class this
+	// phase decodes but does not yet act on: pc-dropped-hw, pc-buffer-full and
+	// pc-non-user-kernel (see internal/gpuabi's DropClass* and
+	// DropClassName). They are Tier B completeness and loss figures, and
+	// turning them into operator-visible numbers is a separate task; this
+	// counter is what keeps them from being silent in the meantime, exactly
+	// as Undecoded did before gpu_dropped_v1 had an applyBatch arm at all.
+	//
+	// It counts RECORDS, not the losses they describe. A record saying
+	// "17 samples were dropped" adds one here, not seventeen: the sum of the
+	// counts is a per-class figure and belongs with the per-class consumers
+	// that do not exist yet, while what this says is "three statements about
+	// loss arrived and nothing on this side read them".
+	//
+	// Healthy: zero from the CUPTI adapter on a clean run. Non-zero from the
+	// stub, which emits one record per class so that every class is reachable
+	// from a test.
+	DropsUnconsumed uint64
 	// PendingStallSamples and KnownStallNames are gauges: what the two
 	// stall-reason side tables hold right now. PendingStallSamples is also
 	// how many PC samples the consumer is currently holding back - see
@@ -1670,13 +1723,11 @@ type batch struct {
 	StallReasons    []gpuabi.StallReason
 	SamplingWindows []gpuabi.SamplingWindow
 	Configs         []gpuabi.Config
-	// Drops are decoded here and normalized in a later phase. The wire path
-	// had to exist before the shim could emit a drop class at all -- without
-	// it every class Tier B defines would be a counter that could not go
-	// non-zero -- but turning a class into an operator-visible number is the
-	// consumer task, not the producer one. Until that arm exists a dropped
-	// batch lands in applyBatch's default: case and is counted as
-	// Stats.Undecoded, so nothing about it is silent in the meantime.
+	// Drops are decoded here and dispatched by class in noteDropLocked.
+	// GPU_DROP_CLASS_GRAPH_EXEC is acted on - it arms Tier A's CUDA-graph
+	// refusal, issue #94 - and the three Tier B loss classes are counted in
+	// Stats.DropsUnconsumed until the task that turns each into an
+	// operator-visible number lands. Nothing here is silent either way.
 	Drops []gpuabi.Dropped
 }
 
@@ -2066,11 +2117,16 @@ func (c *Consumer) applyBatch(b batch) {
 			c.stats.Records++
 			c.noteConfigLocked(cfg)
 		}
+	case kindDropped:
+		for _, d := range b.Drops {
+			c.stats.Records++
+			c.noteDropLocked(b.PID, d)
+		}
 	default:
-		// Carried on the wire, not normalized. Counted, never silent.
-		// kindDropped is the only kind the ABI defines that still reaches
-		// here; see Stats.Undecoded for that, and for what it means when
-		// any other kind does.
+		// A kind neither side of the wire defines: carried, not normalized,
+		// counted, never silent. Every kind the ABI DOES define has an arm
+		// above, so reaching here is the ABI having drifted. See
+		// Stats.Undecoded.
 		c.stats.Undecoded += uint64(b.RawCount)
 	}
 }
@@ -2268,6 +2324,48 @@ func (c *Consumer) noteSamplingWindowLocked(pid uint32, w gpuabi.SamplingWindow,
 		Lost:        lost,
 	}
 	if err := c.cfg.Sink.EmitSamplingWindow(ev); err != nil {
+		c.stats.SinkRejected++
+	}
+}
+
+// noteDropLocked dispatches one gpu_dropped_v1 record by its class. Caller
+// holds mu.
+//
+// One class is ACTED ON here and the rest are counted: GPU_DROP_CLASS_GRAPH_EXEC
+// arms Tier A's CUDA-graph refusal (issue #94) and is forwarded to the sink,
+// while the three Tier B loss classes land in Stats.DropsUnconsumed until the
+// task that gives each an operator-visible number lands.
+//
+// That asymmetry is not arbitrary. The other three describe LOSS - samples the
+// hardware discarded, a buffer that filled, device time this mechanism
+// structurally cannot see - and loss under-reports a profile, which is bad and
+// is visible as a shortfall. The graph class describes something worse and
+// entirely different: a claim that is FALSE while looking like the strongest
+// answer the pipeline can give. A graph launch fires one runtime callback for
+// N kernels and gpu_exec_v1 carries no graph id, so N executions share one
+// correlation and Tier A bills N kernels to one call site with
+// gpu_join="exact", gpu_pc_attrib="exact" and every counter green. It cannot
+// wait for the general treatment of drop classes, because the whole point of
+// the class is to stop a tier from running.
+//
+// pid is the batch header's - the process that fired the probe - which is what
+// scopes the refusal. A graph-using process in a system-wide profile must not
+// withdraw the exact attribution of every other process being profiled beside
+// it.
+func (c *Consumer) noteDropLocked(pid uint32, d gpuabi.Dropped) {
+	c.stats.DropsDecoded++
+	if d.Class != gpuabi.DropClassGraphExec {
+		c.stats.DropsUnconsumed++
+		return
+	}
+	c.stats.GraphExecReports++
+	c.stats.GraphExecutions += d.Count
+	ev := gpu.GPUGraphExecutions{
+		Backend: c.cfg.Backend,
+		PID:     pid,
+		Count:   d.Count,
+	}
+	if err := c.cfg.Sink.EmitGraphExecutions(ev); err != nil {
 		c.stats.SinkRejected++
 	}
 }

--- a/gpuprobe/consumer_test.go
+++ b/gpuprobe/consumer_test.go
@@ -52,13 +52,14 @@ func newTestConsumer(sink gpu.EventSink) *Consumer {
 // reject so the SinkRejected accounting is exercised. It is mutex-guarded
 // because the lifecycle tests below drive it from Run's goroutine.
 type recordingSink struct {
-	mu        sync.Mutex
-	launches  []gpu.GPUKernelLaunch
-	execs     []gpu.GPUKernelExec
-	pcSamples []gpu.GPUPCSample
-	modules   []gpu.GPUModule
-	windows   []gpu.GPUSamplingWindow
-	err       error
+	mu         sync.Mutex
+	launches   []gpu.GPUKernelLaunch
+	execs      []gpu.GPUKernelExec
+	pcSamples  []gpu.GPUPCSample
+	modules    []gpu.GPUModule
+	windows    []gpu.GPUSamplingWindow
+	graphExecs []gpu.GPUGraphExecutions
+	err        error
 	// onEmit, if set, is called after each accepted event. The lifecycle
 	// tests use it to know Run has completed a loop iteration.
 	onEmit func()
@@ -123,6 +124,17 @@ func (s *recordingSink) EmitSamplingWindow(w gpu.GPUSamplingWindow) error {
 		return s.err
 	}
 	s.windows = append(s.windows, w)
+	s.note()
+	return nil
+}
+
+func (s *recordingSink) EmitGraphExecutions(g gpu.GPUGraphExecutions) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.graphExecs = append(s.graphExecs, g)
 	s.note()
 	return nil
 }
@@ -221,13 +233,13 @@ func TestProbeKindCookiesMatchTheBPFProgram(t *testing.T) {
 	assert.Equal(t, uint64(0), cookieFor("gpu_unknown_v9"), "unknown probes are not attached")
 }
 
-// Stats.Undecoded is the "carried but not interpreted" counter. Every kind
-// the ABI defines has an applyBatch arm except kindDropped, which is decoded
-// and carried while its normalization waits for the consumer task that
-// follows this one. The kind used below is neither - it is a kind neither
-// side of the wire knows, which is the ABI having drifted, and which must
-// still be counted rather than dropped quietly (§6.1 admits no silent loss
-// anywhere).
+// Stats.Undecoded is the "carried but not interpreted" counter. Every kind the
+// ABI defines has an applyBatch arm, including kindDropped since issue #94
+// gave the CUDA-graph refusal something to consume; a drop CLASS this side
+// decodes but does not yet act on is counted in DropsUnconsumed instead. The
+// kind used below is neither - it is a kind neither side of the wire knows,
+// which is the ABI having drifted, and which must still be counted rather than
+// dropped quietly (§6.1 admits no silent loss anywhere).
 func TestUndecodedKindsAreCountedNotDropped(t *testing.T) {
 	c := newTestConsumer(&recordingSink{})
 	buf := make([]byte, batchHdrSize+40)
@@ -2844,6 +2856,10 @@ func TestTheFivePCSamplingKindsAreDecodedNotCountedUndecoded(t *testing.T) {
 		kind uint32
 		size int
 	}{
+		// kindDropped is not in this table. It is a PC-sampling kind and it
+		// does have an arm (issue #94), but a zero-filled record decodes as
+		// DropClassInvalid, which lands in DropsUnconsumed - a different
+		// assertion, made in TestEveryDropRecordIsActedOnOrCountedUnconsumed.
 		{"module", kindModule, gpuabi.SizeModuleLoad},
 		{"pc", kindPC, gpuabi.SizePCSample},
 		{"stallmap", kindStallMap, gpuabi.SizeStallReason},
@@ -3451,6 +3467,14 @@ func TestHealthyTierBRunLeavesEveryNewLossCounterAtZero(t *testing.T) {
 	assert.Zero(t, st.ConfigsDisagreed)
 	assert.Zero(t, st.PendingStallSamples)
 	assert.Zero(t, st.ZeroCorrelationExecs)
+	// The CUDA-graph refusal's counters, zero because this workload launches
+	// no graph. They are asserted here rather than only in their own tests
+	// because the property that matters is exactly this one: green on a
+	// healthy run, and non-zero the instant a graph execution is reported.
+	assert.Zero(t, st.GraphExecutions)
+	assert.Zero(t, st.GraphExecReports)
+	assert.Zero(t, st.DropsDecoded)
+	assert.Zero(t, st.DropsUnconsumed)
 	// The one new counter that is NOT zero on a healthy Tier B run, and the
 	// reason it is its own counter rather than a share of ZeroCorrelation.
 	assert.Equal(t, uint64(2), st.PCSamplesWithoutCorrelation)
@@ -3521,4 +3545,129 @@ func TestDecodeBatchRejectsAnOverlongDroppedBatch(t *testing.T) {
 
 	_, err := decodeBatch(buf)
 	assert.ErrorIs(t, err, gpuabi.ErrShortRecord)
+}
+
+// --- The CUDA-graph refusal, issue #94 ---
+
+// droppedBatch builds one gpu_dropped_v1 batch from (count, class) pairs.
+func droppedBatch(pid uint32, seq uint64, drops ...gpuabi.Dropped) []byte {
+	buf := make([]byte, batchHdrSize+len(drops)*gpuabi.SizeDropped)
+	putU32(buf[0:], kindDropped)
+	putU32(buf[4:], uint32(len(drops)))
+	putU64(buf[8:], seq)
+	putU32(buf[16:], pid)
+	putU64(buf[24:], uint64(len(drops)*gpuabi.SizeDropped))
+	for i, d := range drops {
+		off := batchHdrSize + i*gpuabi.SizeDropped
+		putU64(buf[off:], d.Count)
+		buf[off+8] = d.Class
+	}
+	return buf
+}
+
+// TestGraphExecDropClassReachesTheSink is the wire half of issue #94: the drop
+// class the shim has been emitting since Task 6 is now CONSUMED rather than
+// counted as Undecoded and forgotten.
+//
+// A CUDA graph launch fires ONE runtime callback for N kernels and gpu_exec_v1
+// carries no graph id, so those N executions share one correlation — and Tier
+// A's entire claim is exact launch attribution. Until this arm existed the
+// class arrived, landed in applyBatch's default: case, and nothing anywhere
+// acted on it: Tier A ran happily in a graph-using process and produced
+// attribution that was exact-LOOKING and many-to-one.
+//
+// The pid comes off the BATCH HEADER, which is what scopes the refusal: a
+// graph-using process in a system-wide profile must not withdraw the exact
+// attribution of every other process being profiled beside it.
+func TestGraphExecDropClassReachesTheSink(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+
+	apply(t, c, droppedBatch(4242, 1, gpuabi.Dropped{Count: 6, Class: gpuabi.DropClassGraphExec}))
+
+	require.Len(t, sink.graphExecs, 1)
+	assert.Equal(t, uint32(4242), sink.graphExecs[0].PID,
+		"the refusal is scoped by the process that fired the probe")
+	assert.Equal(t, uint64(6), sink.graphExecs[0].Count)
+
+	st := c.Stats()
+	assert.Equal(t, uint64(6), st.GraphExecutions)
+	assert.Equal(t, uint64(1), st.GraphExecReports)
+	assert.Equal(t, uint64(1), st.DropsDecoded)
+	assert.Zero(t, st.DropsUnconsumed)
+	assert.Equal(t, uint64(1), st.Records)
+	assert.Zero(t, st.Undecoded,
+		"gpu_dropped_v1 has an applyBatch arm now; Undecoded reading non-zero means it fell "+
+			"through to default: and the refusal never fired")
+	assert.Zero(t, st.SinkRejected)
+}
+
+// The three Tier B loss classes are decoded and COUNTED, not acted on and not
+// silently discarded. Turning each into an operator-visible number is a
+// separate task; DropsUnconsumed is what keeps them from being silent until it
+// lands, exactly as Undecoded did before this kind had an arm at all.
+func TestTierBDropClassesAreCountedUnconsumed(t *testing.T) {
+	sink := &recordingSink{}
+	c := newTestConsumer(sink)
+
+	apply(t, c, droppedBatch(4242, 1,
+		gpuabi.Dropped{Count: 3, Class: gpuabi.DropClassPCDroppedHW},
+		gpuabi.Dropped{Count: 1, Class: gpuabi.DropClassPCBufferFull},
+		gpuabi.Dropped{Count: 17, Class: gpuabi.DropClassPCNonUserKernel},
+	))
+
+	st := c.Stats()
+	assert.Empty(t, sink.graphExecs, "only the graph class is forwarded")
+	assert.Zero(t, st.GraphExecutions, "a Tier B loss class must not arm Tier A's refusal")
+	assert.Zero(t, st.GraphExecReports)
+	assert.Equal(t, uint64(3), st.DropsDecoded)
+	assert.Equal(t, uint64(3), st.DropsUnconsumed,
+		"DropsUnconsumed counts RECORDS, not the losses they describe: three statements about "+
+			"loss arrived and nothing on this side read them")
+	assert.Equal(t, uint64(3), st.Records)
+	assert.Zero(t, st.Undecoded)
+}
+
+// The identity that makes the drop counters checkable rather than merely
+// reported: every decoded record is either acted on or counted unconsumed, and
+// there is no third outcome in which one vanishes.
+func TestEveryDropRecordIsActedOnOrCountedUnconsumed(t *testing.T) {
+	c := newTestConsumer(&recordingSink{})
+	// One record per class the ABI defines, exactly as shim/stub/stub.cc
+	// emits, plus a class from a producer newer than this consumer.
+	for i, class := range []uint8{
+		gpuabi.DropClassPCDroppedHW,
+		gpuabi.DropClassPCBufferFull,
+		gpuabi.DropClassPCNonUserKernel,
+		gpuabi.DropClassGraphExec,
+		gpuabi.DropClassGraphExec + 1,
+	} {
+		apply(t, c, droppedBatch(4242, uint64(i+1), gpuabi.Dropped{Count: 1, Class: class}))
+	}
+
+	st := c.Stats()
+	assert.Equal(t, uint64(5), st.DropsDecoded)
+	assert.Equal(t, st.DropsDecoded, st.GraphExecReports+st.DropsUnconsumed,
+		"every decoded drop record must be acted on or counted unconsumed: %+v", st)
+	assert.Equal(t, uint64(1), st.GraphExecReports)
+	assert.Equal(t, uint64(4), st.DropsUnconsumed,
+		"a class this consumer does not know is counted unconsumed, not dropped and not "+
+			"mistaken for the graph class")
+	assert.Zero(t, st.Undecoded)
+	assert.Zero(t, st.SequenceGaps)
+}
+
+// A graph report the sink refuses is counted, like every other refused event.
+// It is the only path on which one can be lost between the wire and the
+// Timeline, which is why gpuprobe.Stats.GraphExecutions and
+// gpu.Snapshot.GraphExecutions are separate numbers that can be compared.
+func TestARefusedGraphReportIsCounted(t *testing.T) {
+	c := newTestConsumer(&recordingSink{err: gpu.ErrSinkFull})
+	apply(t, c, droppedBatch(4242, 1, gpuabi.Dropped{Count: 2, Class: gpuabi.DropClassGraphExec}))
+
+	st := c.Stats()
+	assert.Equal(t, uint64(1), st.SinkRejected)
+	assert.Equal(t, uint64(2), st.GraphExecutions,
+		"the arrival is counted whether or not the sink took it; otherwise a full sink would "+
+			"make the condition invisible on both sides at once")
 }

--- a/gpuprobe/gate_test.go
+++ b/gpuprobe/gate_test.go
@@ -1517,16 +1517,23 @@ func TestStubDrivesPCSamplingToPprofWithoutAGPU(t *testing.T) {
 	assert.Zero(t, stats.KernelDropped)
 	assert.Zero(t, stats.SinkRejected)
 
-	// Assertion 12. Undecoded is zero for every kind THIS PHASE DECODES, and
-	// gpu_dropped_v1 is not one of them: it is decoded into batch.Drops and
-	// carried, and normalizing a drop class into an operator-visible number is
-	// the consumer task after this one (see Stats.Undecoded's own comment). The
-	// stub emits exactly one record per drop class when PC sampling is on, so
-	// this is an equality rather than a tolerance - a sixth undecoded record
-	// would mean a kind arrived that nothing on this side knows about, which is
-	// silent loss.
-	assert.Equal(t, uint64(wantDropRecs), stats.Undecoded,
-		"the only undecoded records in a PC-sampling stub run are the four gpu_dropped_v1 class records; anything else is a KIND_* added on one side of the wire and not the other")
+	// Assertion 12. Undecoded is now zero for EVERY kind the ABI defines,
+	// gpu_dropped_v1 included: issue #94 gave it an applyBatch arm so the
+	// CUDA-graph drop class could arm Tier A's refusal. It used to read
+	// wantDropRecs here, and that is the assertion this one replaces.
+	//
+	// The four class records the stub emits are accounted for exactly, and
+	// they PARTITION: one graph-exec record acted on, three Tier B loss
+	// classes decoded and counted unconsumed until the task that gives each an
+	// operator-visible number lands. A fifth record, or a shortfall in the
+	// partition, means a class arrived that nothing on this side knows about.
+	assert.Zero(t, stats.Undecoded,
+		"every kind the ABI defines has a decode arm; a non-zero Undecoded is a KIND_* added on one side of the wire and not the other")
+	assert.Equal(t, uint64(wantDropRecs), stats.DropsDecoded,
+		"the stub emits exactly one gpu_dropped_v1 record per drop class")
+	assert.Equal(t, stats.DropsDecoded, stats.GraphExecReports+stats.DropsUnconsumed,
+		"every decoded drop record is acted on or counted unconsumed: %+v", stats)
+	assert.Equal(t, uint64(wantDropRecs-1), stats.DropsUnconsumed)
 	assert.Equal(t, uint64(wantPC), stats.PCSamplesDecoded,
 		"every PC record the stub emitted must have been decoded, not carried")
 	assert.Equal(t, uint64(wantCubins), stats.CubinsReceived,
@@ -1606,7 +1613,7 @@ func TestStubDrivesPCSamplingToPprofWithoutAGPU(t *testing.T) {
 		}))
 	}
 	// One per gpu_src_status, each on its own stack-carrying execution.
-	inject(corrOf(0), gateCRCLineInfo, lineIdx, 0x10)    // resolved
+	inject(corrOf(0), gateCRCLineInfo, lineIdx, 0x10)     // resolved
 	inject(corrOf(1), gateCRCNoLineInfo, noLineIdx, 0x10) // no-lineinfo
 	inject(corrOf(2), gateCRCAbsent, 0, 0x10)             // no-module
 	inject(corrOf(3), gateCRCLineInfo, lineIdx, 0x180)    // unmapped: past the function
@@ -1732,6 +1739,44 @@ func TestStubDrivesPCSamplingToPprofWithoutAGPU(t *testing.T) {
 			"every execution at or after an open window's start is either perturbed or unknown, and nothing else")
 	})
 
+	// ---- assertion 10b, first clause: the CUDA-graph refusal, end to end ---
+	//
+	// The stub emits one gpu_dropped_v1 record under GPU_DROP_CLASS_GRAPH_EXEC
+	// whenever PC sampling is on, so this run - Tier A, from a real producer,
+	// across a real uprobe - arms the refusal for real. That is the whole
+	// difference between this and the unprivileged half in gpu/gate_test.go:
+	// here the class crosses the wire, is decoded by the consumer's own arm,
+	// is scoped to the producer's pid from the batch header, and reaches the
+	// Timeline through the ordinary sink.
+	//
+	// Without the refusal this run would report gpu_join="exact" and
+	// gpu_pc_attrib="exact" on every one of the injected samples while a graph
+	// launch was in play - exact-LOOKING and many-to-one, which is issue #94.
+	assert.Equal(t, uint64(2), stats.GraphExecutions,
+		"the stub emits {count: 2, GPU_DROP_CLASS_GRAPH_EXEC}; a zero here means the class crossed the wire and nothing consumed it")
+	assert.Equal(t, uint64(1), stats.GraphExecReports)
+	assert.Equal(t, stats.GraphExecutions, snap.GraphExecutions,
+		"every graph report the consumer decoded must have reached the Timeline; a gap is loss between the wire and the join")
+	assert.Equal(t, uint64(1), snap.GraphExecProcesses)
+	assert.Zero(t, snap.GraphExecUnscoped,
+		"the producer named its process on the batch header, so the refusal must be scoped to it")
+	assert.Zero(t, snap.GraphExecTrackingCapped)
+	assert.True(t, snap.TierAGraphRefused())
+	assert.Equal(t, uint64(len(snap.Executions)), snap.ExecutionsGraphRefused,
+		"every execution of the one graph-using process in this run must be marked")
+	assert.Positive(t, snap.PCJoin.GraphRefusedAttributions,
+		"the injected PC samples joined by correlation, so their gpu_pc_attrib must have been withdrawn from \"exact\"")
+	for i, v := range snap.Executions {
+		require.True(t, v.GraphRefused, "execution %d unmarked", i)
+		assert.NotEqual(t, gpu.PCAttribExact, v.PCAttrib,
+			"execution %d still claims exact attribution in a graph-using process", i)
+	}
+	// And the refusal is LOUD: it reaches the operator on the summary line
+	// every run prints, not only in an anomaly they have to scroll to.
+	graphHealth := gpu.JoinHealth(snap)
+	assert.Contains(t, graphHealth[0], "WITHDRAWN")
+	assert.Contains(t, strings.Join(graphHealth, "\n"), "launched from CUDA GRAPHS")
+
 	// ---- the projection ---------------------------------------------------
 	//
 	// Projected TWICE over the SAME snapshot: once with the default budget, for
@@ -1831,6 +1876,21 @@ func TestStubDrivesPCSamplingToPprofWithoutAGPU(t *testing.T) {
 	}
 	require.Equal(t, len(samples), si, "every projected sample must belong to an execution")
 	t.Logf("pc-derived samples: %d  by status: %v  by attrib: %v", pcDerived, byStatus, byAttrib)
+
+	// Assertion 10b's first clause, at the label. This run's PC samples all
+	// joined by vendor correlation, so without the CUDA-graph refusal every
+	// one of them would read gpu_pc_attrib="exact" - in a run where the
+	// producer reported a graph execution, which makes that word false. There
+	// must be no "exact" left, and the withdrawal must be visible on every
+	// sample rather than only in a counter.
+	assert.Zero(t, byAttrib[string(gpu.PCAttribExact)],
+		"a graph execution was reported on this run; no sample may still claim exact attribution: %v", byAttrib)
+	assert.Equal(t, pcDerived, byAttrib[string(gpu.PCAttribGraphRefused)],
+		"every correlation-joined sample's attribution must have been withdrawn: %v", byAttrib)
+	for i := range samples {
+		assert.Equal(t, "true", samples[i].Labels["gpu_graph_refused"],
+			"gpu_graph_refused rides on EVERY execution of a graph-using process, PC-bearing or not (sample %d)", i)
+	}
 
 	// Assertion 2, stated as a number rather than left implicit in the loop.
 	assert.Positive(t, resolvedWithStack,


### PR DESCRIPTION
Closes #94. Task 10 *stated* that Tier A refuses to start where CUDA graph executions have been observed. It did not — **nothing consumed `DropClassGraphExec`**: no counter, no `Snapshot` field, no anomaly, no gate on the burst controller.

A graph launch is one callback for N kernels, and `gpu_exec_v1` cannot carry `graphId`, so those N executions share one correlation. Tier A's entire claim is *exact* launch attribution — so the result was attribution that is exact-**looking** and many-to-one, with every counter green. This project's signature defect at the top of the stack, and the precise thing the refusal was specified to prevent.

### The chain that did not exist

`consumer.go` gained a `case kindDropped:` arm and `noteDropLocked`, counting every drop record and dispatching by class. The graph class becomes `Stats.GraphExecutions`/`GraphExecReports` and is forwarded as a first-class event `gpu.GPUGraphExecutions{Backend, PID, Count}` through a new `EventSink.EmitGraphExecutions`. `Timeline` latches it per process and cumulatively; `Snapshot` grows five fields plus `PCJoinStats.GraphRefusedAttributions`; `joinhealth` grows a summary clause and two anomalies; the projection grows `gpu_graph_refused="true"` and a fifth `gpu_pc_attrib` value, `"graph-refused"`.

**`CountingSink.EmitGraphExecutions` has no admission control at all**, deliberately: a bounded refusal is not a refusal. Dropping this event under load would restore exactly the defect being fixed.

### Both halves of the refusal

**Never starts** — `PCSamplingRequest.GraphExecutionsObserved` → `ErrPCSamplingGraphExecutions`, resolving to `PCSamplingOff` and never to `"continuous"`, checked **before** the perturbation acknowledgement so no flag buys past it.

**Withdrawn mid-run** — the producer's existing `BurstController` latch plus the agent marking every execution of that process. Loud on the summary line every run prints — `TIER A EXACT ATTRIBUTION WITHDRAWN on N executions` — not only inside an anomaly.

### The pre-refusal window: kept and marked, not discarded

`g_exec_from_graph` comes from `CUpti_ActivityKernel12.graphId` on the **activity** path, which arrives on the drain tick — up to 100 ms, and one or two bursts, after the first graph kernel ran. So Tier A does run briefly before refusing.

Discarding those samples would be the silent-downgrade shape in different clothes, and it would destroy the `gpu_serialized="true"` disclosure for kernels that genuinely *were* serialized. Durations, weights, stall reasons and the serialization disclosure all survive — **only the attribution claim is withdrawn**.

The mark is applied at `Snapshot`, so it is retroactive over everything the Timeline still holds: a driver snapshotting once at the end loses nothing. A periodic driver's already-emitted snapshots are the residue, and that has its own `joinhealth` line rather than being left to be discovered.

### Tier B untouched, enforced four ways

The tier check lives inside `isGraphRefusedLocked`; `Snapshot` replaces `PCAttribExact` and only it; `PCAttribGraphRefused` is unreachable through `worsePCAttrib`; the anomaly is Tier-A-only while the count still rides on every tier's Snapshot. Tier B is unaffected by graphs because it joins through the **module**, not the launch — an asymmetry now stated in the code rather than only in the plan.

### Gate

`TestGateGraphExecutionRefusalIsNotAssertableYet` failed by name exactly as its doc comment promised, and is replaced by `TestGateGraphExecutionRefusalIsReal` composing nine sub-assertions. The privileged gate now drives the refusal through the stub across a real uprobe and asserts no sample is left claiming `"exact"`.

Assertion 12's honest deviation is also closed: `Undecoded == 4` becomes `Undecoded == 0` plus an exact four-record partition, with the other three drop classes decoded-and-counted in `DropsUnconsumed` rather than acted on.

Five mutations applied, run and reverted — all caught.

### Cannot verify

`CapEff: 0`, no GPU. Everything ran unprivileged except `TestStubDrivesPCSamplingToPprofWithoutAGPU`, which compiles and skips. **The pre-refusal window's size stays outstanding for the RTX 3090** — the report names the measurement. Also unverified: the adapter's delta emission rate (which the unbounded-admission argument leans on), whether `graphId` is non-zero for *every* graph-launched execution, and whether producer and agent refusals agree on hardware.