### PR TITLE
bench: add the 1%-duty arm so TIER_A_DEEP_DIVE_ONLY is reachable

### DIFF
--- a/.superpowers/sdd/task-12-overhead-report.md
+++ b/.superpowers/sdd/task-12-overhead-report.md
@@ -2,6 +2,13 @@
 
 Branch `feat/pc-sampling-overhead`, one commit on `origin/main` (`6f7cdf08`, the Task 11 merge).
 
+> **Amended on branch `feat/overhead-1pct-arm`.** A sixth arm — Tier A at 50 ms / 4950 ms, 1%
+> duty — was added so that `TIER_A_DEEP_DIVE_ONLY` becomes reachable; on the original five arms it
+> could not fire without `TIER_A_UNSHIPPABLE` outranking it. **The thresholds are untouched.** What
+> changed besides the arm is the **run length**, which is now derived from the arm table rather
+> than guessed, and the duty at which the plan's fourth clause is evaluated. Both are set out
+> below and in **"The 1%-duty arm"** at the end. Still no number has been measured.
+
 **This task produced the instrument, not the verdict.** The implementer has `CapEff: 0` and no
 GPU. Every number the plan asks for is outstanding and **the tier decision is not yet made**. What
 is here is a `bench/` scenario built so that running it on the RTX 3090 yields a decision rather
@@ -92,7 +99,8 @@ would be measuring the wrong thing twice.
 An **uninjected** run is taken as well, once, *before* the arms. It is labelled `calibration` in
 the output and in the JSON, it is never used as a baseline, and it exists for two reasons: it
 warms the device clocks before the first arm, and it proves the fixed work is sized for the device
-in front of it (the run fails, with the retuning advice, if it falls outside 10–120 s).
+in front of it (the run fails, with the retuning advice, if it falls outside 25–120 s — the
+lower bound is derived from the lowest-duty arm's burst cycle, not a constant).
 
 The consumer runs **without a symbolizer**, identically on every arm. Resolving a sampled launch's
 stack is agent-side work that costs the workload nothing, and it cannot succeed anyway once the
@@ -104,7 +112,7 @@ source that cancels — is left out.
 
 ## The arms, and what each proves it ran
 
-Five arms, **five interleaved runs each** (every arm once per round, not five of one then five of
+Six arms, **five interleaved runs each** (every arm once per round, not five of one then five of
 the next, so thermal drift and boost state fall on all arms alike), medians, fixed work.
 
 | arm | env handed to the producer | duty |
@@ -114,12 +122,16 @@ the next, so thermal drift and boost state fall on all arms alike), medians, fix
 | tier A 50 ms / 450 ms | `=serialized`, `BURST_MS=50`, `MAX_DUTY_PERMILLE=100`, `MAX_GAP_MS=450` | 10% |
 | tier A 50 ms / 950 ms | `=serialized`, `BURST_MS=50`, `MAX_DUTY_PERMILLE=50`, `MAX_GAP_MS=950` | 5% |
 | tier A 50 ms / 1950 ms | `=serialized`, `BURST_MS=50`, `MAX_DUTY_PERMILLE=25`, `MAX_GAP_MS=1950` | 2.5% |
+| tier A 50 ms / 4950 ms | `=serialized`, `BURST_MS=50`, `MAX_DUTY_PERMILLE=10`, `MAX_GAP_MS=4950` | 1% |
 
 **The gaps are pinned from both sides, and that is deliberate.** The burst controller clamps its
-gap into `[min_gap, max_gap]` where `min_gap = burst × (1/max_duty − 1)` — so 450 / 950 / 1950 ms
-after a 50 ms burst *are* 10% / 5% / 2.5%. Setting the ceiling gives the minimum; setting
-`MAX_GAP_MS` to the same value gives the maximum; the interval collapses to a point and whatever
-the closed loop computes, the gap it returns is the arm's gap. With only the ceiling set, a
+gap into `[min_gap, max_gap]` where `min_gap = burst × (1/max_duty − 1)` — so 450 / 950 / 1950 /
+4950 ms after a 50 ms burst *are* 10% / 5% / 2.5% / 1%. Setting the ceiling gives the minimum;
+setting `MAX_GAP_MS` to the same value gives the maximum; the interval collapses to a point and
+whatever the closed loop computes, the gap it returns is the arm's gap. The 1% arm is pinned by
+the same two knobs and the same tests: `TestTierAArmsPinTheGapFromBothSides` now sweeps
+`{100, 50, 25, 10}` per mille, and `TestTheArmTableIsThePlansAndItsDutiesAreExact` re-derives
+every gap from `burst × (1/duty − 1)`, so neither side can drift without the other noticing. With only the ceiling set, a
 workload producing a high pair rate would have the loop lengthen the gap, the arm would run at a
 duty nobody asked for, and the ratio would be divided by a denominator that never happened. The
 tier is written **explicitly on every arm including the off one**, so an exported
@@ -141,14 +153,21 @@ Every clause below **fails the run** when it does not hold:
 | tier B | producer `tier=continuous`; `pc_records > 0`; `PCSamplesDecoded > 0`; **zero** windows and **zero** bursts (a `CONTINUOUS` producer announcing a window would be claiming a perturbation it did not cause) |
 | tier A | producer `tier=serialized`; `bursts ≥ --gpu-min-bursts` (4); `windows == 2N` or `2N−1`; `start_failed == stop_failed == 0`; `graph_execs == graph_refused == 0`; `PCSamplesDecoded > 0`; `SamplingWindowsReceived > 0`; `Snapshot.PCSampling == serialized`; and **`ExecutionsSerialized > 0`** |
 | tier A | achieved duty inside `[configured/2, (burst+2·tick)/(burst+2·tick+gap)]` — the upper bound is *derived* from the burst timer's `burst/5` tick plus two ticks of scheduling slack, not a magic tolerance |
-| cross-arm | a lower duty must open **strictly fewer** bursts than a higher one over the same fixed work |
+| cross-arm | a lower duty must open **strictly fewer** bursts than a higher one over the same fixed work — the check walks the whole table in descending duty, so the 1% arm is held to it on the same terms as the rest |
 
 The two load-bearing ones are the last two rows and the `ExecutionsSerialized > 0` clause. Bursts
 that overlapped no kernel serialized nothing, so an arm with zero serialized executions measured
 the cost of starting and stopping CUPTI and not the cost of serialization — and would report a
-beautifully small number for it. And if the three Tier A arms all opened the same number of
-bursts, the duty environment did not take, they are one arm under three names, and their three
-different ratios are fiction.
+beautifully small number for it. And if the Tier A arms all opened the same number of bursts, the
+duty environment did not take, they are one arm under several names, and their different ratios
+are fiction.
+
+**The 1% arm is the one most exposed to both of those, which is why nothing about it is relaxed.**
+It opens the fewest bursts of any arm, so it is the arm most likely to fall under the
+`--gpu-min-bursts` floor; and its bursts overlap the least kernel time, so it is the arm most
+likely to serialize nothing at all. Both of those failures produce a *small* cost number — the
+flattering direction — and both fail the run instead of contributing one. The run-length floor
+below exists precisely so the first of them is prevented rather than merely detected.
 
 On failure the run still writes its JSON — the arms are the diagnostic — but the `decision` object
 stays at its zero value so nothing in the file can be read as a verdict, stderr says so in as many
@@ -183,7 +202,12 @@ TIER_A_UNSHIPPABLE  >  TIER_A_DEEP_DIVE_ONLY  >  TIER_A_SHIPS_AT_A_SMALLER_DUTY 
 | `tier-b-cost-over-5pct` | tier B cost > 5% | `TIER_B_NOT_ALWAYS_ON` |
 | `tier-a-10pct-duty-within-5pct-and-ratio-within-2` | headline duty within both bars | `TIER_A_SHIPS_OPT_IN` |
 | `tier-a-cost-over-duty-above-2-at-every-duty` | ratio > 2 at every duty tested | `TIER_A_DEEP_DIVE_ONLY` |
-| `tier-a-2.5pct-duty-cost-over-5pct` | lowest duty still over 5% | `TIER_A_UNSHIPPABLE` |
+| `tier-a-lowest-duty-cost-over-5pct` | lowest duty tested still over 5% | `TIER_A_UNSHIPPABLE` |
+
+The fourth identifier used to read `tier-a-2.5pct-duty-cost-over-5pct`, because 2.5% was the
+lowest duty on the table. It is now named for what it evaluates rather than for a duty that is no
+longer the lowest — see **"Where the plan's fourth clause is evaluated"** below, which is a real
+loosening and is disclosed in the output rather than absorbed.
 
 **Two verdicts the plan does not name, and why they exist rather than a silent pick:**
 
@@ -197,39 +221,152 @@ TIER_A_UNSHIPPABLE  >  TIER_A_DEEP_DIVE_ONLY  >  TIER_A_SHIPS_AT_A_SMALLER_DUTY 
   unsound. It prints *"do not read this as a pass"*. It is a named outcome for the same reason
   `gpu_serialized` has an `"unknown"` that must never degrade to `"false"`.
 
-### A finding about the thresholds themselves
+### The finding about the thresholds themselves, and what was done about it
 
 `cost ÷ duty > 2` is the same statement as `cost% > 200 × duty`. At **2.5% duty that is exactly
 `cost% > 5%`** — the wall-clock bar. So on the plan's own three duties, clause 3 **strictly
 implies** clause 4, and `TIER_A_DEEP_DIVE_ONLY` is unreachable: the unshippable verdict always
 outranks it. The two clauses separate only below 2.5% duty.
 
-This is a property of the thresholds, not of the hardware, and it is not something I resolved by
-adjusting a threshold. The harness applies the clauses as written, and **prints the coincidence
-whenever both fire**, so a controller reading a result does not conclude the deep-dive branch was
-considered and rejected:
+This is a property of the thresholds, not of the hardware, and it was not resolved by adjusting a
+threshold. **It was resolved by adding a duty below the coincidence point** — see "The 1%-duty
+arm" below. On the original five arms the harness applied the clauses as written and **printed the
+coincidence whenever both fired**, so a controller reading a result would not conclude the
+deep-dive branch had been considered and rejected:
 
 > `NOTE both harsh clauses fired, and at the lowest duty tested (2.50%) they are the SAME
 > condition: cost/duty > 2.0 means cost > 5.00%, and the wall bar is 5.0%. They separate only
 > below 2.50% duty, which this table does not test — so TIER_A_DEEP_DIVE_ONLY could not have been
 > reached here whatever the numbers. Add a lower-duty arm if that distinction is wanted.`
 
-The reassuring half is pinned too: on the plan's duties the decision is **total**. At 2.5% duty
-"within the wall bar" and "within the ratio bar" are the same condition, so the lowest-duty arm
-either qualifies for both — giving opt-in or a smaller duty — or fails both, giving unshippable.
-`TestOnThePlansDutiesTheDecisionIsTotal` sweeps eight cost tables and asserts none of them reaches
-`INDETERMINATE`.
+That note still exists and is still reachable — if the table is ever trimmed back to 2.5%, the
+coincidence returns and the reader is told. With the 1% arm present the harness prints the other
+half instead, and it is a different statement rather than a milder one:
 
-Whether to add a 1%-duty arm to make clause 3 distinguishable is a decision for whoever runs this.
-I did not add one: the plan's arm table is what was pre-committed, and quietly extending it would
-be the same category of move as quietly moving a bar.
+> `NOTE both harsh clauses fired and at the lowest duty tested (1.00%) they are DIFFERENT
+> conditions — cost/duty > 2.0 means cost > 2.00% there, well inside the 5.0% wall bar. This table
+> separates them below 2.50% duty, so TIER_A_DEEP_DIVE_ONLY was reachable and was not reached: the
+> lowest duty is over the wall bar on its own.`
+
+The reassuring half was pinned too: on the plan's **original three** duties the decision is
+**total**. At 2.5% duty "within the wall bar" and "within the ratio bar" are the same condition, so
+the lowest-duty arm either qualifies for both — giving opt-in or a smaller duty — or fails both,
+giving unshippable. `TestOnThePlansDutiesTheDecisionIsTotal` sweeps eight cost tables and asserts
+none of them reaches `INDETERMINATE`.
+
+**That totality is the same fact as the unreachability, and the 1% arm trades it away
+deliberately.** Below the coincidence point the two bars separate, so a cost table can now fail
+both without either harsh clause firing, and `TIER_A_INDETERMINATE` becomes reachable on the
+harness's own duties. That is not a regression: `INDETERMINATE` says *cost did not fall with duty
+the way serialization says it must, so re-run before deciding anything; do not read this as a
+pass*, which is the correct thing to say about such a table.
+`TestOnTheHarnessDutiesIndeterminateIsReachableAndIsNotAPass` pins it, and the original
+three-duty totality test is kept unchanged beside it.
+
+---
+
+## The 1%-duty arm
+
+**Tier A at 50 ms burst / 4950 ms gap.** `min_gap = 50 × (1/0.01 − 1) = 4950 ms`, so
+`MAX_DUTY_PERMILLE=10` and `MAX_GAP_MS=4950` clamp the burst controller's interval to a single
+point, exactly as the other three Tier A arms do.
+
+### Why it exists
+
+`cost ÷ duty > 2` is the same statement as `cost% > 200 × duty`, so the deep-dive clause and the
+wall-clock clause are the *identical condition* at `duty = 5 / (100 × 2) = 2.5%` — the lowest duty
+the original table tested. Above that duty the ratio clause strictly implies the wall clause and
+the harsher verdict outranks it; `TIER_A_DEEP_DIVE_ONLY` could not fire alone whatever the numbers
+were. The two verdicts mean materially different things — *"the tier does not ship"* versus *"the
+tier works, but only as a deliberate tool"* — so a harness that could only ever produce the first
+was applying three clauses, not four.
+
+At 1% duty, `ratio > 2` means `cost > 2%`, comfortably inside the 5% bar. A tier that is
+consistently inefficient but genuinely cheap at low duty now lands in deep-dive instead of being
+killed.
+
+Worked example, and the test that pins it
+(`TestTheOnePercentArmMakesDeepDiveOnlyReachable`): costs of 22% / 11% / 5.5% / 3% at
+10% / 5% / 2.5% / 1% give ratios 2.2 / 2.2 / 2.2 / 3.0 — every one above the bar, so the ratio
+clause fires — while the lowest duty costs 3%, inside the wall bar, so the unshippable clause does
+not. Verdict: `TIER_A_DEEP_DIVE_ONLY`. The same test feeds the same three costs to the original
+three duties and asserts they still land on `TIER_A_UNSHIPPABLE`, so the finding is recorded
+rather than erased.
+
+### Where the plan's fourth clause is evaluated — a real loosening, disclosed
+
+The plan words its fourth clause *"Tier A at 2.5% duty > 5% wall-clock"*, and gives as its reason
+that *"duty-cycling has no remaining lever"*. The lever it names is the lowest duty on the table.
+With a 1% arm present that is no longer 2.5%, so the clause is evaluated at 1% — which is what its
+own reason asks for, and which is what the worked example above depends on.
+
+**This makes the clause strictly weaker than its literal wording.** A table where the 2.5% arm is
+over the bar and the 1% arm is not now escapes `TIER_A_UNSHIPPABLE`, where before it could not.
+That is exactly the kind of change that must not happen quietly, so it does not:
+
+- the clause identifier is now `tier-a-lowest-duty-cost-over-5pct`, naming what it evaluates
+  rather than a duty that is not the one being tested;
+- whenever the difference changes the answer — the 2.5% arm over the bar, the lowest arm not — the
+  harness prints, above the verdict:
+
+  > `NOTE the plan words its fourth clause as "Tier A at 2.5% duty > 5.0%", and the tier A 2.5%
+  > duty arm DOES cost +5.50%. It is evaluated at the lowest duty tested (tier A 1% duty, +3.00%)
+  > because the clause's own reason is that duty-cycling has no remaining lever, and 1.0% duty is
+  > a remaining lever. Read this result as "unshippable does not fire at 1.0% duty", NOT as "2.5%
+  > duty is within budget".`
+
+- `TestThePlansLiteralFourthClauseIsReportedWhenItWouldHaveFired` pins the note, and
+  `TestNoLiteralClauseNoteWhenThe25PercentArmIsWithinTheBar` pins that it stays silent when there
+  is nothing to disclose — a note that fires unconditionally is a note nobody reads.
+
+### What it costs: run length, and that is the whole cost
+
+**A 1% duty at a 50 ms burst is a 4950 ms gap, so one burst opens every 5 seconds.** Every Tier A
+arm must open at least `--gpu-min-bursts` (4) of them or its duty fraction means nothing, and the
+2.5% arm needed only 8 s of fixed work for that. The 1% arm needs **20 s**, and the harness demands
+**25 s** — one extra cycle, because the count is of *completed* cycles, the first burst does not
+open at `t=0`, and a floor met only exactly would turn ordinary jitter into a failed run of the
+whole benchmark after twenty minutes of GPU time.
+
+That floor is **derived from the arm table**, not written down: `gpuPCMinFixedWorkSec` takes the
+longest burst+gap cycle among the Tier A arms and multiplies by `MinBursts + 1`. Trimming or
+adding an arm moves it automatically, and `TestTheFixedWorkFloorIsDerivedFromTheLowestDutyArm`
+pins both the cycle and the product. `--gpu-min-calibration-sec` is now a floor that is *raised*
+to the derived value and never lowered below it.
+
+Two things make the check conservative in the right direction rather than the flattering one. It
+is applied to the **uninjected calibration run**, which is the fastest run the benchmark takes —
+every arm is slower and therefore opens *more* bursts. And it is applied to the workload's
+fixed-work `elapsed_ms`, while the adapter's burst timer runs for the whole process, including
+CUDA init, warm-up and teardown.
+
+It is also checked **before** anything runs. The harness prints the derived floor and the run
+count up front, and a configuration where the floor exceeds `--gpu-max-calibration-sec` is refused
+immediately rather than discovered after the GPU time is spent
+(`TestAnImpossibleFixedWorkWindowIsRefusedBeforeAnythingRuns`).
+
+### The consequence for the operator, stated plainly
+
+**The run gets materially longer, in two ways at once: five more fixed-work runs, and each run has
+to be about half as long again.**
+
+- **26 → 31 fixed-work runs** (1 calibration + 6 arms × 5 rounds).
+- **The fixed work must now take 25–120 s uninjected, not 10–120 s.** The old default of
+  `--gpu-iters 20000` was *estimated* at ~20–30 s, which straddles the new 25 s floor, so the
+  default is now `--gpu-iters 30000` — estimated at ~30–45 s. Both figures are estimates from a
+  dependency-chain latency guess, not measurements; the calibration pass is what turns a wrong
+  guess into a named retuning instruction, and it now names the `--gpu-iters` value to try.
+- **Budget 25–40 minutes** rather than the 15–25 the original five-arm table quoted. If that is
+  too long, `--gpu-min-bursts 4` and the 1% arm are the two knobs — but lowering the burst floor
+  buys time by making the lowest arm's duty mean less, which is the trade the floor exists to
+  refuse by default.
 
 ---
 
 ## The exact command for the RTX 3090
 
 ```bash
-cd /home/diego/github/perf-agent            # on the branch feat/pc-sampling-overhead
+cd /home/diego/github/perf-agent            # on the branch feat/overhead-1pct-arm
 export CGO_CFLAGS="-I /usr/include/bpf -I /usr/include/pcap -I /home/diego/github/blazesym/capi/include"
 export CGO_LDFLAGS="-L/home/diego/github/blazesym/target/release -lblazesym_c"
 export LD_LIBRARY_PATH=/home/diego/github/blazesym/target/release
@@ -253,11 +390,23 @@ Equivalently, by hand:
 `cap_sys_admin` is the standing Phase 1 assertion. Do not put the binary in `/tmp` — that mount is
 `nosuid` and file caps do not survive exec.
 
-**Expect roughly 26 fixed-work runs** (one calibration + 5 arms × 5 rounds). At the default sizing
-each is ~20–30 s plus attach and drain, so budget 15–25 minutes.
+**Expect 31 fixed-work runs** (one calibration + 6 arms × 5 rounds). The harness prints that count
+and the derived fixed-work floor before it runs anything:
+
+```
+gpu-pc-overhead: 6 arms x 5 interleaved runs + 1 calibration = 31 fixed-work runs; the fixed
+work must take 25-120 s (the 25 s floor is derived: the lowest-duty arm's 5.0 s cycle x 4
+bursts + one cycle of slack)
+```
+
+At the default sizing (`--gpu-iters 30000`) each run is an estimated ~30–45 s plus attach and
+drain, so **budget 25–40 minutes** — up from the 15–25 the five-arm table quoted, because there
+are five more runs *and* each must be about half as long again for the 1% arm to open its bursts.
+That is a real cost and the operator should know it before starting.
 
 **If the calibration pass says the work is mis-sized**, retune and re-run — the failure message
-names the flags. `--gpu-rounds` sets kernel duration (the dependency chain length);
+names the flags and now also names an `--gpu-iters` value to try, computed from the time the
+calibration run actually took. `--gpu-rounds` sets kernel duration (the dependency chain length);
 `--gpu-iters` sets how many. If the baseline arm fails the concurrency floor, raise
 `--gpu-streams` or lower `--gpu-blocks` so each kernel occupies less of the device and more of
 them co-reside.
@@ -287,6 +436,10 @@ make -C shim nvidia-concurrent                          exit 0 (nvcc 13.3, sm_86
     exit 0, no output file written
 ```
 
+Re-run unchanged on `feat/overhead-1pct-arm` after the 1% arm: build, vet, `go test ./... -count=1`
+and `golangci-lint` all clean, and the capability-less skip is still one `BENCH_SKIPPED` line,
+exit 0, **no JSON file written**. The other scenarios' skip behaviour is untouched.
+
 The skip is clean: exit 0, one `BENCH_SKIPPED` line, and **no JSON file** — a partial file with no
 numbers in it is the thing most likely to be mistaken for a result. The other scenarios' skip
 behaviour is unchanged (`--scenario pid-large` still reports the larger capability set).
@@ -306,7 +459,8 @@ argument validation: unknown flag, --rounds past 2^23, and a zero dimension all
                    exit 2 with the reason, before any CUDA call
 ```
 
-New tests, all offline, all in `bench/cmd/scenario/gpupc_test.go` (45 cases):
+New tests, all offline, all in `bench/cmd/scenario/gpupc_test.go` (**62 cases**, up from 45; the
+1%-duty arm added 17 rather than starting a parallel set):
 
 - **the four clauses**, each fired and each *not* fired, including exactly-at-the-bar (the plan
   says `> 5%`, so 5.0 does not fire — a strict-versus-non-strict slip is the classic way a
@@ -337,6 +491,28 @@ New tests, all offline, all in `bench/cmd/scenario/gpupc_test.go` (45 cases):
 - **all four skip branches**, reachable via an injected-predicate variant, since only the first
   can ever fire on this machine.
 
+Added with the 1% arm:
+
+- **the arm exists and is 50 ms / 4950 ms**, found by its duty rather than by its index so a
+  reordering of the table cannot make the test examine a different arm;
+- **deep-dive is reachable** — the worked example above — *and* the same costs on the original
+  three duties still land on unshippable;
+- **all four clauses and all four Tier A verdicts fire** on the duties the harness actually runs,
+  asserted as a property rather than inferred from one table;
+- **`TIER_A_INDETERMINATE` is reachable** on the new table and still says "do not read this as a
+  pass";
+- **both halves of the coincidence note**: DIFFERENT below 2.5% duty, SAME at or above it;
+- **the plan's literal fourth clause is disclosed** when the evaluation point changes the answer,
+  and silent when it does not;
+- **the run-length floor** is derived from the table, and an impossible fixed-work window is
+  refused before anything runs;
+- **the 1% arm proves its own mode**, on the same terms as every other arm and each shown red:
+  too few bursts, nothing serialized, windows that do not reconcile, a duty that overshoots the
+  derived ceiling (and one that legitimately overshoots, which must pass), a duty far *below* the
+  configured one, a graph process, and a failed `cuptiPCSamplingStart`;
+- **the cross-arm burst check extends to four arms**: 1% must open strictly fewer bursts than
+  2.5%, and a 1% arm that opened as many is refused.
+
 ---
 
 ## Cannot verify — every number is outstanding
@@ -348,8 +524,9 @@ kernel in `cuda_concurrent.cu` has ever run; it has been compiled and disassembl
 
 Outstanding, all of it:
 
-1. **Every number in the arm table.** Baseline wall-clock, Tier B's cost, Tier A's cost at 10%, 5%
-   and 2.5% duty, every achieved kernel throughput, every cost ÷ duty ratio. None exists.
+1. **Every number in the arm table.** Baseline wall-clock, Tier B's cost, Tier A's cost at 10%,
+   5%, 2.5% **and 1%** duty, every achieved kernel throughput, every cost ÷ duty ratio. None
+   exists. **The 1% arm has never run either** — adding it made a verdict reachable, not measured.
 2. **Which threshold fires, and therefore whether Tier A ships at all**, and whether Tier B
    remains a candidate for always-on.
 3. **Whether the workload is actually concurrent on a 3090.** The design argues 16 blocks × 256
@@ -357,14 +534,26 @@ Outstanding, all of it:
    dependency chain is real, but the achieved concurrency is a hardware measurement. The harness
    asserts a floor rather than assuming it, so a negative answer is a loud failure with retuning
    advice and not a quiet underestimate — but the answer is unknown.
-4. **Whether the default sizing lands in the 10–120 s window** on a 3090. `--gpu-rounds 64000`
+4. **Whether the default sizing lands in the 25–120 s window** on a 3090. `--gpu-rounds 64000`
    was estimated from a dependency-chain latency guess, not measured. The calibration pass exists
    because this is unknown.
 5. **Whether pinning `MAX_DUTY_PERMILLE` and `MAX_GAP_MS` to the same gap really pins the burst
    controller.** It follows from `burst_next_gap_ns`'s clamp read as source, and
    `core/burst_test.cc` proves the clamp against a fake clock, but this exact combination has
    never been given to the adapter on hardware. The achieved-duty assertion is what would catch
-   it.
+   it. **This is sharper for the 1% arm than for the other three**: `MAX_DUTY_PERMILLE=10` makes
+   `burst_min_gap_ns` compute `50 ms × 99 = 4950 ms`, which is *equal to* rather than below
+   `max_gap_ns`, so the clamp returns `max_gap_ns` by its own `g >= max_gap_ns` branch. The value
+   is identical either way, and `TestTierAArmsPinTheGapFromBothSides` pins the environment — but
+   which branch the adapter takes has never been observed on hardware.
+5a. **Whether 25 s of fixed work really opens four bursts at a 5 s cycle.** The floor is derived
+   from arithmetic and is conservative twice over (checked against the fastest, uninjected run,
+   and against `elapsed_ms` rather than the longer process lifetime), but the burst controller's
+   start-up latency on a real process is unmeasured. A shortfall is a **loud failure** —
+   `bursts >= --gpu-min-bursts` — and not a quiet arm running at a duty nobody configured.
+5b. **Whether the default `--gpu-iters 30000` lands inside the new 25–120 s window on a 3090.**
+   It is the old guess scaled by 1.5 and is no more measured than the old one was. The
+   calibration pass is what catches it, and it now names the `--gpu-iters` value to try.
 6. **Whether the adapter's report line parses as expected on a real run.** The parser was written
    against the `logf` format strings in `cupti_adapter.cc` and tested against hand-written
    fixtures reproducing them. A format drift would show up as an empty producer tier, which is a

--- a/bench/cmd/scenario/gpupc.go
+++ b/bench/cmd/scenario/gpupc.go
@@ -103,13 +103,35 @@ const (
 
 // The threshold clause identifiers, in the plan's own order.
 const (
-	clauseTierBOverBudget      = "tier-b-cost-over-5pct"
-	clauseTierAHeadlineWithin  = "tier-a-10pct-duty-within-5pct-and-ratio-within-2"
-	clauseTierARatioOverAtAll  = "tier-a-cost-over-duty-above-2-at-every-duty"
-	clauseTierASmallestOverBud = "tier-a-2.5pct-duty-cost-over-5pct"
+	clauseTierBOverBudget     = "tier-b-cost-over-5pct"
+	clauseTierAHeadlineWithin = "tier-a-10pct-duty-within-5pct-and-ratio-within-2"
+	clauseTierARatioOverAtAll = "tier-a-cost-over-duty-above-2-at-every-duty"
+	// The plan spells its fourth clause "Tier A at 2.5% duty > 5%
+	// wall-clock" because 2.5% was the lowest duty its arm table tested,
+	// and the reason it gives is that "duty-cycling has no remaining
+	// lever". The lever the clause names is the lowest duty on the table.
+	// With a 1% arm on the table that is no longer 2.5%, so the clause is
+	// evaluated at the lowest duty tested and the identifier says so
+	// rather than naming a duty that is not the one being tested.
+	//
+	// This makes the clause STRICTLY WEAKER than its literal 2.5%
+	// wording: a table where the 2.5% arm is over the bar and the 1% arm
+	// is not now escapes the unshippable verdict, where before it could
+	// not. That is precisely what makes TIER_A_DEEP_DIVE_ONLY reachable,
+	// and it is exactly the sort of loosening that must not happen
+	// quietly — so decideGPUPC prints a NOTE naming the 2.5% arm's cost
+	// whenever the plan's literal wording would have fired and the
+	// evaluated clause did not.
+	clauseTierASmallestOverBud = "tier-a-lowest-duty-cost-over-5pct"
 )
 
-// gpuPCArmSpec is one arm's configuration. The three Tier A arms differ only
+// gpuPCPlanNamedLowestDuty is the duty the plan's fourth clause names in
+// prose. It is not a threshold and nothing is decided from it; it exists so
+// the harness can tell the reader when the clause's evaluation point has moved
+// below the duty the plan wrote down.
+const gpuPCPlanNamedLowestDuty = 0.025
+
+// gpuPCArmSpec is one arm's configuration. The four Tier A arms differ only
 // in their gap, which is what makes the duty the single moving variable.
 type gpuPCArmSpec struct {
 	Name    string
@@ -118,21 +140,92 @@ type gpuPCArmSpec struct {
 	GapMs   int
 }
 
-// gpuPCArms is the arm table from the plan, in the order it runs them:
-// baseline first (everything else is measured against it), then Tier B, then
-// Tier A at decreasing duty.
+// gpuPCArms is the arm table, in the order it runs them: baseline first
+// (everything else is measured against it), then Tier B, then Tier A at
+// decreasing duty.
 //
 // The Tier A gaps are not free parameters. The adapter derives its minimum gap
 // from the duty ceiling -- min_gap = burst * (1/max_duty - 1) -- so 450 / 950
-// / 1950 ms after a 50 ms burst ARE 10% / 5% / 2.5%, and setting the maximum
-// gap to the same value pins the burst controller's closed loop to exactly
-// that gap instead of letting it tune. See gpuPCArmEnv.
+// / 1950 / 4950 ms after a 50 ms burst ARE 10% / 5% / 2.5% / 1%, and setting
+// the maximum gap to the same value pins the burst controller's closed loop to
+// exactly that gap instead of letting it tune. See gpuPCArmEnv.
+//
+// WHY THERE IS A 1% ARM, which the plan's original table did not have.
+//
+// "cost / duty > 2" is the same statement as "cost% > 200 x duty". At 2.5%
+// duty that is exactly "cost% > 5%", which is the wall-clock bar. So on the
+// plan's original three duties the every-duty ratio clause STRICTLY IMPLIES
+// the lowest-duty wall clause, the harsher verdict outranks it, and
+// TIER_A_DEEP_DIVE_ONLY could not be reached whatever the numbers were. The
+// two clauses separate only BELOW 2.5% duty.
+//
+// That mattered because the two verdicts mean materially different things.
+// "The tier does not ship" and "the tier works, but only as a deliberate
+// deep-dive tool" are different answers, and a harness that can only ever
+// produce the first is not applying four clauses, it is applying three.
+//
+// At 1% duty "ratio > 2" means "cost > 2%", comfortably inside the 5% bar, so
+// a tier that is consistently inefficient but genuinely cheap at low duty
+// lands in deep-dive instead of being killed. The thresholds are untouched;
+// only the input space is now wide enough for all four clauses to be told
+// apart. The cost is run length -- see gpuPCMinFixedWorkSec.
 var gpuPCArms = []gpuPCArmSpec{
 	{Name: "baseline (pc sampling off)", Tier: gpu.PCSamplingOff},
 	{Name: "tier B continuous", Tier: gpu.PCSamplingContinuous},
 	{Name: "tier A 50ms/450ms (10% duty)", Tier: gpu.PCSamplingSerialized, BurstMs: 50, GapMs: 450},
 	{Name: "tier A 50ms/950ms (5% duty)", Tier: gpu.PCSamplingSerialized, BurstMs: 50, GapMs: 950},
 	{Name: "tier A 50ms/1950ms (2.5% duty)", Tier: gpu.PCSamplingSerialized, BurstMs: 50, GapMs: 1950},
+	{Name: "tier A 50ms/4950ms (1% duty)", Tier: gpu.PCSamplingSerialized, BurstMs: 50, GapMs: 4950},
+}
+
+// gpuPCLongestTierACycleMs is the longest burst+gap cycle in the arm table:
+// the 1%-duty arm's 5 s. Derived from the table rather than written down, so
+// adding or removing an arm cannot leave it stale.
+func gpuPCLongestTierACycleMs() int {
+	longest := 0
+	for _, a := range gpuPCArms {
+		if a.Tier != gpu.PCSamplingSerialized {
+			continue
+		}
+		if c := a.BurstMs + a.GapMs; c > longest {
+			longest = c
+		}
+	}
+	return longest
+}
+
+// lowestConfiguredDuty is the smallest duty the arm table asks for, which is
+// the arm the fixed-work floor and the plan's fourth clause both key on.
+func lowestConfiguredDuty() float64 {
+	lowest := 0.0
+	for _, a := range gpuPCArms {
+		if d := a.dutyConfigured(); d > 0 && (lowest == 0 || d < lowest) {
+			lowest = d
+		}
+	}
+	return lowest
+}
+
+// gpuPCMinFixedWorkSec is the shortest fixed work that lets EVERY Tier A arm
+// clear its own "bursts >= MinBursts" floor. It is what the 1% arm costs: not
+// five more runs, but a longer run.
+//
+// One burst opens per burst+gap cycle, so an arm whose cycle is C seconds
+// opens roughly T/C bursts over T seconds of work. At 2.5% duty C is 2 s and
+// the default floor of four bursts needs 8 s; at 1% duty C is 5 s and the same
+// four bursts need 20 s. The extra cycle of slack is not a fudge factor: the
+// count is of COMPLETED cycles, the first burst does not open at t=0, and a
+// floor met only exactly would turn ordinary jitter into a failed run of the
+// entire benchmark after twenty minutes of GPU time.
+//
+// Two things make this conservative in the right direction rather than the
+// flattering one. It is checked against the UNINJECTED calibration run, which
+// is the fastest run the benchmark takes -- every arm is slower and therefore
+// opens MORE bursts. And it is checked against the workload's fixed-work
+// elapsed_ms, while the adapter's burst timer runs for the whole process
+// including CUDA init, warm-up and teardown.
+func gpuPCMinFixedWorkSec(minBursts uint64) float64 {
+	return float64(minBursts+1) * float64(gpuPCLongestTierACycleMs()) / 1000
 }
 
 // dutyConfigured is burst/(burst+gap): the fraction of wall-clock the arm asks
@@ -262,7 +355,7 @@ func hasNVIDIADevice() bool {
 // Running the arms.
 // ---------------------------------------------------------------------------
 
-// runGPUPCOverhead runs the calibration pass and then the five arms,
+// runGPUPCOverhead runs the calibration pass and then the six arms,
 // interleaved, five runs each, and fills doc.GPUPC. It returns false when any
 // assertion failed; main exits non-zero on that, because a benchmark that
 // could not prove what it measured must not look like one that did.
@@ -277,6 +370,30 @@ func runGPUPCOverhead(doc *schema.Document, cfg gpuPCConfig, out io.Writer) bool
 	}
 	doc.GPUPC = res
 	doc.Config.Runs = cfg.Runs
+
+	// How long the fixed work must take for the LOWEST-duty arm to clear
+	// its own bursts floor. Derived from the arm table, announced before
+	// anything runs, and checked before the twenty minutes of GPU time
+	// rather than after them.
+	minSec := cfg.MinCalibrationSec
+	derived := gpuPCMinFixedWorkSec(cfg.MinBursts)
+	if derived > minSec {
+		minSec = derived
+	}
+	_, _ = fmt.Fprintf(out, "gpu-pc-overhead: %d arms x %d interleaved runs + 1 calibration = "+
+		"%d fixed-work runs; the fixed work must take %.0f-%.0f s (the %.0f s floor is "+
+		"derived: the lowest-duty arm's %.1f s cycle x %d bursts + one cycle of slack)\n",
+		len(gpuPCArms), cfg.Runs, len(gpuPCArms)*cfg.Runs+1, minSec, cfg.MaxCalibrationSec,
+		derived, float64(gpuPCLongestTierACycleMs())/1000, cfg.MinBursts)
+	if minSec > cfg.MaxCalibrationSec {
+		_, _ = fmt.Fprintf(out, "gpu-pc-overhead: FAILED: the lowest-duty arm needs at least "+
+			"%.0f s of fixed work to open %d bursts, but --gpu-max-calibration-sec is "+
+			"%.0f s. No sizing can satisfy both, so this configuration could only ever "+
+			"produce a Tier A arm whose duty means nothing. Raise "+
+			"--gpu-max-calibration-sec, or lower --gpu-min-bursts and accept a coarser "+
+			"duty measurement.\n", derived, cfg.MinBursts, cfg.MaxCalibrationSec)
+		return false
+	}
 
 	// The calibration pass: the same fixed work with NO adapter injected.
 	// It warms the device clocks before the first arm and it proves the
@@ -295,13 +412,17 @@ func runGPUPCOverhead(doc *schema.Document, cfg gpuPCConfig, out io.Writer) bool
 	}
 	_, _ = fmt.Fprintf(out, "gpu-pc-overhead: calibration (uninjected, not an arm): "+
 		"%.1f ms for %d kernels, %.0f kernels/s\n", calRun.WallMs, kernels, calRun.KernelsPerS)
-	if sec := calRun.WallMs / 1000; sec < cfg.MinCalibrationSec || sec > cfg.MaxCalibrationSec {
+	if sec := calRun.WallMs / 1000; sec < minSec || sec > cfg.MaxCalibrationSec {
+		want := minSec * 1.2
 		_, _ = fmt.Fprintf(out, "gpu-pc-overhead: FAILED: the fixed work takes %.1f s uninjected, "+
-			"outside the sane window [%.0f s, %.0f s]. Retune with --gpu-rounds (kernel "+
-			"duration) and --gpu-iters (how many), then re-run. Too short and the 2.5%%-duty "+
-			"arm cannot open enough bursts for its duty to mean anything; too long and the "+
-			"five interleaved runs take longer than the operator will wait.\n",
-			sec, cfg.MinCalibrationSec, cfg.MaxCalibrationSec)
+			"outside the sane window [%.0f s, %.0f s]. Retune with --gpu-iters (how many "+
+			"kernels) or --gpu-rounds (how long each one takes), then re-run. Too short "+
+			"and the %.0f%%-duty arm cannot open %d bursts for its duty to mean anything; "+
+			"too long and the %d interleaved runs take longer than the operator will "+
+			"wait. At this sizing, --gpu-iters %d would land near %.0f s.\n",
+			sec, minSec, cfg.MaxCalibrationSec,
+			lowestConfiguredDuty()*100, cfg.MinBursts, len(gpuPCArms)*cfg.Runs+1,
+			int(float64(cfg.Iters)*want/max(sec, 0.001)), want)
 		return false
 	}
 
@@ -316,7 +437,7 @@ func runGPUPCOverhead(doc *schema.Document, cfg gpuPCConfig, out io.Writer) bool
 
 	// INTERLEAVED, per §9.1's method: every arm once per round, rather
 	// than five of one arm then five of the next. Thermal drift, clock
-	// boost state and any other slow drift then fall on all five arms
+	// boost state and any other slow drift then fall on all six arms
 	// alike instead of on whichever ran last.
 	ok := true
 	for run := 1; run <= cfg.Runs; run++ {
@@ -825,14 +946,16 @@ func assertBaselineIsRealistic(cfg gpuPCConfig, base schema.GPUPCArm) error {
 	return nil
 }
 
-// assertDutyKnobDidSomething is the cross-arm proof that the three Tier A arms
-// are three arms and not the same arm three times.
+// assertDutyKnobDidSomething is the cross-arm proof that the Tier A arms are
+// as many arms as they claim to be and not one arm under several names.
 //
 // Burst count over a fixed run length is inversely proportional to burst+gap,
 // so 10% duty must open strictly more bursts than 5%, which must open strictly
-// more than 2.5%. If the three came out equal, the duty environment did not
-// take and all three "duties" are one duty — from which a cost-over-duty ratio
-// would be pure fiction.
+// more than 2.5%, which must open strictly more than 1%. The check walks the
+// whole table in descending duty, so the 1% arm is held to it on exactly the
+// same terms as the others. If two came out equal the duty environment did not
+// take, those "duties" are one duty, and a cost-over-duty ratio computed from
+// them would be pure fiction.
 func assertDutyKnobDidSomething(arms []schema.GPUPCArm) error {
 	var a []schema.GPUPCArm
 	for _, arm := range arms {
@@ -851,9 +974,9 @@ func assertDutyKnobDidSomething(arms []schema.GPUPCArm) error {
 			return fmt.Errorf(
 				"arm %q opened a median of %d bursts and the lower-duty arm %q opened %d: "+
 					"a lower duty must open strictly fewer bursts over the same fixed "+
-					"work. The duty environment did not take, so the three Tier A arms "+
-					"are one arm under three names and their cost-over-duty ratios are "+
-					"meaningless",
+					"work. The duty environment did not take, so these Tier A arms "+
+					"are one arm under different names and their cost-over-duty ratios "+
+					"are meaningless",
 				a[i-1].Name, hi, a[i].Name, lo)
 		}
 	}
@@ -1037,28 +1160,66 @@ func decideGPUPC(arms []schema.GPUPCArm, maxWallPercent, maxCostOverDuty float64
 			"THRESHOLD FIRED %s: the lowest duty tested (%s) still costs %+.2f%%, above the %.1f%% bar",
 			clauseTierASmallestOverBud, smallest.Name, smallest.CostPercent, maxWallPercent))
 	}
-	// The two harshest clauses can coincide arithmetically, and when they do
-	// the reader is told rather than left to notice.
+	// The two harshest clauses can coincide arithmetically, and whether
+	// they did on THIS table is stated rather than left to be noticed.
 	//
-	// cost/duty > R is the same statement as cost% > 100*R*duty. At
-	// duty = R*... — concretely, with the plan's bars (R = 2, W = 5%) the
-	// two coincide EXACTLY at duty = W/(100*R) = 2.5%, which is the lowest
-	// duty the plan's arm table tests. So on that table "ratio above 2 at
-	// every duty" strictly IMPLIES "the lowest duty is over the wall bar",
-	// and the deep-dive-only verdict is unreachable: the unshippable one
-	// always outranks it. That is a property of the thresholds, not of the
-	// hardware, and it is stated here so a controller reading a result does
-	// not conclude that the deep-dive branch was considered and rejected.
+	// cost/duty > R is the same statement as cost% > 100*R*duty, so the
+	// two clauses are the identical condition at exactly
+	// duty = W/(100*R) -- with the plan's bars (R = 2, W = 5%), 2.5%.
+	// At or above that duty the every-duty ratio clause strictly IMPLIES
+	// the lowest-duty wall clause and TIER_A_DEEP_DIVE_ONLY is
+	// unreachable, because the unshippable verdict outranks it. Below it
+	// the two separate and the deep-dive verdict becomes a real outcome.
+	//
+	// The arm table now goes down to 1%, so the separating case is the
+	// normal one; the coinciding case remains reachable if the table is
+	// ever trimmed back, and is still reported rather than assumed away.
+	coincideAtDuty := maxWallPercent / (100 * maxCostOverDuty)
 	if ratioOverEverywhere && smallestOverBudget {
+		if smallest.DutyConfigured >= coincideAtDuty-1e-12 {
+			d.Lines = append(d.Lines, fmt.Sprintf(
+				"NOTE both harsh clauses fired, and at the lowest duty tested (%.2f%%) they "+
+					"are the SAME condition: cost/duty > %.1f means cost > %.2f%%, and "+
+					"the wall bar is %.1f%%. They separate only below %.2f%% duty, "+
+					"which this table does not test — so %s could not have been "+
+					"reached here whatever the numbers. Add a lower-duty arm if that "+
+					"distinction is wanted.",
+				smallest.DutyConfigured*100, maxCostOverDuty,
+				maxCostOverDuty*smallest.DutyConfigured*100, maxWallPercent,
+				coincideAtDuty*100, verdictTierADeepDiveOnly))
+		} else {
+			d.Lines = append(d.Lines, fmt.Sprintf(
+				"NOTE both harsh clauses fired and at the lowest duty tested (%.2f%%) they "+
+					"are DIFFERENT conditions — cost/duty > %.1f means cost > %.2f%% "+
+					"there, well inside the %.1f%% wall bar. This table separates them "+
+					"below %.2f%% duty, so %s was reachable and was not reached: the "+
+					"lowest duty is over the wall bar on its own.",
+				smallest.DutyConfigured*100, maxCostOverDuty,
+				maxCostOverDuty*smallest.DutyConfigured*100, maxWallPercent,
+				coincideAtDuty*100, verdictTierADeepDiveOnly))
+		}
+	}
+
+	// The plan's fourth clause is worded "Tier A at 2.5% duty > 5%
+	// wall-clock". Evaluating it at the lowest duty tested is what its own
+	// reason ("duty-cycling has no remaining lever") asks for, but with a
+	// 1% arm on the table that evaluation point is BELOW the duty the plan
+	// wrote down, and the clause is therefore harder to fire than its
+	// literal wording. When that difference changes the answer, the reader
+	// is told in as many words — a verdict that got friendlier because the
+	// table grew a lower arm must not read as a verdict the numbers earned.
+	if planArm, ok := armAtDuty(tierA, gpuPCPlanNamedLowestDuty); ok &&
+		!smallestOverBudget && planArm.CostPercent > maxWallPercent {
 		d.Lines = append(d.Lines, fmt.Sprintf(
-			"NOTE both harsh clauses fired, and at the lowest duty tested (%.2f%%) they are "+
-				"the SAME condition: cost/duty > %.1f means cost > %.2f%%, and the "+
-				"wall bar is %.1f%%. They separate only below %.2f%% duty, which this "+
-				"table does not test — so %s could not have been reached here whatever "+
-				"the numbers. Add a lower-duty arm if that distinction is wanted.",
-			smallest.DutyConfigured*100, maxCostOverDuty,
-			maxCostOverDuty*smallest.DutyConfigured*100, maxWallPercent,
-			maxWallPercent/(100*maxCostOverDuty)*100, verdictTierADeepDiveOnly))
+			"NOTE the plan words its fourth clause as \"Tier A at %.1f%% duty > %.1f%%\", and "+
+				"the %s arm DOES cost %+.2f%%. It is evaluated at the lowest duty "+
+				"tested (%s, %+.2f%%) because the clause's own reason is that "+
+				"duty-cycling has no remaining lever, and %.1f%% duty is a remaining "+
+				"lever. Read this result as \"unshippable does not fire at %.1f%% "+
+				"duty\", NOT as \"%.1f%% duty is within budget\".",
+			gpuPCPlanNamedLowestDuty*100, maxWallPercent, planArm.Name, planArm.CostPercent,
+			smallest.Name, smallest.CostPercent, smallest.DutyConfigured*100,
+			smallest.DutyConfigured*100, gpuPCPlanNamedLowestDuty*100))
 	}
 
 	switch {
@@ -1097,6 +1258,17 @@ func decideGPUPC(arms []schema.GPUPCArm, maxWallPercent, maxCostOverDuty float64
 		}
 	}
 	return d
+}
+
+// armAtDuty finds the arm configured at a particular duty, if the table has
+// one. Used only for reporting, never for deciding.
+func armAtDuty(tierA []schema.GPUPCArm, duty float64) (schema.GPUPCArm, bool) {
+	for _, a := range tierA {
+		if math.Abs(a.DutyConfigured-duty) < 1e-9 {
+			return a, true
+		}
+	}
+	return schema.GPUPCArm{}, false
 }
 
 // largestQualifyingDuty returns the highest-duty arm that is within BOTH bars.

--- a/bench/cmd/scenario/gpupc_test.go
+++ b/bench/cmd/scenario/gpupc_test.go
@@ -56,10 +56,25 @@ func armsWith(tierBCost float64, duties, costs []float64) []schema.GPUPCArm {
 	return arms
 }
 
-// planDuties is the plan's own arm table: 10%, 5%, 2.5%.
+// planDuties is the plan's ORIGINAL arm table: 10%, 5%, 2.5%. It is kept as a
+// fixture because the arithmetic finding below is a property of exactly those
+// three duties, and a test that quietly moved to the new table would stop
+// pinning the reason the 1% arm exists.
 var planDuties = []float64{0.10, 0.05, 0.025}
 
-// armsFor is armsWith over the plan's three duties.
+// benchDuties is what the harness actually runs, and it must stay derived from
+// gpuPCArms rather than written down twice.
+func benchDuties() []float64 {
+	var out []float64
+	for _, a := range gpuPCArms {
+		if d := a.dutyConfigured(); d > 0 {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// armsFor is armsWith over the plan's original three duties.
 func armsFor(tierBCost float64, tierACosts [3]float64) []schema.GPUPCArm {
 	return armsWith(tierBCost, planDuties, tierACosts[:])
 }
@@ -202,12 +217,18 @@ func TestTierAWithNothingQualifyingAnywhereIsIndeterminateNotAPass(t *testing.T)
 	assert.Contains(t, strings.Join(d.Lines, "\n"), "do not read this as a pass")
 }
 
-// The counterpart, and the reassuring half: on the PLAN's own duties the
-// decision is total. At 2.5% duty "within the wall bar" and "within the ratio
-// bar" are the same condition, so the lowest-duty arm either qualifies for
-// both — giving opt-in or a smaller duty — or fails both, giving unshippable.
-// Indeterminate is unreachable there, which is why it exists as a guard for
-// other duty tables rather than as an expected outcome.
+// The counterpart, and the reassuring half: on the plan's ORIGINAL three
+// duties the decision is total. At 2.5% duty "within the wall bar" and "within
+// the ratio bar" are the same condition, so the lowest-duty arm either
+// qualifies for both — giving opt-in or a smaller duty — or fails both, giving
+// unshippable. Indeterminate is unreachable there.
+//
+// That totality is exactly what made deep-dive unreachable, and it does NOT
+// survive the 1% arm: see
+// TestOnTheHarnessDutiesIndeterminateIsReachableAndIsNotAPass. Trading it for
+// a reachable deep-dive verdict is the whole point of the new arm, and it is
+// why INDETERMINATE is a named verdict rather than a fallthrough to the
+// friendliest neighbouring answer.
 func TestOnThePlansDutiesTheDecisionIsTotal(t *testing.T) {
 	for _, costs := range [][3]float64{
 		{1, 0.5, 0.25}, {4, 2, 1}, {8, 4, 2}, {12, 7, 4},
@@ -388,6 +409,7 @@ func TestTheGoodArmsPass(t *testing.T) {
 	cfg := testCfg()
 	require.NoError(t, assertArmRanInItsMode(cfg, gpuPCArms[0], goodOffRun()))
 	require.NoError(t, assertArmRanInItsMode(cfg, gpuPCArms[2], goodTierARun()))
+	require.NoError(t, assertArmRanInItsMode(cfg, onePercentArm(), goodOnePercentRun()))
 }
 
 // The single most important negative: an arm that ran nothing at all. It
@@ -534,7 +556,7 @@ func TestThreeTierAArmsWithTheSameBurstCountFail(t *testing.T) {
 	}
 	err := assertDutyKnobDidSomething(arms)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "one arm under three names")
+	assert.Contains(t, err.Error(), "one arm under different names")
 }
 
 func TestDecreasingBurstCountsAcrossDutiesPass(t *testing.T) {
@@ -563,14 +585,18 @@ func runsWithBursts(v ...uint64) []schema.GPUPCRun {
 // The arm table itself, and the environment it produces.
 // ---------------------------------------------------------------------------
 
-// The three Tier A gaps are not free numbers: they are exactly what the
+// The four Tier A gaps are not free numbers: they are exactly what the
 // adapter's own duty ceiling produces for a 50 ms burst, which is why setting
 // the ceiling pins the gap. If either side ever changes, this fails.
+//
+// The 1% arm is held to the identical rule: 50 ms / 4950 ms is what
+// burst * (1/0.01 - 1) gives, so it cannot drift to a duty nobody configured
+// any more than the other three can.
 func TestTheArmTableIsThePlansAndItsDutiesAreExact(t *testing.T) {
-	require.Len(t, gpuPCArms, 5)
+	require.Len(t, gpuPCArms, 6)
 	assert.Equal(t, gpu.PCSamplingOff, gpuPCArms[0].Tier)
 	assert.Equal(t, gpu.PCSamplingContinuous, gpuPCArms[1].Tier)
-	for i, want := range []float64{0.10, 0.05, 0.025} {
+	for i, want := range []float64{0.10, 0.05, 0.025, 0.01} {
 		a := gpuPCArms[2+i]
 		assert.Equal(t, gpu.PCSamplingSerialized, a.Tier)
 		assert.Equal(t, 50, a.BurstMs, "the plan's burst length")
@@ -603,7 +629,7 @@ func TestEveryArmWritesItsTierExplicitly(t *testing.T) {
 // loop lengthen the gap and the arm would run at a duty nobody asked for.
 func TestTierAArmsPinTheGapFromBothSides(t *testing.T) {
 	cfg := gpuPCConfig{ShimPath: "x"}
-	for i, permille := range []int{100, 50, 25} {
+	for i, permille := range []int{100, 50, 25, 10} {
 		env := gpuPCArmEnv(cfg, gpuPCArms[2+i])
 		joined := strings.Join(env, " ")
 		assert.Contains(t, joined, "PERFAGENT_GPU_PC_BURST_MS=50")
@@ -717,4 +743,307 @@ func TestSkipReasonsAreReachableAndOrdered(t *testing.T) {
 	assert.Empty(t, gpuPCSkipReasonWith(true, true, full),
 		"with caps, a GPU and both binaries present, nothing may skip — otherwise the "+
 			"scenario would skip on the one machine it exists to run on")
+}
+
+// ---------------------------------------------------------------------------
+// The 1%-duty arm: why it exists, what it costs, and what it still has to
+// prove.
+//
+// It exists because "cost/duty > 2" is the same statement as
+// "cost% > 200 x duty", so at 2.5% duty it IS the 5% wall bar and
+// TIER_A_DEEP_DIVE_ONLY could not fire without TIER_A_UNSHIPPABLE outranking
+// it. The thresholds are unchanged; the input space is now wide enough for the
+// four clauses to be told apart.
+// ---------------------------------------------------------------------------
+
+// onePercentArm is the arm under test, found by its duty rather than by its
+// index, so a reordering of the table cannot make this test silently examine a
+// different arm.
+func onePercentArm() gpuPCArmSpec {
+	for _, a := range gpuPCArms {
+		if d := a.dutyConfigured(); d > 0 && d < 0.02 {
+			return a
+		}
+	}
+	panic("no sub-2% duty arm in gpuPCArms")
+}
+
+func TestTheOnePercentArmIsFiftyOverFourNineFiveZero(t *testing.T) {
+	a := onePercentArm()
+	assert.Equal(t, 50, a.BurstMs)
+	assert.Equal(t, 4950, a.GapMs)
+	assert.InDelta(t, 0.01, a.dutyConfigured(), 1e-12)
+	assert.InDelta(t, 0.01, lowestConfiguredDuty(), 1e-12)
+}
+
+// THE TEST THIS CHANGE EXISTS FOR. On the harness's own four duties, a Tier A
+// that is consistently inefficient (ratio above 2 everywhere) but genuinely
+// cheap at the lowest duty must reach TIER_A_DEEP_DIVE_ONLY — and must NOT
+// reach TIER_A_UNSHIPPABLE, which on the plan's original three duties it
+// always did.
+//
+// 22% / 11% / 5.5% / 3% at 10% / 5% / 2.5% / 1%: ratios 2.2, 2.2, 2.2, 3.0 —
+// every one above the bar — while the lowest duty costs 3%, inside the 5%
+// wall bar. Before the 1% arm the lowest duty was 2.5%, where 5.5% is over
+// that bar, and the harsher verdict took it.
+func TestTheOnePercentArmMakesDeepDiveOnlyReachable(t *testing.T) {
+	d := decide(armsWith(1.0, benchDuties(), []float64{22.0, 11.0, 5.5, 3.0}))
+
+	assert.Equal(t, verdictTierADeepDiveOnly, d.TierA,
+		"ratio above 2 at every duty with the lowest duty inside the wall bar is "+
+			"deep-dive-only; before the 1%% arm this verdict was unreachable")
+	assert.Contains(t, d.Fired, clauseTierARatioOverAtAll)
+	assert.NotContains(t, d.Fired, clauseTierASmallestOverBud)
+	joined := strings.Join(d.Lines, "\n")
+	assert.Contains(t, joined, "deliberate deep-dive mode")
+
+	// And the same table on the plan's original three duties still lands on
+	// unshippable, which is the finding this arm answers rather than hides.
+	before := decide(armsFor(1.0, [3]float64{22.0, 11.0, 5.5}))
+	assert.Equal(t, verdictTierAUnshippable, before.TierA)
+}
+
+// The loosening is disclosed. Evaluating the plan's fourth clause at the
+// lowest duty TESTED rather than at the 2.5% it names in prose can only make
+// it harder to fire, and on the table above the 2.5% arm really is over the
+// wall bar. A verdict that got friendlier because the table grew a lower arm
+// must not read as a verdict the numbers earned.
+func TestThePlansLiteralFourthClauseIsReportedWhenItWouldHaveFired(t *testing.T) {
+	d := decide(armsWith(1.0, benchDuties(), []float64{22.0, 11.0, 5.5, 3.0}))
+	joined := strings.Join(d.Lines, "\n")
+	assert.Contains(t, joined, "the plan words its fourth clause")
+	assert.Contains(t, joined, "DOES cost +5.50%")
+	assert.Contains(t, joined, "NOT as \"2.5% duty is within budget\"")
+}
+
+// The mirror: when the plan's literal wording agrees with the evaluated
+// clause, there is nothing to disclose and the note must not appear. A note
+// that fires unconditionally is a note nobody reads.
+func TestNoLiteralClauseNoteWhenThe25PercentArmIsWithinTheBar(t *testing.T) {
+	d := decide(armsWith(1.0, benchDuties(), []float64{4.0, 2.0, 1.0, 0.5}))
+	assert.Equal(t, verdictTierAOptIn, d.TierA)
+	assert.NotContains(t, strings.Join(d.Lines, "\n"), "the plan words its fourth clause")
+}
+
+// The coincidence note now has to say which of the two things happened. Below
+// 2.5% duty the harsh clauses are DIFFERENT conditions, so both firing means
+// the lowest duty is over the wall bar on its own merits — not that the
+// deep-dive branch was never available.
+func TestTheCoincidenceNoteSaysTheClausesSeparateBelowTwoAndAHalfPercent(t *testing.T) {
+	d := decide(armsWith(1.0, benchDuties(), []float64{30.0, 18.0, 9.0, 6.0}))
+	assert.Equal(t, verdictTierAUnshippable, d.TierA)
+	assert.Contains(t, d.Fired, clauseTierARatioOverAtAll)
+	assert.Contains(t, d.Fired, clauseTierASmallestOverBud)
+	joined := strings.Join(d.Lines, "\n")
+	assert.Contains(t, joined, "are DIFFERENT conditions")
+	assert.Contains(t, joined, "was reachable and was not reached")
+	assert.NotContains(t, joined, "the SAME condition",
+		"the old note claimed this table could not reach deep-dive; it can")
+}
+
+// All four pre-committed clauses, and all four Tier A verdicts, reachable on
+// the duties the harness actually runs. This is the property the 1% arm was
+// added for, asserted as a property rather than inferred from the one table
+// above.
+func TestAllFourClausesAndAllFourTierAVerdictsAreReachable(t *testing.T) {
+	duties := benchDuties()
+	require.Len(t, duties, 4)
+
+	optIn := decide(armsWith(7.5, duties, []float64{4.0, 2.0, 1.0, 0.5}))
+	smaller := decide(armsWith(1.0, duties, []float64{8.0, 4.0, 2.0, 1.0}))
+	deepDive := decide(armsWith(1.0, duties, []float64{22.0, 11.0, 5.5, 3.0}))
+	unship := decide(armsWith(1.0, duties, []float64{30.0, 18.0, 9.0, 6.0}))
+
+	fired := map[string]bool{}
+	for _, d := range []schema.GPUPCDecision{optIn, smaller, deepDive, unship} {
+		for _, c := range d.Fired {
+			fired[c] = true
+		}
+	}
+	for _, c := range []string{
+		clauseTierBOverBudget, clauseTierAHeadlineWithin,
+		clauseTierARatioOverAtAll, clauseTierASmallestOverBud,
+	} {
+		assert.True(t, fired[c], "clause %q must be reachable on the harness's own duties", c)
+	}
+
+	assert.Equal(t, verdictTierBExplicitOnly, optIn.TierB)
+	assert.Equal(t, verdictTierBAlwaysOnCandidate, smaller.TierB)
+	assert.Equal(t, verdictTierAOptIn, optIn.TierA)
+	assert.Equal(t, verdictTierASmallerDuty, smaller.TierA)
+	assert.Equal(t, verdictTierADeepDiveOnly, deepDive.TierA)
+	assert.Equal(t, verdictTierAUnshippable, unship.TierA)
+}
+
+// The price of the new arm, stated rather than discovered. On the plan's three
+// duties the decision was total because 2.5% was the coincidence point; below
+// it the two bars separate, so a table can now fail both without either harsh
+// clause firing. That is not a pass and does not become one — it means cost
+// did not fall with duty the way serialization says it must.
+//
+// 8% / 6% / 6% / 3%: at 1% duty 3% is inside the wall bar but its ratio is 3.0,
+// so nothing qualifies anywhere; the 5% arm's ratio is 1.2, so the every-duty
+// clause does not fire; and the lowest duty is inside the wall bar, so the
+// lowest-duty clause does not fire either.
+func TestOnTheHarnessDutiesIndeterminateIsReachableAndIsNotAPass(t *testing.T) {
+	d := decide(armsWith(1.0, benchDuties(), []float64{8.0, 6.0, 6.0, 3.0}))
+	assert.Empty(t, d.Fired, "no Tier A clause fires on this table")
+	assert.Equal(t, verdictTierAIndeterminate, d.TierA)
+	assert.Contains(t, strings.Join(d.Lines, "\n"), "do not read this as a pass")
+}
+
+// ---------------------------------------------------------------------------
+// What the 1% arm costs: run length, derived from the table and announced
+// before the GPU time is spent.
+// ---------------------------------------------------------------------------
+
+// A burst opens once per burst+gap cycle, so the arm with the longest cycle
+// sets the floor on how long the fixed work must take. At 1% duty the cycle is
+// 5 s and four bursts need 20 s, against the 8 s the 2.5% arm needed. The
+// floor is DERIVED from the table so that trimming or adding an arm cannot
+// leave it stale, and it carries one extra cycle because the count is of
+// completed cycles and the first burst does not open at t=0.
+func TestTheFixedWorkFloorIsDerivedFromTheLowestDutyArm(t *testing.T) {
+	assert.Equal(t, 5000, gpuPCLongestTierACycleMs(), "the 1% arm's 50 ms + 4950 ms")
+	assert.InDelta(t, 25.0, gpuPCMinFixedWorkSec(4), 1e-9, "(4+1) bursts x 5 s")
+	assert.InDelta(t, 10.0, gpuPCMinFixedWorkSec(1), 1e-9)
+
+	// Strictly more than the 8 s the plan's old lowest arm needed, which is
+	// the whole cost of the change and must not be silently absorbed.
+	assert.Greater(t, gpuPCMinFixedWorkSec(4), 5*2.0,
+		"the 1% arm demands a longer run than the 2.5% arm did")
+}
+
+// ---------------------------------------------------------------------------
+// The 1% arm proves its own mode on exactly the same terms as every other arm.
+// An arm that cannot prove its mode is this project's standing defect wearing
+// a stopwatch.
+// ---------------------------------------------------------------------------
+
+// A 25 s run at a 5 s cycle opens about five bursts, so this is the shape a
+// passing 1% arm really has: few bursts, ten windows, a duty just over 0.01,
+// and at least one execution actually marked serialized.
+func goodOnePercentRun() schema.GPUPCRun {
+	return schema.GPUPCRun{Evidence: schema.GPUPCEvidence{
+		ProducerTier: gpu.PCSamplingNameSerialized, ProducerPCRecords: 210,
+		ProducerBursts: 5, ProducerWindows: 10, ProducerDuty: 0.0104,
+		PCSamplesDecoded: 210, SamplingWindowsDecoded: 10,
+		SamplingWindowsReceived: 10, ExecutionsSeen: 4000,
+		ExecutionsSerialized: 41, ExecutionsNotSerialized: 3959,
+		SnapshotTier: gpu.PCSamplingNameSerialized,
+	}}
+}
+
+func TestTheOnePercentArmMustOpenItsBursts(t *testing.T) {
+	r := goodOnePercentRun()
+	r.Evidence.ProducerBursts, r.Evidence.ProducerWindows = 3, 6
+	err := assertArmRanInItsMode(testCfg(), onePercentArm(), r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "want at least 4")
+}
+
+func TestTheOnePercentArmMustSerializeSomething(t *testing.T) {
+	r := goodOnePercentRun()
+	r.Evidence.ExecutionsSerialized = 0
+	err := assertArmRanInItsMode(testCfg(), onePercentArm(), r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not measure serialization")
+}
+
+// The achieved-duty bound is derived per arm, not shared: at a 50 ms burst
+// with a 10 ms tick the ceiling is (50+20)/(50+20+4950) = 1.39%, so an arm
+// that actually ran at the 2.5% arm's duty is caught rather than averaged in.
+func TestTheOnePercentArmMustRunAtOnePercent(t *testing.T) {
+	r := goodOnePercentRun()
+	r.Evidence.ProducerDuty = 0.025
+	err := assertArmRanInItsMode(testCfg(), onePercentArm(), r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "achieved duty 0.0250")
+
+	// The burst timer's granularity legitimately overshoots; that must pass.
+	r.Evidence.ProducerDuty = 0.0135
+	require.NoError(t, assertArmRanInItsMode(testCfg(), onePercentArm(), r))
+
+	// And a duty far BELOW the configured one is a failure too: it would
+	// mean bursts were being skipped, and the ratio's denominator would be
+	// a duty that never happened.
+	r.Evidence.ProducerDuty = 0.002
+	require.Error(t, assertArmRanInItsMode(testCfg(), onePercentArm(), r))
+}
+
+func TestTheOnePercentArmMustReconcileItsWindows(t *testing.T) {
+	r := goodOnePercentRun()
+	r.Evidence.ProducerWindows = 7 // neither 10 nor 9
+	err := assertArmRanInItsMode(testCfg(), onePercentArm(), r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "want 2N or 2N-1")
+}
+
+func TestTheOnePercentArmMustNotRunInAGraphProcess(t *testing.T) {
+	r := goodOnePercentRun()
+	r.Evidence.ProducerGraphRefuse = 1
+	err := assertArmRanInItsMode(testCfg(), onePercentArm(), r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CUDA graph executions observed")
+}
+
+func TestTheOnePercentArmMustNotFailToStartOrStop(t *testing.T) {
+	r := goodOnePercentRun()
+	r.Evidence.ProducerStartFailed = 1
+	err := assertArmRanInItsMode(testCfg(), onePercentArm(), r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cuptiPCSamplingStart failed")
+}
+
+// The cross-arm proof extends to four arms: 1% must open strictly fewer bursts
+// than 2.5%. If it did not, the duty environment did not take on the new arm
+// and its ratio — the one that makes deep-dive reachable — is fiction.
+func TestFourDecreasingBurstCountsPass(t *testing.T) {
+	require.NoError(t, assertDutyKnobDidSomething(fourArmBursts(
+		[]uint64{48, 49, 48}, []uint64{24, 25, 24},
+		[]uint64{12, 12, 13}, []uint64{5, 5, 6})))
+}
+
+func TestTheOnePercentArmOpeningAsManyBurstsAsTheTwoAndAHalfFails(t *testing.T) {
+	err := assertDutyKnobDidSomething(fourArmBursts(
+		[]uint64{48, 49, 48}, []uint64{24, 25, 24},
+		[]uint64{12, 12, 13}, []uint64{12, 13, 12}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "one arm under different names")
+	assert.Contains(t, err.Error(), "1% duty")
+}
+
+func fourArmBursts(ten, five, twoFive, one []uint64) []schema.GPUPCArm {
+	arms := []schema.GPUPCArm{{Name: "baseline", Tier: gpu.PCSamplingNameOff}}
+	for i, duty := range benchDuties() {
+		arms = append(arms, schema.GPUPCArm{
+			Name:           fmt.Sprintf("tier A %g%% duty", duty*100),
+			Tier:           gpu.PCSamplingNameSerialized,
+			DutyConfigured: duty,
+			Runs:           runsWithBursts([][]uint64{ten, five, twoFive, one}[i]...),
+		})
+	}
+	return arms
+}
+
+// The floor is announced and enforced BEFORE any GPU time is spent, and a
+// configuration no sizing can satisfy is refused rather than discovered
+// twenty minutes in. The workload path here does not exist, so reaching the
+// calibration run at all would produce a different message.
+func TestAnImpossibleFixedWorkWindowIsRefusedBeforeAnythingRuns(t *testing.T) {
+	var out strings.Builder
+	doc := &schema.Document{}
+	ok := runGPUPCOverhead(doc, gpuPCConfig{
+		WorkloadPath: "/nonexistent/cuda_concurrent", Runs: 5, MinBursts: 4,
+		MinCalibrationSec: 10, MaxCalibrationSec: 20,
+	}, &out)
+
+	assert.False(t, ok)
+	s := out.String()
+	assert.Contains(t, s, "6 arms x 5 interleaved runs + 1 calibration = 31 fixed-work runs")
+	assert.Contains(t, s, "the fixed work must take 25-20 s")
+	assert.Contains(t, s, "No sizing can satisfy both")
+	assert.NotContains(t, s, "calibration run failed",
+		"the guard must fire before the calibration run, not after it")
+	assert.Zero(t, doc.GPUPC.Decision.TierA, "no verdict may be recorded")
 }

--- a/bench/cmd/scenario/main.go
+++ b/bench/cmd/scenario/main.go
@@ -55,9 +55,17 @@ func main() {
 		// tunes only --gpu-rounds and --gpu-iters, and only if the
 		// calibration pass says the fixed work is mis-sized for the
 		// device in front of it.
-		gpuShim        = flag.String("gpu-shim", "", "gpu-pc-overhead: the CUPTI adapter .so (default ./shim/libperfagent-gpu-nvidia.so)")
-		gpuWorkload    = flag.String("gpu-workload", "", "gpu-pc-overhead: the concurrent CUDA workload (default ./shim/nvidia/testdata/cuda_concurrent)")
-		gpuIters       = flag.Int("gpu-iters", 20000, "gpu-pc-overhead: timed iterations; each launches --gpu-streams kernels")
+		gpuShim     = flag.String("gpu-shim", "", "gpu-pc-overhead: the CUPTI adapter .so (default ./shim/libperfagent-gpu-nvidia.so)")
+		gpuWorkload = flag.String("gpu-workload", "", "gpu-pc-overhead: the concurrent CUDA workload (default ./shim/nvidia/testdata/cuda_concurrent)")
+		// 30000 rather than 20000 because the 1%-duty arm's burst+gap
+		// cycle is 5 s and it must open --gpu-min-bursts of them: the
+		// fixed work therefore has a DERIVED floor of ~25 s (see
+		// gpuPCMinFixedWorkSec), and 20000 iterations was estimated at
+		// ~20-30 s, straddling it. Both figures are estimates from a
+		// dependency-chain latency guess, not measurements; the
+		// calibration pass is what turns a wrong guess into a named
+		// retuning instruction instead of a meaningless arm.
+		gpuIters       = flag.Int("gpu-iters", 30000, "gpu-pc-overhead: timed iterations; each launches --gpu-streams kernels")
 		gpuWarmup      = flag.Int("gpu-warmup", 64, "gpu-pc-overhead: untimed warm-up iterations before the clock starts")
 		gpuStreams     = flag.Int("gpu-streams", 4, "gpu-pc-overhead: concurrent CUDA streams — the concurrency Tier A destroys")
 		gpuRounds      = flag.Int("gpu-rounds", 64000, "gpu-pc-overhead: FMA rounds per direction; this is what sets kernel duration")
@@ -67,7 +75,7 @@ func main() {
 		gpuMinConc     = flag.Float64("gpu-min-concurrency", 1.5, "gpu-pc-overhead: minimum kernel concurrency the BASELINE arm must show, or the run fails as a microbenchmark")
 		gpuMinKernelUs = flag.Float64("gpu-min-kernel-us", 50, "gpu-pc-overhead: minimum mean kernel duration the BASELINE arm must show, in microseconds")
 		gpuMinBursts   = flag.Uint64("gpu-min-bursts", 4, "gpu-pc-overhead: minimum bursts every Tier A arm must open for its duty to mean anything")
-		gpuMinCalSec   = flag.Float64("gpu-min-calibration-sec", 10, "gpu-pc-overhead: shortest acceptable uninjected fixed-work time")
+		gpuMinCalSec   = flag.Float64("gpu-min-calibration-sec", 10, "gpu-pc-overhead: shortest acceptable uninjected fixed-work time; RAISED to the floor derived from the lowest-duty arm's cycle x --gpu-min-bursts, never lowered below it")
 		gpuMaxCalSec   = flag.Float64("gpu-max-calibration-sec", 120, "gpu-pc-overhead: longest acceptable uninjected fixed-work time")
 	)
 	flag.Parse()

--- a/bench/internal/schema/schema.go
+++ b/bench/internal/schema/schema.go
@@ -23,7 +23,7 @@ type Document struct {
 
 	// GPUPC holds the gpu-pc-overhead scenario's whole result. It hangs
 	// off Document rather than off Run because that scenario's unit of
-	// result is the ARM (five of them, five interleaved runs each), not
+	// result is the ARM (six of them, five interleaved runs each), not
 	// the run. Nil, and absent from the JSON, for every other scenario.
 	GPUPC *GPUPCOverhead `json:"gpu_pc_overhead,omitempty"`
 }
@@ -155,7 +155,7 @@ type GPUPCOverhead struct {
 	// clocks before the first arm.
 	Calibration GPUPCArm `json:"calibration,omitzero"`
 
-	// Arms are the five arms in the order they were run, baseline first.
+	// Arms are the six arms in the order they were run, baseline first.
 	Arms []GPUPCArm `json:"arms"`
 
 	// Decision is what the thresholds say. See GPUPCDecision.
@@ -188,7 +188,7 @@ type GPUPCArm struct {
 	BurstMs int `json:"burst_ms,omitzero"`
 	GapMs   int `json:"gap_ms,omitzero"`
 	// DutyConfigured is burst/(burst+gap) as configured: 0.10, 0.05,
-	// 0.025. It is the denominator the pre-committed thresholds name
+	// 0.025, 0.01. It is the denominator the pre-committed thresholds name
 	// ("Tier A at 10% duty"), so it is what the ratio is computed
 	// against. DutyAchieved is what the producer reported it actually
 	// did, and the two disagreeing by more than the tolerance FAILS the

--- a/docs/superpowers/plans/2026-08-25-gpu-pc-sampling.md
+++ b/docs/superpowers/plans/2026-08-25-gpu-pc-sampling.md
@@ -535,6 +535,19 @@ Because Tier A perturbs the workload, `serialized` must also be refused unless e
 | Tier A, 50 ms burst / 450 ms gap (10% duty) | the headline number |
 | Tier A, 50 ms / 950 ms (5%) | |
 | Tier A, 50 ms / 1950 ms (2.5%) | |
+| Tier A, 50 ms / 4950 ms (1%) | added after the finding below; the duty at which the third and fourth clauses stop being the same condition |
+
+The 1% arm is not a sixth row for its own sake. Without a duty **below 2.5%** the third
+clause cannot fire without the fourth firing too, and *"ships only as a deliberate deep-dive
+mode"* is unreachable whatever the numbers are — see the finding at the end of this task. The
+thresholds are unchanged; the arm table is what widened.
+
+**It costs run length, and that is worth knowing before starting.** A 1% duty at a 50 ms burst is
+a 4950 ms gap, so one burst opens every 5 s. Every Tier A arm must open at least four of them for
+its duty fraction to mean anything, so the fixed work must take **at least ~25 s** — against the
+~8 s the 2.5% arm needed. The harness derives that floor from the arm table, announces it before
+running anything, and refuses a configuration no sizing can satisfy. Together with the extra five
+runs this takes the benchmark from ~26 runs / 15–25 minutes to **31 runs / 25–40 minutes**.
 
 **The number that matters is cost ÷ duty fraction, not cost alone.** Serialization's damage does not stop when the burst does — concurrency has to refill afterwards — so if the ratio is near 1, duty-cycling works and the tier is tunable to any budget. If the ratio is much greater than 1, duty-cycling is not buying what it appears to and a smaller duty will not rescue it.
 
@@ -543,11 +556,11 @@ Because Tier A perturbs the workload, `serialized` must also be refused unless e
 - **Tier B > 5% wall-clock on a realistic workload → Tier B does not ship as always-on**; it becomes an explicitly-enabled mode like Tier A.
 - **Tier A at 10% duty ≤ 5% wall-clock, and cost ÷ duty ≤ 2 → ships as an opt-in tier**, as planned.
 - **cost ÷ duty > 2 at every duty tested → Tier A ships only as a deliberate deep-dive mode**, with the operator warning of Task 11 and no suggestion that it is suitable for continuous use.
-- **Tier A at 2.5% duty > 5% wall-clock → Tier A is unshippable in this phase.** Serialization would then be costing more than the sampling window can explain, and duty-cycling has no remaining lever.
+- **Tier A at 2.5% duty > 5% wall-clock → Tier A is unshippable in this phase.** Serialization would then be costing more than the sampling window can explain, and duty-cycling has no remaining lever. **The lever this clause names is the lowest duty on the table**, so with the 1% arm added the harness evaluates it there — which makes it strictly weaker than its literal 2.5% wording. That is a real loosening and it is what makes the third clause reachable; the harness therefore names the clause `tier-a-lowest-duty-cost-over-5pct` and prints the 2.5% arm's cost in as many words whenever the difference changes the answer.
 
 Record the numbers in this file when they exist. A threshold decided after seeing the data is not a threshold.
 
-**The harness exists; the numbers do not.** `bench/cmd/scenario --scenario gpu-pc-overhead` implements everything above — the five arms, the interleaving, the medians, the ratio and the four clauses — and prints the verdict as a stable identifier rather than as prose. The workload is `shim/nvidia/testdata/cuda_concurrent.cu` (see `.superpowers/sdd/task-12-overhead-report.md` for why it is a second workload and not a change to `cuda_workload.cu`). On the RTX 3090:
+**The harness exists; the numbers do not.** `bench/cmd/scenario --scenario gpu-pc-overhead` implements everything above — the six arms, the interleaving, the medians, the ratio and the four clauses — and prints the verdict as a stable identifier rather than as prose. The workload is `shim/nvidia/testdata/cuda_concurrent.cu` (see `.superpowers/sdd/task-12-overhead-report.md` for why it is a second workload and not a change to `cuda_workload.cu`). On the RTX 3090:
 
 ```bash
 make -C shim nvidia nvidia-concurrent && make bench-build
@@ -555,9 +568,13 @@ sudo setcap cap_bpf,cap_perfmon,cap_checkpoint_restore+ep ./bench/cmd/scenario/s
 make bench-gpu-pc-overhead
 ```
 
-**Nothing here has been measured.** The arm table above is still expectations, not results, and the tier decision is not yet made.
+**Nothing here has been measured.** The arm table above is still expectations, not results, and the tier decision is not yet made. The 1% arm has never executed either: adding it made a verdict *reachable*, not measured.
 
-One finding from building it, which is a property of the thresholds rather than of the hardware: `cost ÷ duty > 2` is the same statement as `cost > 200 × duty` percent, so at **2.5% duty it is exactly `cost > 5%`** — the wall-clock bar. On the three duties above, the third clause therefore strictly implies the fourth and *"ships only as a deliberate deep-dive mode"* is unreachable; the unshippable verdict always outranks it. The two clauses separate only below 2.5% duty. The harness reports this whenever both fire rather than letting a reader conclude the deep-dive branch was considered and rejected. Adding a 1%-duty arm would make the distinction real; that is a decision for whoever runs it.
+One finding from building it, which is a property of the thresholds rather than of the hardware: `cost ÷ duty > 2` is the same statement as `cost > 200 × duty` percent, so at **2.5% duty it is exactly `cost > 5%`** — the wall-clock bar. On the plan's original three duties the third clause therefore strictly implied the fourth and *"ships only as a deliberate deep-dive mode"* was unreachable; the unshippable verdict always outranked it. The two clauses separate only below 2.5% duty.
+
+**That is why the 1% arm is in the table above.** At 1% duty `ratio > 2` means `cost > 2%`, comfortably inside the 5% bar, so a tier that is consistently inefficient but genuinely cheap at low duty lands in deep-dive rather than being killed. Worked example, pinned by `TestTheOnePercentArmMakesDeepDiveOnlyReachable`: costs of 22% / 11% / 5.5% / 3% at 10% / 5% / 2.5% / 1% give ratios 2.2 / 2.2 / 2.2 / 3.0 — all above the bar, so the third clause fires — while the lowest duty costs 3%, inside the wall bar, so the fourth does not. Verdict: `TIER_A_DEEP_DIVE_ONLY`.
+
+The trade, stated rather than absorbed: on three duties the decision was *total* (2.5% was the coincidence point, so the lowest arm either passed both bars or failed both). Below that point the bars separate, so `TIER_A_INDETERMINATE` — *"cost did not fall with duty the way serialization says it must; do not read this as a pass"* — becomes reachable. That is the correct thing to say about such a table, and it is a named verdict rather than a fallthrough to the friendliest neighbouring answer. The harness still reports the coincidence if the table is ever trimmed back to 2.5%.
 
 **Verification without a GPU or capabilities — partial.** The scenario harness builds and reports `BENCH_SKIPPED` without caps or GPU, in the shape `bench/cmd/scenario/main.go` already uses. That is all that can be proven offline.
 


### PR DESCRIPTION
Task 12's own analysis found that on the plan's three duties, one of the four pre-committed outcomes is **unreachable**.

`cost ÷ duty > 2` is the same statement as `cost > 200 × duty` percent — so at 2.5% duty it is *exactly* the 5% wall-clock bar. `TIER_A_DEEP_DIVE_ONLY` requires ratio > 2 at **every** duty tested, which includes 2.5%, so it strictly implies `TIER_A_UNSHIPPABLE`. Deep-dive could never fire alone, whatever the numbers.

That matters because deep-dive means *"the tier works, but only as a deliberate tool"* — a materially different answer from *"the tier does not ship"*.

### The arm

Tier A at 50 ms burst / 4950 ms gap = 1% duty. `min_gap = 50 × (1/0.01 − 1) = 4950 ms`, and `MAX_DUTY_PERMILLE=10` + `MAX_GAP_MS=4950` collapse the burst controller's clamp interval to a point, exactly as the other three do.

Every existing guarantee applies unchanged, because they were written per-arm: bursts ≥ floor, windows = 2N or 2N−1, no start/stop failures, no graph execs, `ExecutionsSerialized > 0`, `SnapshotTier == serialized`, and an achieved duty inside its own derived bound (1.39%). The cross-arm *"lower duty opens strictly fewer bursts"* check already walked the table in descending duty, so 1% is held against 2.5% automatically; tests now pin that.

**No threshold was changed.** The plan's four clauses stay exactly as written; this only widens the input space so all four become distinguishable.

### Two consequences, disclosed rather than absorbed

**The run gets materially longer.** At 1% duty one burst opens every 5 s, so the four-burst floor needs 20 s of fixed work against the 8 s the 2.5% arm needed. `gpuPCMinFixedWorkSec` derives a **25 s** floor from the arm table, raises `--gpu-min-calibration-sec` to it, prints it before anything runs, and **refuses a window no sizing can satisfy before spending GPU time**. Default `--gpu-iters` moves 20000 → 30000.

**26 runs / 15–25 min becomes 31 runs / 25–40 min.** Both sizings are unmeasured guesses; the calibration pass now also names an `--gpu-iters` value to try.

**The fourth clause's evaluation point moved, and it is a real loosening.** The plan words clause 4 *"at 2.5% duty"* but reasons from *"duty-cycling has no remaining lever"* — the lowest duty on the table. Evaluating at 1% is what that reason asks for, and it is exactly what makes clause 3 reachable. But it is strictly weaker than the literal wording.

So the clause id is now `tier-a-lowest-duty-cost-over-5pct`, and whenever the difference changes the answer the harness prints the 2.5% arm's actual cost above the verdict: *"Read this as 'unshippable does not fire at 1.0% duty', NOT as '2.5% duty is within budget'."* Silent when there is nothing to disclose.

### One property traded away, deliberately

On three duties the decision was **total** *because* 2.5% was the coincidence point. Below it the bars separate, so `TIER_A_INDETERMINATE` becomes reachable. That is the same fact as the unreachability, seen from the other side — it is the price. It is pinned as "not a pass", with the original three-duty totality test kept unchanged beside it.

The old coincidence note claimed *"this table does not test below 2.5%"*, which is now false; it branches, and the old branch stays reachable if the table is ever trimmed back.

### Tests: 45 → 62

The one that was previously impossible: `TestTheOnePercentArmMakesDeepDiveOnlyReachable` — 22/11/5.5/3% at 10/5/2.5/1% gives ratios 2.2/2.2/2.2/3.0 with the lowest costing 3%, verdict `TIER_A_DEEP_DIVE_ONLY`. **The same costs on the original three duties still assert `TIER_A_UNSHIPPABLE`**, so the finding is recorded rather than erased.

Plus `TestAllFourClausesAndAllFourTierAVerdictsAreReachable`, both halves of the coincidence note, the disclosure note firing and staying silent, the derived floor, the impossible-window guard proven to fire before any run, and the 1% arm shown red on each of: too few bursts, nothing serialized, windows not reconciling, duty over the ceiling, duty far below configured, graph process, failed `cuptiPCSamplingStart`.

### Not measured

`CapEff: 0`, no GPU. **No arm of this benchmark has ever executed**, and that is stated in both documents and the commit message. The plan's Task 12 arm table gains the row, and its finding paragraph now records what was done about it.