### PR TITLE
gpu: serialise every adapter-initiated CUPTI call

### DIFF
--- a/.superpowers/sdd/issue-99-deadlock-report.md
+++ b/.superpowers/sdd/issue-99-deadlock-report.md
@@ -1,0 +1,437 @@
+# Issue #99 — Tier A deadlocks the profiled process inside CUPTI
+
+Branch `fix/cupti-call-serialization`, one commit on top of `origin/main` (`93cccd69`, the Task 12
+merge).
+
+The adapter called CUPTI from two independent background threads with nothing serialising them.
+It now calls CUPTI from **one** background thread, and every call it makes — from that thread or
+from an application thread inside one of our callbacks — goes through **one guard**. The raw CUPTI
+entry points are poisoned in the adapter's translation unit, so a future call site that skips the
+guard does not compile.
+
+---
+
+## 1. What the headers say about concurrent use
+
+This was the first thing to establish, because it decides whether the fix is mandatory or merely
+defensive. CUDA 13.3, `/usr/local/cuda-13.3/targets/x86_64-linux/include/`.
+
+**CUPTI documents thread safety per function — and does it in three of its headers:**
+
+| header | `\note \b Thread-safety:` occurrences |
+| --- | --- |
+| `cupti_events.h` | 32 |
+| `cupti_callbacks.h` | 8 |
+| `cupti_result.h` | 2 |
+| **`cupti_activity.h`** | **0** |
+| **`cupti_pcsampling.h`** | **0** |
+
+`cupti_callbacks.h` shows the vendor is precise about it when it matters, in both directions:
+
+> `\note \b Thread-safety: a subscriber must serialize access to cuptiGetCallbackState,
+> cuptiEnableCallback, cuptiEnableDomain, and cuptiEnableAllDomains. For example, if
+> cuptiGetCallbackState(sub, d, c) and cuptiEnableCallback(sub, d, c) are called concurrently,
+> the results are undefined.`
+
+So: **neither `cuptiActivityFlushAll` nor any PC-sampling entry point carries a thread-safety
+guarantee of any kind.** Not "documented unsafe" — *unstated*, in a library that states it
+elsewhere. Calling two of them concurrently was never sanctioned; it was untested, and on an
+RTX 3090 it deadlocked.
+
+**That makes the fix mandatory rather than defensive**, and it changes the design: there is no
+documented lock ordering inside CUPTI to reason about and no subset of pairs that is known safe, so
+the correct target is *never overlap*, not *overlap carefully*. That is why the fix is a single
+lock plus a single thread rather than an ordering rule.
+
+Two further things the headers say that the design uses:
+
+- `cuptiActivityFlushAll` is **"a blocking call"** which returns buffers "using the callback
+  registered in `cuptiActivityRegisterCallbacks`", and "Default flush can be done at a regular
+  interval in a separate thread." A separate thread is sanctioned; a *second* separate thread doing
+  something else is not mentioned either way.
+- The buffer-completed callback: "After this call CUPTI relinquished ownership of the buffer and
+  will not use it anymore."
+
+**Callback-context restriction.** CUPTI does not publish a general "these entry points must not be
+called from within a callback" list in these headers. The only positive statement is on
+`cuptiGetDeviceId`, which is documented as behaving like `cuCtxGetDevice` "but **may** be called
+from within callback functions" — phrasing that only means anything if the general case is not
+assured. The adapter's own timers are not callbacks, so this does not bear on them directly; the
+application thread that deadlocked *was* inside a launch callback, but that is CUPTI's own frame,
+not a call we made. What the adapter does do from inside callbacks is call the PC-sampling API and
+`cuptiGetCubinCrc` on `CONTEXT_CREATED` / `CONTEXT_DESTROY_STARTING` / `MODULE_UNLOAD_STARTING` /
+`MODULE_LOADED` — that predates this issue, is unchanged, and is now covered by the same guard.
+
+Nothing here is a hardware measurement. It is a reading of the shipped headers, which is a
+different kind of evidence and a stronger one for this particular question.
+
+---
+
+## 2. The option chosen, and why
+
+The issue offers two: give the activity flush the same mutex, or put drain and burst work on one
+thread. **Both are implemented, because neither alone is sufficient, and the reasons differ.**
+
+**One thread alone is not sufficient.** It removes the *reported* deadlock — the two threads in the
+backtrace merge into one — but the adapter also calls CUPTI from the application's threads, inside
+`CONTEXT_CREATED`, `CONTEXT_DESTROY_STARTING`, `MODULE_UNLOAD_STARTING` and `MODULE_LOADED`. Those
+were serialised against the timers only for the PC-sampling family (`g_pc_mu`) and not at all for
+`cuptiGetCubinCrc`. A single timer thread leaves an app thread and the timer thread able to be
+inside CUPTI at once.
+
+**One lock alone is not sufficient either** — or rather, it is sufficient for correctness but weak
+as an argument. It excludes the bad state by discipline: every call site must remember. The bug
+being fixed *is* a call site that did not remember. A lock alone would leave the same failure mode
+one careless patch away.
+
+So:
+
+**(a) Structural half — one background thread.** The second `Drainer` is gone. One timer runs at the
+shorter of the two periods (the burst tick when Tier A is on, the drain period otherwise) and
+dispatches the burst poll and then, rate-limited, the activity drain (`core/tickplan.h`,
+`on_timer_tick`). *The adapter now has exactly one thread of its own from which it can ever call
+CUPTI.* "Two of our background threads inside CUPTI" is not a state the process can represent,
+whatever a future call site does.
+
+**(b) Discipline half — one guard over the whole vendor surface.** `g_pc_mu` is replaced by
+`perfagent::cupti::guard()` (`shim/nvidia/cupti_guard.h`, built on `shim/core/callguard.h`), taken by
+every CUPTI call the adapter initiates — PC sampling, activity, subscription, timestamp, cubin CRC,
+result strings. One lock rather than one per subsystem, so there is **no ordering between our own
+locks left to get wrong**.
+
+**(c) The bit that makes (b) not depend on memory.** `cupti_guard.h` defines a guarded wrapper for
+every CUPTI entry point the adapter uses, and then `#define`s the raw names to identifiers that
+exist nowhere. From that include onward, `cuptiActivityFlushAll(0)` is a compile error naming the
+wrapper to use. Since each wrapper *takes the guard itself*, there is no way to name a CUPTI
+function in this translation unit without acquiring the lock.
+
+### The claim, stated exactly
+
+> **At most one adapter-initiated CUPTI call is in flight at any instant, process-wide.**
+
+with one named exception (§5). This is a structural claim, not a probabilistic one: it follows from
+(i) every call site acquiring a single mutual-exclusion primitive, and (ii) the impossibility of
+writing a call site that does not. It is not "the window is now very small".
+
+The reported deadlock is specifically unreachable: it required `cuptiPCSamplingStop` and
+`cuptiActivityFlushAll` to be in flight simultaneously, and both halves of the fix independently
+prevent that.
+
+### What it does *not* claim
+
+It does not claim CUPTI cannot deadlock. CUPTI invokes its own callbacks on its own worker threads
+concurrently with whatever we are doing, and the adapter cannot serialise CUPTI against itself. It
+claims only that the adapter no longer *creates* the concurrency, which is what issue #99 says the
+cause was.
+
+---
+
+## 3. The lock ordering, in the code
+
+Written at the top of `shim/nvidia/cupti_guard.h`:
+
+> `perfagent::cupti::guard()` is the **outermost** lock in this adapter. Every other mutex it owns —
+> the clock fit, the device list, `Batch`, `KernelNameTable`, `ReplayLog`, `CubinQueue`,
+> `BurstController`, `PCDrainSchedule` — is a **leaf**: each is taken and released without calling
+> CUPTI and without acquiring the guard, so they may all be taken while holding it and none may be
+> held while acquiring it.
+
+Checked path by path against the current source:
+
+| path | locks, in order |
+| --- | --- |
+| `resample_clock` | guard (inside `GetTimestamp`), released; then `g_clock_mu` |
+| `on_module_loaded` → `CubinQueue::capture` → `cupti_cubin_crc` | guard; `CubinQueue::mu_` is taken *after* the CRC returns, never across it |
+| `pc_drain_ctx_locked` | guard → `Batch::mu_` (leaf) |
+| `pc_query_stall_reasons` | guard → `ReplayLog::mu_` (leaf) |
+| `burst_close` | `BurstController::mu_` taken and released by `poll()` first, **then** guard → `PCDrainSchedule::mu_`; guard released before `emit_window` and `g_burst->closed()` |
+| `on_finalize` | `BurstController::mu_` (released), then guard via `TryCallScope` |
+| `buffer_completed` | no guard; `g_clock_mu`, `g_dev_mu`, `Batch::mu_` |
+| `at_exit_handler` | no guard held across `g_timer->stop()` |
+
+With one vendor lock and every other mutex a leaf, a cycle would need two adapter locks with a
+CUPTI call between them, and there is none.
+
+The guard is **re-entrant on the owning thread**, and that is a requirement rather than a
+convenience — see §4 and §6.
+
+---
+
+## 4. How a future call site is prevented from bypassing it
+
+Three layers, weakest to strongest.
+
+1. **Naming.** The only spelling of a CUPTI call in the adapter is
+   `perfagent::cupti::PCSamplingStop(...)`, and the wrappers do nothing except take the guard and
+   forward.
+
+2. **The poison.** After the wrappers, `cupti_guard.h` contains 19 lines of the form
+
+   ```c
+   #define cuptiActivityFlushAll PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_ActivityFlushAll
+   ```
+
+   A call site that reaches for the raw name gets `error: use of undeclared identifier
+   'PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_ActivityFlushAll'`, which names the fix.
+   Only function names are poisoned; `CUpti_*` types and enumerators are untouched.
+
+3. **`make -C shim check-cupti-guard`**, a build step and a prerequisite of `make -C shim nvidia`,
+   built to the same shape as the existing `check-cubin-defer`: `nvidia/cupti_guard_test.cc`
+   compiled six times.
+
+   - **Mode 0 is the control and MUST compile.** Without it the whole check would pass just as
+     happily on a file that fails to build for an unrelated reason — a typo, a CUDA version bump —
+     and would then be proving nothing, which is the exact shape of the defects this project has
+     shipped reading green at the worst moment.
+   - Modes 1–5 must all be rejected: `cuptiActivityFlushAll` from a timer (**literally the bug**),
+     `cuptiPCSamplingStop` (**the other thread in the same backtrace**), `cuptiPCSamplingGetData`,
+     taking the raw function's address to call later, and a `::`-qualified raw call.
+
+   ```
+   check-cupti-guard: OK - the guarded call compiles, all 5 unguarded do not
+   ```
+
+The guard primitive itself has a unit test with no GPU: `shim/core/callguard_test.cc`, run by
+`make -C shim test` and again under ThreadSanitizer by `make -C shim test-tsan`. It asserts mutual
+exclusion across 8 threads × 2000 iterations (an unguarded `long` increment plus an explicit
+overlap detector), three-deep re-entrancy, the two `try` refusals, and that a re-entrantly released
+guard is genuinely free afterwards. **It is not vacuous:** with the exclusion removed from
+`CallGuard::enter`/`leave`, the test fails.
+
+`shim/core/tickplan_test.cc` covers the merged schedule against a fake clock: the tick period with
+Tier A on and off, that the drain period is never lengthened by more than one tick over a simulated
+minute, that a late tick leaves no debt firing catch-up drains, and — the case that matters most —
+that the **default** configuration gets no rate limit at all (see §7).
+
+---
+
+## 5. The one exemption, and its boundary
+
+`cuptiActivityGetNextRecord` and `cuptiActivityGetNumDroppedRecords`, called from inside CUPTI's
+`buffer_completed` callback, are **not** guarded.
+
+This is a reasoned boundary, not an oversight, and the reason is that guarding them would rebuild
+the very deadlock: `cuptiActivityFlushAll` is documented as a blocking call that returns buffers
+through that callback. If CUPTI delivers them on a worker thread while our timer thread holds the
+guard across the flush, a guarded callback blocks the worker on a lock the flusher is waiting for
+it to release.
+
+The boundary is: **the guard covers calls the adapter initiates on a thread of its own choosing.
+It does not cover the documented way to consume a buffer CUPTI has just handed us and, in its own
+words, "relinquished ownership of."**
+
+Because "we only call these two from that callback" is exactly the kind of claim this project has
+been wrong about before, it is not left as a comment:
+
+- the wrappers are named `ActivityGetNextRecord_InBufferCompletedOnly` and
+  `ActivityGetNumDroppedRecords_InBufferCompletedOnly`;
+- `buffer_completed` establishes a `BufferCompletedScope` (a thread-local flag) on entry, and both
+  wrappers **count** a call made outside one;
+- the count is reported as `cupti_calls_misplaced` and **must be 0**.
+
+---
+
+## 6. What the two preserved properties cost under the new scheme
+
+### Property 1 — `on_finalize` must not block (and must not proceed under an in-flight call)
+
+**Preserved, and strengthened.** It was `std::unique_lock<std::mutex>(g_pc_mu, std::try_to_lock)`;
+it is now `perfagent::cupti::TryCallScope`, whose `owns()` is false when the guard is held by
+**anyone, the calling thread included**.
+
+The distinction is load-bearing now that the guard is re-entrant: a plain try from a thread that
+already holds it would *succeed*, and `on_finalize` would then call `cuptiPCSamplingDisable` out
+from under the CUPTI call its own outer frame is standing in. `CallGuard::try_enter_uncontended`
+refuses that case and counts it separately (`cupti_try_failed_self`) from losing the race to another
+thread (`cupti_try_failed_other`). Both feed `finalize_contended`, which must still be 0 on a
+healthy run.
+
+**A latent bug fixed on the way:** `std::mutex::try_lock()` from a thread that already owns the
+mutex is *undefined behaviour*, and the old line was on precisely the path where that can happen —
+a fatal-error callback arriving on a thread already holding `g_pc_mu`. It was UB in the code
+written to avoid a deadlock on that exact path.
+
+**Cost:** the guard is now held for more of the run than `g_pc_mu` was — it also covers the activity
+flush — so the probability that a fatal-error callback finds it held is *higher* than before. The
+outcome of that is unchanged (teardown skipped, tail of the profile lost, counted, logged) and it
+was always the designed-for outcome. Nothing that was previously guaranteed to succeed can now fail:
+the teardown was always best-effort on this path.
+
+### Property 2 — the `MODULE_UNLOAD_STARTING` drain must block
+
+**Preserved.** `on_resource` still calls `pc_drain_all` for `MODULE_UNLOAD_STARTING`, and
+`pc_drain_all` still takes the guard **blocking**. A skipped flush there makes two instructions
+share a PC identity, silently; that is still the worst outcome available and it is still not
+reachable by design.
+
+**Cost, precisely:** the guard is wider than `g_pc_mu`, so this path can now additionally wait
+behind an activity flush. The application's `cuModuleUnload` therefore blocks for at most one
+in-flight CUPTI call rather than at most one in-flight *PC-sampling* call. The wait was never
+bounded by a small constant — it already covered a full PC drain across every context, which is
+the larger of the two — so this widens a stall the design already accepted rather than introducing
+one. Module unloads are tens per process.
+
+**A cost that is genuinely new:** `cuptiGetCubinCrc` on the `MODULE_LOADED` path now takes the guard,
+so the application's `cuModuleLoad` can wait behind one of the timer thread's CUPTI calls. That path
+previously took no lock at all. It is accepted deliberately: the alternative is an exemption, and an
+exemption is discipline — the thing that failed here. It is consistent with what the adapter already
+does to `cuModuleUnload` and `cuCtxCreate`, and it is bounded by one CUPTI call.
+
+**A hazard that gets better, not worse.** Both the Task 6 report (item 13) and the Task 10 report
+(item 11) list as unverified whether `cuptiPCSamplingGetData` / `cuptiPCSamplingStop` can re-enter
+our resource callback — with `g_pc_mu` that was a guaranteed self-deadlock, and widening a
+non-re-entrant mutex over the activity flush would have widened it. Because `CallGuard` is
+re-entrant on the owning thread, such a nested callback now proceeds instead of hanging, and every
+re-entrant acquisition is counted (`cupti_reentrant`). The open question becomes a number in the
+adapter's report on the next hardware run rather than a hang. *Re-entrancy here is not for
+convenience — it is what keeps a vendor-delivered nested callback from being fatal, and it is
+counted so it can never be invisible.*
+
+`burst_close` also spends it deliberately: the stop and its mandatory range-end flush are now **one**
+critical section, which they were not before (the old code released `g_pc_mu` between them, so
+another thread's CUPTI call could land in the gap between a range ending and the flush the header
+requires after it).
+
+### Everything else preserved
+
+The two-record window protocol (open at start with `end_ns = 0`, closed at stop with the same
+`start_ns`), the CUDA-graph refusal at both moments, tier selection through one environment
+variable, the cubin capture and its `CubinView` guard (`check-cubin-defer`: still OK, all five
+deferrals still refuse to compile), enable-then-configure ordering, per-attribute `attributeStatus`
+checking, the drop classes, the replay log, and every existing counter. No ABI change, no BPF
+change, no `.o` churn, ten probes, one exported symbol.
+
+---
+
+## 7. Two further defects of the same family, found and fixed
+
+**`at_exit_handler` left the drain timer running.** It stopped `g_burst_timer` and never stopped
+`g_drainer`, so the drain thread's `cuptiActivityFlushAll` ran concurrently with `on_finalize`'s
+`cuptiPCSamplingDisable` — *the same two-threads-in-CUPTI shape as #99, on the exit path, present in
+Tier B too*. There is one timer now and it is stopped and **joined** first, so from that line on the
+only thread of ours that can reach CUPTI is the exiting one.
+
+**A regression the merge would have introduced in the default arm, caught before it shipped.** With
+Tier A off, the merged timer runs at exactly the drain period. A naive "drain at most once per
+period" limit on top of it would turn any tick that arrived a hair early — which sleeping timers do
+routinely — into a skipped drain, pushing the next one out a whole period and roughly halving
+delivery, *in the configuration that has nothing to do with this bug*. `drain_limit_ns` returns 0
+("drain on every tick") whenever the tick is not shorter than the drain period, and
+`tickplan_test.cc` pins it with early-arriving ticks.
+
+`atexit` is now armed **before** the timer starts. The two-timer version got that property from its
+ordering by accident; a burst opening before the exit handler exists could not be closed by it, and
+an unclosed window reports a hard exit that did not happen.
+
+---
+
+## 8. New counters, and what each reads on a healthy run
+
+One line in the adapter's report, emitted **whatever the tier** — the serialisation is a property of
+the process, not of PC sampling:
+
+| counter | healthy |
+| --- | --- |
+| `cupti_calls` | > 0 on any run that touched CUPTI |
+| `cupti_reentrant` | **not** expected to be 0 — nearly every wrapper call is made inside an outer `CallScope`, and `burst_close` nests on purpose. `cupti_max_depth` is what discriminates |
+| `cupti_waits` | > 0 is healthy on a busy process: the application's callbacks meeting the timer. **0 on a Tier A run would mean the guard is never contended and therefore proving nothing** |
+| `cupti_try_failed_self` / `cupti_try_failed_other` | **0** — the two halves of `finalize_contended` |
+| `cupti_max_depth` | **3** on Tier A (`burst_close` → `pc_drain_all` → the `GetData` wrapper), **2** in Tier B and on the context callbacks, 1 with PC sampling off. **Anything above 3 means CUPTI re-entered us through a callback** — the Task 6 (item 13) / Task 10 (item 11) open question, now a number instead of a self-deadlock |
+| `cupti_calls_misplaced` | **0** — nobody widened the one unguarded hole |
+| `timer_ticks` / `timer_drains` / `timer_skipped` | `drains ≈ ticks × tick_ms / drain_ms`; ticks moving with drains at 0 is a drain that silently stopped |
+
+---
+
+## 9. Verification actually run
+
+```
+make -C shim                    exit 0
+make -C shim test               exit 0  (callguard_test OK, tickplan_test OK, burst_test OK,
+                                         pcdrain_test OK, check-cubin-defer OK, and all the rest)
+make -C shim check-fpless       OK
+make -C shim check-cubin-defer  OK - the compliant capture compiles, all 5 deferrals do not
+make -C shim check-cupti-guard  OK - the guarded call compiles, all 5 unguarded do not
+make -C shim nvidia             exit 0 (CUDA 13.3, real libcupti; runs check-cupti-guard first)
+make -C shim nvidia-concurrent  exit 0
+make -C shim test-tsan          exit 0 (callguard_test clean under ThreadSanitizer)
+go build ./... && go vet ./...  clean
+go test ./gpu/ ./gpuprobe/ ./internal/... -count=1   all pass
+go test ./gpu/ ./gpuprobe/ -race -count=4            ok gpu 23.1s, gpuprobe 19.8s
+~/go/bin/golangci-lint run --timeout=5m              0 issues
+```
+
+Ten probes in the built adapter and one exported symbol, unchanged:
+
+```
+$ readelf -n shim/libperfagent-gpu-nvidia.so | grep -o 'gpu_[a-z_0-9]*' | sort -u
+gpu_config_v1  gpu_dropped_v1  gpu_exec_v1  gpu_kernel_name_v1  gpu_launch_sampled_v1
+gpu_launch_v1  gpu_module_load_v1  gpu_pc_sample_batch_v1  gpu_sampling_window_v1
+gpu_stall_reason_map_v1
+$ nm -D --defined-only shim/libperfagent-gpu-nvidia.so
+00000000000068a0 T InitializeInjection
+```
+
+No Go code changed. No ABI, BPF program or `.o` file changed.
+
+### Proven / argued / unproven — the honest split
+
+**Proven, here, without a GPU:**
+
+- CUPTI does not document `cuptiActivityFlushAll` or any PC-sampling entry point as thread safe,
+  while documenting 42 other functions as such (a fact about the shipped headers — reproducible with
+  `grep -c "Thread-safety" cupti_*.h`).
+- The guard excludes, is re-entrant, and refuses the two `try` cases — with a negative control
+  showing the test detects the exclusion being removed, and under ThreadSanitizer.
+- An unguarded CUPTI call site does not compile, in five spellings, with a compliant control that
+  does.
+- The merged schedule keeps the burst tick's granularity and the drain's period, leaves no catch-up
+  debt after a late tick, and imposes no rate limit in the default configuration.
+
+**Argued, from structure, not measured:**
+
+- That at most one adapter-initiated CUPTI call is in flight at any instant. This follows from one
+  mutual-exclusion primitive plus the impossibility of writing a call site that skips it — a
+  structural argument, and the reason the fix is a lock *and* a thread merge rather than either
+  alone.
+- That the lock ordering is acyclic: one vendor lock, every other adapter mutex a leaf, verified
+  path by path in §3. It is not enforced by a tool.
+- That the buffer-completed exemption cannot deadlock, which rests on the header's description of
+  the flush as blocking and on that callback taking no adapter lock that the flusher holds.
+
+### Cannot verify — needs the RTX 3090
+
+**Nothing below has been executed. `CapEff: 0`, no GPU on this machine, and no `CUpti_` code path
+touched by this commit has ever run.**
+
+**The fix is unproven on hardware. Nobody has observed the deadlock not happening.** What has been
+established is that the two calls the backtrace named can no longer be in flight together, and that
+the mechanism which guarantees that cannot be bypassed by a later edit without failing the build.
+Whether CUPTI has another deadlock of its own that this does not touch is unknown and unknowable
+from here.
+
+Specifically unverified:
+
+1. **That Tier A completes a run at all.** The only real test is Task 12's overhead run on the
+   3090 — the one that hung.
+2. **`cupti_waits` moving.** If it stays 0 on a Tier A run, the guard was never contended and this
+   fix has demonstrated nothing on hardware even if the run passes.
+3. **`cupti_max_depth` staying at 3.** Above 3 is CUPTI re-entering us through a callback — the
+   hazard both prior reports listed as open, now measurable rather than fatal. If it moves, the
+   per-context `CUpti_PCSamplingData` buffer is being re-entered by a nested drain, and that needs a
+   per-call buffer, not a lock.
+4. **`cupti_calls_misplaced == 0`**, and `cupti_try_failed_self`/`_other == 0`.
+5. **The real duty figure under the merged timer.** `duty=` is measured, not assumed, and the merge
+   means a slow activity flush can delay a burst stop by its own duration and lengthen the burst
+   that actually ran. The size of that is the flush duration on a busy GPU, which is unmeasured.
+   The 10 % ceiling bounds what the controller may *ask* for, never what the OS and the flush
+   deliver; this makes the gap between the two slightly larger than it was.
+6. **The cost of `cuptiGetCubinCrc` now taking the guard**, i.e. how long the application's
+   `cuModuleLoad` waits. Bounded by one CUPTI call, unmeasured.
+7. **Whether CUPTI delivers `buffer_completed` on the flushing thread or on a worker.** The design
+   is correct either way — that is why the exemption exists — but which it is decides whether
+   `cupti_reentrant` is inflated by that path.
+8. **Whether stopping and joining the single timer inside `atexit` can wedge process exit.** It
+   waits for at most one tick's work, which includes one activity flush; a flush that never returns
+   would hang exit where the old code would have exited with the timer still running. That trade is
+   deliberate — an exit that races CUPTI teardown is the shape of this whole issue — but it is a
+   new way for exit to be slow and it has not been observed.

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -2,6 +2,8 @@
 #   all         libperfagent-gpu-core.a
 #   test        fast unit tests: batch, clock, drain, and the C11 ABI header
 #   test-tsan   the concurrency case under ThreadSanitizer (clang++ only)
+#   check-cupti-guard  issue #99: proves an unguarded CUPTI call site does not
+#                   compile (needs the CUDA toolkit; a prerequisite of `nvidia`)
 #   nvidia      libperfagent-gpu-nvidia.so, the CUPTI adapter (needs the CUDA toolkit)
 #   nvidia-workload  the CUDA test workload the adapter is proven against
 #   nvidia-concurrent the CONCURRENT CUDA workload the PC-sampling overhead
@@ -26,7 +28,7 @@ CUDA_ARCH ?= sm_86
 CORE_SRC := core/batch.cc core/clock.cc core/cubin.cc core/cubinqueue.cc core/drain.cc core/enroll.cc core/sampler.cc
 CORE_OBJ := $(CORE_SRC:.cc=.o)
 
-.PHONY: all test test-tsan check-cubin-defer nvidia nvidia-workload nvidia-concurrent clean
+.PHONY: all test test-tsan check-cubin-defer check-cupti-guard nvidia nvidia-workload nvidia-concurrent clean
 all: libperfagent-gpu-core.a
 
 libperfagent-gpu-core.a: $(CORE_OBJ)
@@ -164,7 +166,7 @@ libperfagent-gpu-stub.so: CXXFLAGS += -g -fno-omit-frame-pointer -fasynchronous-
 # -fvisibility=hidden comes from CXXFLAGS and is what keeps core/ from leaking
 # symbols into somebody else's address space; InitializeInjection carries an
 # explicit default-visibility attribute to survive it (see cupti_adapter.cc).
-nvidia: libperfagent-gpu-nvidia.so
+nvidia: check-cupti-guard libperfagent-gpu-nvidia.so
 libperfagent-gpu-nvidia.so: nvidia/cupti_adapter.cc nvidia/export.map $(CORE_SRC)
 	$(CXX) $(CXXFLAGS) -pthread -I core -I $(CUDA_INC) -shared -o $@ \
 		nvidia/cupti_adapter.cc $(CORE_SRC) \
@@ -230,6 +232,41 @@ check-cubin-defer: core/cubin_defer_test.cc core/cubinqueue.h
 	[ $$rc -eq 0 ] && echo "check-cubin-defer: OK - the compliant capture compiles, all 5 deferrals do not"; \
 	exit $$rc
 
+# Issue #99's structural assertion, run as a BUILD step for the same reason
+# check-cubin-defer is: the fix's claim is that a CUPTI call site which skips
+# the one guard CANNOT BE WRITTEN in the adapter, and a guarantee nobody has
+# tried to violate is a claim. nvidia/cupti_guard.h defines a guarded wrapper
+# for every CUPTI entry point and then #defines the raw names to identifiers
+# that exist nowhere; this target tries five ways round it and requires every
+# one to be rejected by the compiler.
+#
+# It needs the CUDA headers, so it hangs off `nvidia` rather than off `test` --
+# `test` runs on machines with no toolkit. Mode 0 is the control and it MUST
+# compile: without it the check would pass just as happily on a file that fails
+# to build for an unrelated reason, which is the exact shape of the defects
+# this project has shipped reading green at the worst possible moment.
+#
+# 2>/dev/null on the negative arms: the compiler errors ARE the pass.
+check-cupti-guard: nvidia/cupti_guard_test.cc nvidia/cupti_guard.h core/callguard.h
+	@$(CXX) -std=c++17 -Wall -Werror -I core -I $(CUDA_INC) -fsyntax-only \
+		-DPERFAGENT_CUPTI_UNGUARDED=0 nvidia/cupti_guard_test.cc || { \
+	  echo "check-cupti-guard: the COMPLIANT call does not compile; this check would"; \
+	  echo "                   otherwise pass for the wrong reason. Fix nvidia/cupti_guard.h."; \
+	  exit 1; }
+	@rc=0; for m in 1 2 3 4 5; do \
+	  if $(CXX) -std=c++17 -Wall -Werror -I core -I $(CUDA_INC) -fsyntax-only \
+		-DPERFAGENT_CUPTI_UNGUARDED=$$m nvidia/cupti_guard_test.cc 2>/dev/null; then \
+	    echo "check-cupti-guard: unguarded mode $$m COMPILED. A CUPTI call site can reach"; \
+	    echo "                   the vendor without perfagent::cupti::guard(), which is"; \
+	    echo "                   exactly what issue #99 was: two of our threads inside"; \
+	    echo "                   CUPTI at once deadlocked the profiled application"; \
+	    echo "                   permanently. See nvidia/cupti_guard_test.cc mode $$m."; \
+	    rc=1; \
+	  fi; \
+	done; \
+	[ $$rc -eq 0 ] && echo "check-cupti-guard: OK - the guarded call compiles, all 5 unguarded do not"; \
+	exit $$rc
+
 # stub/pc_tier_test.cc is the "off means off" assertion, and it is built the
 # same way probe_order_test is and for the same reason: it drives the real
 # producer (stub/stub.cc with PERFAGENT_STUB_NO_MAIN) and reads its probe fires
@@ -253,12 +290,14 @@ check-cubin-defer: core/cubin_defer_test.cc core/cubinqueue.h
 # _Static_asserts are the test. Compiling it only as C++ leaves the C11 spelling
 # unguarded -- which is how the header's validity broke earlier in this branch,
 # when a C++ translation unit included it for the first time.
-test: check-cubin-defer core/batch_test.cc core/clock_test.cc core/cubin_test.cc core/cubinqueue_test.cc core/drain_test.cc core/pcdrain_test.cc core/burst_test.cc core/pctier_test.cc core/enroll_test.cc core/usdt_abi_test.c core/sampler_test.cc core/probe_args_test.cc stub/probe_order_test.cc stub/pc_tier_test.cc stub/stub.cc $(CORE_SRC)
+test: check-cubin-defer core/batch_test.cc core/clock_test.cc core/cubin_test.cc core/cubinqueue_test.cc core/drain_test.cc core/pcdrain_test.cc core/burst_test.cc core/callguard_test.cc core/tickplan_test.cc core/pctier_test.cc core/enroll_test.cc core/usdt_abi_test.c core/sampler_test.cc core/probe_args_test.cc stub/probe_order_test.cc stub/pc_tier_test.cc stub/stub.cc $(CORE_SRC)
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/batch_test core/batch_test.cc core/batch.cc && /tmp/batch_test
 	$(CXX) -std=c++17 -I core -o /tmp/clock_test core/clock_test.cc core/clock.cc && /tmp/clock_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/drain_test core/drain_test.cc core/drain.cc && /tmp/drain_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/pcdrain_test core/pcdrain_test.cc && /tmp/pcdrain_test
 	$(CXX) -std=c++17 -Wall -Werror -pthread -I core -o /tmp/burst_test core/burst_test.cc && /tmp/burst_test
+	$(CXX) -std=c++17 -Wall -Werror -pthread -I core -o /tmp/callguard_test core/callguard_test.cc && /tmp/callguard_test
+	$(CXX) -std=c++17 -Wall -Werror -pthread -I core -o /tmp/tickplan_test core/tickplan_test.cc && /tmp/tickplan_test
 	$(CXX) -std=c++17 -Wall -Werror -I core -o /tmp/pctier_test core/pctier_test.cc && /tmp/pctier_test
 	$(CXX) -std=c++17 -pthread -I core -o /tmp/enroll_test core/enroll_test.cc core/enroll.cc && /tmp/enroll_test
 	$(CXX) -std=c++17 -Wall -Werror -pthread -I core -o /tmp/cubin_test core/cubin_test.cc core/cubin.cc core/enroll.cc && /tmp/cubin_test
@@ -282,13 +321,19 @@ test: check-cubin-defer core/batch_test.cc core/clock_test.cc core/cubin_test.cc
 # design turns on drain() not holding the mutex across an offer. A test that
 # only checks the counters passes with the lock held the wrong way round; only
 # TSan sees the unsynchronized access if one is ever introduced.
-test-tsan: core/batch_test.cc core/batch.cc core/batch.h core/sampler_test.cc core/sampler.cc core/sampler.h core/cubinqueue_test.cc core/cubinqueue.cc core/cubinqueue.h
+# callguard_test is here for a fourth reason: its mutual-exclusion case
+# increments a plain `long` under the guard, which comes out right on most runs
+# even with the exclusion removed. Only the sanitizer proves the guard actually
+# excludes -- and the guard is the whole of issue #99's fix.
+test-tsan: core/batch_test.cc core/batch.cc core/batch.h core/sampler_test.cc core/sampler.cc core/sampler.h core/cubinqueue_test.cc core/cubinqueue.cc core/cubinqueue.h core/callguard_test.cc core/callguard.h
 	$(TSAN_CXX) -std=c++17 -g -O1 -fsanitize=thread -pthread -I core \
 		-o /tmp/batch_test_tsan core/batch_test.cc core/batch.cc && /tmp/batch_test_tsan
 	$(TSAN_CXX) -std=c++17 -g -O1 -fsanitize=thread -pthread -I core \
 		-o /tmp/sampler_test_tsan core/sampler_test.cc core/sampler.cc && /tmp/sampler_test_tsan
 	$(TSAN_CXX) -std=c++17 -g -O1 -fsanitize=thread -pthread -I core \
 		-o /tmp/cubinqueue_test_tsan core/cubinqueue_test.cc core/cubinqueue.cc && /tmp/cubinqueue_test_tsan
+	$(TSAN_CXX) -std=c++17 -g -O1 -fsanitize=thread -pthread -I core \
+		-o /tmp/callguard_test_tsan core/callguard_test.cc && /tmp/callguard_test_tsan
 
 clean:
 	rm -f $(CORE_OBJ) libperfagent-gpu-core.a perfagent-gpu-stub libperfagent-gpu-stub.so \

--- a/shim/core/callguard.h
+++ b/shim/core/callguard.h
@@ -1,0 +1,183 @@
+// One lock, held across every call the adapter makes into a vendor library
+// that does not document concurrent entry.
+//
+// Why this class exists (issue #99)
+// ---------------------------------
+// The CUPTI adapter deadlocked the profiled application on the first Tier A
+// burst. Three threads, two of them ours:
+//
+//   application  __cudaLaunchKernel_helper -> CUPTI callback -> mutex
+//   burst timer  cuptiPCSamplingStop                         -> rwlock
+//   drain timer  cuptiActivityFlushAll                        (inside CUPTI)
+//   CUPTI worker                                             -> rwlock
+//
+// The adapter held a mutex over the PC-sampling family and nothing at all over
+// the activity flush, so two of its own threads were inside CUPTI, in
+// different subsystems, at the same time. Neither cupti_activity.h nor
+// cupti_pcsampling.h documents a single entry point in either family as thread
+// safe -- while cupti_result.h, cupti_events.h and cupti_callbacks.h document
+// theirs per function -- so the concurrency was never sanctioned, only
+// untested.
+//
+// The three properties this class has, and why each one is load bearing
+// --------------------------------------------------------------------
+// 1. MUTUAL EXCLUSION between threads. That is the fix.
+//
+// 2. RE-ENTRANCY on one thread, counted. A vendor library may deliver a
+//    callback on the very thread that is already inside a call we made -- the
+//    CUPTI adapter's own reports list "can cuptiPCSamplingGetData re-enter our
+//    resource callback" and "can cuptiPCSamplingStop" as open questions that
+//    need hardware to answer. With a plain std::mutex that is a self-deadlock,
+//    and widening the mutex to cover more of the vendor surface widens the
+//    hazard rather than narrowing it. Same-thread re-entry is not concurrency,
+//    so permitting it is sound for the purpose this lock serves; every
+//    re-entrant acquisition is COUNTED so the answer to that open question
+//    arrives as a number on the next hardware run instead of as a hang.
+//
+// 3. try_enter_uncontended(), which fails when the lock is held BY ANYONE,
+//    the calling thread included. A fatal-error callback that must tear the
+//    session down can neither block (it would hang the host) nor proceed while
+//    a call is in flight (it would tear down underneath one). std::mutex has
+//    nothing that answers that question: try_lock() on a mutex the calling
+//    thread already owns is undefined behaviour, so the obvious spelling is
+//    not merely awkward, it is wrong.
+//
+// No vendor headers, no CUDA, no clock: it is a lock and its accounting, so
+// core/callguard_test.cc proves all three properties on a machine with no GPU.
+#ifndef PERFAGENT_CALLGUARD_H
+#define PERFAGENT_CALLGUARD_H
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+
+namespace perfagent {
+
+// A per-thread identity that costs no syscall: the address of a thread_local
+// object is unique per thread and stable for its lifetime. Not a tid -- a tid
+// is fine to log and wrong to compare after a thread exits and the number is
+// reused.
+inline uintptr_t call_guard_self() {
+    static thread_local char tag = 0;
+    return (uintptr_t)&tag;
+}
+
+class CallGuard {
+public:
+    // Blocking acquisition. Re-entrant on the owning thread.
+    void enter() {
+        const uintptr_t self = call_guard_self();
+        if (owner_.load(std::memory_order_acquire) == self) {
+            // Only this thread can have written `self` there, and it has not
+            // released, so reading it is proof we hold the lock.
+            depth_++;
+            reentries_.fetch_add(1, std::memory_order_relaxed);
+            if (depth_ > max_depth_) max_depth_ = depth_;
+            return;
+        }
+        if (!mu_.try_lock()) {
+            waits_.fetch_add(1, std::memory_order_relaxed);
+            mu_.lock();
+        }
+        owner_.store(self, std::memory_order_release);
+        depth_ = 1;
+        if (max_depth_ < 1) max_depth_ = 1;
+        entries_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void leave() {
+        if (depth_ > 1) {
+            depth_--;
+            return;
+        }
+        depth_ = 0;
+        owner_.store(0, std::memory_order_release);
+        mu_.unlock();
+    }
+
+    // For a path that must not block and must not proceed under an in-flight
+    // call: fails if the lock is held by ANY thread, this one included.
+    //
+    // The self-held case is refused rather than granted, and that is the whole
+    // reason this is not std::unique_lock(mu, try_to_lock). A teardown that
+    // ran re-entrantly from inside a vendor call would disable the subsystem
+    // the outer call is standing in.
+    bool try_enter_uncontended() {
+        if (owner_.load(std::memory_order_acquire) == call_guard_self()) {
+            try_failed_self_.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        if (!mu_.try_lock()) {
+            try_failed_other_.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        owner_.store(call_guard_self(), std::memory_order_release);
+        depth_ = 1;
+        entries_.fetch_add(1, std::memory_order_relaxed);
+        return true;
+    }
+
+    // Whether this thread is inside the guard. The wrappers assert on it, so
+    // a call site that reaches the vendor without the lock is counted rather
+    // than merely commented against.
+    bool held_by_this_thread() const {
+        return owner_.load(std::memory_order_acquire) == call_guard_self();
+    }
+
+    // Every counter is assertable at a known value from a test, which is the
+    // standing rule here: a lock that stopped being taken must not look like a
+    // workload that stopped calling.
+    uint64_t entries() const { return entries_.load(std::memory_order_relaxed); }
+    uint64_t reentries() const { return reentries_.load(std::memory_order_relaxed); }
+    uint64_t waits() const { return waits_.load(std::memory_order_relaxed); }
+    uint64_t try_failed_self() const { return try_failed_self_.load(std::memory_order_relaxed); }
+    uint64_t try_failed_other() const { return try_failed_other_.load(std::memory_order_relaxed); }
+    // Read only while holding the guard, or after every thread has left.
+    unsigned max_depth() const { return max_depth_; }
+
+    // Blocking RAII. This is what call sites use.
+    class Scope {
+    public:
+        explicit Scope(CallGuard &g) : g_(g) { g_.enter(); }
+        ~Scope() { g_.leave(); }
+        Scope(const Scope &) = delete;
+        Scope &operator=(const Scope &) = delete;
+
+    private:
+        CallGuard &g_;
+    };
+
+    // Non-blocking RAII for the teardown path. owns() is false when the lock
+    // was held by anybody, including this thread.
+    class TryScope {
+    public:
+        explicit TryScope(CallGuard &g) : g_(g), owns_(g.try_enter_uncontended()) {}
+        ~TryScope() {
+            if (owns_) g_.leave();
+        }
+        bool owns() const { return owns_; }
+        TryScope(const TryScope &) = delete;
+        TryScope &operator=(const TryScope &) = delete;
+
+    private:
+        CallGuard &g_;
+        bool owns_;
+    };
+
+private:
+    std::mutex mu_;
+    // Written only by the owning thread (under mu_), read by any thread.
+    std::atomic<uintptr_t> owner_{0};
+    // Touched only by the owner while it holds mu_, so plain ints are correct.
+    unsigned depth_ = 0;
+    unsigned max_depth_ = 0;
+    std::atomic<uint64_t> entries_{0};
+    std::atomic<uint64_t> reentries_{0};
+    std::atomic<uint64_t> waits_{0};
+    std::atomic<uint64_t> try_failed_self_{0};
+    std::atomic<uint64_t> try_failed_other_{0};
+};
+
+}  // namespace perfagent
+
+#endif

--- a/shim/core/callguard_test.cc
+++ b/shim/core/callguard_test.cc
@@ -1,0 +1,147 @@
+// CallGuard: the three properties issue #99's fix rests on, proven without a
+// GPU, a CUDA toolkit or CUPTI.
+//
+// The deadlock this class exists to prevent cannot be reproduced on this
+// machine -- it needs an RTX 3090 and a CUPTI that deadlocks. What CAN be
+// proven here is the lock discipline itself: that two threads are never inside
+// at once, that one thread may re-enter without hanging, that the teardown
+// path's try never blocks and never grants itself entry from inside a call,
+// and that every one of those outcomes is counted rather than silent.
+#include "callguard.h"
+
+#include <atomic>
+#include <cassert>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+using perfagent::CallGuard;
+
+int main() {
+    // Ordinary acquisition and release, and the counters that say so.
+    {
+        CallGuard g;
+        assert(!g.held_by_this_thread());
+        {
+            CallGuard::Scope s(g);
+            assert(g.held_by_this_thread());
+        }
+        assert(!g.held_by_this_thread());
+        assert(g.entries() == 1);
+        assert(g.reentries() == 0);
+        assert(g.max_depth() == 1);
+    }
+
+    // RE-ENTRANCY. A vendor library that delivers a callback on the thread
+    // already inside a call we made must not hang the host. Three deep,
+    // counted, and still held throughout.
+    {
+        CallGuard g;
+        CallGuard::Scope a(g);
+        {
+            CallGuard::Scope b(g);
+            {
+                CallGuard::Scope c(g);
+                assert(g.held_by_this_thread());
+                assert(g.max_depth() == 3);
+            }
+            assert(g.held_by_this_thread());   // still held at depth 2
+        }
+        assert(g.held_by_this_thread());       // and at depth 1
+        assert(g.entries() == 1);              // one acquisition...
+        assert(g.reentries() == 2);            // ...and two re-entries
+    }
+
+    // try_enter_uncontended REFUSES when this thread already holds the lock.
+    // This is the property std::mutex cannot express: try_lock() on a mutex
+    // the calling thread owns is undefined behaviour, and "succeed" would let
+    // a fatal-error teardown run underneath an in-flight vendor call.
+    {
+        CallGuard g;
+        CallGuard::Scope s(g);
+        CallGuard::TryScope t(g);
+        assert(!t.owns());
+        assert(g.try_failed_self() == 1);
+        assert(g.try_failed_other() == 0);
+    }
+
+    // ...and when ANOTHER thread holds it, without blocking.
+    {
+        CallGuard g;
+        std::atomic<bool> held{false}, release{false};
+        std::thread other([&] {
+            CallGuard::Scope s(g);
+            held.store(true);
+            while (!release.load()) std::this_thread::yield();
+        });
+        while (!held.load()) std::this_thread::yield();
+        {
+            CallGuard::TryScope t(g);
+            assert(!t.owns());
+        }
+        assert(g.try_failed_other() == 1);
+        assert(g.try_failed_self() == 0);
+        release.store(true);
+        other.join();
+        // Free again once the holder left.
+        CallGuard::TryScope t(g);
+        assert(t.owns());
+    }
+
+    // MUTUAL EXCLUSION, which is the fix itself: no two threads inside at
+    // once. The counter is incremented non-atomically on purpose -- under a
+    // guard that does not exclude, the reads and writes race and the total
+    // comes out short. `inside` additionally catches an overlap the arithmetic
+    // would have absorbed.
+    {
+        CallGuard g;
+        long counter = 0;
+        std::atomic<int> inside{0};
+        std::atomic<int> overlaps{0};
+        std::vector<std::thread> ts;
+        constexpr int kThreads = 8;
+        constexpr int kIters = 2000;
+        for (int t = 0; t < kThreads; t++) {
+            ts.emplace_back([&] {
+                for (int i = 0; i < kIters; i++) {
+                    CallGuard::Scope s(g);
+                    if (inside.fetch_add(1) != 0) overlaps.fetch_add(1);
+                    counter++;
+                    // Re-enter from inside, as a nested vendor callback would.
+                    {
+                        CallGuard::Scope inner(g);
+                        counter++;
+                    }
+                    inside.fetch_sub(1);
+                }
+            });
+        }
+        for (auto &t : ts) t.join();
+        assert(overlaps.load() == 0);
+        assert(counter == (long)kThreads * kIters * 2);
+        assert(g.entries() == (uint64_t)kThreads * kIters);
+        assert(g.reentries() == (uint64_t)kThreads * kIters);
+        assert(g.max_depth() == 2);
+    }
+
+    // A guard released by re-entrant scopes is genuinely free afterwards: an
+    // unbalanced leave would leave the mutex locked and the next acquisition
+    // from another thread would hang rather than fail an assert.
+    {
+        CallGuard g;
+        {
+            CallGuard::Scope a(g);
+            CallGuard::Scope b(g);
+        }
+        std::thread other([&] {
+            CallGuard::Scope s(g);
+            assert(g.held_by_this_thread());
+        });
+        other.join();
+        assert(!g.held_by_this_thread());
+        assert(g.entries() == 2);
+    }
+
+    printf("callguard_test OK\n");
+    return 0;
+}

--- a/shim/core/tickplan.h
+++ b/shim/core/tickplan.h
@@ -1,0 +1,124 @@
+// One timer thread for both the activity drain and Tier A's burst cycle.
+//
+// Why one thread and not two (issue #99)
+// --------------------------------------
+// The adapter used to run two: a 100 ms drain timer calling
+// cuptiActivityFlushAll, and a 10 ms burst timer calling cuptiPCSamplingStop.
+// Nothing serialised them, so two of the profiler's own threads could be
+// inside CUPTI at the same time in different subsystems, and on an RTX 3090
+// that deadlocked the profiled application permanently on the first burst.
+//
+// A lock over both call sites excludes that state. One thread makes it
+// UNREPRESENTABLE: with a single timer there is no second thread of ours to be
+// in CUPTI concurrently, whatever a future call site does. The lock is still
+// there (the application's own threads enter CUPTI through our callbacks) but
+// it is no longer the only thing standing between the profiler and a hang.
+//
+// What the merge costs, stated rather than discovered
+// ---------------------------------------------------
+// The two jobs have different periods -- 100 ms for the drain, burst_ns/5 for
+// the burst poll -- so the merged timer runs at the SHORTER of the two and the
+// drain is rate-limited on top of it. The burst poll therefore keeps its
+// granularity exactly. What it loses is isolation: a tick that runs the drain
+// does the flush BEFORE the next burst poll, so a slow flush delays a burst
+// transition by its own duration. Tier A's burst length is measured from the
+// timestamps this file's caller takes around the start and stop, so a delayed
+// stop lengthens the burst that is actually observed and reported --- it is
+// visible in `duty=` in the adapter's report, which is measured and not
+// assumed, and it is bounded by one flush.
+//
+// With Tier A off there is no burst poll, the timer runs at the drain period
+// and this class changes nothing about the drain's cadence.
+//
+// Pure, so the schedule is provable without a GPU: the caller supplies now_ns.
+#ifndef PERFAGENT_TICKPLAN_H
+#define PERFAGENT_TICKPLAN_H
+
+#include <cstdint>
+#include <mutex>
+
+namespace perfagent {
+
+// The period the single timer thread runs at.
+//
+// Tier A off: the drain period, unchanged -- there is no burst poll to serve.
+// Tier A on:  the shorter of the two, so NEITHER job's cadence is lengthened
+//             by the merge. Never zero: a zero-period timer is a spin.
+inline uint64_t tick_period_ns(uint64_t drain_ns, uint64_t burst_tick_ns, bool tier_a) {
+    uint64_t t = drain_ns;
+    if (tier_a && burst_tick_ns && burst_tick_ns < t) t = burst_tick_ns;
+    return t ? t : 1000000ull;   // 1 ms floor
+}
+
+// The rate limit to put on the drain, given the timer it now rides.
+//
+// ZERO -- "drain on every tick" -- when the timer already runs at or slower
+// than the drain period, and that case is not a curiosity: it is the DEFAULT
+// configuration. With Tier A off the merged timer runs at exactly the drain
+// period, and a rate limit of one drain per period would turn any tick that
+// arrived a hair early into a skipped drain and push the next one out a whole
+// period. Sleeping timers arrive early often enough that this would have
+// halved the delivery rate of a profiler that is shipping today, in the arm
+// that has nothing to do with the bug being fixed.
+inline uint64_t drain_limit_ns(uint64_t drain_ns, uint64_t tick_ns) {
+    return tick_ns >= drain_ns ? 0 : drain_ns;
+}
+
+// The drain's rate limit on top of the merged tick.
+//
+// Side-effecting on the true path, exactly like PCDrainSchedule::due: the
+// caller is expected to drain, so "ask and then forget to act" is not a shape
+// this API offers.
+class TickPlan {
+public:
+    // period_ns of 0 means "drain on every tick", which is what the caller
+    // gets if the drain period is set at or below the tick: the plan degrades
+    // to the timer rather than to never draining.
+    explicit TickPlan(uint64_t period_ns) : period_ns_(period_ns) {}
+
+    // Called once, immediately before the timer thread starts, so the first
+    // drain lands one full period in rather than on the first tick. Without
+    // it a 10 ms tick would drain immediately and then again at 100 ms.
+    void start(uint64_t now_ns) {
+        std::lock_guard<std::mutex> g(mu_);
+        last_ns_ = now_ns;
+        started_ = true;
+    }
+
+    bool drain_due(uint64_t now_ns) {
+        std::lock_guard<std::mutex> g(mu_);
+        ticks_++;
+        if (started_ && now_ns - last_ns_ < period_ns_) {
+            skipped_++;
+            return false;
+        }
+        // The phase is set from NOW, not from last + period. A tick that
+        // arrived late -- because the flush before it was slow, which is
+        // exactly the cost the merge introduces -- must not leave a debt that
+        // fires several drains back to back afterwards.
+        last_ns_ = now_ns;
+        started_ = true;
+        drains_++;
+        return true;
+    }
+
+    uint64_t period_ns() const { return period_ns_; }
+    // Assertable at known values from a test: a merged timer that quietly
+    // stopped draining must not look like a workload that stopped running.
+    uint64_t ticks() const { std::lock_guard<std::mutex> g(mu_); return ticks_; }
+    uint64_t drains() const { std::lock_guard<std::mutex> g(mu_); return drains_; }
+    uint64_t skipped() const { std::lock_guard<std::mutex> g(mu_); return skipped_; }
+
+private:
+    mutable std::mutex mu_;
+    const uint64_t period_ns_;
+    uint64_t last_ns_ = 0;
+    bool started_ = false;
+    uint64_t ticks_ = 0;
+    uint64_t drains_ = 0;
+    uint64_t skipped_ = 0;
+};
+
+}  // namespace perfagent
+
+#endif

--- a/shim/core/tickplan_test.cc
+++ b/shim/core/tickplan_test.cc
@@ -1,0 +1,129 @@
+// The merged timer's schedule, against a fake clock.
+//
+// Issue #99's fix puts the activity drain and Tier A's burst poll on ONE
+// thread, so that two of the profiler's threads can never be inside CUPTI at
+// once. The deadlock that motivated it cannot be reproduced here -- it needs
+// the GPU -- but the scheduling consequences can be, and they are what would
+// otherwise be discovered on hardware: a burst poll that lost its granularity
+// or a drain that quietly stopped happening.
+#include "tickplan.h"
+
+#include <cassert>
+#include <cstdio>
+
+using perfagent::drain_limit_ns;
+using perfagent::TickPlan;
+using perfagent::tick_period_ns;
+
+static const uint64_t kMs = 1000000ull;
+
+int main() {
+    // With Tier A off the timer runs at the drain period: the merge changes
+    // nothing when there is no burst poll to serve.
+    assert(tick_period_ns(100 * kMs, 10 * kMs, false) == 100 * kMs);
+
+    // With Tier A on it runs at the SHORTER of the two, so neither job's
+    // cadence is lengthened. A 10 ms burst tick quantized onto a 100 ms drain
+    // would silently multiply the burst length -- and therefore the duty
+    // fraction, the one number Tier A exists to bound -- by ten.
+    assert(tick_period_ns(100 * kMs, 10 * kMs, true) == 10 * kMs);
+    // A burst tick longer than the drain period does not lengthen the drain.
+    assert(tick_period_ns(100 * kMs, 250 * kMs, true) == 100 * kMs);
+    // Degenerate configuration lands on the floor, never on a spin.
+    assert(tick_period_ns(0, 0, true) == 1 * kMs);
+    assert(tick_period_ns(0, 0, false) == 1 * kMs);
+    assert(tick_period_ns(100 * kMs, 0, true) == 100 * kMs);
+
+    // The DEFAULT configuration -- Tier A off, so the timer runs at the drain
+    // period -- gets NO rate limit, and this is the case that matters most.
+    // A limit there would turn a tick that arrived a hair early into a skipped
+    // drain and push the next one out a whole period, halving the delivery
+    // rate of a profiler that ships today in the arm that has nothing to do
+    // with issue #99.
+    {
+        const uint64_t tick = tick_period_ns(100 * kMs, 10 * kMs, false);
+        assert(tick == 100 * kMs);
+        assert(drain_limit_ns(100 * kMs, tick) == 0);
+        TickPlan p(drain_limit_ns(100 * kMs, tick));
+        p.start(0);
+        // Every tick drains, including the ones that arrived early.
+        assert(p.drain_due(99 * kMs));
+        assert(p.drain_due(197 * kMs));
+        assert(p.drain_due(298 * kMs));
+        assert(p.drains() == 3);
+        assert(p.skipped() == 0);
+    }
+
+    // Tier A on: the timer is faster than the drain, so the limit is the drain
+    // period and the drain is quantized onto the tick.
+    {
+        const uint64_t tick = tick_period_ns(100 * kMs, 10 * kMs, true);
+        assert(tick == 10 * kMs);
+        assert(drain_limit_ns(100 * kMs, tick) == 100 * kMs);
+    }
+
+    // One drain per ten 10 ms ticks, and the first lands a full period in
+    // rather than on the first tick.
+    {
+        TickPlan p(100 * kMs);
+        p.start(0);
+        uint64_t drains = 0;
+        for (int i = 1; i <= 100; i++)
+            if (p.drain_due((uint64_t)i * 10 * kMs)) drains++;
+        assert(drains == 10);
+        assert(p.ticks() == 100);
+        assert(p.drains() == 10);
+        assert(p.skipped() == 90);
+    }
+
+    // The drain period is not lengthened by the merge: over a simulated
+    // minute the gap between consecutive drains never exceeds the period plus
+    // one tick, which is the whole of the quantization the merge introduces.
+    {
+        TickPlan p(100 * kMs);
+        p.start(0);
+        uint64_t last = 0, worst = 0;
+        for (int i = 1; i <= 6000; i++) {
+            const uint64_t now = (uint64_t)i * 10 * kMs;
+            if (!p.drain_due(now)) continue;
+            const uint64_t gap = now - last;
+            if (gap > worst) worst = gap;
+            last = now;
+        }
+        assert(worst <= 100 * kMs + 10 * kMs);
+        assert(p.drains() == 600);
+    }
+
+    // A late tick -- the cost the merge introduces, a slow flush delaying the
+    // next tick -- does not leave a debt that fires several drains back to
+    // back afterwards. One drain, then the phase restarts from the late tick.
+    {
+        TickPlan p(100 * kMs);
+        p.start(0);
+        assert(p.drain_due(1000 * kMs));      // 900 ms late
+        assert(!p.drain_due(1010 * kMs));
+        assert(!p.drain_due(1090 * kMs));
+        assert(p.drain_due(1100 * kMs));
+        assert(p.drains() == 2);
+    }
+
+    // period 0 degrades to "every tick", never to "never".
+    {
+        TickPlan p(0);
+        p.start(0);
+        for (int i = 1; i <= 5; i++) assert(p.drain_due((uint64_t)i * kMs));
+        assert(p.drains() == 5);
+        assert(p.skipped() == 0);
+    }
+
+    // Without start(), the first tick drains -- a plan nobody seeded must not
+    // wait for a period it has no phase for.
+    {
+        TickPlan p(100 * kMs);
+        assert(p.drain_due(50 * kMs));
+        assert(!p.drain_due(60 * kMs));
+    }
+
+    printf("tickplan_test OK\n");
+    return 0;
+}

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -20,6 +20,7 @@
 #include "pcdrain.h"
 #include "pctier.h"
 #include "sampler.h"
+#include "tickplan.h"
 #include "usdt_abi.h"
 #include "usdt_probe.h"
 
@@ -27,6 +28,13 @@
 // cuptiGetCubinCrc lives here, not in cupti.h -- so this header is needed by
 // the module-capture path as well as by the whole PC-sampling block below.
 #include <cupti_pcsampling.h>
+
+// MUST come after the CUPTI headers and before everything else in this file.
+// It defines a guarded wrapper for every CUPTI entry point this adapter uses
+// and then POISONS the raw names, so from this line down a call site that
+// reaches CUPTI without the one lock is a compile error rather than a hang in
+// somebody else's process. That is issue #99's fix; read that header first.
+#include "cupti_guard.h"
 
 #include <atomic>
 #include <cstdarg>
@@ -120,7 +128,7 @@ std::mutex g_clock_mu;
 
 void resample_clock() {
     uint64_t vendor = 0;
-    if (cuptiGetTimestamp(&vendor) != CUPTI_SUCCESS) return;
+    if (perfagent::cupti::GetTimestamp(&vendor) != CUPTI_SUCCESS) return;
     const uint64_t mono = mono_ns();
     std::lock_guard<std::mutex> g(g_clock_mu);
     g_clock.resample(vendor, mono);
@@ -211,7 +219,13 @@ perfagent::Batch<gpu_launch_v1, 32> *g_lb = nullptr;
 perfagent::Batch<gpu_exec_v1, 32> *g_eb = nullptr;
 perfagent::Sampler *g_sampler = nullptr;
 perfagent::KernelNameTable *g_names = nullptr;
-perfagent::Drainer *g_drainer = nullptr;
+// THE timer. Singular, and that is the structural half of issue #99's fix: the
+// adapter has exactly one thread of its own from which it ever calls CUPTI, so
+// "two of our threads inside CUPTI at once" is not a state this process can
+// reach. g_tick_plan rate-limits the 100 ms activity drain on top of the
+// shorter burst tick; see core/tickplan.h.
+perfagent::Drainer *g_timer = nullptr;
+perfagent::TickPlan *g_tick_plan = nullptr;
 perfagent::CubinQueue *g_cubins = nullptr;
 CUpti_SubscriberHandle g_subscriber = nullptr;
 
@@ -288,7 +302,11 @@ uint64_t cupti_cubin_crc(const void *bytes, size_t len) {
     p.size = CUpti_GetCubinCrcParamsSize;
     p.cubinSize = len;
     p.cubin = bytes;
-    if (cuptiGetCubinCrc(&p) != CUPTI_SUCCESS) return 0;
+    // Takes the CUPTI guard, like every other call this adapter initiates.
+    // It runs on the APPLICATION's cuModuleLoad path, so it can now wait
+    // behind one of the timer thread's CUPTI calls -- see issue-99's report
+    // for the size of that and why it is the right trade.
+    if (perfagent::cupti::GetCubinCrc(&p) != CUPTI_SUCCESS) return 0;
     return p.cubinCrc;
 }
 
@@ -484,14 +502,25 @@ struct PCContext {
     bool enabled = false;
 };
 
-// One mutex over the map AND the per-context buffers. It is held across
-// cuptiPCSamplingGetData, which is what makes the module-unload drain safe:
-// that callback runs on the application's thread while the drain timer runs on
-// ours, and CUPTI's buffer is a single-writer structure. The unload path
-// BLOCKS on this rather than trying the lock, because a skipped unload flush
-// is exactly the silent PC-identity corruption this whole path exists to
-// avoid.
-std::mutex g_pc_mu;
+// The per-context map and buffers are covered by the SAME lock every CUPTI
+// call in this adapter takes: perfagent::cupti::guard(), declared in
+// nvidia/cupti_guard.h.
+//
+// It used to be a mutex of its own, g_pc_mu, and that is what issue #99 was.
+// It serialised the PC-sampling family against itself and nothing else, so the
+// 100 ms drain timer's cuptiActivityFlushAll -- which took no lock at all --
+// ran concurrently with the burst timer's cuptiPCSamplingStop. Two of our
+// threads inside CUPTI, in different CUPTI subsystems, with the application in
+// a launch callback: the profiled process deadlocked, permanently, on the
+// first Tier A burst.
+//
+// One lock over the whole vendor surface, rather than one per subsystem, is
+// what removes the ordering question between our own locks entirely. Holding
+// it across cuptiPCSamplingGetData is still what makes the module-unload drain
+// safe: that callback runs on the application's thread while the timer runs on
+// ours, and CUPTI's buffer is a single-writer structure. The unload path still
+// BLOCKS rather than trying the lock, because a skipped unload flush is
+// exactly the silent PC-identity corruption this whole path exists to avoid.
 std::vector<PCContext *> g_pc_ctxs;       // leaked with everything else; see below
 
 perfagent::PCDrainSchedule *g_pc_schedule = nullptr;
@@ -506,17 +535,23 @@ std::atomic<unsigned long> g_window_seq{0};
 
 // ------------------------------------------------------ Tier A duty cycle
 //
-// The burst controller and its own timer. It is a SECOND timer, not the drain
-// tick, and that is a deliberate deviation from the plan's "the existing drain
-// timer is its natural home": the drain tick is 100 ms and a 50 ms burst
-// cannot be expressed on it. Quantizing the burst to the drain period would
-// silently double the burst length and therefore the duty fraction --- the one
-// number this tier exists to bound --- so the burst rides a tick of its own
-// whose period is a fraction of the burst length. The flush that CUPTI
-// requires after every range end runs on the stop, immediately, and marks the
-// SHARED PCDrainSchedule so the 100 ms tick coalesces instead of repeating it.
+// The burst controller. It used to have a timer thread of its own, and issue
+// #99 is why it no longer does: two timer threads meant two of our threads
+// could be inside CUPTI at once, which deadlocked the profiled application.
+//
+// The burst cycle still cannot be expressed on a 100 ms drain tick -- a 50 ms
+// burst quantized to 100 ms silently doubles the burst length and therefore
+// the duty fraction, the one number this tier exists to bound. So the SINGLE
+// timer runs at the burst tick (a fifth of the burst length) and the activity
+// drain is rate-limited on top of it by core/tickplan.h. The burst poll keeps
+// its granularity exactly; what it loses is isolation from a slow flush, which
+// is measured in `duty=` rather than assumed away.
+//
+// The flush CUPTI requires after every range end still runs on the stop,
+// immediately, inside the same critical section as the stop, and marks the
+// SHARED PCDrainSchedule so the periodic drain coalesces instead of repeating
+// it.
 perfagent::BurstController *g_burst = nullptr;
-perfagent::Drainer *g_burst_timer = nullptr;
 unsigned g_burst_tick_ms = 10;
 
 // Bursts and their total open time. The pair is what bounds the perturbation:
@@ -622,7 +657,8 @@ void emit_dropped(uint64_t count, uint8_t klass) {
 }
 
 // Queries the device's stall-reason table and puts it on the wire. Called once
-// per process, under g_pc_mu, from the first context that enables sampling.
+// per process, under the CUPTI guard, from the first context that enables
+// sampling.
 //
 // The table is also handed to the ReplayLog: the query happens at context
 // creation, which on a CUDA process is before a consumer can realistically
@@ -637,7 +673,8 @@ bool pc_query_stall_reasons(CUcontext ctx) {
     np.size = CUpti_PCSamplingGetNumStallReasonsParamsSize;
     np.ctx = ctx;
     np.numStallReasons = &num;
-    if (!check(cuptiPCSamplingGetNumStallReasons(&np), "cuptiPCSamplingGetNumStallReasons"))
+    if (!check(perfagent::cupti::PCSamplingGetNumStallReasons(&np),
+               "cuptiPCSamplingGetNumStallReasons"))
         return false;
     if (!num) {
         logf("perfagent-cupti: PC sampling reports zero stall reasons; not enabling\n");
@@ -657,7 +694,7 @@ bool pc_query_stall_reasons(CUcontext ctx) {
     sp.numStallReasons = num;
     sp.stallReasonIndex = indices.data();
     sp.stallReasons = names.data();
-    if (!check(cuptiPCSamplingGetStallReasons(&sp), "cuptiPCSamplingGetStallReasons"))
+    if (!check(perfagent::cupti::PCSamplingGetStallReasons(&sp), "cuptiPCSamplingGetStallReasons"))
         return false;
 
     g_stall_indices = indices;
@@ -703,12 +740,14 @@ void pc_disable_ctx(PCContext *c, const char *why) {
     CUpti_PCSamplingDisableParams dp{};
     dp.size = CUpti_PCSamplingDisableParamsSize;
     dp.ctx = c->ctx;
-    if (!check(cuptiPCSamplingDisable(&dp), why))
+    if (!check(perfagent::cupti::PCSamplingDisable(&dp), why))
         g_ctx_disable_failed.fetch_add(1, std::memory_order_relaxed);
     c->enabled = false;
 }
 
-// Enables and configures PC sampling on one context. Caller holds g_pc_mu.
+// Enables and configures PC sampling on one context. Caller holds the CUPTI
+// guard (perfagent::cupti::guard()); the wrappers below take it again, which
+// is free because it is re-entrant on the owning thread.
 //
 // Enable first, then configure: cuptiPCSamplingGetNumStallReasons and the
 // configuration attributes are all keyed on a context CUPTI already knows is
@@ -736,7 +775,7 @@ void pc_enable_ctx(CUcontext ctx) {
     CUpti_PCSamplingEnableParams en{};
     en.size = CUpti_PCSamplingEnableParamsSize;
     en.ctx = ctx;
-    if (!check(cuptiPCSamplingEnable(&en), "cuptiPCSamplingEnable")) {
+    if (!check(perfagent::cupti::PCSamplingEnable(&en), "cuptiPCSamplingEnable")) {
         g_ctx_enable_failed.fetch_add(1, std::memory_order_relaxed);
         return;
     }
@@ -802,7 +841,7 @@ void pc_enable_ctx(CUcontext ctx) {
     cp.ctx = ctx;
     cp.numAttributes = n;
     cp.pPCSamplingConfigurationInfo = info;
-    if (!check(cuptiPCSamplingSetConfigurationAttribute(&cp),
+    if (!check(perfagent::cupti::PCSamplingSetConfigurationAttribute(&cp),
                "cuptiPCSamplingSetConfigurationAttribute")) {
         pc_disable_ctx(c, "cuptiPCSamplingDisable (configure failed)");
         g_ctx_enable_failed.fetch_add(1, std::memory_order_relaxed);
@@ -816,7 +855,7 @@ void pc_enable_ctx(CUcontext ctx) {
     for (size_t i = 0; i < n; i++) {
         if (info[i].attributeStatus != CUPTI_SUCCESS) {
             const char *msg = "?";
-            cuptiGetResultString(info[i].attributeStatus, &msg);
+            perfagent::cupti::GetResultString(info[i].attributeStatus, &msg);
             logf("perfagent-cupti: pc sampling attribute %d refused: %s\n",
                  (int)info[i].attributeType, msg);
             pc_disable_ctx(c, "cuptiPCSamplingDisable (attribute refused)");
@@ -836,7 +875,7 @@ void pc_enable_ctx(CUcontext ctx) {
         qp.ctx = ctx;
         qp.numAttributes = 1;
         qp.pPCSamplingConfigurationInfo = &q;
-        if (cuptiPCSamplingGetConfigurationAttribute(&qp) == CUPTI_SUCCESS &&
+        if (perfagent::cupti::PCSamplingGetConfigurationAttribute(&qp) == CUPTI_SUCCESS &&
             q.attributeStatus == CUPTI_SUCCESS)
             g_pc_period = q.attributeData.samplingPeriodData.samplingPeriod;
     }
@@ -851,7 +890,7 @@ void pc_enable_ctx(CUcontext ctx) {
 }
 
 // Pulls whatever CUPTI has for one context and turns it into wire records.
-// Caller holds g_pc_mu.
+// Caller holds the CUPTI guard.
 //
 // ONE RECORD PER (PC, stall reason) PAIR. That is the price of the ABI's
 // fixed-size record rule (spec §6.3): CUpti_PCSamplingPCData carries a
@@ -874,7 +913,7 @@ void pc_drain_ctx_locked(PCContext *c) {
         gp.ctx = c->ctx;
         gp.pcSamplingData = &c->data;
         g_pc_getdata_calls.fetch_add(1, std::memory_order_relaxed);
-        const CUptiResult st = cuptiPCSamplingGetData(&gp);
+        const CUptiResult st = perfagent::cupti::PCSamplingGetData(&gp);
         if (st == CUPTI_ERROR_OUT_OF_MEMORY) {
             // The documented "hardware buffer is full" return. The PC data for
             // this window is gone; the fact that it is gone is not.
@@ -947,7 +986,7 @@ void pc_drain_ctx_locked(PCContext *c) {
 }
 
 void pc_drain_all(perfagent::PCDrainReason reason) {
-    std::lock_guard<std::mutex> g(g_pc_mu);
+    perfagent::cupti::CallScope hold;
     for (PCContext *c : g_pc_ctxs) pc_drain_ctx_locked(c);
     if (reason != perfagent::PCDrainReason::kPeriodic && g_pcb) g_pcb->flush();
 }
@@ -989,7 +1028,7 @@ void pc_start_ctxs_locked() {
         CUpti_PCSamplingStartParams sp{};
         sp.size = CUpti_PCSamplingStartParamsSize;
         sp.ctx = c->ctx;
-        if (!check(cuptiPCSamplingStart(&sp), "cuptiPCSamplingStart"))
+        if (!check(perfagent::cupti::PCSamplingStart(&sp), "cuptiPCSamplingStart"))
             g_burst_start_failed.fetch_add(1, std::memory_order_relaxed);
     }
 }
@@ -1000,27 +1039,38 @@ void pc_stop_ctxs_locked() {
         CUpti_PCSamplingStopParams sp{};
         sp.size = CUpti_PCSamplingStopParamsSize;
         sp.ctx = c->ctx;
-        if (!check(cuptiPCSamplingStop(&sp), "cuptiPCSamplingStop"))
+        if (!check(perfagent::cupti::PCSamplingStop(&sp), "cuptiPCSamplingStop"))
             g_burst_stop_failed.fetch_add(1, std::memory_order_relaxed);
     }
 }
 
 // Closes an open burst: stop every context, drain (CUPTI requires the flush
 // after every range end), close the window, and hand the yield to the loop.
-// Caller must NOT hold g_pc_mu.
+//
+// The stop and its mandatory flush are ONE critical section, which they were
+// not before issue #99: the old code released the PC mutex between them, so
+// another thread's CUPTI call could land in the gap between a range ending and
+// the flush the header requires after it. pc_drain_all takes the guard again
+// inside this scope, which costs a depth increment and no lock -- that is what
+// the re-entrancy in core/callguard.h buys, spent on making a two-call
+// sequence atomic rather than on convenience.
+//
+// The guard is released before the window is emitted and before the controller
+// is told, so a USDT fire and the controller's own mutex are never taken with
+// the whole vendor surface locked.
 void burst_close(uint64_t now_ns, uint64_t start_ns) {
     {
-        std::lock_guard<std::mutex> g(g_pc_mu);
+        perfagent::cupti::CallScope hold;
         pc_stop_ctxs_locked();
+        // The range-end flush. cupti_pcsampling.h: "If configuration option
+        // ENABLE_START_STOP_CONTROL is enabled, then after every range end
+        // i.e. cuptiPCSamplingStop()". Missing it does not lose data --- it
+        // makes two instructions share a PC identity, silently. force() also
+        // moves the shared schedule's phase so the periodic drain coalesces
+        // rather than repeating the pull microseconds later.
+        if (g_pc_schedule) g_pc_schedule->force(now_ns, perfagent::PCDrainReason::kRangeEnd);
+        pc_drain_all(perfagent::PCDrainReason::kRangeEnd);
     }
-    // The range-end flush. cupti_pcsampling.h: "If configuration option
-    // ENABLE_START_STOP_CONTROL is enabled, then after every range end i.e.
-    // cuptiPCSamplingStop()". Missing it does not lose data --- it makes two
-    // instructions share a PC identity, silently. force() also moves the
-    // shared schedule's phase so the 100 ms tick coalesces rather than
-    // repeating the pull microseconds later.
-    if (g_pc_schedule) g_pc_schedule->force(now_ns, perfagent::PCDrainReason::kRangeEnd);
-    pc_drain_all(perfagent::PCDrainReason::kRangeEnd);
     emit_window(start_ns, now_ns);
     g_sampling_burst_ns.fetch_add(now_ns > start_ns ? now_ns - start_ns : 0,
                                   std::memory_order_relaxed);
@@ -1032,7 +1082,8 @@ void burst_close(uint64_t now_ns, uint64_t start_ns) {
     if (g_burst) g_burst->closed(g_pc_records.load(std::memory_order_relaxed));
 }
 
-// The burst timer's tick. Runs on its own thread; see the note on g_burst.
+// The burst half of the single timer's tick. Called from on_timer_tick, on the
+// one thread this adapter runs; see the note on g_burst.
 void on_burst_tick() {
     if (!g_pc_tier_a || !g_burst) return;
     // No enabled context means nothing can be serialized, so there is no
@@ -1055,7 +1106,7 @@ void on_burst_tick() {
     switch (g_burst->poll(now, graphs)) {
         case perfagent::BurstAction::kStart: {
             {
-                std::lock_guard<std::mutex> g(g_pc_mu);
+                perfagent::cupti::CallScope hold;
                 pc_start_ctxs_locked();
             }
             g_sampling_bursts.fetch_add(1, std::memory_order_relaxed);
@@ -1137,9 +1188,9 @@ void on_finalize(const char *why) {
 
     // Tier A: stop the duty cycle before anything else, so no burst can open
     // against contexts this function is about to disable. Only the
-    // controller's own mutex is taken here --- deliberately NOT g_pc_mu, which
-    // this function may fail to acquire below and which the fatal-error
-    // callback can already be holding.
+    // controller's own mutex is taken here --- deliberately NOT the CUPTI
+    // guard, which this function may fail to acquire below and which the
+    // fatal-error callback can already be holding.
     //
     // On the fatal-error path an open window is left OPEN on the wire. That is
     // correct and it is the point: a CUPTI fatal error IS the hard case, and
@@ -1149,18 +1200,28 @@ void on_finalize(const char *why) {
     // mean the hard case specifically.
     if (g_burst) g_burst->shutdown(mono_ns());
 
-    // try_lock, not lock, and this is the one place that is right.
+    // A try, not a blocking acquire, and this is the one place that is right.
     //
     // The fatal-error callback can arrive on the very thread that is inside a
-    // CUPTI call this adapter made while holding g_pc_mu --- a drain, say ---
+    // CUPTI call this adapter made while holding the guard --- a drain, say ---
     // and a blocking acquire there would deadlock somebody else's process at
     // the worst possible moment. Skipping the teardown loses the tail of the
     // profile; deadlocking loses the application. The skip is counted so it is
     // a known outcome rather than an invisible one.
-    std::unique_lock<std::mutex> g(g_pc_mu, std::try_to_lock);
-    if (!g.owns_lock()) {
+    //
+    // TryCallScope, not std::unique_lock(mu, std::try_to_lock), and the
+    // difference is not cosmetic. The guard is re-entrant, so a plain try from
+    // a thread that already holds it would SUCCEED, and this function would
+    // then disable PC sampling out from under the CUPTI call the outer frame
+    // is standing in. TryCallScope refuses when the guard is held by anybody,
+    // this thread included. (std::mutex could not express that at all:
+    // try_lock() on a mutex the calling thread owns is undefined behaviour,
+    // which is what the line this replaces did on exactly that path.)
+    perfagent::cupti::TryCallScope g;
+    if (!g.owns()) {
         g_finalize_contended.fetch_add(1, std::memory_order_relaxed);
-        logf("perfagent-cupti: finalize (%s): pc sampling lock held; teardown skipped\n", why);
+        logf("perfagent-cupti: finalize (%s): the CUPTI guard is held (a call is in "
+             "flight); teardown skipped rather than deadlocking the host\n", why);
         return;
     }
     logf("perfagent-cupti: finalize (%s): disabling pc sampling on %zu context(s)\n",
@@ -1283,13 +1344,13 @@ void on_resource(CUpti_CallbackId cbid, const CUpti_ResourceData *rd) {
     switch (cbid) {
         case CUPTI_CBID_RESOURCE_CONTEXT_CREATED: {
             g_ctx_seen.fetch_add(1, std::memory_order_relaxed);
-            std::lock_guard<std::mutex> g(g_pc_mu);
+            perfagent::cupti::CallScope hold;
             pc_enable_ctx(rd->context);
             break;
         }
         case CUPTI_CBID_RESOURCE_CONTEXT_DESTROY_STARTING: {
             g_ctx_destroyed.fetch_add(1, std::memory_order_relaxed);
-            std::lock_guard<std::mutex> g(g_pc_mu);
+            perfagent::cupti::CallScope hold;
             for (size_t i = 0; i < g_pc_ctxs.size(); i++) {
                 if (g_pc_ctxs[i]->ctx != rd->context) continue;
                 PCContext *c = g_pc_ctxs[i];
@@ -1312,8 +1373,11 @@ void on_resource(CUpti_CallbackId cbid, const CUpti_ResourceData *rd) {
             // unique. Missing it does not lose data -- it makes two different
             // instructions share a PC identity, silently, which is the worst
             // failure available here. So this drains before returning, and it
-            // BLOCKS on g_pc_mu rather than trying the lock: a skipped flush
-            // is exactly what must not happen.
+            // BLOCKS on the CUPTI guard rather than trying it: a skipped flush
+            // is exactly what must not happen. Since #99 the guard covers every
+            // CUPTI call the adapter makes rather than only the PC-sampling
+            // family, so this now waits for an activity flush as well -- one
+            // CUPTI call's duration, on the application's cuModuleUnload path.
             g_module_unload_drains.fetch_add(1, std::memory_order_relaxed);
             if (g_pc_schedule)
                 g_pc_schedule->force(mono_ns(), perfagent::PCDrainReason::kModuleUnload);
@@ -1426,13 +1490,34 @@ void handle_kernel(const CUpti_ActivityKernel12 *k) {
     g_eb->add(e);
 }
 
+// CUPTI's buffer-completed callback, and the ONE place in this adapter that
+// reaches CUPTI without taking the guard.
+//
+// It is an exemption with a reason rather than an oversight.
+// cuptiActivityFlushAll is documented as "a blocking call" that hands buffers
+// back "using the callback registered in cuptiActivityRegisterCallbacks". If
+// CUPTI delivers them on a worker thread while our timer thread holds the
+// guard across that flush, a guarded callback would block the worker on a lock
+// the flusher is waiting for it to release -- issue #99's deadlock, rebuilt
+// inside its own fix.
+//
+// The boundary: the guard covers calls this adapter initiates on a thread of
+// its own choosing. It does not cover the documented way to consume a buffer
+// CUPTI has just handed us and, in its own words, "relinquished ownership of".
+// The two entry points used here carry that in their names, and they COUNT a
+// call made outside this scope rather than trusting the name -- see
+// perfagent::cupti::misplaced_callback_calls(), reported as
+// cupti_calls_misplaced and required to be 0.
 void CUPTIAPI buffer_completed(CUcontext, uint32_t, uint8_t *buffer, size_t,
                                size_t valid_size) {
+    const perfagent::cupti::BufferCompletedScope in_callback;
     g_buffers.fetch_add(1, std::memory_order_relaxed);
     if (buffer && valid_size) {
         CUpti_Activity *record = nullptr;
         for (;;) {
-            const CUptiResult st = cuptiActivityGetNextRecord(buffer, valid_size, &record);
+            const CUptiResult st =
+                perfagent::cupti::ActivityGetNextRecord_InBufferCompletedOnly(
+                    buffer, valid_size, &record);
             if (st == CUPTI_ERROR_MAX_LIMIT_REACHED) break;
             if (st != CUPTI_SUCCESS) break;
             if (record->kind == CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL ||
@@ -1454,7 +1539,9 @@ void CUPTIAPI buffer_completed(CUcontext, uint32_t, uint8_t *buffer, size_t,
     }
     // CUPTI's own overflow. Counted, never silent.
     size_t dropped = 0;
-    if (cuptiActivityGetNumDroppedRecords(nullptr, 0, &dropped) == CUPTI_SUCCESS && dropped)
+    if (perfagent::cupti::ActivityGetNumDroppedRecords_InBufferCompletedOnly(
+            nullptr, 0, &dropped) == CUPTI_SUCCESS &&
+        dropped)
         g_cupti_dropped.fetch_add(dropped, std::memory_order_relaxed);
     free(buffer);   // free(nullptr) is a no-op, and a declined request lands here too
 }
@@ -1522,6 +1609,52 @@ void report(const char *why) {
     logf("perfagent-cupti: graph_execs=%llu multi_device=%llu devices=%zu\n",
          (unsigned long long)g_exec_from_graph.load(),
          (unsigned long long)g_multi_device.load(), g_devices_seen.size());
+    // The CUPTI call guard (issue #99). Every one of these is assertable:
+    //
+    //   cupti_calls        acquisitions; must move on any run that touched CUPTI
+    //   cupti_reentrant    acquisitions by a thread already inside one. NOT
+    //                      expected to be zero: nearly every wrapper call is
+    //                      made inside an outer CallScope, and burst_close
+    //                      nests two deep on purpose. cupti_max_depth is the
+    //                      counter that discriminates -- see below.
+    //   cupti_max_depth    the deepest nesting reached. 3 on a healthy Tier A
+    //                      run (burst_close -> pc_drain_all -> the GetData
+    //                      wrapper), 2 in Tier B and on the context callbacks,
+    //                      1 with PC sampling off. ANYTHING ABOVE 3 means CUPTI
+    //                      re-entered us through a callback while we were
+    //                      inside one of its calls -- the hazard the Task 6
+    //                      report (item 13) and the Task 10 report (item 11)
+    //                      both listed as unverified. This is the answer to
+    //                      them, and before this guard existed that same
+    //                      condition was a self-deadlock rather than a number.
+    //   cupti_waits        acquisitions that had to block. Non-zero is healthy:
+    //                      it is the application's callbacks meeting the timer.
+    //                      Zero on a Tier A run would mean the guard is never
+    //                      contended and therefore proving nothing.
+    //   cupti_try_failed_* the fatal-error teardown finding the guard held, by
+    //                      another thread or by its own. MUST be 0 on a healthy
+    //                      run; they are the two halves of finalize_contended.
+    //   cupti_calls_misplaced  a buffer-completed-only entry point called from
+    //                      outside that callback. MUST be 0: it is the one
+    //                      unguarded hole in the adapter and this is what says
+    //                      nobody widened it.
+    //   timer_ticks/drains/skipped  the merged timer. drains must be about
+    //                      ticks * tick_ms / drain_ms; a drains of 0 with ticks
+    //                      moving is a drain that silently stopped.
+    logf("perfagent-cupti: cupti_calls=%llu cupti_reentrant=%llu cupti_waits=%llu "
+         "cupti_try_failed_self=%llu cupti_try_failed_other=%llu cupti_max_depth=%u "
+         "cupti_calls_misplaced=%llu "
+         "timer_ticks=%llu timer_drains=%llu timer_skipped=%llu\n",
+         (unsigned long long)perfagent::cupti::guard().entries(),
+         (unsigned long long)perfagent::cupti::guard().reentries(),
+         (unsigned long long)perfagent::cupti::guard().waits(),
+         (unsigned long long)perfagent::cupti::guard().try_failed_self(),
+         (unsigned long long)perfagent::cupti::guard().try_failed_other(),
+         perfagent::cupti::guard().max_depth(),
+         (unsigned long long)perfagent::cupti::misplaced_callback_calls().load(),
+         (unsigned long long)(g_tick_plan ? g_tick_plan->ticks() : 0),
+         (unsigned long long)(g_tick_plan ? g_tick_plan->drains() : 0),
+         (unsigned long long)(g_tick_plan ? g_tick_plan->skipped() : 0));
     if (!g_pc_enabled) {
         logf("perfagent-cupti: pc_sampling=off tier_refused=%llu "
              "(set PERFAGENT_GPU_PC_SAMPLING=continuous or =serialized)\n",
@@ -1626,7 +1759,10 @@ void on_tick() {
     // Resample first, so the conversion the flush is about to feed through
     // ClockFit is the freshest offset available.
     resample_clock();
-    cuptiActivityFlushAll(0);
+    // THE call site issue #99 was. It took no lock; it now goes through the
+    // guard like every other, and it cannot be written any other way -- the
+    // raw name does not compile below nvidia/cupti_guard.h.
+    perfagent::cupti::ActivityFlushAll(0);
     g_lb->flush();
     g_eb->flush();
 
@@ -1693,16 +1829,45 @@ void on_tick() {
     g_replay->replay_if_newly_attached(gpu_stall_reason_map_v1_enabled());
 }
 
+// THE tick. One timer thread, and therefore one thread of ours that can ever
+// be inside CUPTI --- which is the structural half of issue #99's fix: it does
+// not exclude the bad state, it makes it unrepresentable. There is no second
+// timer to race with, whatever a future call site does.
+//
+// Order matters. The burst poll runs FIRST, because a burst transition is
+// timestamped by on_burst_tick itself and Tier A's duty fraction is measured
+// from those timestamps: a stop deferred behind a flush lengthens the burst
+// that actually happened. Running it first means a transition waits for at
+// most the PREVIOUS tick's drain, never for this one's.
+//
+// The activity drain is rate-limited on top of the shorter tick by
+// core/tickplan.h, so its period is what it always was (100 ms by default) and
+// the burst poll keeps its own granularity. What the merge costs is stated at
+// tick_period_ns: a slow flush delays the next burst poll by its own duration,
+// and that shows up in `duty=` in the report, which is measured rather than
+// assumed.
+void on_timer_tick() {
+    on_burst_tick();   // a no-op unless Tier A is on; see its head
+    if (!g_tick_plan || g_tick_plan->drain_due(mono_ns())) on_tick();
+}
+
 // The documented CUPTI shutdown hook. Without it the records still sitting in
 // a partly filled CUPTI buffer at exit are lost, and so is whatever is in the
 // batches.
 void at_exit_handler() {
-    // Tier A's duty cycle first of all. The timer thread is stopped before the
-    // controller is asked to close, so no tick can open a burst against
-    // contexts the finalize below is about to disable -- and the open window
-    // is closed with the exit timestamp, which is precisely what makes
-    // end_ns == 0 on the wire mean a HARD exit and nothing else.
-    if (g_burst_timer) g_burst_timer->stop();
+    // The timer thread first of all, and this is a fix in its own right: the
+    // old handler stopped the burst timer and left the DRAIN timer running, so
+    // its cuptiActivityFlushAll ran concurrently with on_finalize's
+    // cuptiPCSamplingDisable below -- the same two-threads-in-CUPTI shape as
+    // issue #99, on the exit path. There is one timer now and it is stopped
+    // and JOINED here, so from this line on the only thread of ours that can
+    // reach CUPTI is this one.
+    //
+    // Stopping before burst_shutdown also means no tick can open a burst
+    // against contexts the finalize below is about to disable, and the open
+    // window is closed with the exit timestamp -- which is precisely what
+    // makes end_ns == 0 on the wire mean a HARD exit and nothing else.
+    if (g_timer) g_timer->stop();
     burst_shutdown();
     // PC sampling next, and specifically before cuptiActivityFlushAll: the
     // finalize handler drains and then disables each context, and
@@ -1711,7 +1876,7 @@ void at_exit_handler() {
     // flush for no reason, and doing it not at all is the undefined state this
     // handler exists to remove.
     on_finalize("exit");
-    cuptiActivityFlushAll(1);
+    perfagent::cupti::ActivityFlushAll(1);
     if (g_lb) g_lb->flush();
     if (g_eb) g_eb->flush();
     if (g_pcb) g_pcb->flush();
@@ -1750,7 +1915,7 @@ uint64_t env_u64(const char *name, uint64_t dflt) {
 bool check(CUptiResult r, const char *what) {
     if (r == CUPTI_SUCCESS) return true;
     const char *msg = "?";
-    cuptiGetResultString(r, &msg);
+    perfagent::cupti::GetResultString(r, &msg);
     logf("perfagent-cupti: %s failed: %s\n", what, msg);
     return false;
 }
@@ -1833,7 +1998,7 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
                                       env_u64("PERFAGENT_GPU_SAMPLE_SEED",
                                               perfagent::Sampler::kDefaultSeed));
     g_names = new perfagent::KernelNameTable();
-    g_drainer = new perfagent::Drainer();
+    g_timer = new perfagent::Drainer();
     // Leaked with the rest, and for the same reason: a CUPTI worker thread
     // can still be inside a RESOURCE callback during teardown, and a
     // destroyed queue under it is a use-after-free in somebody else's
@@ -1925,15 +2090,15 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
         bc.max_duty = (double)env_uint("PERFAGENT_GPU_PC_MAX_DUTY_PERMILLE", 100) / 1000.0;
         bc.max_gap_ns = (uint64_t)env_uint("PERFAGENT_GPU_PC_MAX_GAP_MS", 10000) * 1000000ull;
         g_burst = new perfagent::BurstController(bc);
-        // The burst timer's period. A fifth of the burst length by default, so
+        // The burst poll's period. A fifth of the burst length by default, so
         // a "50 ms" burst is 50..60 ms rather than 50..150 ms on the 100 ms
-        // drain tick. It costs one wakeup per period doing an atomic load and
-        // a compare when no transition is due.
+        // drain tick. Since issue #99 this is the period of the ONE timer
+        // thread rather than of a second one; the drain is rate-limited on top
+        // of it. It costs one wakeup per period doing an atomic load and a
+        // compare when no transition is due.
         unsigned burst_tick_ms = env_uint("PERFAGENT_GPU_PC_BURST_TICK_MS",
                                           (unsigned)(bc.burst_ns / 5000000ull));
         if (!burst_tick_ms) burst_tick_ms = 1;
-        g_burst_timer = new perfagent::Drainer();
-        g_burst_timer->on_tick(on_burst_tick);
         logf("perfagent-cupti: tier A duty cycle burst_ms=%llu target_rate=%.0f/s "
              "max_duty=%.3f min_gap_ms=%llu max_gap_ms=%llu tick_ms=%u\n",
              (unsigned long long)(bc.burst_ns / 1000000ull), bc.target_rate, bc.max_duty,
@@ -1942,49 +2107,61 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
         g_burst_tick_ms = burst_tick_ms;
     }
 
-    if (!check(cuptiSubscribe(&g_subscriber, (CUpti_CallbackFunc)on_callback, nullptr),
+    if (!check(perfagent::cupti::Subscribe(&g_subscriber, (CUpti_CallbackFunc)on_callback,
+                                          nullptr),
                "cuptiSubscribe"))
         return 0;
     // RUNTIME_API and RESOURCE only. Adding DRIVER_API more than doubled
     // correlation-id consumption in the spike (2.242 vs 1.004 ids per launch),
     // which halves the time to a uint32 wrap, and buys this ABI nothing.
-    check(cuptiEnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_RUNTIME_API),
+    check(perfagent::cupti::EnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_RUNTIME_API),
           "enable RUNTIME_API");
-    check(cuptiEnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_RESOURCE),
+    check(perfagent::cupti::EnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_RESOURCE),
           "enable RESOURCE");
     if (g_pc_enabled) {
         // The only notification that CUPTI is about to finalize itself. Not
         // subscribed when Tier B is off: with no PC sampling enabled there is
         // nothing for the handler to tear down, and the subscription is not
         // free.
-        check(cuptiEnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_STATE),
+        check(perfagent::cupti::EnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_STATE),
               "enable STATE");
     }
 
-    check(cuptiActivityRegisterCallbacks(buffer_requested, buffer_completed),
+    check(perfagent::cupti::ActivityRegisterCallbacks(buffer_requested, buffer_completed),
           "cuptiActivityRegisterCallbacks");
-    check(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL),
+    check(perfagent::cupti::ActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL),
           "enable CONCURRENT_KERNEL");
     if (g_pc_enabled) {
         // sm_count and clock_hz for gpu_config_v1 have no other source: CUPTI
         // has no device attribute for either and this adapter does not link
         // libcuda. One record per device, delivered once.
-        check(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_DEVICE), "enable DEVICE");
+        check(perfagent::cupti::ActivityEnable(CUPTI_ACTIVITY_KIND_DEVICE), "enable DEVICE");
     }
 
     // Seed the fit before any activity record can be converted.
     resample_clock();
 
     const unsigned drain_ms = env_uint("PERFAGENT_GPU_DRAIN_MS", 100);
-    g_drainer->on_tick(on_tick);
-    g_drainer->start(drain_ms);
+    // ONE timer, at the shorter of the two periods, with the drain rate-limited
+    // on top of it. Two timer threads is what issue #99 was; see on_timer_tick
+    // and core/tickplan.h.
+    const uint64_t tick_ns = perfagent::tick_period_ns(
+        (uint64_t)drain_ms * 1000000ull, (uint64_t)g_burst_tick_ms * 1000000ull, g_pc_tier_a);
+    // drain_limit_ns, not the drain period: with Tier A off the timer already
+    // runs at the drain period and a rate limit on top of it would skip any
+    // tick that arrived a hair early. See core/tickplan.h.
+    g_tick_plan = new perfagent::TickPlan(
+        perfagent::drain_limit_ns((uint64_t)drain_ms * 1000000ull, tick_ns));
 
-    // Started AFTER the drain timer and after atexit is armed: a burst that
-    // opened before the exit handler existed could not be closed by it, and
-    // an unclosed window would report a hard exit that did not happen.
-    if (g_burst_timer) g_burst_timer->start(g_burst_tick_ms);
-
+    // ARMED BEFORE THE TIMER STARTS, which the two-timer version got by
+    // accident from its ordering and this one has to get on purpose: a burst
+    // that opened before the exit handler existed could not be closed by it,
+    // and an unclosed window would report a hard exit that did not happen.
     atexit(at_exit_handler);
+
+    g_tick_plan->start(mono_ns());
+    g_timer->on_tick(on_timer_tick);
+    g_timer->start((unsigned)(tick_ns / 1000000ull));
 
     // The seed is logged because it IS the schedule: with it and the period,
     // the exact set of sampled launch ordinals is replayable offline

--- a/shim/nvidia/cupti_guard.h
+++ b/shim/nvidia/cupti_guard.h
@@ -1,0 +1,295 @@
+// The one lock over CUPTI, and the reason a future call site cannot forget it.
+//
+// Issue #99: the adapter deadlocked the profiled application, permanently, on
+// the first Tier A burst. It held a mutex over the PC-sampling family and
+// nothing at all over cuptiActivityFlushAll, so its 100 ms drain thread and its
+// 10 ms burst thread were inside CUPTI at the same time, in different CUPTI
+// subsystems, while the application sat in a launch callback. The bug was not a
+// wrong lock -- it was a CALL SITE THAT TOOK NO LOCK, added later, next to call
+// sites that did.
+//
+// What the headers actually say
+// -----------------------------
+// CUPTI documents thread safety per function, and it does so in three of its
+// headers: cupti_result.h ("this function is thread safe"), cupti_events.h (32
+// such notes) and cupti_callbacks.h (8, including "a subscriber must serialize
+// access to cuptiGetCallbackState, cuptiEnableCallback, cuptiEnableDomain and
+// cuptiEnableAllDomains ... if called concurrently, the results are
+// undefined").
+//
+// cupti_activity.h and cupti_pcsampling.h contain ZERO thread-safety notes
+// between them, in CUDA 13.3. Not "not thread safe" -- unstated. So neither
+// cuptiActivityFlushAll nor any PC-sampling entry point is documented as safe
+// to call concurrently with anything, and the concurrency the adapter had was
+// never sanctioned by the vendor, only untested by us. That makes serialising
+// them MANDATORY rather than defensive, and it is why this file exists instead
+// of a rule about lock ordering written in a comment.
+//
+// The discipline, in one sentence
+// -------------------------------
+// EVERY CUPTI call the adapter initiates goes through a wrapper below, and
+// every wrapper takes the one guard. There is no other way to reach CUPTI from
+// this adapter: the raw entry points are #defined to identifiers that do not
+// exist, at the bottom of this header, so a call site that skips the guard
+// FAILS TO COMPILE with a message naming the wrapper it should have used.
+// `make -C shim check-cupti-guard` proves that by trying it, the way
+// check-cubin-defer proves the CubinView guard.
+//
+// Lock ordering
+// -------------
+// perfagent::cupti::guard() is the OUTERMOST lock in this adapter. Every other
+// mutex it owns -- the clock fit, the device list, Batch, KernelNameTable,
+// ReplayLog, CubinQueue, BurstController, PCDrainSchedule -- is a leaf: each is
+// taken and released without calling CUPTI and without acquiring the guard, so
+// they may all be taken while holding it and none may be held while acquiring
+// it. With one lock over the whole vendor surface there is no ordering between
+// OUR locks left to get wrong, which is the point of it being one lock rather
+// than a lock per CUPTI subsystem.
+//
+// The guard is RE-ENTRANT on the owning thread; see core/callguard.h for why
+// that is a requirement and not a convenience, and note that every re-entrant
+// acquisition is counted.
+//
+// The one exemption, and its boundary
+// -----------------------------------
+// cuptiActivityGetNextRecord and cuptiActivityGetNumDroppedRecords, called
+// from inside CUPTI's own buffer-completed callback, are NOT guarded, and that
+// is deliberate rather than an oversight:
+//
+//   cuptiActivityFlushAll is documented as "a blocking call" that returns
+//   buffers "using the callback registered in cuptiActivityRegisterCallbacks".
+//   If CUPTI delivers those buffers on a worker thread while our thread holds
+//   the guard across the flush, a guarded callback would block the worker on a
+//   lock the flusher holds -- which is the exact deadlock shape this file
+//   exists to remove, rebuilt inside the fix.
+//
+// The boundary is principled: the guard covers calls the adapter initiates on a
+// thread of its own choosing. It does not cover the documented way to consume a
+// buffer CUPTI has just handed us and, in its own words, "relinquished
+// ownership of". The two wrappers carry that in their names so they cannot be
+// reached for anywhere else by habit, and they COUNT a call made outside a
+// buffer-completed callback rather than trusting the name.
+#ifndef PERFAGENT_CUPTI_GUARD_H
+#define PERFAGENT_CUPTI_GUARD_H
+
+#include <cupti.h>
+#include <cupti_pcsampling.h>
+
+#include "callguard.h"
+
+#include <atomic>
+#include <cstdint>
+
+namespace perfagent {
+namespace cupti {
+
+// The one guard. Never destroyed, deliberately and for the same reason every
+// other object in this adapter is leaked: CUPTI worker threads and the atexit
+// handler both reach it during process teardown, and a destroyed mutex under
+// them is undefined behaviour in somebody else's process.
+inline CallGuard &guard() {
+    static CallGuard *g = new CallGuard();
+    return *g;
+}
+
+// Held across a sequence of CUPTI calls that must not be interleaved with
+// another thread's -- stop every context, then flush, for instance. The
+// individual wrappers take the guard too; it is re-entrant, so nesting is
+// free and the outer scope is what makes the sequence atomic.
+class CallScope {
+public:
+    CallScope() : s_(guard()) {}
+
+private:
+    CallGuard::Scope s_;
+};
+
+// The teardown path's acquisition: never blocks, and refuses when the guard is
+// held by ANY thread including this one. See on_finalize in cupti_adapter.cc.
+class TryCallScope {
+public:
+    TryCallScope() : s_(guard()) {}
+    bool owns() const { return s_.owns(); }
+
+private:
+    CallGuard::TryScope s_;
+};
+
+// ------------------------------------------------- the buffer-completed hole
+
+// True while this thread is inside CUPTI's buffer-completed callback. The two
+// unguarded wrappers below check it, so using them anywhere else is counted
+// instead of being merely discouraged by their names.
+inline bool &in_buffer_completed() {
+    static thread_local bool flag = false;
+    return flag;
+}
+
+inline std::atomic<uint64_t> &misplaced_callback_calls() {
+    static std::atomic<uint64_t> *n = new std::atomic<uint64_t>(0);
+    return *n;
+}
+
+class BufferCompletedScope {
+public:
+    BufferCompletedScope() { in_buffer_completed() = true; }
+    ~BufferCompletedScope() { in_buffer_completed() = false; }
+};
+
+// --------------------------------------------------------- guarded wrappers
+//
+// One per CUPTI entry point the adapter uses. Each takes the guard; none does
+// anything else, so the wrapper layer adds a lock and no behaviour.
+
+inline CUptiResult GetTimestamp(uint64_t *ts) {
+    CallScope s;
+    return cuptiGetTimestamp(ts);
+}
+
+inline CUptiResult GetResultString(CUptiResult r, const char **msg) {
+    // cupti_result.h: "Thread-safety: this function is thread safe." It is
+    // guarded anyway. The exemption list is a liability and one documented
+    // exception does not earn a second; this call happens on error paths only.
+    CallScope s;
+    return cuptiGetResultString(r, msg);
+}
+
+inline CUptiResult GetCubinCrc(CUpti_GetCubinCrcParams *p) {
+    CallScope s;
+    return cuptiGetCubinCrc(p);
+}
+
+inline CUptiResult Subscribe(CUpti_SubscriberHandle *sub, CUpti_CallbackFunc cb, void *ud) {
+    CallScope s;
+    return cuptiSubscribe(sub, cb, ud);
+}
+
+inline CUptiResult EnableDomain(uint32_t enable, CUpti_SubscriberHandle sub,
+                                CUpti_CallbackDomain domain) {
+    CallScope s;
+    return cuptiEnableDomain(enable, sub, domain);
+}
+
+inline CUptiResult ActivityRegisterCallbacks(CUpti_BuffersCallbackRequestFunc req,
+                                             CUpti_BuffersCallbackCompleteFunc done) {
+    CallScope s;
+    return cuptiActivityRegisterCallbacks(req, done);
+}
+
+inline CUptiResult ActivityEnable(CUpti_ActivityKind kind) {
+    CallScope s;
+    return cuptiActivityEnable(kind);
+}
+
+inline CUptiResult ActivityFlushAll(uint32_t flag) {
+    CallScope s;
+    return cuptiActivityFlushAll(flag);
+}
+
+inline CUptiResult PCSamplingEnable(CUpti_PCSamplingEnableParams *p) {
+    CallScope s;
+    return cuptiPCSamplingEnable(p);
+}
+
+inline CUptiResult PCSamplingDisable(CUpti_PCSamplingDisableParams *p) {
+    CallScope s;
+    return cuptiPCSamplingDisable(p);
+}
+
+inline CUptiResult PCSamplingStart(CUpti_PCSamplingStartParams *p) {
+    CallScope s;
+    return cuptiPCSamplingStart(p);
+}
+
+inline CUptiResult PCSamplingStop(CUpti_PCSamplingStopParams *p) {
+    CallScope s;
+    return cuptiPCSamplingStop(p);
+}
+
+inline CUptiResult PCSamplingGetData(CUpti_PCSamplingGetDataParams *p) {
+    CallScope s;
+    return cuptiPCSamplingGetData(p);
+}
+
+inline CUptiResult PCSamplingSetConfigurationAttribute(
+    CUpti_PCSamplingConfigurationInfoParams *p) {
+    CallScope s;
+    return cuptiPCSamplingSetConfigurationAttribute(p);
+}
+
+inline CUptiResult PCSamplingGetConfigurationAttribute(
+    CUpti_PCSamplingConfigurationInfoParams *p) {
+    CallScope s;
+    return cuptiPCSamplingGetConfigurationAttribute(p);
+}
+
+inline CUptiResult PCSamplingGetNumStallReasons(
+    CUpti_PCSamplingGetNumStallReasonsParams *p) {
+    CallScope s;
+    return cuptiPCSamplingGetNumStallReasons(p);
+}
+
+inline CUptiResult PCSamplingGetStallReasons(CUpti_PCSamplingGetStallReasonsParams *p) {
+    CallScope s;
+    return cuptiPCSamplingGetStallReasons(p);
+}
+
+// ------------------------------------------- the two unguarded exemptions
+//
+// Long names on purpose: these are the only two ways into CUPTI in this
+// adapter that do not take the guard, and the name is the warning. See the
+// header comment for why guarding them would rebuild the deadlock.
+
+inline CUptiResult ActivityGetNextRecord_InBufferCompletedOnly(uint8_t *buffer,
+                                                               size_t valid_size,
+                                                               CUpti_Activity **record) {
+    if (!in_buffer_completed()) misplaced_callback_calls().fetch_add(1, std::memory_order_relaxed);
+    return cuptiActivityGetNextRecord(buffer, valid_size, record);
+}
+
+inline CUptiResult ActivityGetNumDroppedRecords_InBufferCompletedOnly(CUcontext ctx,
+                                                                      uint32_t stream_id,
+                                                                      size_t *dropped) {
+    if (!in_buffer_completed()) misplaced_callback_calls().fetch_add(1, std::memory_order_relaxed);
+    return cuptiActivityGetNumDroppedRecords(ctx, stream_id, dropped);
+}
+
+}  // namespace cupti
+}  // namespace perfagent
+
+// ------------------------------------------------------------------- poison
+//
+// Everything above this line is the only code in the adapter permitted to name
+// a raw CUPTI entry point. Below it, the raw names expand to identifiers that
+// are declared nowhere, so a new call site that reaches CUPTI without the
+// guard is a COMPILE ERROR whose message names the wrapper to use instead.
+//
+// That is the structural half of the fix for issue #99. The bug was a call
+// site that took no lock; this makes such a call site impossible to write in
+// this translation unit rather than merely wrong. `make -C shim
+// check-cupti-guard` proves it, with a compliant control that must compile so
+// the check cannot pass for the wrong reason.
+//
+// Only function names are poisoned. CUpti_* types, enumerators and the
+// CUPTIAPI macro are untouched.
+#define cuptiGetTimestamp                        PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_GetTimestamp
+#define cuptiGetResultString                     PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_GetResultString
+#define cuptiGetCubinCrc                         PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_GetCubinCrc
+#define cuptiSubscribe                           PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_Subscribe
+#define cuptiEnableDomain                        PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_EnableDomain
+#define cuptiActivityRegisterCallbacks           PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_ActivityRegisterCallbacks
+#define cuptiActivityEnable                      PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_ActivityEnable
+#define cuptiActivityFlushAll                    PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_ActivityFlushAll
+#define cuptiActivityGetNextRecord               PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_ActivityGetNextRecord_InBufferCompletedOnly
+#define cuptiActivityGetNumDroppedRecords        PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_ActivityGetNumDroppedRecords_InBufferCompletedOnly
+#define cuptiPCSamplingEnable                    PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_PCSamplingEnable
+#define cuptiPCSamplingDisable                   PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_PCSamplingDisable
+#define cuptiPCSamplingStart                     PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_PCSamplingStart
+#define cuptiPCSamplingStop                      PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_PCSamplingStop
+#define cuptiPCSamplingGetData                   PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_PCSamplingGetData
+#define cuptiPCSamplingSetConfigurationAttribute PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_PCSamplingSetConfigurationAttribute
+#define cuptiPCSamplingGetConfigurationAttribute PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_PCSamplingGetConfigurationAttribute
+#define cuptiPCSamplingGetNumStallReasons        PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_PCSamplingGetNumStallReasons
+#define cuptiPCSamplingGetStallReasons           PERFAGENT_UNGUARDED_CUPTI_CALL_use_perfagent_cupti_PCSamplingGetStallReasons
+
+#endif

--- a/shim/nvidia/cupti_guard_test.cc
+++ b/shim/nvidia/cupti_guard_test.cc
@@ -1,0 +1,89 @@
+// A compile-time test with no runtime: it passes by FAILING to compile.
+//
+// Issue #99's bug was a CALL SITE THAT TOOK NO LOCK -- cuptiActivityFlushAll on
+// the drain thread, added next to PC-sampling call sites that all took g_pc_mu.
+// The fix's structural claim is that such a call site can no longer be written
+// in the adapter: nvidia/cupti_guard.h poisons every raw CUPTI entry point
+// after defining a guarded wrapper for each, so reaching CUPTI without the
+// guard is a compile error rather than a review finding.
+//
+// A guarantee nobody has tried to violate is a claim, so this file tries, five
+// ways, and shim/Makefile's `check-cupti-guard` target fails the build if any
+// of them succeeds.
+//
+// Build it with -DPERFAGENT_CUPTI_UNGUARDED=<n>:
+//
+//   0  the COMPLIANT shape. Must compile. Without this control the check would
+//      pass just as happily on a file that fails to compile for some unrelated
+//      reason -- a typo, a missing include, a CUDA version bump -- and would
+//      then be proving nothing at all.
+//   1  the exact shape of the bug: cuptiActivityFlushAll from a timer
+//   2  the other half of the deadlock: cuptiPCSamplingStop
+//   3  a drain that skips the guard: cuptiPCSamplingGetData
+//   4  "I'll take the address and call it later" -- the wrapper dodged by
+//      indirection
+//   5  "the macro is for unqualified names" -- a ::-qualified raw call
+#include "cupti_guard.h"
+
+#ifndef PERFAGENT_CUPTI_UNGUARDED
+#define PERFAGENT_CUPTI_UNGUARDED 0
+#endif
+
+#if PERFAGENT_CUPTI_UNGUARDED == 0
+
+// The compliant shape. Two CUPTI calls that must not interleave with another
+// thread's, made atomic by one outer scope; the wrappers take the re-entrant
+// guard again inside, which costs a depth increment and no lock.
+CUptiResult compliant(CUcontext ctx) {
+    perfagent::cupti::CallScope hold;
+    CUpti_PCSamplingStopParams sp{};
+    sp.size = CUpti_PCSamplingStopParamsSize;
+    sp.ctx = ctx;
+    const CUptiResult st = perfagent::cupti::PCSamplingStop(&sp);
+    if (st != CUPTI_SUCCESS) return st;
+    return perfagent::cupti::ActivityFlushAll(0);
+}
+
+#elif PERFAGENT_CUPTI_UNGUARDED == 1
+
+// Issue #99 itself: the 100 ms drain tick flushing activity with no lock,
+// while the burst thread is inside the PC-sampling API.
+void on_tick_unguarded() { cuptiActivityFlushAll(0); }
+
+#elif PERFAGENT_CUPTI_UNGUARDED == 2
+
+// The other thread in the same deadlock.
+void burst_close_unguarded(CUcontext ctx) {
+    CUpti_PCSamplingStopParams sp{};
+    sp.size = CUpti_PCSamplingStopParamsSize;
+    sp.ctx = ctx;
+    cuptiPCSamplingStop(&sp);
+}
+
+#elif PERFAGENT_CUPTI_UNGUARDED == 3
+
+// A new drain path that forgets the guard the existing ones take.
+void drain_unguarded(CUcontext ctx, CUpti_PCSamplingData *data) {
+    CUpti_PCSamplingGetDataParams gp{};
+    gp.size = CUpti_PCSamplingGetDataParamsSize;
+    gp.ctx = ctx;
+    gp.pcSamplingData = data;
+    cuptiPCSamplingGetData(&gp);
+}
+
+#elif PERFAGENT_CUPTI_UNGUARDED == 4
+
+// "I'll keep the function pointer and call it from wherever." Indirection does
+// not dodge the poison: the name has to be written down somewhere.
+using FlushFn = CUptiResult (*)(uint32_t);
+FlushFn defer_by_pointer() { return &cuptiActivityFlushAll; }
+
+#elif PERFAGENT_CUPTI_UNGUARDED == 5
+
+// "The macro only catches unqualified names." It does not: the preprocessor
+// runs before the qualification means anything.
+void qualified_unguarded() { ::cuptiActivityFlushAll(0); }
+
+#endif
+
+int main() { return 0; }


### PR DESCRIPTION
Closes #99. **Tier A deadlocked the profiled process, permanently**, on its first burst — observed on the RTX 3090 during Task 12's overhead run: 21 minutes at 0.0% CPU and 0% GPU, holding 270 MiB.

Three-way block: the application in `__cudaLaunchKernel_helper` → CUPTI callback → `pthread_mutex_lock`; our burst timer in `cuptiPCSamplingStop` → `pthread_rwlock_wrlock`; our drain timer in `cuptiActivityFlushAll`. `g_pc_mu` serialised the PC-sampling family against itself and nothing else, so two of our threads sat in CUPTI in different subsystems while the app was inside a callback.

Tier B never raced — no burst timer — which is exactly why the hang began with the first Tier A arm.

### What the headers say, and why it decided the design

CUPTI documents thread safety **per function**: 32 such notes in `cupti_events.h`, 8 in `cupti_callbacks.h` (including *"a subscriber must serialize access to…"*), 2 in `cupti_result.h`. **`cupti_activity.h` and `cupti_pcsampling.h` contain zero between them** in CUDA 13.3.

Not *documented unsafe* — **unstated, in a library that states it elsewhere.** So the concurrency was never sanctioned, the fix is mandatory rather than defensive, and with no documented ordering to lean on the target is *never overlap*, not *overlap carefully*.

No general callback-context restriction is published; the only adjacent statement is that `cuptiGetDeviceId` "**may** be called from within callback functions" — phrasing that only means something if the general case is not assured.

### Both options, because neither alone suffices

- **One thread.** The second `Drainer` is gone. One timer runs at the shorter period and dispatches the burst poll, then the activity drain, rate-limited. The reported deadlock's two threads are now one.
- **One guard.** `g_pc_mu` becomes `perfagent::cupti::guard()`, taken by *every* adapter-initiated CUPTI call. This is why one thread is not enough: **the app's threads still enter CUPTI through our resource callbacks**, and `cuptiGetCubinCrc` took no lock at all.

Lock ordering: the guard is outermost, every other adapter mutex is a leaf, verified path by path.

**It cannot be bypassed.** `shim/nvidia/cupti_guard.h` defines a guarded wrapper per entry point, then `#define`s the 19 raw names to identifiers that exist nowhere. `make -C shim check-cupti-guard` — a prerequisite of `nvidia` — tries five spellings **including the bug verbatim**, with a compliant control that must compile. The current bug is precisely a call site that did not take the lock; this makes that unrepresentable rather than discouraged.

**The guard is re-entrant and counts re-entries**, required rather than convenient: CUPTI may deliver a callback on a thread already inside our call (Task 6 item 13, Task 10 item 11), which a plain mutex turns into self-deadlock — and widening a plain mutex over the flush would have widened that hazard.

### Both preserved properties held

`on_finalize` now uses `TryCallScope`, which fails when the guard is held by anyone **including the caller**. That also removes real undefined behaviour: `std::mutex::try_lock()` from the owning thread is UB, and the replaced line sat exactly on that path.

`MODULE_UNLOAD_STARTING` still **blocks** — a skipped flush corrupts PC identity silently. It can now also wait behind an activity flush, but it already waited for a full PC drain across every context, which is the larger of the two.

### Two more defects of the same family, found on the way

`at_exit_handler` stopped the burst timer and **left the drain timer running**, so its flush ran concurrently with `on_finalize`'s `cuptiPCSamplingDisable` — same shape, on the exit path, **in Tier B too**.

And a regression the merge itself would have introduced: with Tier A off the timer runs at exactly the drain period, so a naive rate limit would skip any early-arriving tick and halve delivery in the default arm. Fixed with `drain_limit_ns` and a test.

### Proven vs argued vs unproven

**Proven here:** the header evidence; `CallGuard` excludes, re-enters and refuses both `try` cases — under TSan, with a negative control showing the test detects the exclusion being removed; an unguarded call site fails to compile in five spellings; the merged schedule keeps both cadences.

**Argued, not measured:** that at most one adapter-initiated CUPTI call is in flight at any instant. This is structural — one primitive, impossible to skip — rather than "the window is smaller", which was the failure mode to avoid.

**Unproven:** `CapEff: 0`, no GPU. The deadlock cannot be reproduced here and its absence cannot be shown. The next 3090 run must check `cupti_waits > 0`, `cupti_max_depth == 3`, `cupti_calls_misplaced == 0`, and the real achieved `duty=`.

No ABI, BPF or Go change; ten probes and one exported symbol unchanged.