### PR TITLE
gpu: Tier A PC sampling — start/stop on the app thread (#101), and collectNumPcs=64 so bursts actually collect (#102)

### DIFF
--- a/shim/core/burst.h
+++ b/shim/core/burst.h
@@ -85,20 +85,35 @@ struct BurstConfig {
     double gain = 0.5;
 };
 
-// The smallest gap the duty ceiling permits after a burst of cfg.burst_ns.
+// The smallest gap the duty ceiling permits after a burst that ACTUALLY ran for
+// dur_ns.
 //
 // duty = burst / (burst + gap) <= max_duty  <=>  gap >= burst * (1/max_duty - 1)
 //
 // max_duty is clamped into (0, 1] first: a zero or negative ceiling would ask
 // for an infinite gap and a ceiling above 1 is not a ceiling at all.
-inline uint64_t burst_min_gap_ns(const BurstConfig &cfg) {
+//
+// dur_ns is a parameter rather than cfg.burst_ns because since issue #101 a
+// burst does not end when it wants to: both transitions happen on the
+// application's launch callbacks, so a burst closes at the first launch AFTER
+// its length elapses and overruns by however long the application took to get
+// there. On a workload that synchronises between launch groups that was
+// measured at 50 ms configured -> 104 ms actual, which drove the ACHIEVED duty
+// to 0.17 against a ceiling of 0.10. Charging the gap for the burst that
+// happened instead of the one that was asked for is what keeps the ceiling a
+// hard bound rather than an aspiration.
+inline uint64_t burst_min_gap_for_ns(const BurstConfig &cfg, uint64_t dur_ns) {
     double duty = cfg.max_duty;
     if (!(duty > 0.0)) duty = 0.001;  // also catches NaN
     if (duty > 1.0) duty = 1.0;
-    const double g = (double)cfg.burst_ns * (1.0 / duty - 1.0);
+    const double g = (double)dur_ns * (1.0 / duty - 1.0);
     if (!(g > 0.0)) return 0;
     if (g >= (double)cfg.max_gap_ns) return cfg.max_gap_ns;
     return (uint64_t)g;
+}
+
+inline uint64_t burst_min_gap_ns(const BurstConfig &cfg) {
+    return burst_min_gap_for_ns(cfg, cfg.burst_ns);
 }
 
 // THE LOOP, as a pure function of (target rate, observed rate, elapsed).
@@ -199,25 +214,47 @@ public:
     // shape this API offers.
     BurstAction poll(uint64_t now_ns, bool graphs_observed) {
         std::lock_guard<std::mutex> g(mu_);
-        if (graphs_observed && !refused_) {
-            refused_ = true;
-            graph_refusals_++;
-        }
-        if (sampling_) {
-            if (refused_) return stop_locked(now_ns, BurstStopReason::kGraph);
-            if (now_ns - burst_start_ns_ < cfg_.burst_ns) return BurstAction::kNone;
-            return stop_locked(now_ns, BurstStopReason::kDutyCycle);
-        }
-        if (refused_) return BurstAction::kNone;
-        if (started_ && now_ns < next_start_ns_) return BurstAction::kNone;
-        sampling_ = true;
-        if (!started_) {
-            started_ = true;
-            first_start_ns_ = now_ns;
-        }
-        burst_start_ns_ = now_ns;
-        bursts_++;
-        return BurstAction::kStart;
+        note_graphs_locked(graphs_observed);
+        if (sampling_) return close_locked(now_ns);
+        return open_locked(now_ns);
+    }
+
+    // The two HALVES of poll(), for a caller that can only act on one of them
+    // at this instant.
+    //
+    // Issue #101: the CUPTI calls this class schedules cannot be made from a
+    // thread of our own --- cuptiPCSamplingStop taken on a timer deadlocks
+    // against the application's own launch path inside CUPTI. They have to run
+    // on the application's thread, from inside the launch callback, which
+    // means the START fires at a launch ENTER and the STOP at a launch EXIT.
+    // Those are two different call sites and each can act on exactly one of
+    // the two transitions.
+    //
+    // Splitting is not optional and a `sampling()` test at the call site does
+    // NOT stand in for it. poll() is side-effecting: it COMMITS the transition
+    // it returns. A launch EXIT that called poll() and got kStart --- which it
+    // can, if the burst it meant to close was already closed by another thread
+    // and the gap has since elapsed --- would have opened a burst in the
+    // controller that the call site is not able to act on, leaving CUPTI
+    // stopped while this class believes it is sampling. That is the failure
+    // this pair makes unrepresentable rather than unlikely: poll_open never
+    // returns kStop and poll_close never returns kStart, whatever the state
+    // and whatever raced.
+    //
+    // Both halves still observe the graph refusal, because either call site
+    // may be the first to see a graph launch.
+    BurstAction poll_open(uint64_t now_ns, bool graphs_observed) {
+        std::lock_guard<std::mutex> g(mu_);
+        note_graphs_locked(graphs_observed);
+        if (sampling_) return BurstAction::kNone;
+        return open_locked(now_ns);
+    }
+
+    BurstAction poll_close(uint64_t now_ns, bool graphs_observed) {
+        std::lock_guard<std::mutex> g(mu_);
+        note_graphs_locked(graphs_observed);
+        if (!sampling_) return BurstAction::kNone;
+        return close_locked(now_ns);
     }
 
     // Called after the range-end flush, with the process-wide RUNNING TOTAL of
@@ -243,6 +280,10 @@ public:
         pairs_ += pairs;
         const uint64_t elapsed = last_burst_dur_ + gap_ns_;
         gap_ns_ = burst_next_gap_ns(cfg_, gap_ns_, pairs, elapsed);
+        // The loop clamps to the floor for a NOMINAL burst; this raises it to
+        // the floor for the one that ran. Without it an overrunning burst
+        // breaks the duty ceiling, which is documented as a hard bound.
+        gap_ns_ = gap_for_duration_locked(last_burst_dur_);
         next_start_ns_ = last_burst_end_ns_ + gap_ns_;
     }
 
@@ -280,6 +321,15 @@ public:
     // The duty fraction actually achieved so far, over the interval since the
     // first burst opened. Reported rather than assumed: max_duty bounds what
     // the loop may ASK for, and this is what the process actually did.
+    //
+    // It OVER-reports by up to one gap, and that is arithmetic rather than a
+    // fault: the interval ends wherever the caller asks, which at process exit
+    // is typically just after a burst closed and long before the gap that
+    // burst is owed has elapsed. The numerator has the whole burst, the
+    // denominator has none of its gap. A run reporting duty=0.125 against a
+    // ceiling of 0.10 at exit is the expected shape of a bound that holds over
+    // complete cycles, not evidence that it was breached; core/burst_test.cc
+    // asserts the bound at a cycle boundary for exactly this reason.
     double duty(uint64_t now_ns) const {
         std::lock_guard<std::mutex> g(mu_);
         if (!started_ || now_ns <= first_start_ns_) return 0.0;
@@ -287,6 +337,42 @@ public:
     }
 
 private:
+    // gap_ns_ raised to whatever the duty ceiling demands after a burst of
+    // dur_ns. Never lowers it: the controller owns the gap upward, this only
+    // enforces the bound.
+    uint64_t gap_for_duration_locked(uint64_t dur_ns) const {
+        const uint64_t floor = burst_min_gap_for_ns(cfg_, dur_ns);
+        return gap_ns_ > floor ? gap_ns_ : floor;
+    }
+
+    void note_graphs_locked(bool graphs_observed) {
+        if (graphs_observed && !refused_) {
+            refused_ = true;
+            graph_refusals_++;
+        }
+    }
+
+    // Precondition: !sampling_. Returns kStart or kNone, never kStop.
+    BurstAction open_locked(uint64_t now_ns) {
+        if (refused_) return BurstAction::kNone;
+        if (started_ && now_ns < next_start_ns_) return BurstAction::kNone;
+        sampling_ = true;
+        if (!started_) {
+            started_ = true;
+            first_start_ns_ = now_ns;
+        }
+        burst_start_ns_ = now_ns;
+        bursts_++;
+        return BurstAction::kStart;
+    }
+
+    // Precondition: sampling_. Returns kStop or kNone, never kStart.
+    BurstAction close_locked(uint64_t now_ns) {
+        if (refused_) return stop_locked(now_ns, BurstStopReason::kGraph);
+        if (now_ns - burst_start_ns_ < cfg_.burst_ns) return BurstAction::kNone;
+        return stop_locked(now_ns, BurstStopReason::kDutyCycle);
+    }
+
     BurstAction stop_locked(uint64_t now_ns, BurstStopReason why) {
         sampling_ = false;
         last_stop_ = why;
@@ -298,6 +384,12 @@ private:
         // Provisional: the next burst is scheduled at the gap already in
         // force, so a caller that never calls closed() keeps duty-cycling
         // instead of either stalling or free-running.
+        //
+        // Raised to the ceiling's floor for the burst that ACTUALLY ran, which
+        // is what holds the duty bound when a burst overruns its configured
+        // length. Applied here as well as in closed() because closed() is the
+        // call a caller may legitimately never make.
+        gap_ns_ = gap_for_duration_locked(dur);
         next_start_ns_ = now_ns + gap_ns_;
         return BurstAction::kStop;
     }

--- a/shim/core/burst_test.cc
+++ b/shim/core/burst_test.cc
@@ -298,6 +298,171 @@ int main() {
         assert(c.burst_ns() == 0);
     }
 
+    // ---- Issue #101: the split halves, and the state that makes the split
+    // load-bearing rather than tidy.
+    //
+    // A launch EXIT may only ever CLOSE. The dangerous instant is the one
+    // where the controller would happily start: no burst open, and the gap
+    // already elapsed. A plain poll() there returns kStart and COMMITS it ---
+    // which at an EXIT call site means the controller believes it is sampling
+    // while CUPTI is stopped, and every execution until the next transition is
+    // labelled serialized when it was not. poll_close must decline, and must
+    // leave no trace that it was asked.
+    {
+        BurstConfig cfg;
+        BurstController c(cfg);
+        // Reach the dangerous state: open, close, let the gap run out.
+        assert(c.poll_open(0, false) == BurstAction::kStart);
+        assert(c.poll_close(cfg.burst_ns, false) == BurstAction::kStop);
+        c.closed(0);
+        assert(!c.sampling());
+        const uint64_t after_gap = cfg.burst_ns + c.gap_ns() + kSec;
+        // The control: poll() WOULD start here. This is what makes the
+        // assertion below a real one rather than a restatement of kNone.
+        {
+            BurstController probe(cfg);
+            assert(probe.poll_open(0, false) == BurstAction::kStart);
+            assert(probe.poll_close(cfg.burst_ns, false) == BurstAction::kStop);
+            probe.closed(0);
+            assert(probe.poll(after_gap, false) == BurstAction::kStart);
+        }
+        const uint64_t bursts_before = c.bursts();
+        assert(c.poll_close(after_gap, false) == BurstAction::kNone);
+        assert(!c.sampling());                    // did not open
+        assert(c.bursts() == bursts_before);      // and did not count one
+    }
+
+    // ---- The mirror: a launch ENTER may only ever OPEN. With a burst open
+    // and past its length, poll() would return kStop; poll_open must decline
+    // and must leave the burst OPEN, because the ENTER site cannot stop CUPTI.
+    {
+        BurstConfig cfg;
+        BurstController c(cfg);
+        assert(c.poll_open(0, false) == BurstAction::kStart);
+        const uint64_t past = cfg.burst_ns + kSec;
+        {
+            BurstController probe(cfg);
+            assert(probe.poll_open(0, false) == BurstAction::kStart);
+            assert(probe.poll(past, false) == BurstAction::kStop);   // the control
+        }
+        assert(c.poll_open(past, false) == BurstAction::kNone);
+        assert(c.sampling());                     // still open, as CUPTI is
+        assert(c.burst_start_ns() == 0);          // and it is the SAME burst
+        assert(c.poll_close(past, false) == BurstAction::kStop);
+    }
+
+    // ---- Swept: over a full duty cycle driven at launch boundaries, neither
+    // half ever returns the other's action. This is the invariant the call
+    // sites rely on, asserted across the whole state space the cycle visits
+    // rather than at the two points above.
+    {
+        BurstConfig cfg;
+        BurstController c(cfg);
+        uint64_t now = 0, pairs = 0, opens = 0, closes = 0;
+        for (unsigned i = 0; i < 20000; i++) {
+            const BurstAction o = c.poll_open(now, false);
+            assert(o != BurstAction::kStop);      // ENTER never stops
+            if (o == BurstAction::kStart) opens++;
+            now += kMs;
+            const BurstAction cl = c.poll_close(now, false);
+            assert(cl != BurstAction::kStart);    // EXIT never starts
+            if (cl == BurstAction::kStop) {
+                closes++;
+                pairs += 100;
+                c.closed(pairs);
+            }
+            now += kMs;
+        }
+        // The cycle actually ran -- otherwise the two assertions above hold
+        // vacuously, which is the failure mode this project keeps finding.
+        assert(opens > 5);
+        // Open and close stay paired: at most one burst outstanding, ever.
+        assert(opens - closes <= 1);
+        assert(c.duty(now) <= cfg.max_duty * 1.05);
+    }
+
+    // ---- Both halves observe the graph refusal, because either call site may
+    // be the first to see a graph launch. Refused at an ENTER, the open burst
+    // still closes with kGraph at the next EXIT rather than being abandoned.
+    {
+        BurstConfig cfg;
+        BurstController c(cfg);
+        assert(c.poll_open(0, false) == BurstAction::kStart);
+        assert(c.poll_open(kMs, true) == BurstAction::kNone);   // notices, cannot act
+        assert(c.refused());
+        assert(c.sampling());                                   // still open
+        assert(c.poll_close(2 * kMs, false) == BurstAction::kStop);
+        assert(c.last_stop_reason() == BurstStopReason::kGraph);
+        assert(c.graph_refusals() == 1);
+        // Never reopens.
+        assert(c.poll_open(10 * kSec, false) == BurstAction::kNone);
+    }
+
+    // ---- A graph seen first at an EXIT refuses there too.
+    {
+        BurstConfig cfg;
+        BurstController c(cfg);
+        assert(c.poll_open(0, false) == BurstAction::kStart);
+        assert(c.poll_close(kMs, true) == BurstAction::kStop);
+        assert(c.last_stop_reason() == BurstStopReason::kGraph);
+        assert(c.graph_refusals() == 1);
+    }
+
+    // ---- Issue #101: a burst that OVERRUNS its configured length must not
+    // break the duty ceiling. Since the transitions moved onto launch
+    // boundaries a burst ends at the first launch after its length elapses,
+    // which on a synchronising workload was measured at 50 ms configured ->
+    // 104 ms actual. Charging the next gap for the nominal 50 ms would let the
+    // achieved duty run to 0.17 against a ceiling of 0.10.
+    {
+        BurstConfig cfg;
+        cfg.burst_ns = 50 * kMs;
+        cfg.max_duty = 0.1;
+        BurstController c(cfg);
+        uint64_t now = 0;
+        const uint64_t overrun = 2;   // every burst runs twice its length
+        unsigned bursts = 0;
+        uint64_t first_open = 0;
+        // A workload that yields NOTHING, which is what pins the ceiling
+        // rather than the loop. With pairs coming in at the target rate the
+        // controller holds the gap far above either floor and the floor is
+        // never the binding constraint -- a version of this test that fed it
+        // 100 pairs per burst passed against the unfixed code, which is why it
+        // does not do that. At zero yield the loop walks the gap DOWN to the
+        // floor, so the floor is the only thing holding the bound.
+        for (unsigned i = 0; i < 200000 && bursts < 12; i++) {
+            if (c.poll_open(now, false) == BurstAction::kStart) {
+                if (!bursts) first_open = now;
+                // Closed only after `overrun` x the configured length.
+                now += overrun * cfg.burst_ns;
+                const BurstAction a = c.poll_close(now, false);
+                assert(a == BurstAction::kStop);
+                bursts++;
+                c.closed(0);
+            }
+            now += kMs;
+        }
+        assert(bursts == 12);
+        // The gap must have been charged for the burst that HAPPENED: a
+        // 100 ms burst at a 0.1 ceiling needs 900 ms, not the 450 ms a 50 ms
+        // burst needs.
+        assert(c.gap_ns() >= burst_min_gap_ns(cfg) * overrun);
+        // And the achieved duty must be under the ceiling. Measured, not
+        // reasoned about -- this is the number the ceiling is a claim about.
+        //
+        // Measured at the end of the last COMPLETE cycle, not at the last
+        // close: duty() over an interval that ends mid-gap counts the burst
+        // but not the gap it is owed, which over-states it by one gap and
+        // would fail here for a reason that has nothing to do with the bound.
+        now += c.gap_ns();
+        const double d = c.duty(now);
+        printf("burst_test: overrun x%llu duty=%.4f (ceiling %.2f) gap=%llums\n",
+               (unsigned long long)overrun, d, cfg.max_duty,
+               (unsigned long long)(c.gap_ns() / kMs));
+        assert(d <= cfg.max_duty);
+        (void)first_open;
+    }
+
     printf("burst_test: OK\n");
     return 0;
 }

--- a/shim/core/tickplan.h
+++ b/shim/core/tickplan.h
@@ -44,6 +44,16 @@ namespace perfagent {
 // Tier A off: the drain period, unchanged -- there is no burst poll to serve.
 // Tier A on:  the shorter of the two, so NEITHER job's cadence is lengthened
 //             by the merge. Never zero: a zero-period timer is a spin.
+//
+// NOTE (issue #101): the CUPTI adapter no longer has a burst poll in EITHER
+// tier. PC-sampling start and stop cannot be taken from a thread of ours at
+// all -- they deadlock against the application's own launch path inside CUPTI
+// -- so both transitions moved onto the application's launch callbacks and the
+// adapter now passes tier_a=false unconditionally. The tier_a branch below is
+// kept, and kept tested, because it is the correct answer for any FUTURE
+// second job on this timer; it is not currently reached from production code.
+// A reader chasing why a Tier A run ticks at the drain period should stop
+// here rather than concluding the merge broke.
 inline uint64_t tick_period_ns(uint64_t drain_ns, uint64_t burst_tick_ns, bool tier_a) {
     uint64_t t = drain_ns;
     if (tier_a && burst_tick_ns && burst_tick_ns < t) t = burst_tick_ns;

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -42,6 +42,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <dlfcn.h>
 #include <mutex>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -552,8 +553,6 @@ std::atomic<unsigned long> g_window_seq{0};
 // SHARED PCDrainSchedule so the periodic drain coalesces instead of repeating
 // it.
 perfagent::BurstController *g_burst = nullptr;
-unsigned g_burst_tick_ms = 10;
-
 // Bursts and their total open time. The pair is what bounds the perturbation:
 // burst_ns / wall_ns is the fraction of the run that ran serialized, and it is
 // REPORTED rather than assumed to equal the configured ceiling.
@@ -572,6 +571,50 @@ std::atomic<uint64_t> g_burst_stop_failed{0};
 // exact launch attribution had become false. It is never zero-and-silent: the
 // same condition also rides gpu_dropped_v1 under GPU_DROP_CLASS_GRAPH_EXEC.
 std::atomic<uint64_t> g_tier_a_graph_refused{0};
+
+// Issue #101. Tier A's cuptiPCSamplingStart/Stop run on the APPLICATION's
+// thread, from inside the launch callback; a timer of ours must never make
+// them. This is the counter that says so, and it is the reason the timer's tid
+// is recorded at all: taking a PC start or stop on the timer thread is exactly
+// the deadlock this design exists to remove, so it is worth a number rather
+// than a comment. MUST be 0 on every run, healthy or not.
+std::atomic<uint64_t> g_timer_tid{0};
+std::atomic<uint64_t> g_burst_calls_on_timer{0};
+// The pre-start device sync. cuCtxSynchronize is resolved at runtime rather
+// than linked: this adapter deliberately does not link libcuda, and libcuda is
+// unconditionally present by the time a launch callback runs. missing MUST be
+// 0 on any run that opened a burst --- a non-zero value means bursts started
+// against a busy GPU, which is the condition parcagpu's comment says CUPTI
+// does not want.
+std::atomic<uint64_t> g_burst_sync_missing{0};
+std::atomic<uint64_t> g_burst_sync_failed{0};
+// Launch boundaries the burst path actually saw. Both must move on a Tier A
+// run: zero opens with a non-zero launch count would mean the transitions are
+// no longer reachable at all, which is what a return-early bug looks like from
+// the outside and is otherwise indistinguishable from an idle GPU.
+std::atomic<uint64_t> g_burst_enter_polls{0};
+std::atomic<uint64_t> g_burst_exit_polls{0};
+// Bursts that closed having pulled NOT ONE PC from CUPTI.
+//
+// Measured on a 3090, CUDA 13.3: cuptiPCSamplingStart has a dead time of
+// roughly 400 ms before the hardware delivers anything. Below it a burst
+// serializes every kernel it covers --- the throughput cost is real and
+// measurable --- and yields nothing at all. At the 50 ms default EVERY burst
+// is empty, and every other counter on this path still reads healthy:
+// bursts=17, duty=0.49, start_failed=0, stop_failed=0, getdata_failed=0.
+//
+// That is the exact shape this pipeline treats as a defect rather than a
+// tuning matter: a profiler paying the full price of its perturbation and
+// silently collecting none of the data it perturbed the workload to get. So it
+// is counted, and an all-empty run says so in as many words at exit.
+std::atomic<uint64_t> g_bursts_empty{0};
+// g_pc_pcs as it stood when the open burst started. Sampled at OPEN and not
+// merely around the range-end drain: the periodic drain runs on the timer and
+// will already have pulled most of a long burst's PCs by the time it closes,
+// so a before/after around the range end alone reports a productive burst as
+// empty --- which it did, on the first hardware run of this counter. One
+// global is enough because BurstController never has two bursts open.
+std::atomic<uint64_t> g_pc_pcs_at_open{0};
 
 // Every one of these is assertable at a known value on a healthy run, which is
 // the whole point: a context that failed to enable is otherwise a silent hole
@@ -1022,7 +1065,88 @@ void emit_window(uint64_t start_ns, uint64_t end_ns) {
     g_windows_emitted.fetch_add(1, std::memory_order_relaxed);
 }
 
+// Issue #101's standing check, on the two calls that caused it.
+//
+// The deadlock was not a race we lost occasionally: cuptiPCSamplingStop taken
+// on a thread of ours blocks in pthread_rwlock_wrlock against the CUDA
+// runtime's own launch path, and the application blocks behind it forever. The
+// fix is that these two calls only ever run on the application's thread, from
+// inside the launch callback. That is a property of the CALL SITES, which is
+// exactly the kind of property that quietly stops holding when somebody adds a
+// third one. So it is checked here, at the calls themselves, where a new call
+// site inherits the check whether or not its author knew about it.
+void note_burst_thread() {
+    const uint64_t timer = g_timer_tid.load(std::memory_order_relaxed);
+    if (timer != 0 && (uint64_t)current_tid() == timer)
+        g_burst_calls_on_timer.fetch_add(1, std::memory_order_relaxed);
+}
+
+// cuCtxSynchronize, resolved at runtime.
+//
+// parcagpu quiesces the GPU before every cuptiPCSamplingStart --- "CUPTI
+// requires the GPU to be idle before starting PC sampling". That requirement
+// is NOT in cupti_pcsampling.h; it is their empirical finding, and it is
+// carried here because theirs is the configuration known to work rather than
+// because the header asks for it. Being at a launch ENTER does not make the
+// GPU idle: kernels issued earlier on other streams are very likely still
+// running.
+//
+// dlsym rather than a link: this adapter does not link libcuda (see the note
+// at ActivityEnable(DEVICE)), and it does not need to --- nothing can reach a
+// launch callback in a process where libcuda is absent.
+//
+// RTLD_DEFAULT is NOT enough and that was measured, not assumed: the first
+// version of this looked there and reported sync_missing=7 out of 7 bursts on
+// the 3090. The CUDA runtime dlopens libcuda into a LOCAL scope, so its
+// symbols never enter the global one and RTLD_DEFAULT cannot see them. The
+// handle has to be asked for by name.
+//
+// RTLD_NOLOAD: find the copy this process already has, or nothing. Loading a
+// second libcuda from a profiler would be a far worse bug than not quiescing.
+using CuCtxSynchronizeFn = int (*)(void);
+CuCtxSynchronizeFn g_cu_ctx_sync = nullptr;
+
+// Resolved on FIRST USE, not at injection time. InitializeInjection can run
+// before the CUDA runtime has finished bringing libcuda up; the first launch
+// callback cannot. Doing it here removes a startup ordering question that has
+// no other reason to exist.
+//
+// Called only from the burst-open path, which is single-threaded per burst by
+// BurstController's own mutex... except that it is NOT: two application
+// threads can be inside burst_open_at_launch at once, and only one of them
+// gets kStart. The resolve therefore has to tolerate a race. It does: both
+// racers compute the same pointer and store it, so the write is idempotent and
+// a torn read is impossible for a pointer-sized relaxed atomic.
+std::atomic<bool> g_cu_ctx_sync_tried{false};
+
+void pc_resolve_ctx_sync() {
+    // The global scope first: cheap, and correct for an application that links
+    // libcuda directly rather than going through the runtime.
+    CuCtxSynchronizeFn f = (CuCtxSynchronizeFn)dlsym(RTLD_DEFAULT, "cuCtxSynchronize");
+    if (!f) {
+        if (void *h = dlopen("libcuda.so.1", RTLD_NOLOAD | RTLD_LAZY))
+            f = (CuCtxSynchronizeFn)dlsym(h, "cuCtxSynchronize");
+    }
+    g_cu_ctx_sync = f;
+    g_cu_ctx_sync_tried.store(true, std::memory_order_relaxed);
+}
+
+// Deliberately OUTSIDE the CUPTI guard: this is not a CUPTI call, and holding
+// the guard across a full device synchronise would park the drain timer for
+// however long the GPU takes to go idle --- which on a saturated device is the
+// longest lock hold in the adapter, taken for no reason.
+void pc_sync_before_start() {
+    if (!g_cu_ctx_sync_tried.load(std::memory_order_relaxed)) pc_resolve_ctx_sync();
+    if (!g_cu_ctx_sync) {
+        g_burst_sync_missing.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    if (g_cu_ctx_sync() != 0)  // CUDA_SUCCESS
+        g_burst_sync_failed.fetch_add(1, std::memory_order_relaxed);
+}
+
 void pc_start_ctxs_locked() {
+    note_burst_thread();
     for (PCContext *c : g_pc_ctxs) {
         if (!c->enabled) continue;
         CUpti_PCSamplingStartParams sp{};
@@ -1034,6 +1158,7 @@ void pc_start_ctxs_locked() {
 }
 
 void pc_stop_ctxs_locked() {
+    note_burst_thread();
     for (PCContext *c : g_pc_ctxs) {
         if (!c->enabled) continue;
         CUpti_PCSamplingStopParams sp{};
@@ -1059,6 +1184,7 @@ void pc_stop_ctxs_locked() {
 // is told, so a USDT fire and the controller's own mutex are never taken with
 // the whole vendor surface locked.
 void burst_close(uint64_t now_ns, uint64_t start_ns) {
+    const uint64_t pcs_at_open = g_pc_pcs_at_open.load(std::memory_order_relaxed);
     {
         perfagent::cupti::CallScope hold;
         pc_stop_ctxs_locked();
@@ -1071,6 +1197,10 @@ void burst_close(uint64_t now_ns, uint64_t start_ns) {
         if (g_pc_schedule) g_pc_schedule->force(now_ns, perfagent::PCDrainReason::kRangeEnd);
         pc_drain_all(perfagent::PCDrainReason::kRangeEnd);
     }
+    // AFTER the range-end drain above, so the PCs this burst produced but that
+    // only arrive on the post-stop flush are counted where they belong.
+    if (g_pc_pcs.load(std::memory_order_relaxed) == pcs_at_open)
+        g_bursts_empty.fetch_add(1, std::memory_order_relaxed);
     emit_window(start_ns, now_ns);
     g_sampling_burst_ns.fetch_add(now_ns > start_ns ? now_ns - start_ns : 0,
                                   std::memory_order_relaxed);
@@ -1082,58 +1212,110 @@ void burst_close(uint64_t now_ns, uint64_t start_ns) {
     if (g_burst) g_burst->closed(g_pc_records.load(std::memory_order_relaxed));
 }
 
-// The burst half of the single timer's tick. Called from on_timer_tick, on the
-// one thread this adapter runs; see the note on g_burst.
-void on_burst_tick() {
+// Tier A's two transitions, taken on the APPLICATION's thread at a kernel-launch
+// boundary: START on a launch ENTER, STOP on a launch EXIT.
+//
+// Issue #101, and this is the shape of the fix rather than a detail of it.
+//
+// These used to be one function called from the drain timer. That deadlocks,
+// and not rarely: cuptiPCSamplingStop taken on any thread of ours blocks in
+// pthread_rwlock_wrlock inside CUPTI while the application sits in
+// __cudaLaunchKernel_helper holding the other side, and neither ever moves. It
+// survived issue #99 --- which was real, and which did collapse our two timer
+// threads into one --- because the surviving conflict is not between two
+// threads of OURS. It is between our thread and the application's, and no
+// amount of self-serialization reaches it. Only not having a thread does.
+//
+// parcagpu (parca-dev/parcagpu, src/cupti.cpp:591) does not have one: it
+// creates no threads at all, and every PC-sampling start and stop runs on the
+// application's own thread from inside a CUPTI callback. Their comment states
+// the rule --- "PC sampling windows are aligned to kernel-launch boundaries:
+// start on a launch ENTER, stop on a launch EXIT" --- and their configuration
+// is otherwise identical to ours: ENABLE_START_STOP_CONTROL, KERNEL_SERIALIZED,
+// Enable/Disable per context rather than per burst. The calling thread is the
+// only difference between a design that works and one that hangs.
+//
+// One deliberate divergence: parcagpu takes the DRIVER_API launch callbacks and
+// this takes the RUNTIME_API ones it already subscribes to. That is not a
+// compromise, it is strictly the safer position --- a runtime cudaLaunchKernel
+// ENTER fires BEFORE the runtime enters the driver, and its EXIT after the
+// driver has returned, so these calls are made from further outside CUPTI's
+// launch path than parcagpu's are. It also avoids the correlation-id cost that
+// adding DRIVER_API was measured to have (2.242 vs 1.004 ids per launch; see
+// the note at EnableDomain).
+//
+// What this gives up, stated rather than discovered later: a burst can only
+// open or close when the application launches a kernel. An application that
+// opens a burst and then stops launching for a second leaves the window open
+// for that second, and the duty figure counts it as perturbed. That
+// OVER-states the perturbation, which is the safe direction and the same
+// direction every other approximation on this path leans --- no kernel is
+// launching, so nothing is in fact being serialized. The exit path still
+// closes the window with a real timestamp (burst_shutdown), so end_ns == 0 on
+// the wire continues to mean a hard exit and nothing else.
+
+// The refusal log, on whichever of the two boundaries first observes a graph.
+void note_graph_refusal(bool was_refused, bool graphs) {
+    if (was_refused || !g_burst->refused() || !graphs) return;
+    g_tier_a_graph_refused.fetch_add(1, std::memory_order_relaxed);
+    logf("perfagent-cupti: REFUSING Tier A: %llu CUDA-graph execution(s) observed "
+         "mid-run. N executions share one correlation, so exact launch "
+         "attribution is false while still looking exact. Bursts have STOPPED "
+         "permanently; this is not a downgrade to Tier B. Executions already "
+         "inside a window stay marked serialized.\n",
+         (unsigned long long)g_exec_from_graph.load(std::memory_order_relaxed));
+}
+
+// Launch ENTER. Opens a burst if the duty cycle is due for one; can never
+// close one --- see BurstController::poll_open for why that is enforced there
+// rather than by testing sampling() here.
+void burst_open_at_launch(uint64_t now) {
     if (!g_pc_tier_a || !g_burst) return;
-    // No enabled context means nothing can be serialized, so there is no
-    // burst to open and no window to announce. This timer starts at the end
-    // of InitializeInjection, which is before the first CONTEXT_CREATED
-    // callback can have fired, so without this the first burst would announce
-    // a window covering executions that were never perturbed. Over-stating
-    // perturbation is the safe direction and would not be a defect --- but it
-    // would be a lie about an interval nothing was sampling, and there is no
-    // reason to tell it.
-    if (!g_ctx_enabled.load(std::memory_order_relaxed) && !g_burst->sampling()) return;
-    const uint64_t now = mono_ns();
-    // The graph refusal, re-checked on every tick and not only at enable
+    // No enabled context means nothing can be serialized, so there is no burst
+    // to open and no window to announce. A launch can reach this before the
+    // first CONTEXT_CREATED callback has been processed, and without this the
+    // first window would cover executions that were never perturbed.
+    if (!g_ctx_enabled.load(std::memory_order_relaxed)) return;
+    g_burst_enter_polls.fetch_add(1, std::memory_order_relaxed);
+    // The graph refusal, re-checked at every boundary and not only at enable
     // time: a process can run for minutes before its first graph launch, and
-    // the moment one arrives Tier A's exactness claim stops being true. The
-    // controller closes any open burst and never starts another.
+    // the moment one arrives Tier A's exactness claim stops being true.
     const bool graphs = g_exec_from_graph.load(std::memory_order_relaxed) != 0;
     const bool was_refused = g_burst->refused();
-    const uint64_t start_ns = g_burst->burst_start_ns();
-    switch (g_burst->poll(now, graphs)) {
-        case perfagent::BurstAction::kStart: {
-            {
-                perfagent::cupti::CallScope hold;
-                pc_start_ctxs_locked();
-            }
-            g_sampling_bursts.fetch_add(1, std::memory_order_relaxed);
-            // The window is announced even if some or all contexts refused to
-            // start (g_burst_start_failed counts that, and must be 0 on a
-            // healthy run). Over-stating the perturbation for one burst marks
-            // executions "true" that were not perturbed, which is the SAFE
-            // direction: the answer that must never be reachable by accident
-            // is "false", and no path here can produce it.
-            emit_window(now, 0);   // open; closed by the kStop below
-            break;
+    if (g_burst->poll_open(now, graphs) == perfagent::BurstAction::kStart) {
+        // Before the guard is taken, and before the start: quiescing the
+        // device is not a CUPTI call and must not hold the CUPTI guard.
+        pc_sync_before_start();
+        {
+            perfagent::cupti::CallScope hold;
+            pc_start_ctxs_locked();
         }
-        case perfagent::BurstAction::kStop:
-            burst_close(now, start_ns);
-            break;
-        case perfagent::BurstAction::kNone:
-            break;
+        g_pc_pcs_at_open.store(g_pc_pcs.load(std::memory_order_relaxed),
+                               std::memory_order_relaxed);
+        g_sampling_bursts.fetch_add(1, std::memory_order_relaxed);
+        // The window is announced even if some or all contexts refused to
+        // start (g_burst_start_failed counts that, and must be 0 on a healthy
+        // run). Over-stating the perturbation for one burst marks executions
+        // "true" that were not perturbed, which is the SAFE direction: the
+        // answer that must never be reachable by accident is "false", and no
+        // path here can produce it.
+        emit_window(now, 0);   // open; closed by the EXIT below
     }
-    if (!was_refused && g_burst->refused() && graphs) {
-        g_tier_a_graph_refused.fetch_add(1, std::memory_order_relaxed);
-        logf("perfagent-cupti: REFUSING Tier A: %llu CUDA-graph execution(s) observed "
-             "mid-run. N executions share one correlation, so exact launch "
-             "attribution is false while still looking exact. Bursts have STOPPED "
-             "permanently; this is not a downgrade to Tier B. Executions already "
-             "inside a window stay marked serialized.\n",
-             (unsigned long long)g_exec_from_graph.load(std::memory_order_relaxed));
-    }
+    note_graph_refusal(was_refused, graphs);
+}
+
+// Launch EXIT. Closes an open burst once it has run its length, or immediately
+// if a graph launch has been observed. Can never open one.
+void burst_close_at_launch(uint64_t now) {
+    if (!g_pc_tier_a || !g_burst) return;
+    g_burst_exit_polls.fetch_add(1, std::memory_order_relaxed);
+    const bool graphs = g_exec_from_graph.load(std::memory_order_relaxed) != 0;
+    const bool was_refused = g_burst->refused();
+    // Read BEFORE the poll: the poll is what clears it.
+    const uint64_t start_ns = g_burst->burst_start_ns();
+    if (g_burst->poll_close(now, graphs) == perfagent::BurstAction::kStop)
+        burst_close(now, start_ns);
+    note_graph_refusal(was_refused, graphs);
 }
 
 // Teardown for the duty cycle. Closes an open burst with a real end timestamp,
@@ -1419,9 +1601,21 @@ void CUPTIAPI on_callback(void *, CUpti_CallbackDomain domain, CUpti_CallbackId 
     }
     if (domain != CUPTI_CB_DOMAIN_RUNTIME_API) return;
     const CUpti_CallbackData *cb = (const CUpti_CallbackData *)cbdata;
-    if (cb->callbackSite != CUPTI_API_ENTER) return;
+    // Launch cbids only, on BOTH sites now. The EXIT half is new with issue
+    // #101 and it is the only reason this function looks at EXIT at all: it
+    // carries no record and does no work of its own, it exists so that Tier A
+    // has a place to call cuptiPCSamplingStop from the application's thread.
     if (!is_launch_cbid(cbid)) return;
-    on_launch(cb);
+    if (cb->callbackSite == CUPTI_API_ENTER) {
+        // The burst opens BEFORE the launch it is about to serialize, which is
+        // the whole point of taking the ENTER: a window opened after the
+        // launch had been issued would not cover it, and the execution would
+        // be reported unperturbed while running inside a serialized burst.
+        burst_open_at_launch(mono_ns());
+        on_launch(cb);
+        return;
+    }
+    if (cb->callbackSite == CUPTI_API_EXIT) burst_close_at_launch(mono_ns());
 }
 
 // -------------------------------------------------------------- exec path
@@ -1686,6 +1880,44 @@ void report(const char *why) {
              (unsigned long long)g_burst_stop_failed.load(),
              (unsigned long long)g_tier_a_graph_refused.load(),
              g_burst && g_burst->sampling() ? 1 : 0);
+        // Issue #101's evidence, and every one of these is assertable:
+        //
+        //   on_timer   PC starts/stops taken on the timer thread. MUST be 0.
+        //              This is the deadlock itself, counted. It is not a
+        //              proxy for the bug -- a non-zero value IS the condition
+        //              that hung the 3090, observed rather than inferred.
+        //   enter/exit launch boundaries the burst path saw. BOTH must move on
+        //              any Tier A run that launched a kernel. Zero with a
+        //              non-zero launch count means the transitions became
+        //              unreachable, which from the outside is indistinguishable
+        //              from an idle GPU and is what a stray early return looks
+        //              like. exit is expected to be within one of enter.
+        //   sync_*     the pre-start quiesce. missing MUST be 0 once a burst
+        //              has opened: it means cuCtxSynchronize was not found and
+        //              bursts started against a possibly busy GPU. failed
+        //              counts a non-zero CUDA return from it.
+        logf("perfagent-cupti: tier A boundaries enter=%llu exit=%llu on_timer=%llu "
+             "sync_missing=%llu sync_failed=%llu empty_bursts=%llu\n",
+             (unsigned long long)g_burst_enter_polls.load(),
+             (unsigned long long)g_burst_exit_polls.load(),
+             (unsigned long long)g_burst_calls_on_timer.load(),
+             (unsigned long long)g_burst_sync_missing.load(),
+             (unsigned long long)g_burst_sync_failed.load(),
+             (unsigned long long)g_bursts_empty.load());
+        // The one condition on this path that is otherwise invisible: the run
+        // paid for its perturbation and got nothing back. Loud, because every
+        // other counter reads healthy while it holds.
+        const uint64_t closed = g_bursts_empty.load();
+        const uint64_t total = g_sampling_bursts.load();
+        if (total && closed == total) {
+            logf("perfagent-cupti: WARNING every one of the %llu Tier A burst(s) in this run "
+                 "pulled ZERO PCs. Kernels were serialized and the throughput cost was paid "
+                 "in full, for no data. cuptiPCSamplingStart has a start-up dead time "
+                 "(~400ms measured on GA102/CUDA 13.3) and PERFAGENT_GPU_PC_BURST_MS=%llu is "
+                 "inside it. Raise it well past that or turn Tier A off; see issue #102.\n",
+                 (unsigned long long)total,
+                 (unsigned long long)(g_burst ? g_burst->config().burst_ns / 1000000ull : 0));
+        }
     }
     logf("perfagent-cupti: pc %s tier=%s period=%u(=%u cycles) stall_reasons=%zu "
          "ctx_seen=%llu ctx_enabled=%llu ctx_enable_failed=%llu "
@@ -1834,20 +2066,26 @@ void on_tick() {
 // not exclude the bad state, it makes it unrepresentable. There is no second
 // timer to race with, whatever a future call site does.
 //
-// Order matters. The burst poll runs FIRST, because a burst transition is
-// timestamped by on_burst_tick itself and Tier A's duty fraction is measured
-// from those timestamps: a stop deferred behind a flush lengthens the burst
-// that actually happened. Running it first means a transition waits for at
-// most the PREVIOUS tick's drain, never for this one's.
+// It no longer polls the burst. Issue #101: PC-sampling start and stop cannot
+// be taken from a thread of ours at all, whether or not that thread is alone,
+// because the conflict is with the APPLICATION's thread inside CUPTI's launch
+// path. Those two transitions now happen at launch boundaries on the
+// application's own thread (burst_open_at_launch / burst_close_at_launch), and
+// what is left here is the activity drain, which has run from this timer since
+// before Tier A existed and is measured at -0.006% / +0.017% over two hardware
+// runs.
 //
-// The activity drain is rate-limited on top of the shorter tick by
-// core/tickplan.h, so its period is what it always was (100 ms by default) and
-// the burst poll keeps its own granularity. What the merge costs is stated at
-// tick_period_ns: a slow flush delays the next burst poll by its own duration,
-// and that shows up in `duty=` in the report, which is measured rather than
-// assumed.
+// The drain is still rate-limited on top of the tick by core/tickplan.h. With
+// the burst poll gone the tick no longer needs the shorter of the two periods
+// on a Tier A run --- but tick_period_ns keeps deciding that, because
+// PERFAGENT_GPU_DRAIN_MS is the only knob an operator has and a Tier A run
+// still wants its PC data pulled promptly after each burst.
 void on_timer_tick() {
-    on_burst_tick();   // a no-op unless Tier A is on; see its head
+    // Recorded here rather than at timer start because THIS is the thread that
+    // matters: the one note_burst_thread() must never find inside a PC start
+    // or stop. Idempotent and relaxed --- it is written every tick with the
+    // same value, and read only by a counter that must stay 0.
+    g_timer_tid.store(current_tid(), std::memory_order_relaxed);
     if (!g_tick_plan || g_tick_plan->drain_due(mono_ns())) on_tick();
 }
 
@@ -2090,21 +2328,23 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
         bc.max_duty = (double)env_uint("PERFAGENT_GPU_PC_MAX_DUTY_PERMILLE", 100) / 1000.0;
         bc.max_gap_ns = (uint64_t)env_uint("PERFAGENT_GPU_PC_MAX_GAP_MS", 10000) * 1000000ull;
         g_burst = new perfagent::BurstController(bc);
-        // The burst poll's period. A fifth of the burst length by default, so
-        // a "50 ms" burst is 50..60 ms rather than 50..150 ms on the 100 ms
-        // drain tick. Since issue #99 this is the period of the ONE timer
-        // thread rather than of a second one; the drain is rate-limited on top
-        // of it. It costs one wakeup per period doing an atomic load and a
-        // compare when no transition is due.
-        unsigned burst_tick_ms = env_uint("PERFAGENT_GPU_PC_BURST_TICK_MS",
-                                          (unsigned)(bc.burst_ns / 5000000ull));
-        if (!burst_tick_ms) burst_tick_ms = 1;
+        // No burst tick, and no PERFAGENT_GPU_PC_BURST_TICK_MS: issue #101
+        // moved both transitions onto the application's launch callbacks, so
+        // the duty cycle's granularity is now the launch rate, not a period of
+        // ours. A knob that no longer reaches anything is worse than no knob,
+        // so it is gone rather than accepted-and-ignored.
+        //
+        // What this changes in practice: a burst is 50 ms PLUS however long
+        // the application takes to make its next launch after the 50 ms
+        // elapses. On any workload Tier A is worth running on that is
+        // microseconds. On one that stops launching entirely it is unbounded,
+        // and the window stays open --- which over-states the perturbation and
+        // is the safe direction. See burst_open_at_launch.
         logf("perfagent-cupti: tier A duty cycle burst_ms=%llu target_rate=%.0f/s "
-             "max_duty=%.3f min_gap_ms=%llu max_gap_ms=%llu tick_ms=%u\n",
+             "max_duty=%.3f min_gap_ms=%llu max_gap_ms=%llu boundary=launch\n",
              (unsigned long long)(bc.burst_ns / 1000000ull), bc.target_rate, bc.max_duty,
              (unsigned long long)(perfagent::burst_min_gap_ns(bc) / 1000000ull),
-             (unsigned long long)(bc.max_gap_ns / 1000000ull), burst_tick_ms);
-        g_burst_tick_ms = burst_tick_ms;
+             (unsigned long long)(bc.max_gap_ns / 1000000ull));
     }
 
     if (!check(perfagent::cupti::Subscribe(&g_subscriber, (CUpti_CallbackFunc)on_callback,
@@ -2142,11 +2382,14 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
     resample_clock();
 
     const unsigned drain_ms = env_uint("PERFAGENT_GPU_DRAIN_MS", 100);
-    // ONE timer, at the shorter of the two periods, with the drain rate-limited
-    // on top of it. Two timer threads is what issue #99 was; see on_timer_tick
-    // and core/tickplan.h.
+    // ONE timer, serving ONE job: the activity drain. Two timer threads was
+    // issue #99; a timer that touched PC sampling at all was issue #101, and
+    // that half is now on the application's launch callbacks. The burst-tick
+    // arguments are passed as "no burst poll" because there is none --- the
+    // shorter-tick case in tick_period_ns is retained for a future second job
+    // on this timer, not exercised by this one.
     const uint64_t tick_ns = perfagent::tick_period_ns(
-        (uint64_t)drain_ms * 1000000ull, (uint64_t)g_burst_tick_ms * 1000000ull, g_pc_tier_a);
+        (uint64_t)drain_ms * 1000000ull, /*burst_tick_ns=*/0, /*tier_a=*/false);
     // drain_limit_ns, not the drain period: with Tier A off the timer already
     // runs at the drain period and a rate limit on top of it would skip any
     // tick that arrived a hair early. See core/tickplan.h.

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -452,12 +452,39 @@ unsigned env_uint(const char *name, unsigned dflt);
 constexpr uint32_t kPCPeriodMin = 5;
 constexpr uint32_t kPCPeriodMax = 31;
 
-// How many distinct PCs one GetData call may return. The Phase 3 spike saw
-// 352 PC records in CONTINUOUS mode for ~103k samples, so this is roughly six
-// times the measured need and still under a megabyte with 38 stall reasons.
+// How many distinct PCs one GetData call may return.
+//
+// cupti_pcsampling.h documents collectNumPcs purely as a CAPACITY --- "Number
+// of PCs to be collected", sizing the buffer the caller hands over. It is not
+// only that. CUPTI also WITHHOLDS data until it can nearly fill the number
+// asked for, which makes this value decide how often any data arrives at all.
+// That behaviour is undocumented and it was measured (issue #102), on a 3090 /
+// CUDA 13.3, at the 50 ms Tier A burst length:
+//
+//   collectNumPcs    bursts yielding nothing        PCs
+//         32            1 / 124   (  0%)           2553
+//         64            1 / 125   (  0%)           2484
+//        128            1 / 125   (  0%)           2308
+//        256           93 / 124   ( 75%)            150
+//        512          124 / 124   (100%)              0
+//       2048          124 / 124   (100%)              0
+//
+// The old default was 2048, chosen as "six times the measured need" from the
+// Phase 3 spike's 352 records in CONTINUOUS mode. In CONTINUOUS that reasoning
+// held, because nothing there depends on when a buffer fills. For Tier A it
+// meant every burst serialized its kernels, paid the throughput cost in full,
+// and collected NOTHING --- while bursts, duty, start_failed, stop_failed and
+// getdata_failed all read healthy.
+//
+// 64 rather than 32: the same yield, with headroom. And well below 256 rather
+// than just below it, because where the cliff sits depends on how fast the
+// workload produces PCs --- a quieter GPU fills any given buffer more slowly,
+// so the safe direction is smaller. g_bursts_empty is what says the cliff has
+// moved on some other device instead of leaving it silent.
+//
 // The drain loop below keeps calling while remainingNumPcs is non-zero, so
 // this bounds one call's allocation, not the run's data.
-constexpr size_t kPCDefaultCollectNumPcs = 2048;
+constexpr size_t kPCDefaultCollectNumPcs = 64;
 
 // The bound on that loop. CUPTI hands back remainingNumPcs and we keep
 // pulling, but an unbounded loop inside a drain tick is a hang in somebody
@@ -596,12 +623,13 @@ std::atomic<uint64_t> g_burst_enter_polls{0};
 std::atomic<uint64_t> g_burst_exit_polls{0};
 // Bursts that closed having pulled NOT ONE PC from CUPTI.
 //
-// Measured on a 3090, CUDA 13.3: cuptiPCSamplingStart has a dead time of
-// roughly 400 ms before the hardware delivers anything. Below it a burst
-// serializes every kernel it covers --- the throughput cost is real and
-// measurable --- and yields nothing at all. At the 50 ms default EVERY burst
-// is empty, and every other counter on this path still reads healthy:
-// bursts=17, duty=0.49, start_failed=0, stop_failed=0, getdata_failed=0.
+// This found a real one (issue #102). CUPTI withholds PC data until it can
+// nearly fill collectNumPcs, which the header documents only as a buffer
+// capacity. At the old default of 2048 EVERY 50 ms burst came back empty ---
+// 124 of 124 --- while every other counter on this path read healthy:
+// bursts=124, duty within its ceiling, start_failed=0, stop_failed=0,
+// getdata_failed=0, dropped_hw=0. Nothing reported a fault, because there was
+// none: the calls all succeeded and CUPTI was simply still buffering.
 //
 // That is the exact shape this pipeline treats as a defect rather than a
 // tuning matter: a profiler paying the full price of its perturbation and
@@ -1912,10 +1940,14 @@ void report(const char *why) {
         if (total && closed == total) {
             logf("perfagent-cupti: WARNING every one of the %llu Tier A burst(s) in this run "
                  "pulled ZERO PCs. Kernels were serialized and the throughput cost was paid "
-                 "in full, for no data. cuptiPCSamplingStart has a start-up dead time "
-                 "(~400ms measured on GA102/CUDA 13.3) and PERFAGENT_GPU_PC_BURST_MS=%llu is "
-                 "inside it. Raise it well past that or turn Tier A off; see issue #102.\n",
+                 "in full, for no data. The usual cause is PERFAGENT_GPU_PC_MAX_PCS being too "
+                 "large: CUPTI withholds PC data until it can nearly fill collectNumPcs, so a "
+                 "high value means nothing is delivered inside a burst. It is %llu here and "
+                 "the burst is %llums; on GA102/CUDA 13.3 at a 50ms burst, 64 yielded on every "
+                 "burst and 512 on none. Lower it, lengthen the burst, or turn Tier A off. "
+                 "See issue #102.\n",
                  (unsigned long long)total,
+                 (unsigned long long)g_pc_collect_num_pcs,
                  (unsigned long long)(g_burst ? g_burst->config().burst_ns / 1000000ull : 0));
         }
     }


### PR DESCRIPTION
Fixes #101.

## The problem

`cuptiPCSamplingStop` called from a thread of ours deadlocks against the application's own launch path inside CUPTI. Our thread blocks in `pthread_rwlock_wrlock`; the application sits in `__cudaLaunchKernel_helper` holding the other side; neither moves again. It hung the 3090 benchmark twice, on the first Tier A arm both times.

It survived #99 — which was real, and did collapse our two timer threads into one — because the surviving conflict is **not between two threads of ours**. It is between our thread and the application's, and no amount of self-serialization reaches it.

## What Parca does

`parcagpu` does not have the problem because it does not have a thread. `grep -c 'std::thread\|pthread_create\|timer_create' src/ ebpf/` returns 0. Every PC-sampling start and stop runs on the application's own thread from inside a CUPTI callback, aligned to kernel-launch boundaries — `src/cupti.cpp:591` states the rule outright. Their configuration is otherwise identical to ours: `ENABLE_START_STOP_CONTROL`, `KERNEL_SERIALIZED`, `Enable`/`Disable` per context rather than per burst.

The calling thread is the only difference between a design that works and one that hangs.

## The change

START fires at a launch ENTER, STOP at a launch EXIT, both on the application's thread.

- **`BurstController::poll()` splits into `poll_open()`/`poll_close()`.** The split is load-bearing, not tidy. `poll()` *commits* the transition it returns, so an EXIT that called it and got `kStart` — which it can, if the burst it meant to close was already closed by another thread and the gap has since elapsed — would open a burst the call site cannot act on, leaving CUPTI stopped while the controller believes it is sampling. A `sampling()` test at the call site does not substitute, because the state can change between the test and the poll. `poll_open` never returns `kStop` and `poll_close` never returns `kStart`, whatever raced.
- **RUNTIME_API launch callbacks, not parcagpu's DRIVER_API ones.** Strictly the safer position — a runtime launch ENTER fires *before* the runtime enters the driver, so these calls are made from further outside CUPTI's launch path than parcagpu's are — and it avoids the correlation-id cost adding DRIVER_API was measured to have (2.242 vs 1.004 ids per launch).
- **`cuCtxSynchronize` before every start**, as parcagpu does. Resolved through `libcuda.so.1` with `RTLD_NOLOAD`, not `RTLD_DEFAULT`: the CUDA runtime dlopens libcuda into a *local* scope, and the first version of this looked in the global one and reported `sync_missing=7` of 7 bursts on hardware.
- **`PERFAGENT_GPU_PC_BURST_TICK_MS` removed.** The duty cycle's granularity is the launch rate now. A knob that reaches nothing is worse than no knob.

## Duty ceiling

A burst now ends at the first launch *after* its length elapses, so it overruns — 50 ms configured measured at 104 ms actual on a synchronising workload, driving achieved duty to 0.17 against a documented **hard** ceiling of 0.10. The next gap is therefore charged for the burst that happened rather than the one that was asked for.

The test for this needed two attempts and the first one is instructive: fed 100 pairs per burst, the rate controller holds the gap far above either floor, the floor never binds, and the test **passes against the unfixed code**. It now drives a zero-yield workload, where the loop walks the gap down to the floor and the floor is the only thing holding the bound.

## What this gives up

A burst can only open or close when the application launches a kernel. One that stops launching leaves the window open, and the duty figure counts that time as perturbed. That over-states perturbation — the safe direction, and no kernel is launching so nothing is in fact serialized. The exit path still closes the window with a real timestamp, so `end_ns == 0` on the wire still means a hard exit and nothing else.

## Residual risk, stated

The timer still calls `cuptiActivityFlushAll`. That is *not* covered by this fix. It is kept because it predates Tier A, is measured clean twice (−0.006% / +0.017%), and the alternative puts an up-to-8 MiB handover on the application's launch path. The existing app-thread-in-callback-waits-for-our-guard shape already occurs (`on_resource`, `on_module_loaded`) and has never hung. If a future hang shows `ActivityFlushAll` in the trace, that is the next thing to move.

## Verification (3090, CUDA 13.3)

No deadlock. `on_timer=0`, `start_failed=0`, `stop_failed=0`, `sync_missing=0`, bursts open and close, `enter=exit=32200`.

`burst_ms=1000`: `bursts=2 empty_bursts=0 pcs=56 emitted_counts=20,233,414`.

Unit tests: four mutations of the `poll_open`/`poll_close` split are caught (fall-through in either direction, graph refusal dropped from either half), and the duty-ceiling fix is caught by both its assertions independently.

Full `make -C shim test` green, including `check-cupti-guard`, `check-cubin-defer` and `check-fpless`. `make test-unit` green.

## Found on the way, and fixed here — #102

Tier A was collecting nothing, and the cause was our own configuration.

`cupti_pcsampling.h` documents `collectNumPcs` purely as a buffer capacity. It is not only that — **CUPTI withholds PC data until it can nearly fill the number asked for**, so that value decides how often any data arrives. Our default was 2048. Measured at the 50 ms burst length:

| collectNumPcs | bursts yielding nothing | PCs |
|---:|---:|---:|
| 32 | 1 / 124 (0%) | 2553 |
| 64 | 1 / 125 (0%) | 2484 |
| 128 | 1 / 125 (0%) | 2308 |
| 256 | 93 / 124 (75%) | 150 |
| 512 | 124 / 124 (100%) | 0 |
| 2048 | 124 / 124 (100%) | **0** |

Default lowered to 64. Tier A at stock settings now: `bursts=15 empty_bursts=1 pcs=294 emitted_counts=10020986`.

I first reported this as a ~400 ms start-up dead time in `cuptiPCSamplingStart`. **That was wrong.** Holding `collectNumPcs` fixed and varying only burst length produces exactly the signature of a fixed latency — a fitted intercept at 398 ms predicting the observed zero at 400 ms. What broke it was measuring *when* the first PC arrives rather than whether one does: the first arrival moves with `collectNumPcs` (+3258 ms at 2048, +366 ms at 32), not with elapsed time since the start. A start-up latency cannot do that. Full correction in #102.

`empty_bursts` and the loud exit warning stay in regardless — the cliff between 128 and 256 is workload- and device-dependent, and the counter is what says it moved somewhere else.

Tier B is unaffected and still free: 2072.1 kernels/s against 2072.7 with PC sampling off. Its `buffer_full` (~50 per 4000-iteration run) occurs at every value of `collectNumPcs` including the old 2048 — pre-existing at this scale, not caused here, worth its own issue.
