### PR TITLE
gpu: Tier A default duty ceiling 10% -> 5%, per the overhead benchmark

### DIFF
--- a/shim/core/burst.h
+++ b/shim/core/burst.h
@@ -69,9 +69,28 @@ struct BurstConfig {
     // The (PC, stall) pairs per second the loop holds. Parca's default.
     double target_rate = 100.0;
 
-    // The hard ceiling on burst/(burst+gap). 0.1 means at most a tenth of
+    // The hard ceiling on burst/(burst+gap). 0.05 means at most a twentieth of
     // wall-clock time may run serialized. Clamped into (0, 1] on use.
-    double max_duty = 0.1;
+    //
+    // 0.05 and not the 0.1 this shipped with, because 0.1 was measured over
+    // budget. `make bench-gpu-pc-overhead` on a 3090 / CUDA 13.3, 120000
+    // kernels of fixed work per run, 5 interleaved runs per arm:
+    //
+    //   duty    wall ms    cost     cost/duty
+    //    10%    63459.2   +8.93%      0.89
+    //     5%    60766.2   +4.31%      0.86      <- ships here
+    //   2.5%    59446.4   +2.04%      0.82
+    //     1%    58704.6   +0.77%      0.77
+    //
+    // (baseline 58256.2 ms; Tier B -0.03%.) The 10% arm exceeds the overhead
+    // bar, the 5% arm is inside it on both, and the benchmark's own verdict was
+    // TIER_A_SHIPS_AT_A_SMALLER_DUTY. Cost is slightly SUB-linear in duty ---
+    // cost/duty falls from 0.89 to 0.77 --- so halving the ceiling buys back
+    // slightly more than half the cost.
+    //
+    // With the 50 ms burst this pairs with a 950 ms minimum gap, which is
+    // exactly the arm that was measured.
+    double max_duty = 0.05;
 
     // The longest the loop may space bursts out. Without it a workload that
     // produces a huge pair count in one burst would push the next burst out

--- a/shim/core/burst_test.cc
+++ b/shim/core/burst_test.cc
@@ -70,9 +70,14 @@ static SimResult simulate(BurstConfig cfg, uint64_t pairs_per_burst, unsigned cy
 int main() {
     // ---- The duty ceiling, derived rather than asserted by eye.
     {
-        BurstConfig cfg;  // 50 ms burst, 10% ceiling
+        BurstConfig cfg;  // 50 ms burst, 5% ceiling
         const uint64_t lo = burst_min_gap_ns(cfg);
-        assert(lo == 450 * kMs);
+        // gap >= burst * (1/max_duty - 1) = 50ms * 19 = 950ms. The literal is
+        // kept alongside the derivation on purpose: it is what catches the
+        // default moving without anyone noticing, and it moved once already
+        // when the measured overhead at a 10% ceiling came in over budget.
+        assert(lo == 950 * kMs);
+        assert(lo == (uint64_t)((double)cfg.burst_ns * (1.0 / cfg.max_duty - 1.0)));
         const double duty = (double)cfg.burst_ns / (double)(cfg.burst_ns + lo);
         assert(duty <= cfg.max_duty + 1e-12);
     }

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -2357,7 +2357,7 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
         bc.target_rate = (double)env_uint("PERFAGENT_GPU_PC_TARGET_RATE", 100);
         // Per-mille, so a ceiling can be expressed without a float in the
         // environment. 100 = 10%.
-        bc.max_duty = (double)env_uint("PERFAGENT_GPU_PC_MAX_DUTY_PERMILLE", 100) / 1000.0;
+        bc.max_duty = (double)env_uint("PERFAGENT_GPU_PC_MAX_DUTY_PERMILLE", 50) / 1000.0;
         bc.max_gap_ns = (uint64_t)env_uint("PERFAGENT_GPU_PC_MAX_GAP_MS", 10000) * 1000000ull;
         g_burst = new perfagent::BurstController(bc);
         // No burst tick, and no PERFAGENT_GPU_PC_BURST_TICK_MS: issue #101


### PR DESCRIPTION
Acts on the verdict from `make bench-gpu-pc-overhead`, which could finally run end to end once #101 (deadlock) and #102 (`collectNumPcs`) landed.

## The measurement

3090 / CUDA 13.3, 120000 kernels of fixed work per run, 4 streams, 6 arms x 5 **interleaved** runs + 1 calibration. Interleaved rather than blocked so thermal drift over the ~30 minute run hits every arm equally. Baseline is the shipping Phase 4 configuration with PC sampling **off**, not an uninjected run.

| arm | duty | wall ms | cost | cost/duty | kern/s | conc |
|---|---|---|---|---|---|---|
| baseline (pc sampling off) | — | 58256.2 | — | — | 2060 | 3.98 |
| tier B continuous | — | 58240.8 | −0.03% | — | 2060 | 3.98 |
| tier A 50ms/450ms | 10.0% | 63459.2 | **+8.93%** | 0.89 | 1891 | 3.65 |
| tier A 50ms/950ms | 5.0% | 60766.2 | **+4.31%** | 0.86 | 1975 | 3.81 |
| tier A 50ms/1950ms | 2.5% | 59446.4 | +2.04% | 0.82 | 2019 | 3.90 |
| tier A 50ms/4950ms | 1.0% | 58704.6 | +0.77% | 0.77 | 2044 | 3.95 |

Verdict: `TIER_A_SHIPS_AT_A_SMALLER_DUTY`. The 10% ceiling is over the overhead bar; 5% is inside both. Cost is slightly **sub**-linear in duty — cost/duty falls 0.89 → 0.77 — so halving the ceiling buys back slightly more than half the cost.

With the 50 ms burst, a 5% ceiling pairs with a 950 ms minimum gap. That is exactly the arm measured, not an interpolation between arms.

## Why these numbers count when earlier ones would not have

Every arm proved the mode it claims:

```
tier A 10% duty   tier=serialized pc_records=8408 bursts=126 windows=252 duty=0.1031
tier A  5% duty   tier=serialized pc_records=4061 bursts=61  windows=122 duty=0.0530
tier A  2.5%      tier=serialized pc_records=1956 bursts=30  windows=60  duty=0.0271
tier A  1% duty   tier=serialized pc_records=751  bursts=12  windows=24  duty=0.0121
```

`pc_records` is non-zero on all four Tier A arms. Run before #102's fix, all four would have reported `pc_records=0` — measuring the cost of serializing kernels while collecting nothing — and the wall-clock timings would have looked exactly as plausible as these do. `windows == 2 x bursts` in every arm, so no burst died unclosed. Measured duty tracks nominal, slightly over each time, which is the trailing-gap artifact documented on `duty()` rather than a ceiling breach.

## The test change

`burst_test`'s derived-floor assertion moves 450 ms → 950 ms. It now carries both the literal and the derivation:

```cpp
assert(lo == 950 * kMs);
assert(lo == (uint64_t)((double)cfg.burst_ns * (1.0 / cfg.max_duty - 1.0)));
```

The literal is the half that catches the default moving without anyone noticing — and it has now moved once. Every other test references `cfg.max_duty` relatively and needed no change.

## Verified

At stock defaults on hardware: `max_duty=0.050 min_gap_ms=950 bursts=6 duty=0.0497 empty_bursts=1 on_timer=0 pcs=96`.

`make -C shim test` and `make test-unit` both green.

Tier B untouched: −0.03%, a third consecutive independent measurement of free (−0.006%, +0.017%, −0.03%).

## Not addressed here

`unknown` executions rise as duty falls — 315, 1211, 2860, **7787** at 1% duty, or ~12% of executions the consumer cannot classify as serialized or not. It leans the conservative way ("cannot tell" rather than a false "not perturbed") and is plausibly inherent, since fewer window records leave more wall-clock uncovered. But fewer windows producing *more* uncertainty is counterintuitive enough to be worth confirming as intended semantics before anyone ships the 1% arm. It does not affect the 5% default this PR sets.
