### PR TITLE
gpu: answer the tail of a Tier A run (#105), and stop losing 90% of PC data (#106)

### DIFF
--- a/gpu/serialization.go
+++ b/gpu/serialization.go
@@ -1,6 +1,11 @@
 package gpu
 
-import "sort"
+import (
+	"math"
+	"sort"
+
+	"github.com/dpsoft/perf-agent/internal/gpuabi"
+)
 
 // The serialization disclosure: which executions ran while GPU kernels were
 // being serialized by the profiler, which provably did not, and which cannot
@@ -50,6 +55,32 @@ type samplingWindow struct {
 	startNs uint64
 	endNs   uint64 // 0 = still open when the producer stopped reporting
 	mode    SamplingMode
+	// quietMs is the producer's guarantee that no further burst opens before
+	// endNs + quietMs. Zero means it did not say. gpuabi.QuietNever means
+	// never again. See provenQuietUntil.
+	quietMs uint32
+}
+
+// provenQuietUntil is the last instant this window proves nothing further had
+// started, and the second return says whether it proves anything at all.
+//
+// This is the ONLY thing that lets the interval after the last known burst be
+// answered. Without it a genuine gap and an open record that was simply lost
+// look the same from here, so the tail of every run has to be conceded as
+// unknown — and the longer the duty cycle's gap, the more of the run that is.
+// At a 1% duty that was ~12% of executions (issue #105).
+func (w samplingWindow) provenQuietUntil() (uint64, bool) {
+	if w.open() || w.quietMs == 0 {
+		return 0, false
+	}
+	if w.quietMs == gpuabi.QuietNever {
+		return math.MaxUint64, true
+	}
+	end := w.endNs + uint64(w.quietMs)*1e6
+	if end < w.endNs { // overflow; the producer said something absurd
+		return 0, false
+	}
+	return end, true
 }
 
 func (w samplingWindow) open() bool { return w.endNs == 0 }
@@ -166,7 +197,7 @@ func (s *windowStore) add(w GPUSamplingWindow) {
 		set.haveCoverage = true
 	}
 
-	nw := samplingWindow{startNs: w.StartNs, endNs: w.EndNs, mode: w.Mode}
+	nw := samplingWindow{startNs: w.StartNs, endNs: w.EndNs, mode: w.Mode, quietMs: w.NextStartDeltaMs}
 	// Windows arrive in start order from one producer, so the common case is
 	// an append or a match against the tail. The scan is backwards for that
 	// reason and is bounded by maxPerPID in the worst case.
@@ -200,9 +231,21 @@ func (s *windowStore) add(w GPUSamplingWindow) {
 //
 // An OPEN window ends coverage at its own start: the burst was running from
 // there and nothing says when — or whether — it stopped. Otherwise coverage
-// runs to the end of the last closed burst. It deliberately does NOT extend
-// past that: the next burst's open record may simply not have been drained
-// yet, so the interval after the last known window is not a proven gap.
+// runs to the end of the last closed burst, PLUS whatever quiet interval that
+// burst's record promised.
+//
+// Without such a promise it must not extend past the last window at all: the
+// next burst's open record may simply not have been drained yet, so the
+// interval after it is not a proven gap. That conservatism was correct and it
+// was expensive — the whole tail of every run read "unknown", and the longer
+// the duty cycle's gap the more of the run that was (issue #105). The promise
+// removes the ambiguity at its source: the producer's controller refuses to
+// open a burst before a known instant, so it can simply say so, and a gap is
+// then distinguishable from a lost record.
+//
+// An open window still caps everything, promise or no promise: it is evidence
+// that a burst WAS running, which outranks an earlier record's claim about
+// when the next one could start.
 func (set *windowSet) coverageEndNs() (uint64, bool) {
 	if !set.haveCoverage || len(set.wins) == 0 {
 		return 0, false
@@ -216,10 +259,23 @@ func (set *windowSet) coverageEndNs() (uint64, bool) {
 		if w.open() {
 			// The earliest open window at or after the coverage start caps
 			// everything. wins is start-ordered, so this is the answer.
+			//
+			// Redundant with classify's intersects scan, which reaches any
+			// execution at or after this start anyway because an open window
+			// is [startNs, +inf) — removing this line does not change a single
+			// answer, and no test here can tell. It stays because the cap it
+			// expresses is a property of COVERAGE, and a future caller of
+			// coverageEndNs that is not classify would need it and would have
+			// no reason to suspect it was missing.
 			return w.startNs, true
 		}
+		// The window's own end is always proven. Its promised quiet interval
+		// extends that, when the producer made one.
 		if !have || w.endNs > end {
 			end, have = w.endNs, true
+		}
+		if q, ok := w.provenQuietUntil(); ok && q > end {
+			end = q
 		}
 	}
 	return end, have

--- a/gpu/serialization_test.go
+++ b/gpu/serialization_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dpsoft/perf-agent/internal/gpuabi"
 )
 
 // The serialization disclosure, end to end through Timeline.
@@ -540,4 +542,100 @@ func TestSerializationFalseIsOnlyEverReachedFromPositiveEvidence(t *testing.T) {
 			}
 		})
 	}
+}
+
+// burstQuiet is a closed burst that also carries the producer's guarantee that
+// nothing further starts for quietMs after it ends.
+func burstQuiet(pid uint32, startNs, endNs uint64, quietMs uint32) GPUSamplingWindow {
+	w := burst(pid, startNs, endNs)
+	w.NextStartDeltaMs = quietMs
+	return w
+}
+
+// Issue #105. The interval after the last burst a consumer heard about used to
+// be conceded as "unknown", because a genuine gap and a lost open record look
+// identical from here. It cost more the lower the duty cycle went — at a 1%
+// duty, ~12% of executions in a real benchmark run.
+//
+// The producer's controller refuses to open a burst before a known instant, so
+// it now says so, and the two cases become distinguishable.
+func TestAQuietIntervalPromiseAnswersTheTailInsteadOfConcedingIt(t *testing.T) {
+	tl := tierATimeline()
+	// One burst over [100ms, 150ms], then a promised 950ms of quiet.
+	require.NoError(t, tl.EmitSamplingWindow(burst(tierAPID, 100e6, 0)))
+	require.NoError(t, tl.EmitSamplingWindow(burstQuiet(tierAPID, 100e6, 150e6, 950)))
+
+	// Inside the burst; well inside the promised quiet; at its very end; and
+	// one nanosecond past it.
+	require.NoError(t, tl.EmitExec(serializedExec("in", 120e6, 130e6)))
+	require.NoError(t, tl.EmitExec(serializedExec("quiet", 400e6, 500e6)))
+	require.NoError(t, tl.EmitExec(serializedExec("edge", 1000e6, 1100e6)))
+	require.NoError(t, tl.EmitExec(serializedExec("past", 1100e6, 1100e6+1)))
+
+	snap := tl.Snapshot()
+	assert.Equal(t, []string{"true", "false", "false", "unknown"}, states(snap),
+		"the promised interval is answerable; the instant past it is not")
+	assertSumIdentity(t, snap)
+}
+
+// The promise is opt-in on the wire. A producer that does not make one — an
+// older shim, whose padding decodes as zero — must get exactly the old
+// answer, because that is the whole reason the field could ride in padding
+// without a version bump.
+func TestWithoutAQuietPromiseTheTailIsStillUnknown(t *testing.T) {
+	tl := tierATimeline()
+	require.NoError(t, tl.EmitSamplingWindow(burst(tierAPID, 100e6, 0)))
+	require.NoError(t, tl.EmitSamplingWindow(burst(tierAPID, 100e6, 150e6))) // quietMs 0
+	require.NoError(t, tl.EmitExec(serializedExec("after", 400e6, 500e6)))
+
+	snap := tl.Snapshot()
+	assert.Equal(t, []string{"unknown"}, states(snap))
+	assertSumIdentity(t, snap)
+}
+
+// QuietNever is the teardown and graph-refusal case: no burst opens again for
+// the life of the process, so the whole remainder of the run is answerable.
+func TestQuietNeverAnswersTheWholeRemainderOfTheRun(t *testing.T) {
+	tl := tierATimeline()
+	require.NoError(t, tl.EmitSamplingWindow(burst(tierAPID, 100e6, 0)))
+	require.NoError(t, tl.EmitSamplingWindow(burstQuiet(tierAPID, 100e6, 150e6, gpuabi.QuietNever)))
+	require.NoError(t, tl.EmitExec(serializedExec("far", 1e15, 1e15+1e6)))
+
+	snap := tl.Snapshot()
+	assert.Equal(t, []string{"false"}, states(snap))
+	assertSumIdentity(t, snap)
+}
+
+// A promise must never outrank evidence. An OPEN window says a burst WAS
+// running; an earlier record's claim about when the next one could start
+// cannot talk over it, whatever it promised — otherwise a lost close record
+// would turn a perturbed tail into a confident "false", which is the one
+// answer that must never be reachable by accident.
+func TestAnOpenWindowBeatsAnEarlierQuietPromise(t *testing.T) {
+	tl := tierATimeline()
+	require.NoError(t, tl.EmitSamplingWindow(burst(tierAPID, 100e6, 0)))
+	require.NoError(t, tl.EmitSamplingWindow(burstQuiet(tierAPID, 100e6, 150e6, gpuabi.QuietNever)))
+	// A later burst that never closed, inside the "never" the first promised.
+	require.NoError(t, tl.EmitSamplingWindow(burst(tierAPID, 600e6, 0)))
+	require.NoError(t, tl.EmitExec(serializedExec("before", 300e6, 400e6)))
+	require.NoError(t, tl.EmitExec(serializedExec("after", 700e6, 800e6)))
+
+	snap := tl.Snapshot()
+	assert.Equal(t, []string{"false", "unknown"}, states(snap),
+		"coverage still stops dead at the open window despite the never-promise")
+	assertSumIdentity(t, snap)
+}
+
+// A promise on an OPEN record is meaningless and is dropped at the wire, so it
+// cannot extend coverage past a burst whose end nobody knows.
+func TestAQuietPromiseOnAnOpenRecordIsIgnored(t *testing.T) {
+	w := burstQuiet(tierAPID, 100e6, 0, gpuabi.QuietNever)
+	assert.Equal(t, uint64(0), w.EndNs)
+	tl := tierATimeline()
+	require.NoError(t, tl.EmitSamplingWindow(w))
+	require.NoError(t, tl.EmitExec(serializedExec("after", 400e6, 500e6)))
+
+	snap := tl.Snapshot()
+	assert.Equal(t, []string{"unknown"}, states(snap))
+	assertSumIdentity(t, snap)
 }

--- a/gpu/types.go
+++ b/gpu/types.go
@@ -422,6 +422,13 @@ type GPUSamplingWindow struct {
 	// rather than spanning across the hole and reporting an unknown interval
 	// as a proven one.
 	Lost uint64 `json:"lost,omitempty"`
+
+	// NextStartDeltaMs, on a closed window, is the producer's guarantee that
+	// no further burst opens before EndNs + this. Zero means it did not say;
+	// gpuabi.QuietNever means never again. It is what lets the interval after
+	// the last known burst be answered "not serialized" instead of being
+	// conceded as unknown — see the windowStore's coverage logic and #105.
+	NextStartDeltaMs uint32 `json:"next_start_delta_ms,omitempty"`
 }
 
 // Open reports whether this window never closed. See the EndNs doc comment:

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -2322,6 +2322,10 @@ func (c *Consumer) noteSamplingWindowLocked(pid uint32, w gpuabi.SamplingWindow,
 		EndNs:       w.EndNs,
 		Mode:        gpu.SamplingMode(w.Mode),
 		Lost:        lost,
+		// Carried through verbatim. DecodeSamplingWindow has already zeroed it
+		// on an open window, so it cannot arrive claiming a quiet interval
+		// after a burst whose end is unknown.
+		NextStartDeltaMs: w.NextStartDeltaMs,
 	}
 	if err := c.cfg.Sink.EmitSamplingWindow(ev); err != nil {
 		c.stats.SinkRejected++

--- a/internal/gpuabi/records.go
+++ b/internal/gpuabi/records.go
@@ -238,7 +238,22 @@ type SamplingWindow struct {
 	StartNs uint64
 	EndNs   uint64
 	Mode    uint8
+
+	// NextStartDeltaMs, on a closed window, is how long after EndNs the
+	// producer guarantees no further burst can open. Zero means the producer
+	// did not say — which is what an older producer's zero padding decodes to,
+	// so it is also the safe reading. QuietNever means never again.
+	//
+	// It is what lets the tail of a run be answered "not serialized" rather
+	// than "unknown": without it a missing open record and a genuine gap are
+	// indistinguishable, so everything after the last known burst has to be
+	// conceded. See the windowStore's coverage logic.
+	NextStartDeltaMs uint32
 }
+
+// QuietNever is NextStartDeltaMs meaning the producer has refused all further
+// bursts for the life of the process — teardown, or the CUDA-graph refusal.
+const QuietNever uint32 = 0xFFFFFFFF
 
 // Open reports whether the window never closed. An execution at or after an
 // open window's StartNs is "unknown", never "not serialized": the producer
@@ -297,6 +312,15 @@ func DecodeSamplingWindow(b []byte) (SamplingWindow, error) {
 		StartNs: le.Uint64(b[0:]),
 		EndNs:   le.Uint64(b[8:]),
 		Mode:    b[16],
+		// b[17:20] is padding. The field rides in the tail of the record's
+		// existing 7 padding bytes, so the wire size is unchanged at 24 and
+		// REC_SAMPLING_WINDOW in the BPF side needs no version bump.
+		NextStartDeltaMs: le.Uint32(b[20:]),
+	}
+	// Meaningless on an open window, and a producer that sets it there is
+	// confused rather than informative. Dropped rather than trusted.
+	if out.EndNs == 0 {
+		out.NextStartDeltaMs = 0
 	}
 	// EndNs == 0 is the encoded "still open" case, not an inversion.
 	if out.EndNs != 0 && out.EndNs < out.StartNs {

--- a/internal/gpuabi/records_test.go
+++ b/internal/gpuabi/records_test.go
@@ -336,3 +336,47 @@ func TestDropClassesAreDistinctAndNonZero(t *testing.T) {
 	// still render as losses rather than vanish or be guessed at.
 	assert.Equal(t, "unknown-class-200", DropClassName(200))
 }
+
+// A quiet promise is meaningless on an open window — nobody knows when the
+// burst ended, so "nothing started for N ms after it" says nothing. It is
+// dropped here, at the wire, rather than relied on being ignored downstream.
+//
+// This is tested at this level deliberately: gpu.samplingWindow.provenQuietUntil
+// also refuses open windows, so a test that goes through the store cannot tell
+// the two guards apart and passes with either one removed.
+func TestAQuietPromiseIsDroppedFromAnOpenWindowAtTheWire(t *testing.T) {
+	b := make([]byte, SizeSamplingWindow)
+	binary.LittleEndian.PutUint64(b[0:], 1000)
+	binary.LittleEndian.PutUint64(b[8:], 0) // open
+	b[16] = SamplingModeKernelSerialized
+	binary.LittleEndian.PutUint32(b[20:], QuietNever)
+
+	w, err := DecodeSamplingWindow(b)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !w.Open() {
+		t.Fatal("window should be open")
+	}
+	if w.NextStartDeltaMs != 0 {
+		t.Fatalf("quiet promise survived on an open window: got %d, want 0", w.NextStartDeltaMs)
+	}
+}
+
+// The closed case, so the test above is not passing merely because the field
+// never decodes at all.
+func TestAQuietPromiseSurvivesOnAClosedWindow(t *testing.T) {
+	b := make([]byte, SizeSamplingWindow)
+	binary.LittleEndian.PutUint64(b[0:], 1000)
+	binary.LittleEndian.PutUint64(b[8:], 2000)
+	b[16] = SamplingModeKernelSerialized
+	binary.LittleEndian.PutUint32(b[20:], 950)
+
+	w, err := DecodeSamplingWindow(b)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if w.NextStartDeltaMs != 950 {
+		t.Fatalf("quiet promise lost: got %d, want 950", w.NextStartDeltaMs)
+	}
+}

--- a/shim/core/burst.h
+++ b/shim/core/burst.h
@@ -318,6 +318,12 @@ public:
     }
 
     bool sampling() const { std::lock_guard<std::mutex> g(mu_); return sampling_; }
+    // The earliest instant a further burst may open. poll_open refuses until
+    // then, so this is a GUARANTEE and not an intention --- which is what lets
+    // the adapter put it on the wire for a consumer to reason with. Only
+    // meaningful once a burst has closed; read it after closed() so the
+    // controller has finished moving the gap.
+    uint64_t next_start_ns() const { std::lock_guard<std::mutex> g(mu_); return next_start_ns_; }
     bool refused() const { std::lock_guard<std::mutex> g(mu_); return refused_; }
     // The start timestamp of the burst that is currently open. Zero when none
     // is; the caller checks sampling() rather than testing this for zero.

--- a/shim/core/usdt_abi.h
+++ b/shim/core/usdt_abi.h
@@ -184,11 +184,28 @@ struct gpu_stall_reason_map_v1 {
 // "unknown", never "not serialized". The ordinary teardown path closes the
 // window with the exit timestamp, so a zero here is specifically the hard
 // case.
+// next_start_delta_ms, on a CLOSED record, is how long after end_ns the
+// producer guarantees no further burst can OPEN. It is what lets a consumer
+// say "not serialized" about the interval after the last burst it heard about,
+// instead of "cannot tell": without it, the tail of every run is unknown,
+// because a missing open record and a genuine gap look identical.
+//
+//   0            not stated. Means exactly what the absence of the field meant
+//                before it existed, so an old producer's zero-filled padding
+//                decodes as today's behaviour and nothing has to be versioned.
+//   0xFFFFFFFF   never. The producer has refused further bursts for the rest
+//                of the process --- teardown, or the CUDA-graph refusal.
+//   otherwise    milliseconds. No burst opens before end_ns + this.
+//
+// It occupies padding, so the record is still 24 bytes and REC_SAMPLING_WINDOW
+// in bpf/gpu_usdt.bpf.c is unchanged. It is meaningless on an OPEN record
+// (end_ns == 0) and is written zero there.
 struct gpu_sampling_window_v1 {
     uint64_t start_ns;
     uint64_t end_ns;
     uint8_t  mode;
-    uint8_t  _pad[7];
+    uint8_t  _pad[3];
+    uint32_t next_start_delta_ms;
 };
 
 GPU_STATIC_ASSERT(sizeof(struct gpu_launch_v1) == 48, "gpu_launch_v1 layout");

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -486,6 +486,30 @@ constexpr uint32_t kPCPeriodMax = 31;
 // this bounds one call's allocation, not the run's data.
 constexpr size_t kPCDefaultCollectNumPcs = 64;
 
+// How often CUPTI's own worker threads wake to move PC data out of the
+// hardware buffer. CUPTI's default is 100 ms, and that is far too slow for
+// this sampling rate: the hardware buffer fills between wakeups, GetData then
+// returns CUPTI_ERROR_OUT_OF_MEMORY, and the data that would have been in it
+// is gone. Issue #106.
+//
+// It was losing an order of magnitude. Tier B, 4000 iterations of
+// cuda_concurrent on a 3090 / CUDA 13.3:
+//
+//   sleep span    OOM polls    PCs     counts    kernels/s
+//     100 ms         48         195     247M      2072.4     <- CUPTI default
+//      25 ms          0        1051     773M      2071.6
+//      10 ms          0        2012     792M      2070.1     <- here
+//       5 ms          0        2124     801M      2070.1
+//
+// Ten times the PCs and no OOM at all, for no measurable GPU throughput cost.
+// Raising the HARDWARE_BUFFER_SIZE to 1 GiB also removes the OOM but recovers
+// far less (361 PCs) and costs a gigabyte, so this is the better of the two
+// mitigations the header lists.
+//
+// 10 ms rather than 5: the same order of magnitude recovered, half the worker
+// wakeups. Below 10 the curve has flattened.
+constexpr unsigned kPCDefaultWorkerSleepMs = 10;
+
 // The bound on that loop. CUPTI hands back remainingNumPcs and we keep
 // pulling, but an unbounded loop inside a drain tick is a hang in somebody
 // else's process; hitting the bound is counted rather than retried forever.
@@ -505,7 +529,8 @@ std::atomic<uint64_t> g_pc_tier_refused{0};
 uint32_t g_pc_period = 0;                 // the exponent actually in force
 size_t g_pc_collect_num_pcs = kPCDefaultCollectNumPcs;
 size_t g_pc_scratch_bytes = 0;            // 0 = CUPTI's default
-size_t g_pc_hw_buffer_bytes = 0;          // 0 = CUPTI's default
+size_t g_pc_hw_buffer_bytes = 0;
+unsigned g_pc_worker_sleep_ms = kPCDefaultWorkerSleepMs;          // 0 = CUPTI's default
 
 // The device's stall-reason table. Queried once, from the first context that
 // enables sampling: the indices are the device's own and are not stable across
@@ -863,7 +888,7 @@ void pc_enable_ctx(CUcontext ctx) {
     }
     pc_setup_buffer(c);
 
-    CUpti_PCSamplingConfigurationInfo info[8]{};
+    CUpti_PCSamplingConfigurationInfo info[10]{};
     size_t n = 0;
     info[n].attributeType = CUPTI_PC_SAMPLING_CONFIGURATION_ATTR_TYPE_COLLECTION_MODE;
     info[n++].attributeData.collectionModeData.collectionMode =
@@ -901,6 +926,12 @@ void pc_enable_ctx(CUcontext ctx) {
     if (g_pc_hw_buffer_bytes) {
         info[n].attributeType = CUPTI_PC_SAMPLING_CONFIGURATION_ATTR_TYPE_HARDWARE_BUFFER_SIZE;
         info[n++].attributeData.hardwareBufferSizeData.hardwareBufferSize = g_pc_hw_buffer_bytes;
+    }
+    if (g_pc_worker_sleep_ms) {
+        info[n].attributeType =
+            CUPTI_PC_SAMPLING_CONFIGURATION_ATTR_TYPE_WORKER_THREAD_PERIODIC_SLEEP_SPAN;
+        info[n++].attributeData.workerThreadPeriodicSleepSpanData.workerThreadPeriodicSleepSpan =
+            g_pc_worker_sleep_ms;
     }
     // In Tier B, ENABLE_START_STOP_CONTROL is deliberately left off: turning
     // it on in CONTINUOUS mode would change when a flush is required
@@ -988,6 +1019,18 @@ void pc_drain_ctx_locked(PCContext *c) {
         if (st == CUPTI_ERROR_OUT_OF_MEMORY) {
             // The documented "hardware buffer is full" return. The PC data for
             // this window is gone; the fact that it is gone is not.
+            //
+            // The 1 is an OCCURRENCE, not a sample count, and the two are not
+            // close: measured on a 3090, a run taking 48 of these returned 195
+            // PCs where the same run taking none returned 2012. CUPTI does not
+            // say how much was lost --- droppedSamples stays 0 through all of
+            // it, because these samples never reached the counter that feeds
+            // it. So the count here cannot be made honest, and the number that
+            // matters is how OFTEN this fires, not what it sums to. Nothing
+            // downstream should read this class as "N samples lost".
+            //
+            // With kPCDefaultWorkerSleepMs it should fire zero times. See the
+            // exit warning, which names the remedy.
             g_pc_buffer_full.fetch_add(1, std::memory_order_relaxed);
             emit_dropped(1, GPU_DROP_CLASS_PC_BUFFER_FULL);
             return;
@@ -1079,12 +1122,13 @@ void pc_drain_all(perfagent::PCDrainReason reason) {
 // start_ns, and supersedes the open one in the consumer's store. A closed
 // record never loses to an open one there, so the two orderings a lossy
 // transport can produce both end up correct.
-void emit_window(uint64_t start_ns, uint64_t end_ns) {
+void emit_window(uint64_t start_ns, uint64_t end_ns, uint32_t next_start_delta_ms) {
     if (!gpu_sampling_window_v1_enabled()) return;
     gpu_sampling_window_v1 w{};
     w.start_ns = start_ns;
     w.end_ns = end_ns;
     w.mode = GPU_SAMPLING_MODE_KERNEL_SERIALIZED;
+    w.next_start_delta_ms = next_start_delta_ms;
     // UNBATCHED, like gpu_dropped_v1 and for the same reason: two records per
     // burst at a few bursts per second is not volume, and a window still
     // sitting in a partly filled batch when the process dies is a window that
@@ -1197,6 +1241,34 @@ void pc_stop_ctxs_locked() {
     }
 }
 
+// How long the controller guarantees no further burst can open, as
+// milliseconds after now_ns, for gpu_sampling_window_v1.next_start_delta_ms.
+//
+// This is a GUARANTEE rather than a plan: BurstController::poll_open refuses
+// to start before next_start_ns(), so a consumer can treat the interval as
+// proven quiet and answer "not serialized" over it instead of "cannot tell".
+// Read after closed(), which is what finishes moving the gap.
+//
+// 0 means "not stated" and is the safe answer: it is what a consumer that has
+// never heard of this field infers, and it costs only certainty. Anything that
+// cannot be expressed exactly lands there rather than on a guess.
+constexpr uint32_t kWindowQuietNever = 0xFFFFFFFFu;
+
+uint32_t burst_quiet_ms(uint64_t now_ns) {
+    if (!g_burst) return 0;
+    // Refused means no burst opens again for the life of the process ---
+    // teardown, or the CUDA-graph refusal. That is the strongest statement
+    // available and it is exactly what covers the tail of an ordinary run.
+    if (g_burst->refused()) return kWindowQuietNever;
+    const uint64_t next = g_burst->next_start_ns();
+    if (next <= now_ns) return 0;
+    const uint64_t ms = (next - now_ns) / 1000000ull;
+    // Clamp below the sentinel: a gap long enough to collide with it would be
+    // 49 days, but "impossible" is not a thing this pipeline asserts.
+    if (ms >= (uint64_t)kWindowQuietNever) return kWindowQuietNever - 1;
+    return (uint32_t)ms;
+}
+
 // Closes an open burst: stop every context, drain (CUPTI requires the flush
 // after every range end), close the window, and hand the yield to the loop.
 //
@@ -1229,7 +1301,6 @@ void burst_close(uint64_t now_ns, uint64_t start_ns) {
     // only arrive on the post-stop flush are counted where they belong.
     if (g_pc_pcs.load(std::memory_order_relaxed) == pcs_at_open)
         g_bursts_empty.fetch_add(1, std::memory_order_relaxed);
-    emit_window(start_ns, now_ns);
     g_sampling_burst_ns.fetch_add(now_ns > start_ns ? now_ns - start_ns : 0,
                                   std::memory_order_relaxed);
     // AFTER the drain, which is the whole reason BurstController::closed is a
@@ -1238,6 +1309,11 @@ void burst_close(uint64_t now_ns, uint64_t start_ns) {
     // time would measure every burst as having yielded nothing and would sit
     // at the duty floor for the entire run.
     if (g_burst) g_burst->closed(g_pc_records.load(std::memory_order_relaxed));
+    // AFTER closed(), and that ordering is the whole point of emitting here
+    // rather than above: closed() is what finishes moving the gap, so a record
+    // written before it would promise a quiet interval the controller had not
+    // yet committed to --- and could then shorten. Issue #105.
+    emit_window(start_ns, now_ns, burst_quiet_ms(now_ns));
 }
 
 // Tier A's two transitions, taken on the APPLICATION's thread at a kernel-launch
@@ -1327,7 +1403,7 @@ void burst_open_at_launch(uint64_t now) {
         // "true" that were not perturbed, which is the SAFE direction: the
         // answer that must never be reachable by accident is "false", and no
         // path here can produce it.
-        emit_window(now, 0);   // open; closed by the EXIT below
+        emit_window(now, 0, 0);   // open; closed by the EXIT below
     }
     note_graph_refusal(was_refused, graphs);
 }
@@ -2004,6 +2080,22 @@ void report(const char *why) {
     // so this is an inequality, not an equation, and it is stated here rather
     // than claimed anywhere as a check. Closing it would need a
     // gpu_config_v2 field, which is not worth a version bump for a diagnostic.
+    // Issue #106. Zero on a healthy run, and if it is not zero the run lost PC
+    // data it cannot quantify --- so this names the knob rather than leaving
+    // the operator to find it. Loud because the old behaviour was to lose an
+    // order of magnitude of samples in silence, with every other counter on
+    // the path reading clean (dropped_hw=0 in particular, which looks like
+    // proof that nothing was lost and is not).
+    if (g_pc_buffer_full.load()) {
+        logf("perfagent-cupti: WARNING cuptiPCSamplingGetData returned "
+             "CUPTI_ERROR_OUT_OF_MEMORY %llu time(s): CUPTI's hardware buffer filled and the "
+             "PC data in it was DISCARDED. How much is unknowable --- droppedSamples does not "
+             "count it. PERFAGENT_GPU_PC_WORKER_SLEEP_MS is %u; lowering it drains the buffer "
+             "more often and is the cheap fix (100ms->10ms took this from 48 occurrences to 0 "
+             "and 195 PCs to 2012 on GA102). PERFAGENT_GPU_PC_HW_BUFFER_MB and a longer "
+             "PERFAGENT_GPU_PC_PERIOD also work. See issue #106.\n",
+             (unsigned long long)g_pc_buffer_full.load(), g_pc_worker_sleep_ms);
+    }
     logf("perfagent-cupti: pc identity (log only, not a check): "
          "emitted_counts + dropped_hw + non_user = %llu <= total_samples = %llu; "
          "the gap is instructions with all selected stall counts zero, which "
@@ -2333,6 +2425,8 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
                                         (unsigned)kPCDefaultCollectNumPcs);
         g_pc_scratch_bytes = (size_t)env_uint("PERFAGENT_GPU_PC_SCRATCH_MB", 0) << 20;
         g_pc_hw_buffer_bytes = (size_t)env_uint("PERFAGENT_GPU_PC_HW_BUFFER_MB", 0) << 20;
+        g_pc_worker_sleep_ms =
+            env_uint("PERFAGENT_GPU_PC_WORKER_SLEEP_MS", kPCDefaultWorkerSleepMs);
         g_pcb = new perfagent::Batch<gpu_pc_sample_batch_v1, 32>(
             gpu_pc_sample_batch_v1_emit, gpu_pc_sample_batch_v1_enabled);
         // The PC drain rides the drain timer, so its period is the drain


### PR DESCRIPTION
Fixes #105 and #106. Both were found by the overhead benchmark, and both read as healthy on every counter the pipeline had.

## #106 — the worker sleep span was losing an order of magnitude

`cuptiPCSamplingGetData` was returning `CUPTI_ERROR_OUT_OF_MEMORY` on roughly **half of all polls** (44 of 89 on a Tier B run). CUPTI's worker threads — which move PC data out of the hardware buffer — wake every **100 ms** by default, which is far too slow at this sampling rate. The buffer fills between wakeups and its contents are discarded.

**The issue's premise was wrong and the probe is what showed it.** I filed it believing the in-band `hardwareBufferFull` flag was sticky and being over-counted once per poll. Logging every `GetData` call showed `full=0` on all 45 calls that reached the probe, while the exit report said `buffer_full=44`. The 44 were calls returning `OUT_OF_MEMORY` and returning *early*, before the probe. The flag never fires at all; the error does.

| sleep span | OOM polls | PCs | counts | kernels/s |
|---:|---:|---:|---:|---:|
| 100 ms (CUPTI default) | 48 | 195 | 247M | 2072.4 |
| 25 ms | 0 | 1051 | 773M | 2071.6 |
| **10 ms (new default)** | **0** | **2012** | **792M** | **2070.1** |
| 5 ms | 0 | 2124 | 801M | 2070.1 |

Ten times the PCs, no OOM, and no measurable GPU throughput cost. Raising `HARDWARE_BUFFER_SIZE` to 1 GiB also clears the OOM but recovers far less (361 PCs) and costs a gigabyte — so the sleep span is the better of the two mitigations the header lists.

Worth noting which counter misled: `droppedSamples` stayed **0** throughout, because these samples never reach the counter that feeds it. The one number that looked like proof nothing was lost was the number least able to see it.

The `PC_BUFFER_FULL` drop class counts *occurrences* and cannot be made to count samples — CUPTI does not say how many were lost. That is now stated where it is emitted, and a non-zero count gets a loud exit warning naming the knob.

## #105 — the tail of every run was conceded as unknown

Coverage stopped dead at the last burst the consumer had heard about, because a genuine gap and an open record that was merely *lost* are indistinguishable from there. Everything after it read `unknown` — and the longer the duty cycle's gap, the more of the run that was: 315 executions at 10% duty, **7787 (~12%) at 1%**.

The producer's controller already knows the answer. `poll_open` **refuses** to start a burst before `next_start_ns()`, so that instant is a guarantee rather than an intention — it can simply be stated. A closed window record now carries `next_start_delta_ms`, and the consumer extends coverage across the interval it promises.

It rides in the record's existing 7 padding bytes, so the wire size is still **24 bytes** and `REC_SAMPLING_WINDOW` in the BPF side needs no version bump. `0` means "not stated" — exactly what an older producer's zero-filled padding decodes to, so the compatibility case and the safe case are the same case. `0xFFFFFFFF` means never again (teardown, or the CUDA-graph refusal) and covers the whole remainder of a run.

The record is now emitted **after** `BurstController::closed()` rather than before. That ordering is load-bearing: `closed()` is what finishes moving the gap, so a record written earlier would promise an interval the controller had not yet committed to and could still shorten.

**A promise never outranks evidence.** An open window still caps coverage whatever an earlier record claimed — otherwise a lost close record would turn a perturbed tail into a confident `false`, the one answer that must never be reachable by accident.

## On the tests

The `provenQuietUntil` fix is mutation-proved: reverting it to the old behaviour fails `TestAQuietIntervalPromiseAnswersTheTailInsteadOfConcedingIt`.

Two other guards turned out to be **redundant**, and I am flagging that rather than claiming coverage I do not have:

- The open-window cap in `coverageEndNs` changes no answer, because `classify`'s `intersects` scan already reaches anything at or after an open window's start (`[startNs, +inf)`). Removing it fails no test. It stays as a property of *coverage* for a future non-`classify` caller, and the comment now says so.
- Dropping a quiet promise from an open record is duplicated by `provenQuietUntil`'s own `open()` check, so a test through the store passes with either guard removed. It is therefore tested at the **wire** instead, where it is not redundant — and that test does fail under mutation.

## Verified

Tier B at the new defaults: `pcs=1910 buffer_full=0 kernels_per_s=2073.1` (against ~2072 baseline).
Tier A at the new defaults: `bursts=6 empty_bursts=1 pcs=98 buffer_full=0 on_timer=0`.

`make -C shim test`, `make test-unit`, and `go test ./...` all green.

The end-to-end confirmation for #105 — the `unknown` counts from the benchmark that produced the issue — is running and will be posted here.
