### PR TITLE
profile: resolve mappings for processes that exit during the capture (#56)

### DIFF
--- a/offcpu/profiler.go
+++ b/offcpu/profiler.go
@@ -22,6 +22,7 @@ type Profiler struct {
 	symbolizer       symbolize.Symbolizer
 	kernelSymbolizer symbolize.KernelSymbolizer
 	resolver         *procmap.Resolver
+	warmer           *procmap.Warmer
 	link             link.Link
 	tags             []string
 	labels           map[string]string
@@ -82,20 +83,37 @@ func NewProfiler(pid int, systemWide bool, tags []string, labels map[string]stri
 		return nil, fmt.Errorf("attach tp_btf sched_switch: %w", err)
 	}
 
-	return &Profiler{
+	resolver := procmap.NewResolver()
+	pr := &Profiler{
 		objs:             objs,
 		symbolizer:       sym,
 		kernelSymbolizer: kernelSym,
-		resolver:         procmap.NewResolver(),
+		resolver:         resolver,
 		link:             tp,
 		tags:             tags,
 		labels:           labels,
-	}, nil
+	}
+
+	// See the same block in profile/profiler.go: mappings are read at collect
+	// time, so a process that exited during the capture resolves to nothing
+	// unless it was read while alive. Issue #56. Off-CPU is if anything more
+	// exposed — a process that blocked and then exited is precisely the thing
+	// this profiler exists to show.
+	if systemWide {
+		pr.warmer = procmap.NewWarmer(resolver, 0)
+		pr.warmer.Start()
+	} else if pid > 0 {
+		resolver.Warm(uint32(pid))
+	}
+	return pr, nil
 }
 
 // Close releases all resources associated with the profiler.
 // The symbolizer is owned by the Agent; we do not close it here.
 func (pr *Profiler) Close() {
+	if pr.warmer != nil {
+		pr.warmer.Stop()
+	}
 	pr.resolver.Close()
 	_ = pr.link.Close()
 	_ = pr.objs.Close()
@@ -137,12 +155,22 @@ func (pr *Profiler) Collect(w io.Writer) error {
 		Labels:        pr.labels,
 	})
 
+	// PIDs already refreshed in this collect pass; see profile/profiler.go.
+	refreshed := make(map[uint32]struct{}, n)
+
 	for i := 0; i < n; i++ {
 		key := keys[i]
 		value := values[i]
 
 		// Use PID from a sample key for symbolization
 		samplePid := key.Pid
+		// Fresh mappings for a live process, the warmed snapshot for one that
+		// is gone. Refresh rather than Invalidate so the second case keeps
+		// what it has. Issue #56.
+		if _, done := refreshed[samplePid]; !done {
+			refreshed[samplePid] = struct{}{}
+			pr.resolver.Refresh(samplePid)
+		}
 
 		// Kernel stack lookup — only when BPF gated a valid stack ID.
 		var kernelIPs []uint64

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -23,6 +23,7 @@ type Profiler struct {
 	symbolizer       symbolize.Symbolizer
 	kernelSymbolizer symbolize.KernelSymbolizer
 	resolver         *procmap.Resolver
+	warmer           *procmap.Warmer
 	perfSet          *perfevent.Set
 	tags             []string
 	sampleRate       int
@@ -102,22 +103,43 @@ func NewProfiler(pid int, systemWide bool, cpus []uint, tags []string, sampleRat
 		return nil, err
 	}
 
-	return &Profiler{
+	resolver := procmap.NewResolver()
+	pr := &Profiler{
 		objs:             objs,
 		symbolizer:       sym,
 		kernelSymbolizer: kernelSym,
-		resolver:         procmap.NewResolver(),
+		resolver:         resolver,
 		perfSet:          perfSet,
 		tags:             tags,
 		sampleRate:       sampleRate,
 		labels:           labels,
 		perfData:         perfData,
-	}, nil
+	}
+
+	// Mappings are read at COLLECT time, which is after the capture window has
+	// closed — so without this, every process that exited during the window
+	// resolves to nothing and its frames land on the default anonymous
+	// mapping. Issue #56.
+	//
+	// System-wide only sweeps all of /proc. A per-PID capture warms exactly
+	// its target: the same protection where it matters, without reading the
+	// maps of every process on the machine for a profile that can never
+	// contain them.
+	if systemWide {
+		pr.warmer = procmap.NewWarmer(resolver, 0)
+		pr.warmer.Start()
+	} else if pid > 0 {
+		resolver.Warm(uint32(pid))
+	}
+	return pr, nil
 }
 
 // Close releases all resources associated with the profiler.
 // The symbolizer is owned by the Agent; we do not close it here.
 func (pr *Profiler) Close() {
+	if pr.warmer != nil {
+		pr.warmer.Stop()
+	}
 	pr.resolver.Close()
 	_ = pr.perfSet.Close()
 	_ = pr.objs.Close()
@@ -159,12 +181,28 @@ func (pr *Profiler) Collect(w io.Writer) error {
 		Labels:        pr.labels,
 	})
 
+	// PIDs already refreshed in this collect pass. A busy system-wide capture
+	// has many samples per process and re-reading /proc/<pid>/maps for each
+	// would be the most expensive thing in this loop.
+	refreshed := make(map[uint32]struct{}, n)
+
 	for i := range n {
 		key := keys[i]
 		value := values[i]
 
 		// Use PID from sample key for symbolization
 		samplePid := key.Pid
+		// Re-read this PID's mappings if it is still alive, so a process that
+		// loaded a library after the warmer last saw it still resolves. When
+		// it is gone, Refresh keeps whatever was warmed rather than dropping
+		// it — which is the whole reason this is not Invalidate. Issue #56.
+		//
+		// Once per PID per collect, not once per sample: refreshed tracks what
+		// has already been done in this pass.
+		if _, done := refreshed[samplePid]; !done {
+			refreshed[samplePid] = struct{}{}
+			pr.resolver.Refresh(samplePid)
+		}
 
 		// Kernel stack lookup — only when BPF gated a valid stack ID.
 		var kernelIPs []uint64
@@ -288,5 +326,3 @@ func (pr *Profiler) createSample(sb *stackBuilder, value uint64, pid int) pprof.
 		Value:       value,
 	}
 }
-
-

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2992,3 +2992,81 @@ func findLibcWithLocalDebuginfo(t *testing.T) (string, string) {
 	t.Skip("no libc.so.6 with local /usr/lib/debug/.build-id debuginfo found — install glibc-debuginfo")
 	return "", ""
 }
+
+// TestSystemWideResolvesAProcessThatExitsDuringTheCapture is issue #56.
+//
+// The profilers resolve mappings at COLLECT time, which is after the capture
+// window closes. A process sampled during the window but gone by the end has
+// no /proc/<pid>/maps left to read, so every frame it contributed used to land
+// on the default anonymous mapping. System-wide is where it bites: short-lived
+// processes are exactly what `-a` exists to catch, and exactly the ones certain
+// to be gone when anything asks.
+//
+// The timing is chosen so neither half of the test is a coin flip. The
+// workload burns CPU on every core for most of the window, so it is certain to
+// be sampled; and it exits with seconds to spare, so it is certain to be gone
+// before the agent resolves anything. An earlier version ran it for 2s of a 6s
+// window and failed for the uninteresting reason that it was never sampled at
+// all.
+func TestSystemWideResolvesAProcessThatExitsDuringTheCapture(t *testing.T) {
+	requireBPFRunnable(t, getAgentPath(t))
+
+	agentPath := getAgentPath(t)
+	binPath := "./workloads/rust/target/release/rust-workload"
+	if _, err := os.Stat(binPath); err != nil {
+		t.Skipf("rust workload not built: %v", err)
+	}
+	absBin, err := filepath.Abs(binPath)
+	require.NoError(t, err)
+
+	outputFile := "profile-shortlived-sys.pb.gz"
+	defer os.Remove(outputFile)
+
+	// Frame pointers rather than DWARF: the defect is in the shared
+	// procmap.Resolver, so either unwinder exercises it, and fp keeps the
+	// agent's shutdown short on machines with large Go binaries running (whose
+	// .eh_frame compilation can take minutes and has nothing to do with this).
+	const window = 10 * time.Second
+	agent := exec.Command(agentPath,
+		"--profile",
+		"--profile-output", outputFile,
+		"--unwind", "fp",
+		"-a",
+		"--duration", window.String(),
+	)
+	require.NoError(t, agent.Start())
+
+	// Let the agent attach and take its first warming sweep.
+	time.Sleep(1 * time.Second)
+
+	// Dominant CPU consumer for 6 of the remaining 9 seconds, then gone.
+	short := exec.Command(absBin, "6")
+	require.NoError(t, short.Start())
+	shortPID := short.Process.Pid
+	require.NoError(t, short.Wait())
+
+	require.NoDirExists(t, fmt.Sprintf("/proc/%d", shortPID),
+		"the workload must be gone before the agent collects, or this test "+
+			"passes for the wrong reason")
+	t.Logf("workload pid=%d exited with ~%v of capture left", shortPID, window-7*time.Second)
+
+	require.NoError(t, agent.Wait(), "perf-agent failed")
+
+	prof, err := readProfile(outputFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, prof.Sample, "no samples: %s", describeProfile(prof))
+
+	assert.True(t, mappingNamed(prof, "rust-workload"),
+		"a process that exited during the capture must still resolve to its "+
+			"binary; %s mappings=%s", describeProfile(prof), describeMappings(prof))
+}
+
+// mappingNamed reports whether any mapping's file path contains want.
+func mappingNamed(p *profile.Profile, want string) bool {
+	for _, m := range p.Mapping {
+		if strings.Contains(m.File, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/unwind/dwarfagent/common.go
+++ b/unwind/dwarfagent/common.go
@@ -67,6 +67,7 @@ type session struct {
 	symbolizer       symbolize.Symbolizer
 	kernelSymbolizer symbolize.KernelSymbolizer
 	resolver         *procmap.Resolver
+	warmer           *procmap.Warmer
 
 	stop      chan struct{}
 	trackerWG sync.WaitGroup
@@ -212,7 +213,8 @@ func newSession(objs sessionObjs, pid int, systemWide bool, cpus []uint, tags []
 		}
 	}
 
-	return &session{
+	resolver := procmap.NewResolver()
+	sess := &session{
 		pid:              pid,
 		tags:             tags,
 		labels:           labels,
@@ -224,12 +226,29 @@ func newSession(objs sessionObjs, pid int, systemWide bool, cpus []uint, tags []
 		missReader:       missReader,
 		symbolizer:       sym,
 		kernelSymbolizer: kernelSym,
-		resolver:         procmap.NewResolver(),
+		resolver:         resolver,
 		stop:             make(chan struct{}),
 		samples:          map[sampleKey]uint64{},
 		attachStats:      stats,
 		perfData:         perfData,
-	}, nil
+	}
+
+	// Issue #56, and this is the path it was reported on. The unwinder already
+	// tracks mappings live — that is what AttachAllProcesses and the mmap
+	// watcher above are for — but the pprof resolver is a SEPARATE cache that
+	// populates lazily, and its first read happens at collect time. So the
+	// tables needed to walk a short-lived process's stack were installed while
+	// it lived, and then every frame that walk produced resolved to nothing.
+	//
+	// The observed failure was a system-wide capture in which every sampled
+	// frame landed on the default anonymous mapping.
+	if systemWide {
+		sess.warmer = procmap.NewWarmer(resolver, 0)
+		sess.warmer.Start()
+	} else if pid > 0 {
+		resolver.Warm(uint32(pid))
+	}
+	return sess, nil
 }
 
 // runTracker starts the background goroutine that consumes mmap events
@@ -386,7 +405,15 @@ func (s *session) collect(w io.Writer, sampleType pprof.SampleType, sampleRate i
 		Resolver:      s.resolver,
 		Labels:        s.labels,
 	})
+	// PIDs already refreshed in this collect pass. Fresh mappings for a live
+	// process, the warmed snapshot for one that is gone. Issue #56.
+	refreshed := make(map[uint32]struct{}, len(samples))
+
 	for key, val := range samples {
+		if _, done := refreshed[key.pid]; !done {
+			refreshed[key.pid] = struct{}{}
+			s.resolver.Refresh(key.pid)
+		}
 		frames := symbolizePIDWithKernel(s.symbolizer, s.kernelSymbolizer, key.pid, stacks[key], kernStacks[key])
 		sample := pprof.ProfileSample{
 			Pid:         key.pid,
@@ -415,6 +442,13 @@ func (s *session) collect(w io.Writer, sampleType pprof.SampleType, sampleRate i
 // Idempotent at the stop-channel level. Returns the first non-nil error
 // encountered; subsequent close calls still execute.
 func (s *session) close() error {
+	// Before the stop channel: the warmer owns a goroutine of its own and
+	// Stop joins it, so doing this first keeps the teardown order the same
+	// shape as everything else here — signal and join each thing in turn,
+	// rather than leaving one running across the rest of the teardown.
+	if s.warmer != nil {
+		s.warmer.Stop()
+	}
 	select {
 	case <-s.stop:
 	default:

--- a/unwind/procmap/procmap_test.go
+++ b/unwind/procmap/procmap_test.go
@@ -389,3 +389,75 @@ func TestMappingOpenablePath(t *testing.T) {
 		})
 	}
 }
+
+// Issue #56. The resolver populates lazily, on the first Lookup for a PID —
+// and in the profilers that first Lookup happens at COLLECT time, after the
+// whole capture window has closed. A process sampled during the window but
+// gone by the end therefore has no /proc/<pid>/maps left to read, and every
+// frame it contributed resolves to nothing.
+//
+// System-wide is where this bites: short-lived processes are exactly what a
+// `-a` capture exists to catch, and they are exactly the ones guaranteed to be
+// gone by the time anything tries to resolve them. On a busy machine an entire
+// capture can come back with real_mappings=0, which is the shape #56 was
+// filed for.
+func TestAPIDThatExitsBeforeItIsResolvedHasNoMappings(t *testing.T) {
+	tmp := t.TempDir()
+	pidDir := filepath.Join(tmp, "4321")
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mapsPath := filepath.Join(pidDir, "maps")
+	const maps = "00400000-00401000 r-xp 00000000 fd:01 111 /usr/bin/shortlived\n"
+	if err := os.WriteFile(mapsPath, []byte(maps), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewResolver(WithProcRoot(tmp))
+	defer r.Close()
+
+	// The process exits before anything asks about it — /proc/<pid> goes away.
+	if err := os.RemoveAll(pidDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := r.Lookup(4321, 0x400500); ok {
+		t.Fatal("expected no mapping for a PID that is already gone")
+	}
+}
+
+// The fix: populate while the process is still alive. The cache then survives
+// the process, and a frame sampled from it still names its binary.
+func TestWarmingBeforeExitKeepsTheMappingsResolvable(t *testing.T) {
+	tmp := t.TempDir()
+	pidDir := filepath.Join(tmp, "4321")
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mapsPath := filepath.Join(tmp, "4321", "maps")
+	const maps = "00400000-00401000 r-xp 00000000 fd:01 111 /usr/bin/shortlived\n"
+	if err := os.WriteFile(mapsPath, []byte(maps), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewResolver(WithProcRoot(tmp))
+	defer r.Close()
+
+	// Warmed while alive.
+	if n := r.Warm(4321); n != 1 {
+		t.Fatalf("Warm: got %d mappings, want 1", n)
+	}
+
+	// Now it exits.
+	if err := os.RemoveAll(pidDir); err != nil {
+		t.Fatal(err)
+	}
+
+	m, ok := r.Lookup(4321, 0x400500)
+	if !ok {
+		t.Fatal("a warmed PID must stay resolvable after it exits")
+	}
+	if m.Path != "/usr/bin/shortlived" {
+		t.Fatalf("got %q, want /usr/bin/shortlived", m.Path)
+	}
+}

--- a/unwind/procmap/resolver.go
+++ b/unwind/procmap/resolver.go
@@ -83,6 +83,56 @@ func (r *Resolver) Mappings(pid uint32) ([]Mapping, error) {
 	return entry.mappings, nil
 }
 
+// Warm populates pid's cache now, while the process is presumably still
+// alive, and reports how many executable mappings it holds afterwards.
+//
+// This exists because of WHEN the profilers resolve. Lookup populates lazily,
+// and in the profilers the first Lookup for a PID happens at collect time —
+// after the whole capture window has closed. A process sampled during the
+// window but gone by the end has no /proc/<pid>/maps left to read, so every
+// frame it contributed resolves to nothing. System-wide is where that bites:
+// short-lived processes are exactly what a `-a` capture exists to catch, and
+// exactly the ones guaranteed to be gone by the time anything asks. Issue #56.
+//
+// Idempotent and cheap to repeat: the per-PID sync.Once means a second call
+// for the same PID costs a map lookup and nothing else, which is what lets a
+// sweep run on a timer without re-reading /proc for every process each time.
+//
+// It deliberately does NOT freeze the answer. A process still alive at collect
+// time is Refreshed there, so warming only ever supplies a fallback for
+// processes that are gone — it never makes a live process's mappings staler
+// than they would have been.
+func (r *Resolver) Warm(pid uint32) int {
+	m, err := r.Mappings(pid)
+	if err != nil {
+		return 0
+	}
+	return len(m)
+}
+
+// Refresh re-reads pid's mappings, KEEPING the existing cache entry if the
+// re-read yields nothing.
+//
+// That fallback is the whole point, and it is why this is not Invalidate
+// followed by Lookup. Invalidate drops the entry unconditionally, so a process
+// that exits between the drop and the re-read loses mappings that had been
+// warmed while it was alive — turning the fix for #56 back into the bug, in a
+// window narrow enough to be rare and therefore to be mistaken for something
+// else. Here the old entry survives any failure.
+//
+// Returns true when fresh mappings replaced the cached ones.
+func (r *Resolver) Refresh(pid uint32) bool {
+	fresh := &pidEntry{}
+	fresh.once.Do(func() { r.populate(fresh, pid) })
+	if fresh.err != nil || len(fresh.mappings) == 0 {
+		return false // process gone or unreadable; keep whatever we warmed
+	}
+	r.mu.Lock()
+	r.cache[pid] = fresh
+	r.mu.Unlock()
+	return true
+}
+
 // Invalidate drops any cached state for pid. The next Lookup
 // re-parses /proc/<pid>/maps. Call on process exit or when the
 // agent learns of whole-process churn (e.g., exec).
@@ -110,6 +160,16 @@ func (r *Resolver) Close() {
 	r.mu.Lock()
 	r.cache = map[uint32]*pidEntry{}
 	r.mu.Unlock()
+}
+
+// isCached reports whether pid has an entry already, without creating one.
+// The Warmer uses it to count first reads separately from repeats; creating an
+// entry here would make every sweep look like a first read.
+func (r *Resolver) isCached(pid uint32) bool {
+	r.mu.RLock()
+	_, ok := r.cache[pid]
+	r.mu.RUnlock()
+	return ok
 }
 
 // entryFor returns the per-PID entry, creating it under the write

--- a/unwind/procmap/warmer.go
+++ b/unwind/procmap/warmer.go
@@ -1,0 +1,136 @@
+package procmap
+
+import (
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// DefaultWarmInterval is how often a Warmer sweeps /proc.
+//
+// The interval is the resolution of the guarantee, and nothing more: a process
+// that lives longer than one sweep is resolvable after it exits, one that
+// lives less than a sweep may not be. There is no interval that catches
+// everything — a process can start and exit between any two instants — so this
+// buys a bound rather than a certainty, and the bound is what gets reported.
+//
+// 500ms because the cost is not the sweep, it is the first read of each new
+// PID: readdir on /proc is cheap and the per-PID sync.Once means an already
+// warmed process costs a map lookup. Halving the interval therefore does not
+// double the work; it only shortens the window in which a process can be born
+// and die unseen.
+const DefaultWarmInterval = 500 * time.Millisecond
+
+// Warmer keeps a Resolver's per-PID cache populated while the processes are
+// still alive.
+//
+// Without it, a system-wide capture resolves nothing for any process that
+// exited during the capture window — the profilers resolve at collect time,
+// which is after the window closes, and /proc/<pid>/maps is gone by then.
+// Issue #56.
+type Warmer struct {
+	r        *Resolver
+	interval time.Duration
+
+	mu   sync.Mutex
+	stop chan struct{}
+	done chan struct{}
+
+	sweeps atomic.Uint64
+	warmed atomic.Uint64 // PIDs read for the first time
+	seen   atomic.Uint64 // PIDs offered to the cache across all sweeps
+}
+
+// NewWarmer returns a Warmer for r. interval <= 0 means DefaultWarmInterval.
+func NewWarmer(r *Resolver, interval time.Duration) *Warmer {
+	if interval <= 0 {
+		interval = DefaultWarmInterval
+	}
+	return &Warmer{r: r, interval: interval}
+}
+
+// Sweep walks /proc once and warms every process it finds. Returns how many
+// PIDs it saw and how many of those it read for the first time.
+//
+// Exported because it is the whole of the Warmer's behaviour: the goroutine
+// below only calls this on a timer, so a test that drives Sweep directly is
+// testing the real thing rather than a timing-dependent shadow of it.
+func (w *Warmer) Sweep() (seen, warmed int) {
+	entries, err := os.ReadDir(w.r.procRoot)
+	if err != nil {
+		return 0, 0
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		n, err := strconv.ParseUint(e.Name(), 10, 32)
+		if err != nil {
+			continue // not a PID: /proc/self, /proc/sys, ...
+		}
+		pid := uint32(n)
+		seen++
+		if w.r.isCached(pid) {
+			continue
+		}
+		if w.r.Warm(pid) > 0 {
+			warmed++
+		}
+	}
+	w.sweeps.Add(1)
+	w.seen.Add(uint64(seen))
+	w.warmed.Add(uint64(warmed))
+	return seen, warmed
+}
+
+// Start begins sweeping in the background. Idempotent.
+func (w *Warmer) Start() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.stop != nil {
+		return
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	w.stop, w.done = stop, done
+	// A sweep BEFORE the first tick, not after it: the interval is how often
+	// the picture is refreshed, not how long to wait before taking one. A
+	// capture shorter than one interval would otherwise warm nothing at all.
+	w.Sweep()
+	go func() {
+		defer close(done)
+		t := time.NewTicker(w.interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				w.Sweep()
+			}
+		}
+	}()
+}
+
+// Stop ends the background sweeps and waits for the goroutine to exit. Safe to
+// call more than once, and safe to call without a preceding Start.
+func (w *Warmer) Stop() {
+	w.mu.Lock()
+	stop, done := w.stop, w.done
+	w.stop, w.done = nil, nil
+	w.mu.Unlock()
+	if stop == nil {
+		return
+	}
+	close(stop)
+	<-done
+}
+
+// Stats reports what the warmer did. Every one of these is assertable: a
+// warmer that stopped sweeping must not look like a machine that stopped
+// starting processes.
+func (w *Warmer) Stats() (sweeps, pidsSeen, pidsWarmed uint64) {
+	return w.sweeps.Load(), w.seen.Load(), w.warmed.Load()
+}

--- a/unwind/procmap/warmer_live_test.go
+++ b/unwind/procmap/warmer_live_test.go
@@ -1,0 +1,104 @@
+package procmap
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// The warmer against a real /proc and a real process that really exits.
+//
+// The fake-/proc tests prove the logic; this proves the thing the logic is for.
+// It spawns a process, lets the warmer sweep while it lives, kills it, waits
+// for /proc/<pid> to actually disappear, and then asks the resolver to place an
+// address inside its executable mapping. Issue #56.
+func TestWarmerKeepsARealProcessResolvableAfterItExits(t *testing.T) {
+	cmd := exec.Command("/bin/sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot spawn: %v", err)
+	}
+	pid := uint32(cmd.Process.Pid)
+
+	r := NewResolver()
+	defer r.Close()
+	w := NewWarmer(r, 20*time.Millisecond)
+	w.Start()
+
+	// Give the sweep a chance to see it. Poll rather than sleep a fixed span:
+	// a fixed sleep here would be a race dressed up as a constant.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && !r.isCached(pid) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	w.Stop()
+	if !r.isCached(pid) {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		t.Skipf("warmer never saw pid %d (no permission to read its maps?)", pid)
+	}
+
+	// What we warmed, so the post-exit assertion has something concrete to
+	// compare against rather than merely being non-empty.
+	before, err := r.Mappings(pid)
+	if err != nil || len(before) == 0 {
+		t.Fatalf("warmed mappings: %v (%d)", err, len(before))
+	}
+	probe := before[0].Start
+
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+
+	// The kernel removes /proc/<pid> asynchronously after reap; wait for it,
+	// so "still resolvable" cannot be true merely because the process is
+	// somehow still there.
+	gone := false
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat("/proc/" + itoa(int(pid))); os.IsNotExist(err) {
+			gone = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !gone {
+		t.Skipf("pid %d did not leave /proc in time", pid)
+	}
+
+	m, ok := r.Lookup(pid, probe)
+	if !ok {
+		t.Fatalf("a warmed PID must stay resolvable after it exits: lost mapping at %#x", probe)
+	}
+	if m.Path != before[0].Path {
+		t.Fatalf("resolved to %q, want %q", m.Path, before[0].Path)
+	}
+	t.Logf("pid %d exited; %#x still resolves to %s", pid, probe, m.Path)
+}
+
+// The control: a process that exits before anything warms it is unresolvable.
+// Without this, the test above could pass on a resolver that read /proc late
+// and got lucky.
+func TestAnUnwarmedRealProcessIsLostAfterItExits(t *testing.T) {
+	cmd := exec.Command("/bin/sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot spawn: %v", err)
+	}
+	pid := uint32(cmd.Process.Pid)
+
+	r := NewResolver() // no warmer
+	defer r.Close()
+
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat("/proc/" + itoa(int(pid))); os.IsNotExist(err) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if m, ok := r.Lookup(pid, 0x400000); ok {
+		t.Fatalf("expected nothing for an unwarmed, exited pid; got %+v", m)
+	}
+}

--- a/unwind/procmap/warmer_test.go
+++ b/unwind/procmap/warmer_test.go
@@ -1,0 +1,207 @@
+package procmap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const oneMapping = "00400000-00401000 r-xp 00000000 fd:01 111 /usr/bin/shortlived\n"
+
+func writePID(t *testing.T, root string, pid int, maps string) string {
+	t.Helper()
+	dir := filepath.Join(root, itoa(pid))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "maps"), []byte(maps), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// The point of the whole thing: a process that exits during the capture is
+// still resolvable afterwards, because the sweep read its maps while it was
+// alive. Issue #56.
+func TestASweptPIDStaysResolvableAfterItExits(t *testing.T) {
+	tmp := t.TempDir()
+	dir := writePID(t, tmp, 4321, oneMapping)
+
+	r := NewResolver(WithProcRoot(tmp))
+	defer r.Close()
+	w := NewWarmer(r, 0)
+
+	seen, warmed := w.Sweep()
+	if seen != 1 || warmed != 1 {
+		t.Fatalf("sweep: seen=%d warmed=%d, want 1 and 1", seen, warmed)
+	}
+
+	if err := os.RemoveAll(dir); err != nil { // the process exits
+		t.Fatal(err)
+	}
+
+	m, ok := r.Lookup(4321, 0x400500)
+	if !ok {
+		t.Fatal("a swept PID must stay resolvable after it exits")
+	}
+	if m.Path != "/usr/bin/shortlived" {
+		t.Fatalf("got %q", m.Path)
+	}
+}
+
+// The control for the test above. Without the sweep the same PID resolves to
+// nothing — so that test is measuring the sweep and not the fixture.
+func TestWithoutASweepTheSamePIDIsLost(t *testing.T) {
+	tmp := t.TempDir()
+	dir := writePID(t, tmp, 4321, oneMapping)
+
+	r := NewResolver(WithProcRoot(tmp))
+	defer r.Close()
+
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := r.Lookup(4321, 0x400500); ok {
+		t.Fatal("expected the unswept PID to be unresolvable")
+	}
+}
+
+// Repeat sweeps must not re-read /proc for processes already known. This is
+// what makes a timer affordable: the cost is one read per NEW process, not one
+// read per process per sweep.
+func TestRepeatSweepsDoNotRereadKnownPIDs(t *testing.T) {
+	tmp := t.TempDir()
+	writePID(t, tmp, 4321, oneMapping)
+
+	r := NewResolver(WithProcRoot(tmp))
+	defer r.Close()
+	w := NewWarmer(r, 0)
+
+	w.Sweep()
+	after := r.populateCountForTest(4321)
+	for range 5 {
+		w.Sweep()
+	}
+	if got := r.populateCountForTest(4321); got != after {
+		t.Fatalf("populate count moved on repeat sweeps: %d -> %d", after, got)
+	}
+
+	sweeps, seen, warmed := w.Stats()
+	if sweeps != 6 {
+		t.Fatalf("sweeps=%d, want 6", sweeps)
+	}
+	if seen != 6 {
+		t.Fatalf("pidsSeen=%d, want 6 (one PID, six sweeps)", seen)
+	}
+	if warmed != 1 {
+		t.Fatalf("pidsWarmed=%d, want 1 — only the first sweep reads", warmed)
+	}
+}
+
+// Non-numeric entries under /proc (self, sys, net, ...) are not PIDs and must
+// not be offered to the cache.
+func TestSweepIgnoresNonPIDEntries(t *testing.T) {
+	tmp := t.TempDir()
+	writePID(t, tmp, 4321, oneMapping)
+	for _, name := range []string{"self", "sys", "net", "thread-self"} {
+		if err := os.MkdirAll(filepath.Join(tmp, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r := NewResolver(WithProcRoot(tmp))
+	defer r.Close()
+
+	seen, warmed := NewWarmer(r, 0).Sweep()
+	if seen != 1 || warmed != 1 {
+		t.Fatalf("seen=%d warmed=%d, want 1 and 1", seen, warmed)
+	}
+}
+
+// Refresh replaces a warmed snapshot when the process is alive and its maps
+// have changed. Without this a long-lived process would be stuck with whatever
+// the first sweep saw, and a library it loaded later would never resolve —
+// which would make the #56 fix a regression for everything that dlopens.
+func TestRefreshReplacesAWarmedSnapshotWhileTheProcessLives(t *testing.T) {
+	tmp := t.TempDir()
+	writePID(t, tmp, 4321, oneMapping)
+
+	r := NewResolver(WithProcRoot(tmp))
+	defer r.Close()
+	NewWarmer(r, 0).Sweep()
+
+	// The process dlopens something: a second executable mapping appears.
+	const grown = oneMapping +
+		"00500000-00501000 r-xp 00000000 fd:01 222 /usr/lib/late.so\n"
+	if err := os.WriteFile(filepath.Join(tmp, "4321", "maps"), []byte(grown), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := r.Lookup(4321, 0x500500); ok {
+		t.Fatal("the warmed snapshot should predate the new mapping")
+	}
+	if !r.Refresh(4321) {
+		t.Fatal("Refresh should succeed for a live process")
+	}
+	m, ok := r.Lookup(4321, 0x500500)
+	if !ok || m.Path != "/usr/lib/late.so" {
+		t.Fatalf("after Refresh: ok=%v m=%+v, want /usr/lib/late.so", ok, m)
+	}
+}
+
+// And the half that makes Refresh worth having over Invalidate: when the
+// process is gone, the warmed snapshot SURVIVES. Invalidate-then-Lookup would
+// drop it and resolve nothing, reintroducing #56 in a window narrow enough to
+// be mistaken for something else.
+func TestRefreshKeepsTheWarmedSnapshotWhenTheProcessIsGone(t *testing.T) {
+	tmp := t.TempDir()
+	dir := writePID(t, tmp, 4321, oneMapping)
+
+	r := NewResolver(WithProcRoot(tmp))
+	defer r.Close()
+	NewWarmer(r, 0).Sweep()
+
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	if r.Refresh(4321) {
+		t.Fatal("Refresh must report failure for a process that is gone")
+	}
+	m, ok := r.Lookup(4321, 0x400500)
+	if !ok || m.Path != "/usr/bin/shortlived" {
+		t.Fatalf("warmed snapshot lost: ok=%v m=%+v", ok, m)
+	}
+}
+
+// Start/Stop is the timer wrapper around Sweep and nothing more. The first
+// sweep happens on Start rather than one interval later, so a capture shorter
+// than the interval still warms.
+func TestStartSweepsImmediatelyAndStopIsIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	writePID(t, tmp, 4321, oneMapping)
+
+	r := NewResolver(WithProcRoot(tmp))
+	defer r.Close()
+	w := NewWarmer(r, 0)
+
+	w.Stop() // before Start: must not panic or block
+	w.Start()
+	w.Start() // idempotent
+	sweeps, _, warmed := w.Stats()
+	if sweeps < 1 || warmed != 1 {
+		t.Fatalf("Start did not sweep immediately: sweeps=%d warmed=%d", sweeps, warmed)
+	}
+	w.Stop()
+	w.Stop() // idempotent
+}


### PR DESCRIPTION
Fixes #56.

## The cause is structural, and needs no race

The issue left two candidates: a resolver bug, or a benign `-a` race. It is the second — but it is **not benign**, and it needs nothing more exotic than "a process exited during the capture".

The profilers resolve at **collect** time:

- `perfagent/agent.go:597` calls `CollectAndWrite` at shutdown
- that is the first `Lookup` for any PID
- `procmap.Resolver` populates lazily on first `Lookup`

So `/proc/<pid>/maps` is read only *after* the window has closed. Any process sampled during the window but gone by the end resolves to nothing at all.

System-wide is where this bites, and the reported failure is exactly what it looks like: short-lived processes are what `-a` exists to catch, and precisely the ones certain to be gone when anything asks. On a busy machine an entire capture can come back with `real_mappings=0` while carrying plenty of samples.

The DWARF path makes it sharper. The unwinder **already tracks mappings live** — that is what `AttachAllProcesses` and the mmap watcher are for — so the CFI tables needed to walk a short-lived process's stack were installed while it lived, and then every frame that walk produced failed to name a binary. Two views of the same data, one live and one too late.

## The fix

`procmap.Warmer` sweeps `/proc` on a timer and populates the resolver while the processes are alive. The per-PID `sync.Once` is what makes it affordable — a repeat sweep costs one read per **new** PID, not one per process per sweep:

| | 576 processes |
|---|---|
| first sweep | 85 ms |
| every sweep after | 1.3 ms |
| `Refresh`, per PID | 0.1 ms |

**Warming alone would be a regression**, which is why `Refresh` exists. A long-lived process would otherwise be stuck with whatever the first sweep saw, so anything it `dlopen`ed later would stop resolving — trading one class of missing mapping for another. At collect time each sampled PID is therefore refreshed: re-read when alive, **keep the warmed snapshot** when gone.

Deliberately not `Invalidate`-then-`Lookup`: that drops the entry unconditionally, so a process exiting between the drop and the re-read loses mappings that had been warmed while it lived — reintroducing #56 in a window narrow enough to be mistaken for something else.

Wired into all three system-wide paths (on-CPU, off-CPU, DWARF). A per-PID capture warms only its target rather than sweeping the machine.

## Tests, and what each one is worth

- **Fake `/proc`** — the logic. Mutation-proved: a no-op `Warm` fails 7 tests, `Invalidate` semantics inside `Refresh` fails 1, a sweep that re-reads cached PIDs fails 1.
- **Live process** — the thing the logic is *for*. Spawns a real process, sweeps while it lives, kills it, waits for `/proc/<pid>` to actually disappear, then resolves an address inside its mapping. The unwarmed control sits next to it, so the positive case cannot pass on a resolver that merely got lucky.
- **Integration** — covers what neither can: that the warmer is really started on the system-wide path in the shipping agent. Its negative is *not* mutation-proved (that would need a second setcap'd binary), and the unit control carries that weight instead.

The integration test's timing is chosen so neither half is a coin flip: the workload is the dominant CPU consumer for 6 of the 10-second window, so it is certain to be sampled, and it exits 3 seconds before the end, so it is certain to be gone. An earlier version ran it for 2s of a 6s window and failed for the uninteresting reason that it was never sampled at all.

## Note on timing observed while validating

A system-wide capture on the dev box took ~107 s to symbolize 148 samples. That is blazesym loading symbol tables for large Go binaries that happen to be running (Grafana, Prometheus), not this change: the resolver work totals ~140 ms of it, measured. Unrelated to #56 and not addressed here.
