### PR TITLE
symbolize: stop a 5s capture spending 87s in debuginfod (#109)

### DIFF
--- a/offcpu/profiler.go
+++ b/offcpu/profiler.go
@@ -244,6 +244,8 @@ func (pr *Profiler) Collect(w io.Writer) error {
 	}
 
 	// Write profile directly to the provided writer
+	symbolize.LogSymbolizationCost(pr.symbolizer, "offcpu")
+
 	for _, builder := range builders.Builders {
 		_, err = builder.Write(w)
 		if err != nil {

--- a/perfagent/agent.go
+++ b/perfagent/agent.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"log/slog"
 	"maps"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,12 +193,38 @@ func (a *Agent) pidLogStr(hostPID int) string {
 // chooseSymbolizer constructs the agent-owned symbolizer. If DebuginfodURLs
 // is non-empty (or the DEBUGINFOD_URLS env var is set), a Debuginfod
 // symbolizer is returned; otherwise the local blazesym symbolizer is used.
+// debuginfodURLsFromEnv extracts the server URLs from a DEBUGINFOD_URLS value.
+//
+// The variable is whitespace-separated, but it is NOT only URLs. elfutils'
+// debuginfod-client also accepts policy tokens in the same list, and Fedora
+// ships exactly that by default:
+//
+//	DEBUGINFOD_URLS="ima:enforcing https://debuginfod.fedoraproject.org/ ima:ignore"
+//
+// Taking every field as a server, which is what this did, hands two
+// non-servers to the fetcher and asks it to resolve build-ids against them.
+// Only http and https are servers here; anything else is a token this agent
+// does not implement and must ignore rather than dial. Issue #109.
+func debuginfodURLsFromEnv(env string) []string {
+	var urls []string
+	for f := range strings.FieldsSeq(env) {
+		u, err := url.Parse(f)
+		if err != nil {
+			continue
+		}
+		// Scheme AND host: "https://" alone parses cleanly and is not a
+		// server, and a bare path picks up no scheme at all.
+		if (u.Scheme == "http" || u.Scheme == "https") && u.Host != "" {
+			urls = append(urls, f)
+		}
+	}
+	return urls
+}
+
 func chooseSymbolizer(cfg *Config, res *procmap.Resolver, logger *slog.Logger) (symbolize.Symbolizer, error) {
 	urls := cfg.DebuginfodURLs
 	if len(urls) == 0 {
-		for u := range strings.FieldsSeq(os.Getenv("DEBUGINFOD_URLS")) {
-			urls = append(urls, u)
-		}
+		urls = debuginfodURLsFromEnv(os.Getenv("DEBUGINFOD_URLS"))
 	}
 	if len(urls) == 0 {
 		// res names the module behind an address blazesym could not resolve
@@ -214,9 +241,24 @@ func chooseSymbolizer(cfg *Config, res *procmap.Resolver, logger *slog.Logger) (
 		// the same kind of cache - but it does not narrow it either.
 		return symbolize.NewLocalSymbolizer(symbolize.WithModuleIndex(res))
 	}
+	// Announced, because it is the single biggest thing that can change how
+	// long a capture takes and it was previously silent. Measured on a
+	// workstation: the same 5s system-wide capture took 6.4s with the local
+	// symbolizer and 87s with debuginfod reachable, with nothing in the
+	// output to say why (issue #109). DEBUGINFOD_URLS is set by default on
+	// several distributions, so this is on for many users who never asked.
+	log.Printf("perf-agent: debuginfod symbolization ENABLED (%d server(s): %s). "+
+		"Debug info is fetched over the network on first contact with each "+
+		"unknown build-id, which can take far longer than the capture itself; "+
+		"unset DEBUGINFOD_URLS or pass --debuginfod-urls='' to use local "+
+		"symbols only",
+		len(urls), strings.Join(urls, " "))
 	cacheDir := cmp.Or(cfg.SymbolCacheDir, "/tmp/perf-agent-debuginfod")
 	cacheMax := cmp.Or(cfg.SymbolCacheMaxBytes, int64(2<<30))
-	timeout := cmp.Or(cfg.SymbolFetchTimeout, 30*time.Second)
+	// Left to the package default (5s) unless configured; see its rationale
+	// in debuginfod.Options.validate. Raising it trades capture latency for
+	// source detail on slow servers.
+	timeout := cfg.SymbolFetchTimeout
 	return debuginfod.New(debuginfod.Options{
 		URLs:          urls,
 		CacheDir:      cacheDir,
@@ -700,8 +742,38 @@ func (a *Agent) Close() error {
 	return nil
 }
 
+// logDebuginfodStats prints the fetch counters when debuginfod symbolization
+// was in use.
+//
+// The counters already existed; nothing printed them, which is why a run that
+// spent 82 of its 87 seconds fetching produced six lines of output and no clue
+// (issue #109). Fetch counts and bytes are what distinguish "the network was
+// slow" from "this build-id is not on any server and we asked 199 times".
+func (a *Agent) logDebuginfodStats() {
+	d, ok := a.symbolizer.(*debuginfod.Symbolizer)
+	if !ok {
+		return
+	}
+	st := d.Stats()
+	log.Printf("perf-agent: debuginfod: symbolization took %v over %d call(s) "+
+		"[maps %v, symbolize %v; slowest call %v, %d call(s) over 50ms]; "+
+		"fetches ok=%d 404=%d err=%d bytes=%dMB; "+
+		"cache hits=%d misses=%d evictions=%d; dispatcher calls=%d skipped_local=%d; "+
+		"file_mode addrs=%d fetch_fails=%d local_hits=%d parse_fails=%d",
+		time.Duration(st.TotalNs).Round(time.Millisecond), st.Calls,
+		time.Duration(st.MappingsNs).Round(time.Millisecond),
+		time.Duration(st.SymbolizeNs).Round(time.Millisecond),
+		time.Duration(st.SlowestNs).Round(time.Millisecond), st.CallsOver50ms,
+		st.FetchSuccessDebuginfo+st.FetchSuccessExecutable,
+		st.Fetch404s, st.FetchErrors, st.FetchBytesTotal/(1<<20),
+		st.CacheHits, st.CacheMisses, st.CacheEvictions,
+		st.DispatcherCalls, st.DispatcherSkippedLocal,
+		st.FileModeAddrs, st.FileModeFetchFails, st.FileModeLocalHits, st.FileModeParseFails)
+}
+
 // cleanup releases profiler resources.
 func (a *Agent) cleanup() {
+	a.logDebuginfodStats()
 	if a.cpuProfiler != nil {
 		a.cpuProfiler.Close()
 		a.cpuProfiler = nil

--- a/perfagent/debuginfod_env_test.go
+++ b/perfagent/debuginfod_env_test.go
@@ -1,0 +1,63 @@
+package perfagent
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Issue #109. DEBUGINFOD_URLS is whitespace-separated but is not only URLs:
+// elfutils' debuginfod-client also accepts policy tokens in the same list, and
+// Fedora ships exactly that by default. Treating every field as a server hands
+// non-servers to the fetcher.
+func TestDebuginfodURLsFromEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{
+			// The value that is actually set on Fedora, and the one that
+			// motivated this: two of the three fields are not servers.
+			name: "fedora default carries ima policy tokens",
+			env:  "ima:enforcing https://debuginfod.fedoraproject.org/ ima:ignore",
+			want: []string{"https://debuginfod.fedoraproject.org/"},
+		},
+		{
+			name: "plain single url",
+			env:  "https://debuginfod.example/",
+			want: []string{"https://debuginfod.example/"},
+		},
+		{
+			name: "several servers keep their order",
+			env:  "https://a.example/ http://b.example/",
+			want: []string{"https://a.example/", "http://b.example/"},
+		},
+		{
+			name: "unset",
+			env:  "",
+			want: nil,
+		},
+		{
+			name: "only tokens yields nothing, so the local symbolizer is used",
+			env:  "ima:enforcing ima:ignore",
+			want: nil,
+		},
+		{
+			// A scheme with no host is not a server, a bare path has no
+			// scheme at all, and ftp is not something this agent fetches
+			// from. None of these may reach the fetcher.
+			name: "non-http schemes and hostless URLs are refused",
+			env:  "https:// file:///srv/debug ftp://x.example/ /just/a/path",
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := debuginfodURLsFromEnv(tc.env)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("debuginfodURLsFromEnv(%q) = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}

--- a/profile/profiler.go
+++ b/profile/profiler.go
@@ -289,6 +289,8 @@ func (pr *Profiler) Collect(w io.Writer) error {
 	}
 
 	// Write profile directly to the provided writer
+	symbolize.LogSymbolizationCost(pr.symbolizer, "profile")
+
 	for _, builder := range builders.Builders {
 		_, err = builder.Write(w)
 		if err != nil {

--- a/symbolize/debuginfod/options.go
+++ b/symbolize/debuginfod/options.go
@@ -43,7 +43,22 @@ func (o *Options) validate() error {
 		o.CacheMaxBytes = 2 << 30 // 2 GiB
 	}
 	if o.FetchTimeout == 0 {
-		o.FetchTimeout = 30 * time.Second
+		// 5s, not 30s, because this bounds a SYNCHRONOUS stall on the
+		// symbolization path rather than a background download.
+		//
+		// Every distinct build-id the servers cannot serve costs this once —
+		// negFetch stops it recurring, but the first attempt is paid in full,
+		// while the profile waits. Measured on a workstation with ~16 large
+		// Go binaries mapped: a 5s system-wide capture spent 1m12s in
+		// symbolization, the slowest single call taking 31.937s, which is the
+		// old default plus scheduling. Two or three such misses accounted for
+		// the whole of it. Issue #109.
+		//
+		// The cost of being wrong in each direction is asymmetric: too short
+		// and a slow server yields a profile with less source detail, which
+		// degrades gracefully; too long and the profile does not arrive.
+		// A capture is a foreground operation with someone waiting on it.
+		o.FetchTimeout = 5 * time.Second
 	}
 	if o.HTTPClient == nil {
 		o.HTTPClient = &http.Client{Timeout: o.FetchTimeout}

--- a/symbolize/debuginfod/singleflight.go
+++ b/symbolize/debuginfod/singleflight.go
@@ -3,6 +3,8 @@ package debuginfod
 import (
 	"context"
 	"io"
+	"sync"
+	"time"
 
 	"github.com/dpsoft/perf-agent/symbolize/debuginfod/cache"
 	"golang.org/x/sync/singleflight"
@@ -22,14 +24,88 @@ type sfFetcher interface {
 	fetchAndStore(ctx context.Context, kindStr, buildID string) (string, error)
 }
 
+// fetchFailTTL is how long a failed (kind, build-id) lookup is remembered.
+//
+// singleflight collapses CONCURRENT fetches; it does nothing for sequential
+// ones. Symbolization runs once per sample, so a build-id no server can serve
+// was re-attempted on every sample — and a lookup that hangs rather than 404s
+// costs the whole FetchTimeout each time. Measured on a workstation: a 5s
+// system-wide capture spent 1m19s in symbolization, of which the slowest
+// single call was 30.022s, exactly the default timeout. Only 17 of 176 calls
+// were slow; the rest were under 50ms. Issue #109.
+//
+// Five minutes rather than the run's lifetime: a transient outage or a server
+// that was briefly unreachable should not poison symbolization for a
+// long-lived agent, and retrying once every five minutes costs at most one
+// stall per build-id per five minutes. It matches classifier.negFetchTTL
+// deliberately — the two should expire together.
+//
+// This is NOT a duplicate of classifier.negFetch, though it overlaps it. That
+// one guards the classifier's own "debuginfo" fetch and is consulted before
+// the call is made, which is cheaper. The dispatcher's "executable" fetch
+// (dispatcher.go, case 4) consults nothing, so its failures were repeated
+// indefinitely. Putting the memo here, at the chokepoint both paths go
+// through, means a fetch site cannot be added later that forgets to check —
+// which is how the dispatcher path came to be missing one.
+const fetchFailTTL = 5 * time.Minute
+
+// maxFetchFailEntries bounds the memo. A machine can map more distinct
+// build-ids than it is worth remembering failures for, and an unbounded map on
+// a long-lived agent is a leak.
+const maxFetchFailEntries = 4096
+
 type singleflightFetcher struct {
 	upstream *fetcher
 	cache    storer
 	sf       singleflight.Group
+
+	failedMu sync.Mutex
+	failed   map[string]fetchFailure
+}
+
+type fetchFailure struct {
+	err        error
+	retryAfter time.Time
 }
 
 func newSingleflightFetcher(upstream *fetcher, store storer) *singleflightFetcher {
-	return &singleflightFetcher{upstream: upstream, cache: store}
+	return &singleflightFetcher{
+		upstream: upstream,
+		cache:    store,
+		failed:   make(map[string]fetchFailure),
+	}
+}
+
+// recentFailure reports a remembered failure for key, if one is still within
+// its TTL. Expired entries are dropped on the way past.
+func (s *singleflightFetcher) recentFailure(key string) (error, bool) {
+	s.failedMu.Lock()
+	defer s.failedMu.Unlock()
+	f, ok := s.failed[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(f.retryAfter) {
+		delete(s.failed, key)
+		return nil, false
+	}
+	return f.err, true
+}
+
+// noteFailure remembers that key could not be fetched.
+func (s *singleflightFetcher) noteFailure(key string, err error) {
+	s.failedMu.Lock()
+	defer s.failedMu.Unlock()
+	if len(s.failed) >= maxFetchFailEntries {
+		// Drop an arbitrary entry rather than growing without bound. Which one
+		// goes does not matter: every entry is a negative result whose only
+		// cost, if dropped early, is one more attempt.
+		for k := range s.failed {
+			delete(s.failed, k)
+			break
+		}
+	}
+	s.failed[key] = fetchFailure{err: err, retryAfter: time.Now().Add(fetchFailTTL)}
 }
 
 // fetchAndStore collapses concurrent fetches keyed by (kind, buildID).
@@ -37,6 +113,13 @@ func newSingleflightFetcher(upstream *fetcher, store storer) *singleflightFetche
 // final path is returned.
 func (s *singleflightFetcher) fetchAndStore(ctx context.Context, kindStr, buildID string) (string, error) {
 	key := kindStr + ":" + buildID
+	// A lookup that already failed is not retried until its TTL expires.
+	// Without this the same unavailable build-id is re-fetched once per
+	// sample, and each attempt pays the full fetch timeout when the server
+	// hangs rather than answering. See fetchFailTTL.
+	if err, ok := s.recentFailure(key); ok {
+		return "", err
+	}
 	res, err, _ := s.sf.Do(key, func() (any, error) {
 		body, err := s.upstream.fetch(ctx, kindStr, buildID)
 		if err != nil {
@@ -61,6 +144,7 @@ func (s *singleflightFetcher) fetchAndStore(ctx context.Context, kindStr, buildI
 		return abs, nil
 	})
 	if err != nil {
+		s.noteFailure(key, err)
 		return "", err
 	}
 	return res.(string), nil

--- a/symbolize/debuginfod/singleflight_fail_test.go
+++ b/symbolize/debuginfod/singleflight_fail_test.go
@@ -1,0 +1,106 @@
+package debuginfod
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dpsoft/perf-agent/symbolize/debuginfod/cache"
+)
+
+type countingStore struct{}
+
+func (countingStore) WriteAtomic(string, cache.Kind, io.Reader) (string, error) {
+	return "", errors.New("unused")
+}
+func (countingStore) Evict() error { return nil }
+
+// A fetcher whose upstream always fails, counting how often it is actually
+// reached.
+type failingUpstream struct{ calls atomic.Uint64 }
+
+func (f *failingUpstream) fetch(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	f.calls.Add(1)
+	return nil, ErrNotFound
+}
+
+// Issue #109. singleflight collapses concurrent fetches and does nothing for
+// sequential ones. Symbolization runs once per SAMPLE, so a build-id no server
+// can serve was re-attempted on every sample — and when the server hangs
+// instead of answering, each attempt costs the whole fetch timeout. Measured:
+// one call in a real capture took 30.022s, exactly the default timeout.
+func TestAFailedFetchIsNotRetriedWithinItsTTL(t *testing.T) {
+	up := &failingUpstream{}
+	sf := &singleflightFetcher{
+		upstream: nil,
+		cache:    countingStore{},
+		failed:   make(map[string]fetchFailure),
+	}
+	// Drive the memo directly: the upstream field is a concrete *fetcher and
+	// cannot be stubbed, but the memo is what this test is about.
+	key := "debuginfo:deadbeef"
+	if _, ok := sf.recentFailure(key); ok {
+		t.Fatal("nothing should be remembered yet")
+	}
+	sf.noteFailure(key, ErrNotFound)
+
+	err, ok := sf.recentFailure(key)
+	if !ok {
+		t.Fatal("the failure must be remembered")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("remembered error = %v, want ErrNotFound", err)
+	}
+	_ = up
+}
+
+// The memo expires, so a transient outage does not poison symbolization for
+// the life of a long-running agent.
+func TestARememberedFailureExpires(t *testing.T) {
+	sf := &singleflightFetcher{failed: make(map[string]fetchFailure)}
+	key := "debuginfo:cafe"
+	sf.failedMu.Lock()
+	sf.failed[key] = fetchFailure{err: ErrNotFound, retryAfter: time.Now().Add(-time.Second)}
+	sf.failedMu.Unlock()
+
+	if _, ok := sf.recentFailure(key); ok {
+		t.Fatal("an expired failure must not suppress a retry")
+	}
+	// And it is dropped on the way past rather than left to accumulate.
+	sf.failedMu.Lock()
+	_, still := sf.failed[key]
+	sf.failedMu.Unlock()
+	if still {
+		t.Fatal("expired entry should have been deleted")
+	}
+}
+
+// The memo is bounded: a machine can map more distinct build-ids than are
+// worth remembering, and an unbounded map in a long-lived agent is a leak.
+func TestTheFailureMemoIsBounded(t *testing.T) {
+	sf := &singleflightFetcher{failed: make(map[string]fetchFailure)}
+	for i := range maxFetchFailEntries + 100 {
+		sf.noteFailure(string(rune('a'+i%26))+itoa(i), ErrNotFound)
+	}
+	sf.failedMu.Lock()
+	n := len(sf.failed)
+	sf.failedMu.Unlock()
+	if n > maxFetchFailEntries {
+		t.Fatalf("memo grew to %d, want <= %d", n, maxFetchFailEntries)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/symbolize/debuginfod/singleflight_fail_test.go
+++ b/symbolize/debuginfod/singleflight_fail_test.go
@@ -1,10 +1,8 @@
 package debuginfod
 
 import (
-	"context"
 	"errors"
 	"io"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,29 +16,20 @@ func (countingStore) WriteAtomic(string, cache.Kind, io.Reader) (string, error) 
 }
 func (countingStore) Evict() error { return nil }
 
-// A fetcher whose upstream always fails, counting how often it is actually
-// reached.
-type failingUpstream struct{ calls atomic.Uint64 }
-
-func (f *failingUpstream) fetch(_ context.Context, _, _ string) (io.ReadCloser, error) {
-	f.calls.Add(1)
-	return nil, ErrNotFound
-}
-
 // Issue #109. singleflight collapses concurrent fetches and does nothing for
 // sequential ones. Symbolization runs once per SAMPLE, so a build-id no server
 // can serve was re-attempted on every sample — and when the server hangs
 // instead of answering, each attempt costs the whole fetch timeout. Measured:
 // one call in a real capture took 30.022s, exactly the default timeout.
 func TestAFailedFetchIsNotRetriedWithinItsTTL(t *testing.T) {
-	up := &failingUpstream{}
+	// The memo is driven directly rather than through fetchAndStore: upstream
+	// is a concrete *fetcher with no interface to substitute, and the memo is
+	// what this test is about. The wiring that calls noteFailure on a failed
+	// fetch is one line in fetchAndStore.
 	sf := &singleflightFetcher{
-		upstream: nil,
-		cache:    countingStore{},
-		failed:   make(map[string]fetchFailure),
+		cache:  countingStore{},
+		failed: make(map[string]fetchFailure),
 	}
-	// Drive the memo directly: the upstream field is a concrete *fetcher and
-	// cannot be stubbed, but the memo is what this test is about.
 	key := "debuginfo:deadbeef"
 	if _, ok := sf.recentFailure(key); ok {
 		t.Fatal("nothing should be remembered yet")
@@ -54,7 +43,6 @@ func TestAFailedFetchIsNotRetriedWithinItsTTL(t *testing.T) {
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("remembered error = %v, want ErrNotFound", err)
 	}
-	_ = up
 }
 
 // The memo expires, so a transient outage does not poison symbolization for

--- a/symbolize/debuginfod/stats.go
+++ b/symbolize/debuginfod/stats.go
@@ -16,13 +16,38 @@ type Stats struct {
 	// File-mode outcomes.
 	// FileModeAddrs is the total number of addresses (IPs) resolved through
 	// the file-mode path (one per IP, not one per symbolizeFileBucket call).
-	FileModeAddrs, FileModeParseFails uint64
+	FileModeAddrs, FileModeParseFails     uint64
 	FileModeFetchFails, FileModeLocalHits uint64
 	// AddressMapper miss for an individual IP.
 	NormalizationFails uint64
+
+	// Where SymbolizeProcess actually spends its time (issue #109). Calls is
+	// how many times it ran; the three Ns figures are cumulative wall time in
+	// its parts. They exist because the cost of this path was invisible: a
+	// run could spend 82 of its 87 seconds here having made two network
+	// requests, and nothing said which part was slow.
+	Calls       uint64
+	TotalNs     uint64
+	MappingsNs  uint64 // resolver Invalidate + Mappings, per call
+	SymbolizeNs uint64 // the blazesym calls themselves
+	// SlowestNs is the most expensive single call and CallsOver50ms how many
+	// exceeded 50ms. Together they separate the two explanations a large
+	// TotalNs allows: a handful of cold parses of large binaries (few slow
+	// calls, most fast) versus work being redone on every call (nearly all
+	// slow). A total alone cannot tell those apart, and guessing which one it
+	// was cost several wrong theories on issue #109.
+	SlowestNs     uint64
+	CallsOver50ms uint64
 }
 
 type atomicStats struct {
+	calls         atomic.Uint64
+	totalNs       atomic.Uint64
+	mappingsNs    atomic.Uint64
+	symbolizeNs   atomic.Uint64
+	slowestNs     atomic.Uint64
+	callsOver50ms atomic.Uint64
+
 	cacheHits, cacheMisses, cacheEvictions        atomic.Uint64
 	fetchSuccessDebuginfo, fetchSuccessExecutable atomic.Uint64
 	fetch404s, fetchErrors                        atomic.Uint64
@@ -35,7 +60,7 @@ type atomicStats struct {
 	// File-mode outcomes.
 	// fileModeAddrs counts the total number of addresses (IPs) resolved
 	// through the file-mode path; incremented by len(virt) per bucket call.
-	fileModeAddrs, fileModeParseFails atomic.Uint64
+	fileModeAddrs, fileModeParseFails     atomic.Uint64
 	fileModeFetchFails, fileModeLocalHits atomic.Uint64
 	// AddressMapper miss for an individual IP.
 	normalizationFails atomic.Uint64
@@ -43,6 +68,12 @@ type atomicStats struct {
 
 func (a *atomicStats) snapshot() Stats {
 	return Stats{
+		Calls:                  a.calls.Load(),
+		TotalNs:                a.totalNs.Load(),
+		MappingsNs:             a.mappingsNs.Load(),
+		SymbolizeNs:            a.symbolizeNs.Load(),
+		SlowestNs:              a.slowestNs.Load(),
+		CallsOver50ms:          a.callsOver50ms.Load(),
 		CacheHits:              a.cacheHits.Load(),
 		CacheMisses:            a.cacheMisses.Load(),
 		CacheEvictions:         a.cacheEvictions.Load(),

--- a/symbolize/debuginfod/symbolizer.go
+++ b/symbolize/debuginfod/symbolizer.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/dpsoft/perf-agent/symbolize"
 	"github.com/dpsoft/perf-agent/symbolize/debuginfod/cache"
@@ -128,6 +129,23 @@ func (s *Symbolizer) SymbolizeProcess(pid uint32, ips []uint64) ([]symbolize.Fra
 		return nil, nil
 	}
 
+	callStart := time.Now()
+	defer func() {
+		d := time.Since(callStart)
+		ns := uint64(d.Nanoseconds())
+		s.stats.calls.Add(1)
+		s.stats.totalNs.Add(ns)
+		if d > 50*time.Millisecond {
+			s.stats.callsOver50ms.Add(1)
+		}
+		for {
+			prev := s.stats.slowestNs.Load()
+			if ns <= prev || s.stats.slowestNs.CompareAndSwap(prev, ns) {
+				break
+			}
+		}
+	}()
+
 	ctx := context.Background()
 	if s.opts.FetchTimeout > 0 {
 		var cancel context.CancelFunc
@@ -140,6 +158,8 @@ func (s *Symbolizer) SymbolizeProcess(pid uint32, ips []uint64) ([]symbolize.Fra
 	// handles on-demand fetches for build-id-only mappings.
 	if s.resolver == nil {
 		s.stats.classifyProcessMode.Add(uint64(len(ips)))
+		t := time.Now()
+		defer func() { s.stats.symbolizeNs.Add(uint64(time.Since(t).Nanoseconds())) }()
 		return s.cgo.symbolizeProcess(pid, ips)
 	}
 
@@ -150,14 +170,19 @@ func (s *Symbolizer) SymbolizeProcess(pid uint32, ips []uint64) ([]symbolize.Fra
 	// after the first call would leave new mappings invisible, causing IPs
 	// in those regions to fall through findMapping with no hit and be
 	// silently misrouted to process-mode against the wrong (or no) mapping.
+	mapStart := time.Now()
 	s.resolver.Invalidate(pid)
 	mappings, err := s.resolver.Mappings(pid)
+	s.stats.mappingsNs.Add(uint64(time.Since(mapStart).Nanoseconds()))
 	if err != nil || len(mappings) == 0 {
 		s.stats.classifyProcessMode.Add(uint64(len(ips)))
 		return s.cgo.symbolizeProcess(pid, ips)
 	}
 
-	return s.routeAndSymbolize(ctx, pid, ips, mappings)
+	symStart := time.Now()
+	frames, rerr := s.routeAndSymbolize(ctx, pid, ips, mappings)
+	s.stats.symbolizeNs.Add(uint64(time.Since(symStart).Nanoseconds()))
+	return frames, rerr
 }
 
 // routeAndSymbolize is the core per-mapping router. Split out from
@@ -167,11 +192,34 @@ func (s *Symbolizer) SymbolizeProcess(pid uint32, ips []uint64) ([]symbolize.Fra
 func (s *Symbolizer) routeAndSymbolize(
 	ctx context.Context, pid uint32, ips []uint64, mappings []procmap.Mapping,
 ) ([]symbolize.Frame, error) {
-	// Classify each mapping once. Keyed by mapping.Start because that's
-	// unique within a single /proc/<pid>/maps snapshot.
-	routesByMapping := make(map[uint64]classifyResult, len(mappings))
-	for _, m := range mappings {
-		routesByMapping[m.Start] = s.classifier.classify(ctx, m)
+	// Classify LAZILY: only the mappings an address actually falls into.
+	//
+	// This used to classify every mapping in the process, up front, on every
+	// call — and classify is not cheap. It opens the ELF to test for DWARF,
+	// searches for a debug link, and reads the build-id, so its cost is
+	// per-mapping file I/O. A process maps hundreds of objects while a stack
+	// touches a handful, and SymbolizeProcess runs once per SAMPLE, so the
+	// work was O(samples x mappings) to serve O(samples x stack depth).
+	//
+	// Measured on a workstation before this change: a 5s system-wide capture
+	// spent 1m9.88s in symbolization over 178 calls, of which 1m9.67s was
+	// here — against 996ms for the same capture through the local symbolizer.
+	// Two network requests were made in that time, both 404, zero bytes: the
+	// cost was never the fetching. Issue #109.
+	//
+	// Keyed by mapping.Start, which is unique within one /proc/<pid>/maps
+	// snapshot, and memoized for this call only — classification depends on
+	// the debuginfod cache's contents, which a fetch during this same call
+	// can change, so it must not be carried across calls without splitting
+	// the immutable ELF inspection from the mutable cache lookup.
+	routesByMapping := make(map[uint64]classifyResult, 8)
+	classifyFor := func(m procmap.Mapping) classifyResult {
+		if r, ok := routesByMapping[m.Start]; ok {
+			return r
+		}
+		r := s.classifier.classify(ctx, m)
+		routesByMapping[m.Start] = r
+		return r
 	}
 
 	type fileBucket struct {
@@ -199,7 +247,7 @@ func (s *Symbolizer) routeAndSymbolize(
 			processBatch.indices = append(processBatch.indices, i)
 			continue
 		}
-		r := routesByMapping[m.Start]
+		r := classifyFor(m)
 		switch r.route {
 		case routeSkip:
 			s.stats.classifySkipped.Add(1)

--- a/symbolize/local.go
+++ b/symbolize/local.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	blazesym "github.com/libbpf/blazesym/go"
 )
@@ -58,6 +60,20 @@ type localCounters struct {
 	rawAddrBatches  atomic.Uint64
 	modulesAttached atomic.Uint64
 	modulesBare     atomic.Uint64
+
+	// How much wall time symbolization actually cost, and over how many
+	// calls. A profiler that takes two minutes to write a five-second capture
+	// is a real failure mode (issue #109) and it was not attributable from
+	// anything the agent printed: every other counter looked healthy while the
+	// process sat in blazesym. These make the collect path's cost a number.
+	calls   atomic.Uint64
+	totalNs atomic.Uint64
+	// The single most expensive call, with the PID that caused it. A mean
+	// hides the case this is usually about --- one enormous binary parsed
+	// once --- so the maximum is kept alongside the total rather than instead
+	// of it.
+	slowestNs  atomic.Uint64
+	slowestPID atomic.Uint32
 }
 
 // LocalStats is a point-in-time view of what SymbolizeProcess could not
@@ -79,6 +95,40 @@ type LocalStats struct {
 	// a run where it never happens must not look like one where it always
 	// did.
 	ModulesBare uint64
+
+	// Calls is how many times SymbolizeProcess ran, and TotalNs the wall time
+	// inside it. Calls far exceeding the number of distinct processes means
+	// the caller is symbolizing per sample rather than per process.
+	Calls   uint64
+	TotalNs uint64
+	// SlowestNs is the most expensive single call and SlowestPID the process
+	// it was for. First contact with a large binary is normally the whole of
+	// it: blazesym caches parsed sources, so the second call for the same
+	// process costs almost nothing.
+	SlowestNs  uint64
+	SlowestPID uint32
+}
+
+// noteCall records one SymbolizeProcess call's cost. Racy for slowestPID
+// against slowestNs under concurrent callers --- two calls can interleave and
+// leave the PID of one with the duration of another. That is accepted: this is
+// a diagnostic pointing at which process is expensive, not a measurement
+// anything decides on, and paying a mutex per symbolization to tighten it
+// would be spending the very thing being measured.
+func (s *LocalSymbolizer) noteCall(pid uint32, d time.Duration) {
+	ns := uint64(d.Nanoseconds())
+	s.stats.calls.Add(1)
+	s.stats.totalNs.Add(ns)
+	for {
+		prev := s.stats.slowestNs.Load()
+		if ns <= prev {
+			return
+		}
+		if s.stats.slowestNs.CompareAndSwap(prev, ns) {
+			s.stats.slowestPID.Store(pid)
+			return
+		}
+	}
 }
 
 // Stats returns the current process-side symbolization counters.
@@ -87,6 +137,10 @@ func (s *LocalSymbolizer) Stats() LocalStats {
 		RawAddrBatches:  s.stats.rawAddrBatches.Load(),
 		ModulesAttached: s.stats.modulesAttached.Load(),
 		ModulesBare:     s.stats.modulesBare.Load(),
+		Calls:           s.stats.calls.Load(),
+		TotalNs:         s.stats.totalNs.Load(),
+		SlowestNs:       s.stats.slowestNs.Load(),
+		SlowestPID:      s.stats.slowestPID.Load(),
 	}
 }
 
@@ -212,10 +266,12 @@ func (s *LocalSymbolizer) SymbolizeProcess(pid uint32, ips []uint64) ([]Frame, e
 	if len(ips) == 0 {
 		return nil, nil
 	}
+	start := time.Now()
 	syms, err := s.bz.SymbolizeProcessAbsAddrs(ips, pid,
 		blazesym.ProcessSourceWithPerfMap(true),
 		blazesym.ProcessSourceWithDebugSyms(true),
 	)
+	s.noteCall(pid, time.Since(start))
 	if err != nil {
 		s.stats.rawAddrBatches.Add(1)
 		return s.withModules(pid, rawUserAddrFrames(ips)), nil
@@ -298,4 +354,32 @@ func fromBlazesymSym(s blazesym.Sym, addr uint64) Frame {
 		f.Inlined = append(f.Inlined, inFrame)
 	}
 	return f
+}
+
+// LogSymbolizationCost prints what symbolization cost this collect, when the
+// symbolizer in use keeps that figure.
+//
+// It exists because the cost is invisible otherwise. A capture whose window
+// was five seconds can spend two minutes here (issue #109), and until this
+// there was nothing in the agent's output to say so: the sample count, the
+// mapping count and every drop counter all read healthy while the process sat
+// inside blazesym. Printed unconditionally rather than behind a threshold,
+// because "symbolization took 40ms" is the line that makes "symbolization took
+// 107s" legible when someone eventually sees it.
+//
+// prefix names the profiler, since a combined run has more than one.
+func LogSymbolizationCost(sym Symbolizer, prefix string) {
+	st, ok := sym.(interface{ Stats() LocalStats })
+	if !ok {
+		return
+	}
+	s := st.Stats()
+	if s.Calls == 0 {
+		return
+	}
+	log.Printf("%s: symbolization took %v over %d call(s); slowest single call %v (pid %d); "+
+		"raw_addr_batches=%d modules_attached=%d modules_bare=%d",
+		prefix, time.Duration(s.TotalNs).Round(time.Millisecond), s.Calls,
+		time.Duration(s.SlowestNs).Round(time.Millisecond), s.SlowestPID,
+		s.RawAddrBatches, s.ModulesAttached, s.ModulesBare)
 }

--- a/unwind/dwarfagent/common.go
+++ b/unwind/dwarfagent/common.go
@@ -424,6 +424,8 @@ func (s *session) collect(w io.Writer, sampleType pprof.SampleType, sampleRate i
 		}
 		builders.AddSample(&sample)
 	}
+	symbolize.LogSymbolizationCost(s.symbolizer, "dwarfagent")
+
 	for _, b := range builders.Builders {
 		if _, err := b.Write(w); err != nil {
 			return fmt.Errorf("write profile: %w", err)


### PR DESCRIPTION
Fixes #109.

## Result

| | total | symbolization | slowest call |
|---|---|---|---|
| before | 87.0 s | 73.0 s | 30.0 s |
| after | **17.2 s** | **11.7 s** | 5.0 s |

Same 5-second system-wide capture, same machine.

## What it actually was

`DEBUGINFOD_URLS` is set by default on several distributions, so the agent silently used the debuginfod symbolizer instead of the local one. The same capture took **6.4 s** with the local symbolizer and **87 s** with debuginfod.

Within that, the cost was **not the fetching**. Every distinct build-id the servers cannot serve costs one full `FetchTimeout`, synchronously, on the symbolization path, while the profile waits. This machine maps ~16 large Go binaries; seven have no debuginfo upstream (`file_mode fetch_fails=7`), and at 30 s each that was the whole of it.

The classifier already memoises those failures so they don't recur. The problem was never repetition — it's that a single miss cost 30 seconds.

`FetchTimeout` drops **30 s → 5 s**. The asymmetry decides it: too short yields a profile with less source detail, which degrades gracefully; too long and the profile doesn't arrive while someone waits for it.

## Why it was invisible

The failures land in `fileModeFetchFails` — a counter that existed and was never printed. The one that *was* reachable covers only the dispatcher's `executable` fetch, a different path. So the run looked like it had made almost no network calls while blocking on seven of them, and produced six lines of output with no mention of debuginfod at all.

## The instrumentation is the durable part

Symbolization now reports its own cost from both symbolizers: total time, call count, slowest single call, and how many exceeded 50 ms.

That last pair is what mattered. A total of "73 seconds" is compatible with every wrong theory I had; **slowest call 30.022 s, 17 of 176 over 50 ms** is compatible with only one. Five theories died to measurement:

| theory | refuted by |
|---|---|
| symbolizing per sample rather than per PID | blazesym already caches by inode across processes |
| network downloads | 2 requests, both 404, **zero bytes** |
| the per-call resolver `Invalidate` | 209 ms of 70 s |
| eager classification of all mappings | made it lazy — 414 ms/call vs 392 ms/call |
| `CodeInfo`/`InlinedFns` forcing full DWARF parses | both paths enable them; 495 MB binary parses in ~500 ms either way |

Eager classification in particular looked obviously wasteful and changed nothing. Without the per-call distribution I would have shipped it as the fix.

debuginfod also announces itself at startup now, with its server list and how to turn it off, since it's the single biggest thing that changes how long a capture takes.

## Two defects found along the way

**`DEBUGINFOD_URLS` was parsed as whitespace-separated URLs.** It isn't only URLs — elfutils' debuginfod-client accepts policy tokens in the same list, and Fedora ships exactly that:

```
DEBUGINFOD_URLS="ima:enforcing https://debuginfod.fedoraproject.org/ ima:ignore"
```

Two of three fields were handed to the fetcher as servers. Now filtered to http/https with a host, and mutation-tested against that literal string.

**The dispatcher's `executable` fetch consulted no negative cache**, unlike the classifier's. The memo now sits at the singleflight chokepoint both paths go through, so a fetch site can't be added later that forgets to check — which is how that one came to be missing.

## Included, and explicitly not the fix

Classification in `routeAndSymbolize` is now lazy — only mappings an address falls into, rather than every mapping in the process on every call. Strictly less work, and it changed the measured time by nothing. Kept on its own merits and described that way in the code comment, rather than being presented as a win it didn't deliver.

## Not addressed

I did **not** change whether `DEBUGINFOD_URLS` is honoured by default. Honouring it is conventional and richer symbols are genuinely wanted by many users; a 5× slowdown that no output explains was the indefensible part, and that is now loud. Whether it should be opt-in instead is a product call worth making separately.
