### PR TITLE
gpu: charge the cubin total ceiling against resident bytes, not lifetime (#96)

### DIFF
--- a/gpuprobe/cubin.go
+++ b/gpuprobe/cubin.go
@@ -299,6 +299,17 @@ type cubinSink interface {
 	HasCubin(crc uint64) bool
 	// PutCubin takes ownership of bytes.
 	PutCubin(crc uint64, bytes []byte) error
+	// ResidentBytes reports how many bytes the sink currently HOLDS, not how
+	// many have ever passed through it.
+	//
+	// The distinction is the whole of issue #96. The total ceiling used to be
+	// charged against a cumulative tally, while the bytes themselves live in a
+	// bounded store that evicts. The tally therefore climbed forever and
+	// resident usage stayed flat, so a process loading more than the ceiling
+	// in DISTINCT cubins over its lifetime started refusing offers while the
+	// agent held a fraction of it. Asking the sink means the transport's bound
+	// and the store's bound describe the same quantity.
+	ResidentBytes() int64
 }
 
 // moduleStoreSink is the one hop between the cubin transport and the store
@@ -345,6 +356,11 @@ func (m moduleStoreSink) PutCubin(crc uint64, b []byte) error {
 	return nil
 }
 
+// ResidentBytes is the store's own gauge, which is the number its MaxBytes
+// eviction already acts on. Reading it here rather than keeping a second tally
+// is what stops the two bounds from describing different quantities.
+func (m moduleStoreSink) ResidentBytes() int64 { return m.store.Stats().LiveBytes }
+
 // cubinSinkFor picks the sink for a consumer's configuration. A store supplied
 // by the caller is the sink; nothing is constructed here when one is missing,
 // because a store this package owned would be one the projection cannot read.
@@ -360,9 +376,10 @@ func cubinSinkFor(cfg Config) cubinSink {
 // gpu_src_status="no-module", which is the truth for them - there is no store
 // to resolve against. See Config.Modules.
 type memCubinStore struct {
-	mu   sync.Mutex
-	cap  int
-	seen map[uint64][]byte
+	mu    sync.Mutex
+	cap   int
+	seen  map[uint64][]byte
+	bytes int64
 }
 
 func newMemCubinStore(capacity int) *memCubinStore {
@@ -389,7 +406,18 @@ func (s *memCubinStore) PutCubin(crc uint64, b []byte) error {
 		return fmt.Errorf("cubin store full at %d modules", s.cap)
 	}
 	s.seen[crc] = b
+	s.bytes += int64(len(b))
 	return nil
+}
+
+// ResidentBytes is exact here because this store never evicts: it refuses at
+// its module cap instead. Held and lifetime bytes are therefore the same
+// number, which is precisely why this implementation cannot demonstrate the
+// bug the interface exists to fix -- gpu.ModuleStore is the one that evicts.
+func (s *memCubinStore) ResidentBytes() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.bytes
 }
 
 func (s *memCubinStore) get(crc uint64) ([]byte, bool) {
@@ -626,9 +654,12 @@ func (l *cubinListener) handle(conn *net.UnixConn) {
 	// kept", and the reason string says which ceiling it was. What must never
 	// happen for either is a truncated store - a truncated cubin parses into
 	// a WRONG line table, which is the one failure worse than no line table.
-	l.mu.Lock()
-	held := l.stats.bytes
-	l.mu.Unlock()
+	// Resident, not cumulative: what the agent is HOLDING is what the ceiling
+	// is a bound on. Charging it against the lifetime tally (l.stats.bytes)
+	// meant the limit tightened forever while actual usage stayed flat, so a
+	// long-running process with heavy JIT or template instantiation refused
+	// offers with most of the store empty. Issue #96.
+	held := uint64(max(l.sink.ResidentBytes(), 0))
 	if held+hdr.size > l.totalBytes {
 		l.reject(conn, &l.stats.tooLarge,
 			fmt.Sprintf("pid %d crc %#x: %d bytes would pass the total ceiling of %d (%d held)",

--- a/gpuprobe/cubin_test.go
+++ b/gpuprobe/cubin_test.go
@@ -133,6 +133,13 @@ type recordingCubinSink struct {
 	gate    chan struct{}
 	entered chan struct{}
 	once    sync.Once
+
+	// resident models a store that EVICTS: it is what the sink says it holds,
+	// which a test can hold flat while lifetime bytes climb. That divergence
+	// is issue #96 and it cannot be shown with a sink whose two numbers are
+	// always equal.
+	resident int64
+	evicting bool
 }
 
 func newRecordingCubinSink() *recordingCubinSink {
@@ -158,7 +165,17 @@ func (s *recordingCubinSink) PutCubin(crc uint64, b []byte) error {
 		return s.err
 	}
 	s.have[crc] = b
+	if !s.evicting {
+		s.resident += int64(len(b))
+	}
 	return nil
+}
+
+// ResidentBytes is what the listener charges its total ceiling against.
+func (s *recordingCubinSink) ResidentBytes() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.resident
 }
 
 func (s *recordingCubinSink) get(crc uint64) ([]byte, bool) {
@@ -1352,4 +1369,69 @@ func TestAStubRunWithNoModulesTouchesTheCubinChannelAtAll(t *testing.T) {
 	assert.Zero(t, st.bytes)
 	assert.Zero(t, st.mapped)
 	assertNoCubinRejections(t, st)
+}
+
+// Issue #96. The total ceiling used to be charged against a cumulative tally of
+// every byte ever accepted, while the bytes themselves live in a store bounded
+// by MaxBytes with LRU eviction. The tally climbed forever and resident usage
+// stayed flat, so a process loading more than the ceiling in DISTINCT cubins
+// over its lifetime began refusing offers while the agent held almost nothing.
+//
+// The sink here models exactly that: it accepts everything and reports a
+// resident size that never grows, which is what an evicting store looks like
+// from the transport's side.
+func TestTheTotalCeilingIsChargedAgainstResidentNotLifetimeBytes(t *testing.T) {
+	shim := selfExe(t)
+	sink := newRecordingCubinSink()
+	sink.evicting = true // everything stored is immediately evicted
+	const each = 32 * 1024
+	l := testCubinListener(t, Config{ShimPath: shim, CubinTotalBytes: 3 * each}, sink)
+
+	// Ten distinct cubins, together well past the three-cubin ceiling. Every
+	// one must be accepted, because the store is holding none of them.
+	for i := range 10 {
+		body := cubinFixture(each)
+		body[8] = byte(i)
+		crc := crc64.Checksum(body, cubinCRCTable)
+		fd := sealedCubinFD(t, body, cubinRequiredSeals)
+		require.Equal(t, byte(cubinReplyOK), offerCubin(t, l.address(), offerHeader(each, crc), fd),
+			"offer %d: the store holds nothing, so the ceiling cannot be reached", i)
+	}
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(10), st.received)
+	assert.Zero(t, st.tooLarge, "no offer may be refused while the store is empty")
+	// The lifetime counter still climbs — it is a useful figure and stays a
+	// counter. It is simply no longer the bound.
+	assert.Equal(t, uint64(10*each), st.bytes,
+		"CubinBytesReceived remains cumulative; only its use as a limit changed")
+}
+
+// The other half: when the store really is holding the bytes, the ceiling
+// still bites. Without this the test above would pass against a build that
+// removed the ceiling altogether.
+func TestTheTotalCeilingStillRefusesWhenTheStoreIsActuallyFull(t *testing.T) {
+	shim := selfExe(t)
+	sink := newRecordingCubinSink() // evicting=false: resident == lifetime
+	const each = 32 * 1024
+	l := testCubinListener(t, Config{ShimPath: shim, CubinTotalBytes: 2 * each}, sink)
+
+	for i := range 2 {
+		body := cubinFixture(each)
+		body[8] = byte(i)
+		crc := crc64.Checksum(body, cubinCRCTable)
+		fd := sealedCubinFD(t, body, cubinRequiredSeals)
+		require.Equal(t, byte(cubinReplyOK), offerCubin(t, l.address(), offerHeader(each, crc), fd))
+	}
+
+	over := cubinFixture(each)
+	over[8] = 0xFE
+	overCRC := crc64.Checksum(over, cubinCRCTable)
+	overFD := sealedCubinFD(t, over, cubinRequiredSeals)
+	assert.Equal(t, byte(cubinReplyRefused),
+		offerCubin(t, l.address(), offerHeader(each, overCRC), overFD))
+
+	st := l.snapshot()
+	assert.Equal(t, uint64(1), st.tooLarge)
+	assert.Contains(t, st.lastErr, "total ceiling")
 }


### PR DESCRIPTION
Fixes #96.

## The defect

The transport refused offers once a **cumulative** tally of every byte ever accepted crossed the total ceiling (256 MiB default). Since #93 those bytes live in a `gpu.ModuleStore` bounded by `MaxBytes` (64 MiB) with LRU eviction — so the tally climbed forever while resident usage stayed flat.

A process loading more than 256 MiB of *distinct* cubins over its lifetime started refusing offers while the agent held 64 MiB. The workload that reaches it first is heavy JIT or template instantiation, which is precisely the case the plan's own bounding section names.

## The fix

The store already tracks the number the ceiling should bound — it is what its own `MaxBytes` eviction acts on. The sink contract now asks for it (`ResidentBytes`) rather than the transport keeping a second tally, so the two bounds describe the same quantity instead of diverging.

`CubinBytesReceived` stays cumulative. It is a useful lifetime figure and remains a counter; it is simply no longer the bound.

## On the test

The existing test sink could not express this defect: its resident and lifetime bytes are always equal, which is what a store that never evicts looks like. It grows an `evicting` mode, and the regression test accepts **ten** distinct cubins against a three-cubin ceiling while the store reports holding nothing.

Mutation-proved in both directions:

| mutation | result |
|---|---|
| restore the lifetime tally | the new test fails |
| remove the ceiling outright | the two tests asserting it still bites fail |

The second matters: without it, the first test would pass against a build that simply deleted the bound.