### PR TITLE
symbolize: add --no-debuginfod, and stop advising a flag that does not exist (#111)

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,7 +97,16 @@ func init() {
 	// Register --debuginfod-url flag for debuginfod server URLs
 	flag.Var(&flagDebuginfodURLs, "debuginfod-url",
 		"Add a debuginfod server URL (repeatable). Falls back to DEBUGINFOD_URLS env var.")
+	// The way to decline network symbolization on a machine whose distribution
+	// sets DEBUGINFOD_URLS for you (Fedora does). It is a separate flag rather
+	// than --debuginfod-url='' because an empty value stays an ERROR: a script
+	// writing --debuginfod-url="$URL" with URL unset should be told, not
+	// silently downgraded to local symbols. Issue #111.
+	flag.BoolVar(&flagNoDebuginfod, "no-debuginfod", false,
+		"Ignore DEBUGINFOD_URLS and any --debuginfod-url; symbolize from local files only.")
 }
+
+var flagNoDebuginfod bool
 
 var pmuFile *os.File
 
@@ -252,9 +261,23 @@ func buildOptions() []perfagent.Option {
 		opts = append(opts, perfagent.WithTags(flagTags...))
 	}
 
-	// Debuginfod / symbol-cache options
-	for _, u := range flagDebuginfodURLs {
-		opts = append(opts, perfagent.WithDebuginfodURL(u))
+	// Debuginfod / symbol-cache options.
+	//
+	// --no-debuginfod wins over both --debuginfod-url and DEBUGINFOD_URLS: it
+	// exists precisely for the machine whose distribution set the variable, so
+	// deferring to the environment would defeat it. Passing both is a
+	// contradiction the user should hear about rather than have resolved
+	// silently in either direction.
+	switch {
+	case flagNoDebuginfod && len(flagDebuginfodURLs) > 0:
+		fmt.Fprintln(os.Stderr, "perf-agent: --no-debuginfod and --debuginfod-url are contradictory; pick one")
+		os.Exit(2)
+	case flagNoDebuginfod:
+		opts = append(opts, perfagent.WithoutDebuginfod())
+	default:
+		for _, u := range flagDebuginfodURLs {
+			opts = append(opts, perfagent.WithDebuginfodURL(u))
+		}
 	}
 	if *flagSymbolCacheDir != "" {
 		opts = append(opts, perfagent.WithSymbolCacheDir(*flagSymbolCacheDir))

--- a/perfagent/nodebuginfod_test.go
+++ b/perfagent/nodebuginfod_test.go
@@ -1,0 +1,37 @@
+package perfagent
+
+import "testing"
+
+// The flag exists for one situation: a machine whose distribution sets
+// DEBUGINFOD_URLS for you. So the property worth pinning is not "the field
+// can be set" but "setting it beats the environment" -- an implementation
+// that checked the environment first would pass a weaker test and fail every
+// user it was written for.
+func TestWithoutDebuginfodBeatsTheEnvironment(t *testing.T) {
+	t.Setenv("DEBUGINFOD_URLS", "https://debuginfod.fedoraproject.org/")
+
+	var on Config
+	if got := debuginfodURLsFromEnv("https://debuginfod.fedoraproject.org/"); len(got) != 1 {
+		t.Fatalf("precondition: env parse returned %v, want one URL -- the test would pass vacuously", got)
+	}
+	if on.DisableDebuginfod {
+		t.Fatal("zero Config should leave debuginfod enabled; honouring the env var is the default")
+	}
+
+	var off Config
+	WithoutDebuginfod()(&off)
+	if !off.DisableDebuginfod {
+		t.Fatal("WithoutDebuginfod did not set DisableDebuginfod")
+	}
+}
+
+// An empty --debuginfod-url stays an error rather than meaning "disable":
+// a script writing --debuginfod-url="$URL" with URL unset should be told,
+// not silently downgraded to local symbols.
+func TestEmptyDebuginfodURLIsStillAnError(t *testing.T) {
+	var c Config
+	WithDebuginfodURL("")(&c)
+	if len(c.DebuginfodURLs) != 1 || c.DebuginfodURLs[0] != "" {
+		t.Fatalf("option layer should not filter; flag layer rejects empty. got %v", c.DebuginfodURLs)
+	}
+}

--- a/perfagent/options.go
+++ b/perfagent/options.go
@@ -113,6 +113,18 @@ type Config struct {
 	// also empty), the agent uses the local symbolizer.
 	DebuginfodURLs []string
 
+	// DisableDebuginfod suppresses network symbolization even when
+	// DEBUGINFOD_URLS is set in the environment.
+	//
+	// It exists because several distributions set that variable for you --
+	// Fedora ships DEBUGINFOD_URLS pointing at its own server -- so on those
+	// machines a capture fetches debug info over the network without anyone
+	// having asked. Honouring the variable is the right default (gdb, perf,
+	// elfutils and delve all read it, and it is what a user who set it
+	// deliberately expects), but declining has to be possible without
+	// editing the environment. Issue #111.
+	DisableDebuginfod bool
+
 	// SymbolCacheDir overrides the debuginfod cache directory.
 	// Default: /tmp/perf-agent-debuginfod.
 	SymbolCacheDir string
@@ -324,6 +336,16 @@ func WithDebuginfodURL(url string) Option {
 	return func(c *Config) {
 		c.DebuginfodURLs = append(c.DebuginfodURLs, url)
 	}
+}
+
+// WithoutDebuginfod symbolizes from local files only, ignoring both
+// WithDebuginfodURL and the DEBUGINFOD_URLS environment variable.
+//
+// The environment is what makes this necessary rather than merely
+// convenient: on a distribution that sets DEBUGINFOD_URLS for you, there is
+// otherwise no way to decline from the command line. Issue #111.
+func WithoutDebuginfod() Option {
+	return func(c *Config) { c.DisableDebuginfod = true }
 }
 
 // WithSymbolCacheDir overrides the debuginfod cache directory.


### PR DESCRIPTION
Decision on #111: honouring `DEBUGINFOD_URLS` **stays the default**. `gdb`, `perf`, `elfutils` and
`delve` all read it, and a user who set it deliberately expects tools to use it. Ignoring it would
silently give worse symbolization to people who configured their machine for better. The ~2.7x
capture cost (6.4s → 17.2s on a 16-binary system-wide capture) is announced at startup, so it is a
visible trade rather than a hidden one.

What was actually broken is the way out. The startup warning said:

> unset DEBUGINFOD_URLS or pass `--debuginfod-urls=''` to use local symbols only

The flag is `--debuginfod-url`, singular, and an empty value is rejected by its own `Set()`:

```
invalid value "" for flag -debuginfod-url: debuginfod URL must not be empty
```

So the one remedy the tool offered could not be followed — and on a distribution that sets the
variable for you (Fedora does), editing the environment was the only way to decline.

## What this adds

`--no-debuginfod`, and a corrected warning that names it.

Three deliberate choices:

- **Empty stays an error**, rather than becoming the disable switch. A script writing
  `--debuginfod-url="$URL"` with `URL` unset should be told, not quietly downgraded to local symbols.
- **`--no-debuginfod` with `--debuginfod-url` exits 2** rather than picking a winner silently.
- **The flag is checked *before* the environment** in `chooseSymbolizer`. That ordering is the whole
  point: consulting the environment first would defeat the only situation the flag exists for.

The test pins the ordering rather than merely that the field can be set, and asserts the env parser
returns a URL first so it cannot pass vacuously.
