### PR TITLE
flamegraph: classify cuBLAS as vendor runtime, not application code (#122)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,9 +10,17 @@ own README, source workload, and driver script.
 | [`rust-pgo/`](rust-pgo/) | Rust AutoFDO PGO. Build → profile → `create_llvm_prof` → rebuild → strip → measure speedup. |
 | [`cpp-pgo/`](cpp-pgo/) | C++ AutoFDO PGO. Same shape via clang's `-fprofile-sample-use`. |
 | [`flamegraph/`](flamegraph/) | Render a Brendan-Gregg flame graph from a perf-agent capture. |
+| [`kubernetes/`](kubernetes/) | Profile an unmodified PyTorch CUDA pod in k8s via CUPTI injection, as a sidecar. **Not runnable yet — see #121.** |
 
-All three depend on `perf-agent` being built and on PATH with the standard
+The first three depend on `perf-agent` being built and on PATH with the standard
 capability set (`setcap cap_sys_admin,cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep`).
+
+## One exception to "runnable"
+
+`kubernetes/` is a target shape, not a demonstration: the GPU shim cannot yet
+load into the images it would be injected into (#121), and no shim image is
+published. It states this at the top of its own README rather than failing at
+`kubectl apply`. Everything else here runs today.
 
 ## Why these are here
 

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,127 @@
+<!-- examples/kubernetes/README.md -->
+# perf-agent in Kubernetes — CUDA profiling of an unmodified pod
+
+Profile a PyTorch CUDA workload running in Kubernetes, without rebuilding it,
+relinking it, or changing a line of its code — then render the result as a
+flame graph.
+
+> **Status: not runnable yet. This is a target shape, not a demonstration.**
+>
+> Every other directory under `examples/` runs end-to-end today. This one does
+> not, and the README says so rather than letting you discover it at `kubectl
+> apply`. Two things block it:
+>
+> 1. **[#121] The shim cannot load into these images.** It is built against
+>    glibc 2.42 with a hardcoded `RUNPATH` to the build machine's CUDA 13.3,
+>    and measurably fails to load on Ubuntu 22.04, 24.04 and 25.04 — which is
+>    what essentially every PyTorch image is. There is also no published shim
+>    image; `ghcr.io/dpsoft/perf-agent-shim` does not exist yet.
+> 2. **The sidecar's cross-namespace inode open is untested.** Injection is
+>    confirmed on hardware; the agent opening *the same inode* from a
+>    *different mount namespace* is the one part of the design nothing has
+>    exercised.
+>
+> The manifest is here because it is the thing #121 has to make work. It
+> encodes the constraints, so the build fix has a target to satisfy.
+
+## Why a sidecar, when Parca uses a DaemonSet
+
+[Polar Signals' `parcagpu`][ps] established the injection pattern this example
+follows: an init container drops a CUPTI-based `.so` onto an `emptyDir`, and
+the application container loads it via `CUDA_INJECTION64_PATH`. That part we
+take directly.
+
+Where we diverge is the consumer. Parca does not solve the sidecar problem — it
+avoids it, by running as a **node DaemonSet with `hostPID` and `privileged`**.
+perf-agent runs **per-pod**, which is a harder constraint and the reason for
+most of the annotation in the manifest:
+
+| | parcagpu | perf-agent |
+|---|---|---|
+| consumer | node DaemonSet | pod sidecar |
+| process visibility | `hostPID: true` | `shareProcessNamespace: true` (pod only) |
+| privileges | `privileged: true` | 4 capabilities, no `CAP_SYS_ADMIN` |
+| blast radius | every process on the node | one pod |
+
+A per-pod agent that asks for `privileged` gets rejected by admission policy,
+so "drop `CAP_SYS_ADMIN`" is a deployment prerequisite rather than hardening
+for its own sake.
+
+## The three constraints this manifest exists to encode
+
+**1. Same inode, not same bytes.** uprobe attachment keys on `(dev, ino)`. The
+agent must open the *identical file* the application loaded. Any packaging
+convenience that duplicates it — `go:embed`-and-extract, a per-container copy,
+a second init container — yields **zero probe fires and no error message**.
+The shared `emptyDir` exists for this reason alone.
+
+**2. `uprobe_multi`, not `perf_uprobe`.** Measured on hardware: attaching the
+shim's USDT probe through the `perf_uprobe` PMU fails `EACCES` under
+`CAP_BPF`+`CAP_PERFMON` and works only once `CAP_SYS_ADMIN` is added; the
+`uprobe_multi` BPF link works without it. The capability list in the manifest
+is only achievable via the second path. Cost: **Linux ≥ 6.6 on the node.**
+
+**3. CUPTI is yours to supply.** It ships with the CUDA *toolkit*, not the
+driver, and `nvidia-container-toolkit` never injects it (zero `cupti` hits in
+`nvc_info.c`). The pinned image carries the pip CUPTI that PyTorch pulls in; a
+slim inference image may not.
+
+## Apply
+
+```bash
+kubectl apply -f pytorch-gpu-profile.yaml
+kubectl wait --for=condition=Ready pod/pytorch-gpu-profile --timeout=5m
+kubectl logs -f pytorch-gpu-profile -c perf-agent
+```
+
+**Verify injection actually happened before trusting anything else.**
+`CUDA_INJECTION64_PATH` fails **open and silent**: on any error the CUDA loader
+carries on as if you had never set it, so a broken shim is indistinguishable
+from a workload that launched no kernels. The check is that the app process
+mapped the file:
+
+```bash
+kubectl exec pytorch-gpu-profile -c perf-agent -- \
+  grep libperfagent /proc/1/maps
+```
+
+Four file-backed mappings, `r-xp` among them, all sharing one inode. No output
+means injection did not happen — do not read the empty profile as "no GPU work".
+
+## Pull the profile out and render it
+
+```bash
+kubectl cp pytorch-gpu-profile:/profiles/gpu.pb.gz ./gpu.pb.gz -c perf-agent
+go run ./cmd/flamegraph -o gpu.html gpu.pb.gz   # renders an interactive HTML page
+```
+
+See [`../flamegraph/`](../flamegraph/) for the CPU-profile equivalent and the
+Brendan Gregg toolchain path.
+
+### Reading the result without being misled
+
+A GPU flame graph is not a CPU flame graph with extra frames, and three of its
+properties will mislead a reader who assumes otherwise (issue #123):
+
+- **A CPU frame under `[gpu:launch]` is as wide as the GPU time launched *from*
+  it** — not the CPU time spent in it. The Python and C++ frames you recognize
+  are measuring the device, not themselves.
+- **`[gpu:launch unsampled]` is expected, and is not lost data.** Stack capture
+  is sampled (`--period`, default 8); durations never are. At the default, most
+  of the canvas is GPU time whose launch was not stack-sampled. It is drawn
+  hatched and quantified rather than dropped or silently reassigned to a
+  sibling. Use `--period 1` for full attribution, at a throughput cost.
+- **Do not compare these nanoseconds with a CPU profile's.** One is
+  `samples × period`; the other is a measured `EndNs - StartNs` interval. Same
+  printed unit, different quantities.
+
+The axis is labelled `gpu/nanoseconds` and the profile contains exactly one
+sample type — units are not mixed on the canvas.
+
+## Not covered here
+
+Multi-GPU pods, MIG, multi-node jobs, and continuous profiling (this manifest
+is a one-shot `restartPolicy: Never` capture). Profiles land on an `emptyDir`
+and die with the pod; a real deployment wants a PVC or an uploader.
+
+[ps]: https://www.polarsignals.com/blog/posts/2025/12/18/profiling-nvidia-cuda-in-kubernetes

--- a/examples/kubernetes/pytorch-gpu-profile.yaml
+++ b/examples/kubernetes/pytorch-gpu-profile.yaml
@@ -1,0 +1,137 @@
+# examples/kubernetes/pytorch-gpu-profile.yaml
+#
+# Profile an unmodified PyTorch CUDA pod with perf-agent as a SIDECAR.
+#
+# Read examples/kubernetes/README.md before applying this. It does not work
+# yet: the shim's glibc floor (issue #121) exceeds what this image provides,
+# and the sidecar's cross-mount-namespace inode open is untested. This file is
+# the target shape, kept next to the constraints it has to satisfy.
+#
+# Three containers share one emptyDir:
+#
+#   shim-installer (init)  copies libperfagent-gpu-nvidia.so onto the volume
+#   pytorch (app)          loads it via CUDA_INJECTION64_PATH, unmodified
+#   perf-agent (sidecar)   opens THE SAME FILE and attaches USDT probes to it
+#
+# The third container is why the volume exists. uprobe attachment keys on
+# (dev, ino) -- see gpuprobe enrolment -- so the agent must open the identical
+# inode, not a copy of the same bytes. Anything that duplicates the file
+# (go:embed extraction, a per-container copy, a second initContainer) produces
+# zero probe fires and no error.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pytorch-gpu-profile
+  labels:
+    app: pytorch-gpu-profile
+spec:
+  restartPolicy: Never
+
+  # The sidecar reads /proc/<pid>/maps, /proc/<pid>/map_files and
+  # /proc/<pid>/comm of the application process to unwind and symbolize.
+  # This is required by perf-agent's EXISTING function, not by the GPU path.
+  # It is the narrow alternative to hostPID: the sidecar sees the pod's
+  # processes and nothing else on the node.
+  shareProcessNamespace: true
+
+  volumes:
+    # The shim. Written once by the init container, read by both others.
+    - name: perfagent-shim
+      emptyDir: {}
+    # Where the sidecar writes profiles. Swap for a PVC or an object-store
+    # uploader in a real deployment; emptyDir dies with the pod.
+    - name: profiles
+      emptyDir: {}
+
+  initContainers:
+    - name: shim-installer
+      # Ships ONLY the shim. Built against an old-glibc baseline so it can
+      # load into whatever the application image happens to be -- see #121.
+      image: ghcr.io/dpsoft/perf-agent-shim:latest
+      command: ["sh", "-c"]
+      args:
+        - cp /usr/local/lib/libperfagent-gpu-nvidia.so /var/lib/perf-agent/gpu/
+      volumeMounts:
+        - name: perfagent-shim
+          mountPath: /var/lib/perf-agent/gpu
+
+  containers:
+    # ---------------------------------------------------------------- app --
+    - name: pytorch
+      image: pytorch/pytorch:2.6.0-cuda12.6-cudnn9-runtime
+      command: ["python", "-c"]
+      args:
+        - |
+          import torch, time
+          x = torch.randn(4096, 4096, device="cuda")
+          for _ in range(2000):
+              x = (x @ x).relu() * 0.001
+          torch.cuda.synchronize()
+          print("done", flush=True)
+          time.sleep(30)   # keep the process alive so the sidecar can finish
+      env:
+        # The whole injection mechanism. CUDA's loader dlopens this and calls
+        # InitializeInjection. The application is not modified or rebuilt.
+        - name: CUDA_INJECTION64_PATH
+          value: /var/lib/perf-agent/gpu/libperfagent-gpu-nvidia.so
+        # CUPTI ships with the CUDA TOOLKIT, not the driver, and
+        # nvidia-container-toolkit never injects it. This image carries the
+        # pip CUPTI that PyTorch pulls in; a slimmer image may not, and the
+        # shim will then fail to resolve it.
+        - name: LD_LIBRARY_PATH
+          value: /opt/conda/lib/python3.11/site-packages/nvidia/cuda_cupti/lib
+      volumeMounts:
+        - name: perfagent-shim
+          mountPath: /var/lib/perf-agent/gpu
+          readOnly: true
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+
+    # ------------------------------------------------------------ sidecar --
+    - name: perf-agent
+      image: ghcr.io/dpsoft/perf-agent:latest
+      args:
+        - --gpu
+        - --pid=1                       # PID 1 in the shared namespace
+        - --duration=60s
+        - --gpu-shim=/var/lib/perf-agent/gpu/libperfagent-gpu-nvidia.so
+        - --gpu-output=/profiles/gpu.pb.gz
+      securityContext:
+        # NOT privileged. Four narrow capabilities, deliberately.
+        #
+        # CAP_SYS_ADMIN is absent and must stay absent -- it is near-root and
+        # is what gets a per-pod agent rejected by admission policy. Keeping
+        # it out is why the USDT consumer attaches through the uprobe_multi
+        # BPF link rather than the perf_uprobe PMU: measured on hardware, the
+        # PMU path fails EACCES under CAP_BPF+CAP_PERFMON and needs
+        # CAP_SYS_ADMIN, while uprobe_multi succeeds without it. That is a
+        # correctness requirement of this securityContext, not a style choice.
+        # It costs a Linux 6.6 floor on the NODE.
+        capabilities:
+          drop: ["ALL"]
+          add:
+            - BPF                  # load programs, create maps and links
+            - PERFMON              # perf_event_open, including system-wide
+            - SYS_PTRACE           # read another process's memory
+            - CHECKPOINT_RESTORE   # /proc/<pid>/map_files
+            # - SYSLOG             # add only for kernel stacks: without it
+            #                      # /proc/kallsyms reads zeros and kernel
+            #                      # symbolization is silently skipped
+        privileged: false
+        runAsNonRoot: false
+        allowPrivilegeEscalation: false
+      volumeMounts:
+        - name: perfagent-shim
+          # SAME PATH as the app container, on purpose. The requirement is the
+          # same inode; the same path is what makes that auditable by reading
+          # this file.
+          mountPath: /var/lib/perf-agent/gpu
+          readOnly: true
+        - name: profiles
+          mountPath: /profiles
+
+  # The uprobe_multi link requires Linux >= 6.6 on the node. Scheduling on an
+  # older kernel fails at attach with a message about links, not kernels.
+  nodeSelector:
+    nvidia.com/gpu.present: "true"

--- a/internal/flamegraph/domain.go
+++ b/internal/flamegraph/domain.go
@@ -226,6 +226,14 @@ func isShimSymbol(name string) bool {
 
 var vendorModulePrefixes = []string{
 	"libcuda", "libcudart", "libcupti", "libnvidia", "libnvperf",
+	// The CUDA math and communication libraries. cuBLAS is the measured
+	// case -- libcublasLt.so.13 and libcublas.so.13 were the only NVIDIA
+	// modules on a PyTorch stack that no rule here classified, so their
+	// frames were coloured as the user's own application code. The rest of
+	// this line is the same family and is listed to stop the identical
+	// one-word omission recurring per library.
+	"libcublas", "libcudnn", "libcufft", "libcurand", "libcusparse",
+	"libcusolver", "libnccl", "libnvjitlink", "libnvrtc", "libnvToolsExt",
 	"libamdhip", "libhsa-runtime", "librocprofiler", "libroctracer", "libhsakmt",
 }
 
@@ -245,6 +253,18 @@ func isVendorModule(module string) bool {
 var vendorSymbolPrefixes = []string{
 	"cuda", "cuda_", "cuLaunch", "cuMem", "cuStream", "cuModule", "cuCtx", "cuDevice",
 	"cupti", "cuptiActivity", "nvidia", "nvrtc",
+	// The math/comm libraries by SYMBOL as well as by module, and this half
+	// is the one that reaches a GPU flame graph: the GPU builder writes
+	// profiles with empty mappings, so module is "" for every frame in one
+	// and only the name rules run. Adding these to vendorModulePrefixes
+	// alone would fix CPU profiles and change nothing on the page these
+	// frames were reported from.
+	//
+	// They need naming explicitly because the driver-API heuristic below is
+	// "cu" + an UPPERCASE letter, which "cublas", "cufft" and "cusparse" all
+	// fail on their third character.
+	"cublas", "cudnn", "cufft", "curand", "cusparse", "cusolver",
+	"nccl", "ncclComm", "nvjitlink",
 	"hip", "hsa_", "roctracer", "rocprofiler", "amd_",
 }
 

--- a/internal/flamegraph/domain_test.go
+++ b/internal/flamegraph/domain_test.go
@@ -114,3 +114,45 @@ func TestBothUnresolvedFormsShareTheDomainButNotTheLabel(t *testing.T) {
 func TestKernelStillBeatsUnsymbolized(t *testing.T) {
 	assert.Equal(t, DomainKernel, Classify("0xffffffffc0201234", "[kernel]"))
 }
+
+// cuBLAS is NVIDIA runtime and reads as application code today. Two separate
+// rules both miss it, which is why the frames survived review: the module is
+// absent from vendorModulePrefixes, and the symbol heuristic for the driver
+// API ("cu" + an uppercase letter) does not fire on "cublas" because the third
+// character is lowercase. A symbolized cuBLAS frame therefore falls all the way
+// through to DomainApplication and is coloured as the user's own code.
+//
+// Measured in a PyTorch capture: libcublasLt.so.13 (84 frames) and
+// libcublas.so.13 (56) were the only NVIDIA modules on the stack that no rule
+// classified.
+func TestCuBLASIsVendorRuntimeNotApplicationCode(t *testing.T) {
+	const lt = "/usr/lib/python3/site-packages/nvidia/cublas/lib/libcublasLt.so.13"
+	const bl = "/usr/lib/python3/site-packages/nvidia/cublas/lib/libcublas.so.13"
+
+	// The case that motivated this: an address that IS inside an exported
+	// symbol, so it arrives named rather than as module+offset.
+	assert.Equal(t, DomainVendorRuntime, Classify("cublasLtSSSMatmul", lt))
+	assert.Equal(t, DomainVendorRuntime, Classify("cublasSgemm_v2", bl))
+
+	// And an internal name we cannot recognise, carried by the module alone.
+	assert.Equal(t, DomainVendorRuntime, Classify("someInternalGemmKernel", lt))
+
+	// Unsymbolized still wins over the module, exactly as for libcuda: the
+	// hatch is the only thing that says no symbol table named this address.
+	assert.Equal(t, DomainUnsymbolized, Classify("libcublasLt.so.13+0xf9e678", lt))
+
+	// The case that actually reaches the page. GPU profiles carry EMPTY
+	// mappings (see isShimSymbol), so every frame in one arrives with
+	// module == "" and only the name rules run. A module-only fix would pass
+	// the assertions above and change nothing about a real GPU flame graph.
+	assert.Equal(t, DomainVendorRuntime, Classify("cublasLtSSSMatmul", ""))
+	assert.Equal(t, DomainVendorRuntime, Classify("cublasSgemm_v2", ""))
+	assert.Equal(t, DomainUnsymbolized, Classify("libcublasLt.so.13+0xf9e678", ""))
+
+	// PyTorch's own wrapper around cuBLAS, present in the same capture. It
+	// contains "cublas" and is emphatically NOT vendor code -- it is the
+	// caller we most want to see. The rules match on PREFIX for exactly this
+	// reason; a Contains would bill this frame to NVIDIA.
+	assert.Equal(t, DomainApplication, Classify(
+		"void at::cuda::blas::gemm_internal_cublas<float, float>(char, char, long)", ""))
+}


### PR DESCRIPTION
Symbolized cuBLAS frames have been coloured as **your own application code**.

Two independent rules both missed them, which is why this survived review:

- `libcublas` is absent from `vendorModulePrefixes`
- the driver-API symbol heuristic is `"cu"` + an **uppercase** letter, and `cublas` fails on its
  third character

So a frame named `cublasLtSSSMatmul` fell through every case to `DomainApplication`.

Measured in a PyTorch capture: `libcublasLt.so.13` (84 frames) and `libcublas.so.13` (56) were the
only NVIDIA modules on the stack that no rule classified, and `cublasLtSSSMatmul` and
`cublasSgemm_v2` appear there symbolized.

## Fixed in both tables, and only one of them matters

The GPU builder writes profiles with **empty mappings**, so `module == ""` for every frame in one
and the module rules never run. A `vendorModulePrefixes`-only fix would have passed a module-based
test and changed nothing about a real GPU flame graph — so the test asserts the empty-mapping form
explicitly, which is the form that actually reaches the page these frames were reported from.

Both lists also gain the rest of the CUDA math/comm family, to stop the identical one-word omission
recurring per library.

## Matching stays on prefix, deliberately

`at::cuda::blas::gemm_internal_cublas` is PyTorch's own wrapper, contains `"cublas"`, and is the
caller we most want attributed to the application. A `Contains` match would bill it to NVIDIA.
That is asserted, not assumed.

Unsymbolized still wins over both rules, so `libcublasLt.so.13+0xf9e678` keeps its hatch — the
module is known, but no symbol table named that address, and the hatch is the only thing on the
page that says so.

## Verified in the rendered output

Re-rendered all eleven example captures with the built binary:

```
cublasLtSSSMatmul                     data-domain="vendor"   (matches cuLaunchKernel)
at::cuda::blas::gemm_internal_cublas  data-domain="app"      (guard holds)
```

Full unit suite green.
