### PR TITLE
symbolize: recover names when blazesym fails a whole batch (#125)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,9 +10,17 @@ own README, source workload, and driver script.
 | [`rust-pgo/`](rust-pgo/) | Rust AutoFDO PGO. Build → profile → `create_llvm_prof` → rebuild → strip → measure speedup. |
 | [`cpp-pgo/`](cpp-pgo/) | C++ AutoFDO PGO. Same shape via clang's `-fprofile-sample-use`. |
 | [`flamegraph/`](flamegraph/) | Render a Brendan-Gregg flame graph from a perf-agent capture. |
+| [`kubernetes/`](kubernetes/) | Profile an unmodified PyTorch CUDA pod in k8s via CUPTI injection, as a sidecar. **Not runnable yet — see #121.** |
 
-All three depend on `perf-agent` being built and on PATH with the standard
+The first three depend on `perf-agent` being built and on PATH with the standard
 capability set (`setcap cap_sys_admin,cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep`).
+
+## One exception to "runnable"
+
+`kubernetes/` is a target shape, not a demonstration: the GPU shim cannot yet
+load into the images it would be injected into (#121), and no shim image is
+published. It states this at the top of its own README rather than failing at
+`kubectl apply`. Everything else here runs today.
 
 ## Why these are here
 

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,127 @@
+<!-- examples/kubernetes/README.md -->
+# perf-agent in Kubernetes — CUDA profiling of an unmodified pod
+
+Profile a PyTorch CUDA workload running in Kubernetes, without rebuilding it,
+relinking it, or changing a line of its code — then render the result as a
+flame graph.
+
+> **Status: not runnable yet. This is a target shape, not a demonstration.**
+>
+> Every other directory under `examples/` runs end-to-end today. This one does
+> not, and the README says so rather than letting you discover it at `kubectl
+> apply`. Two things block it:
+>
+> 1. **[#121] The shim cannot load into these images.** It is built against
+>    glibc 2.42 with a hardcoded `RUNPATH` to the build machine's CUDA 13.3,
+>    and measurably fails to load on Ubuntu 22.04, 24.04 and 25.04 — which is
+>    what essentially every PyTorch image is. There is also no published shim
+>    image; `ghcr.io/dpsoft/perf-agent-shim` does not exist yet.
+> 2. **The sidecar's cross-namespace inode open is untested.** Injection is
+>    confirmed on hardware; the agent opening *the same inode* from a
+>    *different mount namespace* is the one part of the design nothing has
+>    exercised.
+>
+> The manifest is here because it is the thing #121 has to make work. It
+> encodes the constraints, so the build fix has a target to satisfy.
+
+## Why a sidecar, when Parca uses a DaemonSet
+
+[Polar Signals' `parcagpu`][ps] established the injection pattern this example
+follows: an init container drops a CUPTI-based `.so` onto an `emptyDir`, and
+the application container loads it via `CUDA_INJECTION64_PATH`. That part we
+take directly.
+
+Where we diverge is the consumer. Parca does not solve the sidecar problem — it
+avoids it, by running as a **node DaemonSet with `hostPID` and `privileged`**.
+perf-agent runs **per-pod**, which is a harder constraint and the reason for
+most of the annotation in the manifest:
+
+| | parcagpu | perf-agent |
+|---|---|---|
+| consumer | node DaemonSet | pod sidecar |
+| process visibility | `hostPID: true` | `shareProcessNamespace: true` (pod only) |
+| privileges | `privileged: true` | 4 capabilities, no `CAP_SYS_ADMIN` |
+| blast radius | every process on the node | one pod |
+
+A per-pod agent that asks for `privileged` gets rejected by admission policy,
+so "drop `CAP_SYS_ADMIN`" is a deployment prerequisite rather than hardening
+for its own sake.
+
+## The three constraints this manifest exists to encode
+
+**1. Same inode, not same bytes.** uprobe attachment keys on `(dev, ino)`. The
+agent must open the *identical file* the application loaded. Any packaging
+convenience that duplicates it — `go:embed`-and-extract, a per-container copy,
+a second init container — yields **zero probe fires and no error message**.
+The shared `emptyDir` exists for this reason alone.
+
+**2. `uprobe_multi`, not `perf_uprobe`.** Measured on hardware: attaching the
+shim's USDT probe through the `perf_uprobe` PMU fails `EACCES` under
+`CAP_BPF`+`CAP_PERFMON` and works only once `CAP_SYS_ADMIN` is added; the
+`uprobe_multi` BPF link works without it. The capability list in the manifest
+is only achievable via the second path. Cost: **Linux ≥ 6.6 on the node.**
+
+**3. CUPTI is yours to supply.** It ships with the CUDA *toolkit*, not the
+driver, and `nvidia-container-toolkit` never injects it (zero `cupti` hits in
+`nvc_info.c`). The pinned image carries the pip CUPTI that PyTorch pulls in; a
+slim inference image may not.
+
+## Apply
+
+```bash
+kubectl apply -f pytorch-gpu-profile.yaml
+kubectl wait --for=condition=Ready pod/pytorch-gpu-profile --timeout=5m
+kubectl logs -f pytorch-gpu-profile -c perf-agent
+```
+
+**Verify injection actually happened before trusting anything else.**
+`CUDA_INJECTION64_PATH` fails **open and silent**: on any error the CUDA loader
+carries on as if you had never set it, so a broken shim is indistinguishable
+from a workload that launched no kernels. The check is that the app process
+mapped the file:
+
+```bash
+kubectl exec pytorch-gpu-profile -c perf-agent -- \
+  grep libperfagent /proc/1/maps
+```
+
+Four file-backed mappings, `r-xp` among them, all sharing one inode. No output
+means injection did not happen — do not read the empty profile as "no GPU work".
+
+## Pull the profile out and render it
+
+```bash
+kubectl cp pytorch-gpu-profile:/profiles/gpu.pb.gz ./gpu.pb.gz -c perf-agent
+go run ./cmd/flamegraph -o gpu.html gpu.pb.gz   # renders an interactive HTML page
+```
+
+See [`../flamegraph/`](../flamegraph/) for the CPU-profile equivalent and the
+Brendan Gregg toolchain path.
+
+### Reading the result without being misled
+
+A GPU flame graph is not a CPU flame graph with extra frames, and three of its
+properties will mislead a reader who assumes otherwise (issue #123):
+
+- **A CPU frame under `[gpu:launch]` is as wide as the GPU time launched *from*
+  it** — not the CPU time spent in it. The Python and C++ frames you recognize
+  are measuring the device, not themselves.
+- **`[gpu:launch unsampled]` is expected, and is not lost data.** Stack capture
+  is sampled (`--period`, default 8); durations never are. At the default, most
+  of the canvas is GPU time whose launch was not stack-sampled. It is drawn
+  hatched and quantified rather than dropped or silently reassigned to a
+  sibling. Use `--period 1` for full attribution, at a throughput cost.
+- **Do not compare these nanoseconds with a CPU profile's.** One is
+  `samples × period`; the other is a measured `EndNs - StartNs` interval. Same
+  printed unit, different quantities.
+
+The axis is labelled `gpu/nanoseconds` and the profile contains exactly one
+sample type — units are not mixed on the canvas.
+
+## Not covered here
+
+Multi-GPU pods, MIG, multi-node jobs, and continuous profiling (this manifest
+is a one-shot `restartPolicy: Never` capture). Profiles land on an `emptyDir`
+and die with the pod; a real deployment wants a PVC or an uploader.
+
+[ps]: https://www.polarsignals.com/blog/posts/2025/12/18/profiling-nvidia-cuda-in-kubernetes

--- a/examples/kubernetes/pytorch-gpu-profile.yaml
+++ b/examples/kubernetes/pytorch-gpu-profile.yaml
@@ -1,0 +1,137 @@
+# examples/kubernetes/pytorch-gpu-profile.yaml
+#
+# Profile an unmodified PyTorch CUDA pod with perf-agent as a SIDECAR.
+#
+# Read examples/kubernetes/README.md before applying this. It does not work
+# yet: the shim's glibc floor (issue #121) exceeds what this image provides,
+# and the sidecar's cross-mount-namespace inode open is untested. This file is
+# the target shape, kept next to the constraints it has to satisfy.
+#
+# Three containers share one emptyDir:
+#
+#   shim-installer (init)  copies libperfagent-gpu-nvidia.so onto the volume
+#   pytorch (app)          loads it via CUDA_INJECTION64_PATH, unmodified
+#   perf-agent (sidecar)   opens THE SAME FILE and attaches USDT probes to it
+#
+# The third container is why the volume exists. uprobe attachment keys on
+# (dev, ino) -- see gpuprobe enrolment -- so the agent must open the identical
+# inode, not a copy of the same bytes. Anything that duplicates the file
+# (go:embed extraction, a per-container copy, a second initContainer) produces
+# zero probe fires and no error.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pytorch-gpu-profile
+  labels:
+    app: pytorch-gpu-profile
+spec:
+  restartPolicy: Never
+
+  # The sidecar reads /proc/<pid>/maps, /proc/<pid>/map_files and
+  # /proc/<pid>/comm of the application process to unwind and symbolize.
+  # This is required by perf-agent's EXISTING function, not by the GPU path.
+  # It is the narrow alternative to hostPID: the sidecar sees the pod's
+  # processes and nothing else on the node.
+  shareProcessNamespace: true
+
+  volumes:
+    # The shim. Written once by the init container, read by both others.
+    - name: perfagent-shim
+      emptyDir: {}
+    # Where the sidecar writes profiles. Swap for a PVC or an object-store
+    # uploader in a real deployment; emptyDir dies with the pod.
+    - name: profiles
+      emptyDir: {}
+
+  initContainers:
+    - name: shim-installer
+      # Ships ONLY the shim. Built against an old-glibc baseline so it can
+      # load into whatever the application image happens to be -- see #121.
+      image: ghcr.io/dpsoft/perf-agent-shim:latest
+      command: ["sh", "-c"]
+      args:
+        - cp /usr/local/lib/libperfagent-gpu-nvidia.so /var/lib/perf-agent/gpu/
+      volumeMounts:
+        - name: perfagent-shim
+          mountPath: /var/lib/perf-agent/gpu
+
+  containers:
+    # ---------------------------------------------------------------- app --
+    - name: pytorch
+      image: pytorch/pytorch:2.6.0-cuda12.6-cudnn9-runtime
+      command: ["python", "-c"]
+      args:
+        - |
+          import torch, time
+          x = torch.randn(4096, 4096, device="cuda")
+          for _ in range(2000):
+              x = (x @ x).relu() * 0.001
+          torch.cuda.synchronize()
+          print("done", flush=True)
+          time.sleep(30)   # keep the process alive so the sidecar can finish
+      env:
+        # The whole injection mechanism. CUDA's loader dlopens this and calls
+        # InitializeInjection. The application is not modified or rebuilt.
+        - name: CUDA_INJECTION64_PATH
+          value: /var/lib/perf-agent/gpu/libperfagent-gpu-nvidia.so
+        # CUPTI ships with the CUDA TOOLKIT, not the driver, and
+        # nvidia-container-toolkit never injects it. This image carries the
+        # pip CUPTI that PyTorch pulls in; a slimmer image may not, and the
+        # shim will then fail to resolve it.
+        - name: LD_LIBRARY_PATH
+          value: /opt/conda/lib/python3.11/site-packages/nvidia/cuda_cupti/lib
+      volumeMounts:
+        - name: perfagent-shim
+          mountPath: /var/lib/perf-agent/gpu
+          readOnly: true
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+
+    # ------------------------------------------------------------ sidecar --
+    - name: perf-agent
+      image: ghcr.io/dpsoft/perf-agent:latest
+      args:
+        - --gpu
+        - --pid=1                       # PID 1 in the shared namespace
+        - --duration=60s
+        - --gpu-shim=/var/lib/perf-agent/gpu/libperfagent-gpu-nvidia.so
+        - --gpu-output=/profiles/gpu.pb.gz
+      securityContext:
+        # NOT privileged. Four narrow capabilities, deliberately.
+        #
+        # CAP_SYS_ADMIN is absent and must stay absent -- it is near-root and
+        # is what gets a per-pod agent rejected by admission policy. Keeping
+        # it out is why the USDT consumer attaches through the uprobe_multi
+        # BPF link rather than the perf_uprobe PMU: measured on hardware, the
+        # PMU path fails EACCES under CAP_BPF+CAP_PERFMON and needs
+        # CAP_SYS_ADMIN, while uprobe_multi succeeds without it. That is a
+        # correctness requirement of this securityContext, not a style choice.
+        # It costs a Linux 6.6 floor on the NODE.
+        capabilities:
+          drop: ["ALL"]
+          add:
+            - BPF                  # load programs, create maps and links
+            - PERFMON              # perf_event_open, including system-wide
+            - SYS_PTRACE           # read another process's memory
+            - CHECKPOINT_RESTORE   # /proc/<pid>/map_files
+            # - SYSLOG             # add only for kernel stacks: without it
+            #                      # /proc/kallsyms reads zeros and kernel
+            #                      # symbolization is silently skipped
+        privileged: false
+        runAsNonRoot: false
+        allowPrivilegeEscalation: false
+      volumeMounts:
+        - name: perfagent-shim
+          # SAME PATH as the app container, on purpose. The requirement is the
+          # same inode; the same path is what makes that auditable by reading
+          # this file.
+          mountPath: /var/lib/perf-agent/gpu
+          readOnly: true
+        - name: profiles
+          mountPath: /profiles
+
+  # The uprobe_multi link requires Linux >= 6.6 on the node. Scheduling on an
+  # older kernel fails at attach with a message about links, not kernels.
+  nodeSelector:
+    nvidia.com/gpu.present: "true"

--- a/internal/flamegraph/domain.go
+++ b/internal/flamegraph/domain.go
@@ -226,6 +226,14 @@ func isShimSymbol(name string) bool {
 
 var vendorModulePrefixes = []string{
 	"libcuda", "libcudart", "libcupti", "libnvidia", "libnvperf",
+	// The CUDA math and communication libraries. cuBLAS is the measured
+	// case -- libcublasLt.so.13 and libcublas.so.13 were the only NVIDIA
+	// modules on a PyTorch stack that no rule here classified, so their
+	// frames were coloured as the user's own application code. The rest of
+	// this line is the same family and is listed to stop the identical
+	// one-word omission recurring per library.
+	"libcublas", "libcudnn", "libcufft", "libcurand", "libcusparse",
+	"libcusolver", "libnccl", "libnvjitlink", "libnvrtc", "libnvToolsExt",
 	"libamdhip", "libhsa-runtime", "librocprofiler", "libroctracer", "libhsakmt",
 }
 
@@ -245,6 +253,18 @@ func isVendorModule(module string) bool {
 var vendorSymbolPrefixes = []string{
 	"cuda", "cuda_", "cuLaunch", "cuMem", "cuStream", "cuModule", "cuCtx", "cuDevice",
 	"cupti", "cuptiActivity", "nvidia", "nvrtc",
+	// The math/comm libraries by SYMBOL as well as by module, and this half
+	// is the one that reaches a GPU flame graph: the GPU builder writes
+	// profiles with empty mappings, so module is "" for every frame in one
+	// and only the name rules run. Adding these to vendorModulePrefixes
+	// alone would fix CPU profiles and change nothing on the page these
+	// frames were reported from.
+	//
+	// They need naming explicitly because the driver-API heuristic below is
+	// "cu" + an UPPERCASE letter, which "cublas", "cufft" and "cusparse" all
+	// fail on their third character.
+	"cublas", "cudnn", "cufft", "curand", "cusparse", "cusolver",
+	"nccl", "ncclComm", "nvjitlink",
 	"hip", "hsa_", "roctracer", "rocprofiler", "amd_",
 }
 

--- a/internal/flamegraph/domain_test.go
+++ b/internal/flamegraph/domain_test.go
@@ -114,3 +114,45 @@ func TestBothUnresolvedFormsShareTheDomainButNotTheLabel(t *testing.T) {
 func TestKernelStillBeatsUnsymbolized(t *testing.T) {
 	assert.Equal(t, DomainKernel, Classify("0xffffffffc0201234", "[kernel]"))
 }
+
+// cuBLAS is NVIDIA runtime and reads as application code today. Two separate
+// rules both miss it, which is why the frames survived review: the module is
+// absent from vendorModulePrefixes, and the symbol heuristic for the driver
+// API ("cu" + an uppercase letter) does not fire on "cublas" because the third
+// character is lowercase. A symbolized cuBLAS frame therefore falls all the way
+// through to DomainApplication and is coloured as the user's own code.
+//
+// Measured in a PyTorch capture: libcublasLt.so.13 (84 frames) and
+// libcublas.so.13 (56) were the only NVIDIA modules on the stack that no rule
+// classified.
+func TestCuBLASIsVendorRuntimeNotApplicationCode(t *testing.T) {
+	const lt = "/usr/lib/python3/site-packages/nvidia/cublas/lib/libcublasLt.so.13"
+	const bl = "/usr/lib/python3/site-packages/nvidia/cublas/lib/libcublas.so.13"
+
+	// The case that motivated this: an address that IS inside an exported
+	// symbol, so it arrives named rather than as module+offset.
+	assert.Equal(t, DomainVendorRuntime, Classify("cublasLtSSSMatmul", lt))
+	assert.Equal(t, DomainVendorRuntime, Classify("cublasSgemm_v2", bl))
+
+	// And an internal name we cannot recognise, carried by the module alone.
+	assert.Equal(t, DomainVendorRuntime, Classify("someInternalGemmKernel", lt))
+
+	// Unsymbolized still wins over the module, exactly as for libcuda: the
+	// hatch is the only thing that says no symbol table named this address.
+	assert.Equal(t, DomainUnsymbolized, Classify("libcublasLt.so.13+0xf9e678", lt))
+
+	// The case that actually reaches the page. GPU profiles carry EMPTY
+	// mappings (see isShimSymbol), so every frame in one arrives with
+	// module == "" and only the name rules run. A module-only fix would pass
+	// the assertions above and change nothing about a real GPU flame graph.
+	assert.Equal(t, DomainVendorRuntime, Classify("cublasLtSSSMatmul", ""))
+	assert.Equal(t, DomainVendorRuntime, Classify("cublasSgemm_v2", ""))
+	assert.Equal(t, DomainUnsymbolized, Classify("libcublasLt.so.13+0xf9e678", ""))
+
+	// PyTorch's own wrapper around cuBLAS, present in the same capture. It
+	// contains "cublas" and is emphatically NOT vendor code -- it is the
+	// caller we most want to see. The rules match on PREFIX for exactly this
+	// reason; a Contains would bill this frame to NVIDIA.
+	assert.Equal(t, DomainApplication, Classify(
+		"void at::cuda::blas::gemm_internal_cublas<float, float>(char, char, long)", ""))
+}

--- a/symbolize/fileretry_test.go
+++ b/symbolize/fileretry_test.go
@@ -1,0 +1,88 @@
+package symbolize
+
+import (
+	"testing"
+
+	blazesym "github.com/libbpf/blazesym/go"
+)
+
+// newRetryTestSymbolizer builds a LocalSymbolizer WITHOUT NewLocalSymbolizer's
+// map_files capability check.
+//
+// That check guards the PROCESS source, which needs CAP_CHECKPOINT_RESTORE to
+// dereference /proc/<pid>/map_files symlinks. The retry under test uses only
+// the ELF source and needs no capability, so going through the constructor
+// would make this skip on every unprivileged machine including CI, and a test
+// that always skips asserts nothing.
+func newRetryTestSymbolizer(t *testing.T) *LocalSymbolizer {
+	t.Helper()
+	bz, err := blazesym.NewSymbolizer()
+	if err != nil {
+		t.Fatalf("blazesym.NewSymbolizer: %v", err)
+	}
+	return &LocalSymbolizer{bz: bz}
+}
+
+// The retry must not invent work it cannot do. Each case lacks something that
+// makes a virtual address computable, and a frame it cannot ask about has to
+// come back untouched rather than mangled or renamed.
+//
+// NOTE ON COVERAGE: the positive path -- a frame the process source could not
+// name being named from its module file -- is NOT unit-tested here. It needs a
+// real ELF with ordinary .dynsym/.symtab plus a live mapping; a Go test binary
+// keeps its symbols in .gopclntab, which the ELF source does not read, and
+// reaching a C library's symbols needs dlsym, which this package's tests
+// cannot use (cgo is not supported in _test.go here). Building the mapping
+// arithmetic into the test instead would duplicate procmap.AddressMapper --
+// the very code the retry depends on -- so a shared mistake would pass.
+// That path is covered by measurement on a real capture: PyTorch libtorch
+// frames went from 156 named / 306 module+offset to 421 named / 0, and the
+// whole profile from 59% module+offset to 25%. See issue #125.
+func TestRetrySkipsFramesItCannotAskAbout(t *testing.T) {
+	s := newRetryTestSymbolizer(t)
+	defer func() { _ = s.Close() }()
+
+	cases := map[string]Frame{
+		"already resolved":  {Address: 0x1000, Reason: FailureNone, Name: "known", Module: "/bin/sh", MapStart: 0x1000},
+		"no module":         {Address: 0x1000, Reason: FailureMissingSymbols, MapStart: 0x1000},
+		"no mapping":        {Address: 0x1000, Reason: FailureMissingSymbols, Module: "/bin/sh"},
+		"sentinel [kernel]": {Address: 0x1000, Reason: FailureMissingSymbols, Module: "[kernel]", MapStart: 0x1000},
+		"unreadable module": {Address: 0x1000, Reason: FailureMissingSymbols, Module: "/nonexistent/x.so", MapStart: 0x800},
+	}
+	for name, f := range cases {
+		t.Run(name, func(t *testing.T) {
+			before := f
+			frames := []Frame{f}
+			s.retryAgainstModuleFiles(frames)
+			got := frames[0]
+			// Field by field: Frame carries an Inlined slice and is not
+			// comparable with ==.
+			if got.Name != before.Name || got.Reason != before.Reason ||
+				got.Module != before.Module || got.Address != before.Address ||
+				got.Offset != before.Offset {
+				t.Fatalf("frame must be untouched, was %+v now %+v", before, got)
+			}
+		})
+	}
+}
+
+// A module the retry cannot open must be counted as "could not look", not
+// silently ignored: a run that recovers nothing because every file was
+// unreadable must not read like one where the two sources simply agreed.
+func TestUnreadableModuleIsCountedAsAFailedLook(t *testing.T) {
+	s := newRetryTestSymbolizer(t)
+	defer func() { _ = s.Close() }()
+
+	frames := []Frame{{
+		Address: 0x1000, Reason: FailureMissingSymbols,
+		Module: "/nonexistent/does-not-exist.so", MapStart: 0x800,
+	}}
+	s.retryAgainstModuleFiles(frames)
+
+	if got := s.Stats().FileRetryFailed; got != 1 {
+		t.Fatalf("FileRetryFailed = %d, want 1", got)
+	}
+	if got := s.Stats().FileRetryNamed; got != 0 {
+		t.Fatalf("FileRetryNamed = %d, want 0", got)
+	}
+}

--- a/symbolize/local.go
+++ b/symbolize/local.go
@@ -7,10 +7,13 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	blazesym "github.com/libbpf/blazesym/go"
+
+	"github.com/dpsoft/perf-agent/unwind/procmap"
 )
 
 // ErrClosed is returned from operations on a closed Symbolizer.
@@ -27,8 +30,10 @@ var ErrMapFilesUnavailable = errors.New("symbolize: cannot follow /proc/<pid>/ma
 type LocalSymbolizer struct {
 	bz      *blazesym.Symbolizer
 	modules ModuleIndex
-	closed  atomic.Bool
-	stats   localCounters
+	// batchErrs deduplicates the batch-failure log by message.
+	batchErrs sync.Map
+	closed    atomic.Bool
+	stats     localCounters
 }
 
 // LocalOption configures a LocalSymbolizer.
@@ -60,6 +65,13 @@ type localCounters struct {
 	rawAddrBatches  atomic.Uint64
 	modulesAttached atomic.Uint64
 	modulesBare     atomic.Uint64
+
+	// The module-file retry. Named counts frames the process source could not
+	// name and the file source could: a disagreement between two views of one
+	// address, so zero is the healthy value and non-zero is the size of what
+	// the process source was dropping.
+	fileRetryNamed  atomic.Uint64
+	fileRetryFailed atomic.Uint64
 
 	// How much wall time symbolization actually cost, and over how many
 	// calls. A profiler that takes two minutes to write a five-second capture
@@ -95,6 +107,14 @@ type LocalStats struct {
 	// a run where it never happens must not look like one where it always
 	// did.
 	ModulesBare uint64
+
+	// FileRetryNamed counts frames the process source could not name and the
+	// file source then could, for the same address. Zero is the healthy value.
+	FileRetryNamed uint64
+	// FileRetryFailed counts modules the retry could not ask about at all.
+	// Kept apart from Named so "recovered nothing" and "could not look" stay
+	// different facts.
+	FileRetryFailed uint64
 
 	// Calls is how many times SymbolizeProcess ran, and TotalNs the wall time
 	// inside it. Calls far exceeding the number of distinct processes means
@@ -137,6 +157,8 @@ func (s *LocalSymbolizer) Stats() LocalStats {
 		RawAddrBatches:  s.stats.rawAddrBatches.Load(),
 		ModulesAttached: s.stats.modulesAttached.Load(),
 		ModulesBare:     s.stats.modulesBare.Load(),
+		FileRetryNamed:  s.stats.fileRetryNamed.Load(),
+		FileRetryFailed: s.stats.fileRetryFailed.Load(),
 		Calls:           s.stats.calls.Load(),
 		TotalNs:         s.stats.totalNs.Load(),
 		SlowestNs:       s.stats.slowestNs.Load(),
@@ -273,8 +295,21 @@ func (s *LocalSymbolizer) SymbolizeProcess(pid uint32, ips []uint64) ([]Frame, e
 	)
 	s.noteCall(pid, time.Since(start))
 	if err != nil {
+		// The whole batch failed. Every frame becomes a raw address, and
+		// withModules then places each one in a file -- so the module and the
+		// mapping ARE known here even though no name is.
+		//
+		// That is exactly the input the file-source retry needs, and this is
+		// where it matters most: measured on a PyTorch capture, a single
+		// failed batch turned 35 of 35 frames into module+offset, 17 of them
+		// in libtorch, whose symbols are present on disk and recoverable.
+		// Before this, the retry ran only on the success path, so the frames
+		// that needed it most were the only ones it never saw.
 		s.stats.rawAddrBatches.Add(1)
-		return s.withModules(pid, rawUserAddrFrames(ips)), nil
+		frames := s.withModules(pid, rawUserAddrFrames(ips))
+		s.retryAgainstModuleFiles(frames)
+		s.noteBatchFailure(pid, err)
+		return frames, nil
 	}
 	out := make([]Frame, 0, len(syms))
 	for i, sym := range syms {
@@ -284,7 +319,111 @@ func (s *LocalSymbolizer) SymbolizeProcess(pid uint32, ips []uint64) ([]Frame, e
 		}
 		out = append(out, fromBlazesymSym(sym, addr))
 	}
-	return s.withModules(pid, out), nil
+	frames := s.withModules(pid, out)
+	s.retryAgainstModuleFiles(frames)
+	return frames, nil
+}
+
+// noteBatchFailure records why a batch failed, once per distinct message.
+//
+// The batch-failure path used to be silent apart from a counter nothing
+// printed, and its doc comment asserted the realistic cause was the process
+// having exited. That assertion went unchecked for as long as the counter went
+// unread: in the capture that motivated this, batches failed while the target
+// was demonstrably alive and still launching kernels. Keeping the reason makes
+// the next such claim falsifiable.
+func (s *LocalSymbolizer) noteBatchFailure(pid uint32, err error) {
+	msg := err.Error()
+	if _, seen := s.batchErrs.LoadOrStore(msg, struct{}{}); seen {
+		return
+	}
+	log.Printf("symbolize: batch failed for pid %d: %v (frames fall back to module+offset; "+
+		"names recovered from module files where possible)", pid, msg)
+}
+
+// retryAgainstModuleFiles re-asks blazesym for the frames the PROCESS source
+// could not name, this time against the module file at a file offset.
+//
+// The two sources disagree, and the file source is the one that is right.
+// Measured, for addresses the process source returned missing_symbols for:
+//
+//	0x28f4874 -> at::_ops::add_Tensor::redispatch(...)
+//	0x5119b46 -> torch::autograd::VariableType::(anonymous namespace)::add_Tensor(...)
+//
+// Same library, same addresses, same instant. The second is a .symtab-only
+// symbol which a dynamic-symbol view cannot see; the first is inside an
+// exported .dynsym symbol and should have resolved either way, so "the process
+// source only reads .dynsym" does not fully explain it and is not claimed
+// here. What is established is the disagreement and its direction.
+//
+// Only frames that already carry a module AND a mapping are retried:
+// MapStart/MapOff are what make a file offset computable, and a bare address
+// has nothing to ask about. Frames are grouped by module, so a stack N frames
+// deep into one library costs one call rather than N -- symbolization cost is
+// not a free variable here (issue #109).
+//
+// Failure is not an error: a frame neither source can name keeps the
+// module+offset rendering it already had. This can only add names.
+func (s *LocalSymbolizer) retryAgainstModuleFiles(frames []Frame) {
+	var byModule map[string][]int
+	for i := range frames {
+		f := &frames[i]
+		if f.Reason == FailureNone || f.Module == "" || f.MapStart == 0 {
+			continue
+		}
+		if strings.HasPrefix(f.Module, "[") {
+			continue // [kernel], [jit] and friends are not files
+		}
+		if byModule == nil {
+			byModule = make(map[string][]int, 4)
+		}
+		byModule[f.Module] = append(byModule[f.Module], i)
+	}
+	for mod, idxs := range byModule {
+		// Address - MapStart + MapOff is a FILE offset; blazesym wants a
+		// VIRTUAL one. The two coincide only when a segment's p_vaddr equals
+		// its p_offset -- true of the CUDA and libtorch shared objects, and
+		// false of, say, a non-PIE executable, where the difference is the
+		// whole load address. Getting this wrong does not fail loudly: it
+		// asks about a valid-looking offset and returns a confidently wrong
+		// name. procmap.AddressMapper reads the program headers and does the
+		// conversion properly; symbolize/debuginfod already relies on it.
+		mapper, merr := procmap.NewAddressMapper(mod)
+		if merr != nil {
+			s.stats.fileRetryFailed.Add(1)
+			continue
+		}
+		offs := make([]uint64, 0, len(idxs))
+		keep := make([]int, 0, len(idxs))
+		for _, i := range idxs {
+			fileOff := frames[i].Address - frames[i].MapStart + frames[i].MapOff
+			va, ok := mapper.FileOffsetToVirtualAddress(fileOff)
+			if !ok {
+				continue
+			}
+			offs = append(offs, va)
+			keep = append(keep, i)
+		}
+		if len(offs) == 0 {
+			continue
+		}
+		idxs = keep
+		syms, err := s.bz.SymbolizeElfVirtOffsets(offs, mod, blazesym.ElfSourceWithDebugSyms(true))
+		if err != nil || len(syms) != len(idxs) {
+			s.stats.fileRetryFailed.Add(1)
+			continue
+		}
+		for j, i := range idxs {
+			if syms[j].Name == "" {
+				continue
+			}
+			f := &frames[i]
+			f.Name = syms[j].Name
+			f.Offset = offs[j]
+			f.Reason = FailureNone
+			s.stats.fileRetryNamed.Add(1)
+		}
+	}
 }
 
 // withModules names the module behind every frame blazesym left unresolved,


### PR DESCRIPTION
A PyTorch GPU capture rendered **59% of its frames as `module+offset`**, including the entire
dispatch path — `at::_ops::mm::redispatch`, `at::native::structured_mm_out_cuda::impl`,
`at::cuda::blas::gemm_internal_cublas`. Those symbols are on disk: `libtorch_cpu.so` carries a
`.symtab` and 60,777 exported functions, and blazesym names every one of those addresses when
asked against the file.

## Cause

An early return:

```go
if err != nil {
    s.stats.rawAddrBatches.Add(1)
    return s.withModules(pid, rawUserAddrFrames(ips)), nil
}
```

When the process source fails a **whole batch** — blazesym returns `unsupported` — every frame
becomes a raw address, `withModules` places each one in a file, and the function returns. The
module and the mapping are known at that point; only the name is missing, and the name is
recoverable from the module file.

It was invisible from outside: `RawAddrBatches` is a counter no GPU tool prints, and the path's own
comment asserted the realistic cause was the process having exited — an assertion that went
unchecked for exactly as long as the counter went unread. In these captures batches fail while the
target is alive and still launching kernels.

## Result

Same workload, unmodified binary as control:

| | control | fixed |
|---|---|---|
| libtorch frames | 156 named / **306** module+offset | **421 named / 0** |
| whole profile | 786/1325 module+offset (**59%**) | 320/1286 (**25%**) |
| runtime | 14s | 14s |

Recovered names include `at::native::add_kernel`, `threshold_kernel_cuda`,
`wrapper_CUDA_add_Tensor`.

## Two things worth reviewing closely

**The conversion is not open-coded.** `Address - MapStart + MapOff` is a *file* offset while
blazesym wants a *virtual* one. They coincide only when a segment's `p_vaddr` equals its
`p_offset` — true of the CUDA and libtorch shared objects, false of a non-PIE executable, where the
difference is the whole load address and the result is a confidently wrong name rather than a
visible error. A unit test caught this on the first version. It now uses
`procmap.AddressMapper.FileOffsetToVirtualAddress`, which `symbolize/debuginfod` already relies on.

**Scope is measured, not assumed.** C++ CUDA and both Rust CUDA workloads record **zero** batch
failures and are byte-identical with and without this change. The remaining 25% is NVIDIA library
internals with genuinely no symbols: asked about 9,964 such frames across a run, the file source
recovered none — the correct answer, and why the retry is worth nothing on the success path where
it originally lived.

## Test coverage, stated honestly

The negative paths are unit-tested (frames the retry must leave untouched, and an unreadable module
counted as "could not look" rather than silently ignored).

The **positive** path is not unit-tested, and the test file says why: it needs a real ELF with
ordinary `.dynsym`/`.symtab` plus a live mapping. A Go test binary keeps its symbols in
`.gopclntab`, which the ELF source does not read; reaching a C library's symbols needs `dlsym`, and
cgo is not supported in `_test.go` in this package. Building the mapping arithmetic into the test
would duplicate `procmap.AddressMapper` — the very code the retry depends on — so a shared mistake
would pass. That path is covered by the measurement above.

Only frames that already carry a module and a mapping are retried, grouped by module so a stack N
frames deep into one library costs one call rather than N. Failure is not an error: a frame neither
source can name keeps the rendering it already had. This can only add names.
