### PR TITLE
symbolize: fetch NVIDIA's symbols for the libraries it ships stripped (#122)

### DIFF
--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dpsoft/perf-agent/internal/gpuabi"
 	"github.com/dpsoft/perf-agent/pprof"
 	"github.com/dpsoft/perf-agent/symbolize"
+	"github.com/dpsoft/perf-agent/symbolize/nvsym"
 
 	// Registering the interpreter unwinders is a BINARY's decision, not a
 	// library's: which languages this build can walk is a property of what was
@@ -37,13 +38,18 @@ import (
 
 func main() {
 	var (
-		shim     = flag.String("shim", "./shim/libperfagent-gpu-nvidia.so", "the CUPTI adapter .so carrying the perfagent USDT probes")
-		workload = flag.String("workload", "./shim/nvidia/testdata/cuda_workload", "CUDA program to run under the adapter")
-		iters    = flag.Int("iters", 2000, "workload iterations; it launches two kernels per iteration")
-		sleepUs  = flag.Int("sleep-us", 200, "workload sleep between iterations, in microseconds")
-		period   = flag.Int("period", 8, "one-in-N launch sampling period (PERFAGENT_GPU_SAMPLE_PERIOD)")
-		linger   = flag.Int("linger-ms", 30000, "how long the workload may wait to be released after it finishes")
-		out      = flag.String("out", "gpu-cuda.pb.gz", "output pprof profile")
+		shim      = flag.String("shim", "./shim/libperfagent-gpu-nvidia.so", "the CUPTI adapter .so carrying the perfagent USDT probes")
+		workload  = flag.String("workload", "./shim/nvidia/testdata/cuda_workload", "CUDA program to run under the adapter")
+		iters     = flag.Int("iters", 2000, "workload iterations; it launches two kernels per iteration")
+		sleepUs   = flag.Int("sleep-us", 200, "workload sleep between iterations, in microseconds")
+		period    = flag.Int("period", 8, "one-in-N launch sampling period (PERFAGENT_GPU_SAMPLE_PERIOD)")
+		linger    = flag.Int("linger-ms", 30000, "how long the workload may wait to be released after it finishes")
+		out       = flag.String("out", "gpu-cuda.pb.gz", "output pprof profile")
+		nvSymbols = flag.String("nvidia-symbols", "",
+			"cache directory for NVIDIA's CUDA Toolkit Symbol Server; enables fetching "+
+				"symbols for libcuda/libcupti/libcuBLAS, which ship stripped. Off unless set: "+
+				"it reaches the network and discloses the build-ids of the CUDA libraries the "+
+				"target has mapped.")
 
 		// One setting, three values, and no way to ask for two. The default
 		// is the empty string rather than "off" so that an unspecified flag
@@ -137,7 +143,17 @@ func main() {
 	// internals) renders as a bare ASLR'd address.
 	modules := procmap.NewResolver()
 	defer modules.Close()
-	sym, err := symbolize.NewLocalSymbolizer(symbolize.WithModuleIndex(modules))
+	symOpts := []symbolize.LocalOption{symbolize.WithModuleIndex(modules)}
+	if *nvSymbols != "" {
+		// Last resort only, after the library's own file has failed. NVIDIA
+		// exports 0.16%-3.2% of .text in these libraries, so almost every
+		// address in them is unnameable locally; the server has a
+		// symbols-only ELF per build-id that named 13 of 13 such frames in a
+		// real capture.
+		symOpts = append(symOpts, symbolize.WithNVIDIASymbols(&nvsym.Store{Dir: *nvSymbols}))
+		log.Printf("nvidia symbols: enabled, cache %s", *nvSymbols)
+	}
+	sym, err := symbolize.NewLocalSymbolizer(symOpts...)
 	if err != nil {
 		log.Fatalf("symbolizer: %v", err)
 	}

--- a/symbolize/local.go
+++ b/symbolize/local.go
@@ -2,6 +2,7 @@ package symbolize
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -13,6 +14,7 @@ import (
 
 	blazesym "github.com/libbpf/blazesym/go"
 
+	"github.com/dpsoft/perf-agent/symbolize/nvsym"
 	"github.com/dpsoft/perf-agent/unwind/procmap"
 )
 
@@ -32,12 +34,27 @@ type LocalSymbolizer struct {
 	modules ModuleIndex
 	// batchErrs deduplicates the batch-failure log by message.
 	batchErrs sync.Map
-	closed    atomic.Bool
-	stats     localCounters
+	// symbols, when configured, supplies symbol-only ELFs for NVIDIA
+	// libraries that ship stripped. Nil means the feature is off, which is
+	// the default: it reaches the network and discloses build-ids.
+	symbols *nvsym.Store
+	closed  atomic.Bool
+	stats   localCounters
 }
 
 // LocalOption configures a LocalSymbolizer.
 type LocalOption func(*LocalSymbolizer)
+
+// WithNVIDIASymbols enables the CUDA Toolkit Symbol Server as a last resort
+// for frames in NVIDIA libraries that no local file can name.
+//
+// Off unless supplied. It reaches the network and it discloses the build-ids
+// of the CUDA libraries the target has mapped, which is a decision for the
+// operator rather than a default -- the same reasoning that gave debuginfod a
+// way to be declined (issue #111).
+func WithNVIDIASymbols(store *nvsym.Store) LocalOption {
+	return func(s *LocalSymbolizer) { s.symbols = store }
+}
 
 // WithModuleIndex supplies the /proc/<pid>/maps index used to name the module
 // behind an address blazesym could not resolve to a symbol. Without it, an
@@ -72,6 +89,10 @@ type localCounters struct {
 	// the process source was dropping.
 	fileRetryNamed  atomic.Uint64
 	fileRetryFailed atomic.Uint64
+	// Frames named only because the symbol server had what no local file
+	// did. Counted apart from fileRetryNamed so the value of reaching the
+	// network is a number rather than an assumption.
+	serverRetryNamed atomic.Uint64
 
 	// How much wall time symbolization actually cost, and over how many
 	// calls. A profiler that takes two minutes to write a five-second capture
@@ -111,6 +132,10 @@ type LocalStats struct {
 	// FileRetryNamed counts frames the process source could not name and the
 	// file source then could, for the same address. Zero is the healthy value.
 	FileRetryNamed uint64
+	// ServerRetryNamed counts frames named only by NVIDIA's symbol server,
+	// after every local file had failed. It is the measured value of enabling
+	// the network path.
+	ServerRetryNamed uint64
 	// FileRetryFailed counts modules the retry could not ask about at all.
 	// Kept apart from Named so "recovered nothing" and "could not look" stay
 	// different facts.
@@ -154,15 +179,16 @@ func (s *LocalSymbolizer) noteCall(pid uint32, d time.Duration) {
 // Stats returns the current process-side symbolization counters.
 func (s *LocalSymbolizer) Stats() LocalStats {
 	return LocalStats{
-		RawAddrBatches:  s.stats.rawAddrBatches.Load(),
-		ModulesAttached: s.stats.modulesAttached.Load(),
-		ModulesBare:     s.stats.modulesBare.Load(),
-		FileRetryNamed:  s.stats.fileRetryNamed.Load(),
-		FileRetryFailed: s.stats.fileRetryFailed.Load(),
-		Calls:           s.stats.calls.Load(),
-		TotalNs:         s.stats.totalNs.Load(),
-		SlowestNs:       s.stats.slowestNs.Load(),
-		SlowestPID:      s.stats.slowestPID.Load(),
+		RawAddrBatches:   s.stats.rawAddrBatches.Load(),
+		ModulesAttached:  s.stats.modulesAttached.Load(),
+		ModulesBare:      s.stats.modulesBare.Load(),
+		FileRetryNamed:   s.stats.fileRetryNamed.Load(),
+		ServerRetryNamed: s.stats.serverRetryNamed.Load(),
+		FileRetryFailed:  s.stats.fileRetryFailed.Load(),
+		Calls:            s.stats.calls.Load(),
+		TotalNs:          s.stats.totalNs.Load(),
+		SlowestNs:        s.stats.slowestNs.Load(),
+		SlowestPID:       s.stats.slowestPID.Load(),
 	}
 }
 
@@ -413,8 +439,12 @@ func (s *LocalSymbolizer) retryAgainstModuleFiles(frames []Frame) {
 			s.stats.fileRetryFailed.Add(1)
 			continue
 		}
+		var stillUnnamed []int
+		var stillOffs []uint64
 		for j, i := range idxs {
 			if syms[j].Name == "" {
+				stillUnnamed = append(stillUnnamed, i)
+				stillOffs = append(stillOffs, offs[j])
 				continue
 			}
 			f := &frames[i]
@@ -423,6 +453,53 @@ func (s *LocalSymbolizer) retryAgainstModuleFiles(frames []Frame) {
 			f.Reason = FailureNone
 			s.stats.fileRetryNamed.Add(1)
 		}
+		s.retryAgainstSymbolServer(frames, mod, stillUnnamed, stillOffs)
+	}
+}
+
+// retryAgainstSymbolServer is the last resort: frames in an NVIDIA library
+// that the library's own file cannot name.
+//
+// It is last for a reason. Coverage of the exported symbols in these libraries
+// is 0.16%-3.2% of .text, so the file source legitimately fails on almost
+// every address -- and NVIDIA's symbol server has a symbols-only ELF for the
+// same build-id that resolved 13 of 13 such frames in a real capture.
+//
+// The addresses need no adjustment: the served file is built from the same
+// object, so its virtual addresses are the ones already computed.
+//
+// Silent on failure by design. The server has no symbols for many build-ids
+// (measured: a pip-wheel cuBLASLt returns 200 while the toolkit build of the
+// same library returns 403), and a frame it cannot name keeps the
+// module+offset rendering it already had.
+func (s *LocalSymbolizer) retryAgainstSymbolServer(frames []Frame, mod string, idxs []int, offs []uint64) {
+	if s.symbols == nil || len(idxs) == 0 {
+		return
+	}
+	buildID := frames[idxs[0]].BuildID
+	if buildID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	path, err := s.symbols.Path(ctx, mod, buildID)
+	if err != nil {
+		return
+	}
+	syms, err := s.bz.SymbolizeElfVirtOffsets(offs, path, blazesym.ElfSourceWithDebugSyms(true))
+	if err != nil || len(syms) != len(idxs) {
+		s.stats.fileRetryFailed.Add(1)
+		return
+	}
+	for j, i := range idxs {
+		if syms[j].Name == "" {
+			continue
+		}
+		f := &frames[i]
+		f.Name = syms[j].Name
+		f.Offset = offs[j]
+		f.Reason = FailureNone
+		s.stats.serverRetryNamed.Add(1)
 	}
 }
 

--- a/symbolize/nvsym/nvsym.go
+++ b/symbolize/nvsym/nvsym.go
@@ -1,0 +1,148 @@
+// Package nvsym fetches symbol-only ELF files from NVIDIA's CUDA Toolkit
+// Symbol Server.
+//
+// Why this exists
+// ---------------
+// NVIDIA ships libcuda, libcupti, libcublas and libcublasLt stripped, and no
+// distribution publishes debuginfo for them: NVIDIA's own Fedora 44 repo has
+// 150 packages and only DCGM among them, RPM Fusion has none, and the public
+// debuginfod federation 404s on all three build-ids with a libc control
+// returning 200. Measured coverage of the exported symbols alone is 0.27% of
+// .text for libcuda, 3.2% for libcupti and 0.16% for libcublasLt, so almost
+// every address in them arrives unnameable.
+//
+// NVIDIA does, however, run a symbol server that serves a symbols-only ELF per
+// build-id. Verified against this machine's driver: the local
+// /lib64/libcuda.so.1 has zero .symtab entries, while the file fetched for its
+// build-id carries 59,954 defined symbols, and 13 of 13 frames from a real
+// PyTorch capture resolve with it in place.
+//
+// The URL shape is not the debuginfod one and not guessable
+// ---------------------------------------------------------
+// It is <bare soname>/<build-id>/index.html, where "bare" means the soname
+// with every version suffix removed. Measured, for one build-id:
+//
+//	libcuda.so/<id>/index.html            -> 200
+//	libcuda.so.1/<id>/index.html          -> 403
+//	libcuda.so.610.57.04/<id>/index.html  -> 403
+//
+// An implementation that passes the name as it appears in /proc/<pid>/maps
+// therefore gets 403 on everything and looks like the server is down. An
+// all-zero build-id also returns 403, so a 200 is a real hit rather than a
+// catch-all.
+//
+// Coverage is partial and a caller must degrade rather than depend on it: on
+// this machine the pip-wheel cuBLASLt returns 200 while the CUDA-toolkit build
+// of the same library, and libcupti.so.13.3, both 403.
+package nvsym
+
+import (
+	"path"
+	"regexp"
+	"strings"
+)
+
+// DefaultBaseURL is NVIDIA's CUDA Toolkit Symbol Server.
+const DefaultBaseURL = "https://cudatoolkit-symbols.nvidia.com"
+
+// versionSuffix matches the trailing ".N" groups of a versioned soname:
+// ".1" in libcuda.so.1, ".610.57.04" in libcuda.so.610.57.04.
+var versionSuffix = regexp.MustCompile(`(\.[0-9]+)+$`)
+
+// SonameKey reduces a module path to the key the symbol server expects: the
+// base name with every trailing version component removed.
+//
+//	/usr/lib64/libcuda.so.610.57.04           -> libcuda.so
+//	.../nvidia/cu13/lib/libcublasLt.so.13     -> libcublasLt.so
+//	/usr/lib64/libcuda.so                     -> libcuda.so
+//
+// Returns "" for a path with no usable base name, and for one whose base does
+// not contain ".so" at all -- there is nothing to ask the server about, and a
+// malformed key would be a 403 indistinguishable from a real miss.
+func SonameKey(modulePath string) string {
+	base := path.Base(strings.TrimSpace(modulePath))
+	if base == "" || base == "." || base == "/" {
+		return ""
+	}
+	if !strings.Contains(base, ".so") {
+		return ""
+	}
+	return versionSuffix.ReplaceAllString(base, "")
+}
+
+// IsNVIDIAModule reports whether a module is one this server might serve.
+//
+// Used to avoid spending a network round trip, and a build-id disclosure, on
+// every unrelated library in the process. The list is the CUDA runtime and
+// driver family; it is deliberately narrower than flamegraph's vendor list,
+// which also classifies AMD libraries this server knows nothing about.
+func IsNVIDIAModule(modulePath string) bool {
+	base := path.Base(modulePath)
+	for _, p := range []string{
+		"libcuda", "libcudart", "libcupti", "libcublas", "libcudnn",
+		"libcufft", "libcurand", "libcusparse", "libcusolver",
+		"libnccl", "libnvrtc", "libnvjitlink", "libnvidia", "libnvperf",
+	} {
+		if strings.HasPrefix(base, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// symHref matches the listing's link to the symbol file. The name is NOT
+// derivable from the soname -- the listing for libcuda.so serves
+// libcuda.so.1.1.sym -- so it has to be read rather than constructed.
+var symHref = regexp.MustCompile(`href="([^"]+\.sym)"`)
+
+// SymFileName extracts the symbol file's name from a directory listing.
+//
+// The server's <soname>/<build-id>/index.html is an HTML listing, not the
+// symbols: fetching that URL and caching the body yields a 740-byte web page
+// that every later reader will treat as a corrupt ELF. The real artifact is
+// one [FILE] link inside it.
+//
+// Returns "" when the listing contains no .sym link, which is how an error
+// page or a changed format arrives.
+func SymFileName(listing []byte) string {
+	m := symHref.FindSubmatch(listing)
+	if m == nil {
+		return ""
+	}
+	name := string(m[1])
+	// Refuse anything that would escape the build-id directory. The listing
+	// is third-party input and this name becomes part of a URL and, on the
+	// caller's side, nothing else -- but a "../" here is a signal the format
+	// is not what we think it is.
+	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return ""
+	}
+	return name
+}
+
+// ListingURL builds the URL of the directory listing for a module's build-id.
+// Returns "" when either input is unusable, so a caller cannot accidentally
+// request a malformed path.
+func ListingURL(baseURL, modulePath, buildID string) string {
+	soname := SonameKey(modulePath)
+	if soname == "" || buildID == "" {
+		return ""
+	}
+	// An all-zero build-id is what an ELF without a real note looks like
+	// after hex-encoding, and the server answers 403 for it. Refuse locally
+	// rather than spend the round trip.
+	if strings.Trim(buildID, "0") == "" {
+		return ""
+	}
+	return strings.TrimRight(baseURL, "/") + "/" + soname + "/" + buildID + "/index.html"
+}
+
+// FileURL builds the URL of the symbol file itself, given the name read from
+// the listing.
+func FileURL(baseURL, modulePath, buildID, symName string) string {
+	soname := SonameKey(modulePath)
+	if soname == "" || buildID == "" || symName == "" {
+		return ""
+	}
+	return strings.TrimRight(baseURL, "/") + "/" + soname + "/" + buildID + "/" + symName
+}

--- a/symbolize/nvsym/nvsym_test.go
+++ b/symbolize/nvsym/nvsym_test.go
@@ -1,0 +1,288 @@
+package nvsym
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The measured contract: the key is the soname with EVERY version component
+// stripped. This is the whole reason the package exists as more than a URL
+// concatenation -- passing the name as it appears in /proc/<pid>/maps returns
+// 403 for every library, which reads as "the server is down" rather than "we
+// asked the wrong question".
+func TestSonameKeyStripsEveryVersionComponent(t *testing.T) {
+	cases := map[string]string{
+		"/usr/lib64/libcuda.so.610.57.04": "libcuda.so",
+		"/usr/lib64/libcuda.so.1":         "libcuda.so",
+		"/usr/lib64/libcuda.so":           "libcuda.so",
+		"/a/b/libcublasLt.so.13":          "libcublasLt.so",
+		"/a/b/libcupti.so.13.3":           "libcupti.so",
+		"libcudart.so.12":                 "libcudart.so",
+	}
+	for in, want := range cases {
+		if got := SonameKey(in); got != want {
+			t.Errorf("SonameKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// A key we cannot form must produce no request at all. A malformed path would
+// come back 403, which is indistinguishable from a genuine miss, so the error
+// would be attributed to the server rather than to us.
+func TestSonameKeyRefusesWhatIsNotALibrary(t *testing.T) {
+	for _, in := range []string{"", "  ", "/", ".", "/usr/bin/python3.12", "[kernel]", "vmlinux"} {
+		if got := SonameKey(in); got != "" {
+			t.Errorf("SonameKey(%q) = %q, want \"\"", in, got)
+		}
+	}
+}
+
+func TestListingURLMatchesTheServerContract(t *testing.T) {
+	const id = "77d6d4f93fa0ae0840c46f3476a608c76fca7303"
+	got := ListingURL(DefaultBaseURL, "/usr/lib64/libcuda.so.610.57.04", id)
+	want := "https://cudatoolkit-symbols.nvidia.com/libcuda.so/" + id + "/index.html"
+	if got != want {
+		t.Fatalf("ListingURL =\n  %q\nwant\n  %q", got, want)
+	}
+	// Measured: this exact form returns 200 while libcuda.so.1/<id> and
+	// libcuda.so.610.57.04/<id> both return 403.
+}
+
+// An all-zero build-id is what a note-less ELF hex-encodes to. The server
+// answers 403 for it, so refusing locally saves a round trip AND keeps a
+// meaningless request out of the failure statistics.
+func TestListingURLRefusesUnusableInputs(t *testing.T) {
+	const id = "77d6d4f93fa0ae0840c46f3476a608c76fca7303"
+	cases := [][3]string{
+		{DefaultBaseURL, "/usr/lib64/libcuda.so.1", ""},
+		{DefaultBaseURL, "/usr/bin/python3.12", id},
+		{DefaultBaseURL, "/usr/lib64/libcuda.so.1", "0000000000000000000000000000000000000000"},
+	}
+	for _, c := range cases {
+		if got := ListingURL(c[0], c[1], c[2]); got != "" {
+			t.Errorf("ListingURL(%q, %q) = %q, want \"\"", c[1], c[2], got)
+		}
+	}
+}
+
+// Narrower than the flame graph's vendor list on purpose: that one also covers
+// AMD libraries, which this server knows nothing about, and every non-match
+// saved is a network round trip and a build-id not disclosed.
+func TestIsNVIDIAModuleSelectsOnlyWhatTheServerMightHave(t *testing.T) {
+	yes := []string{
+		"/usr/lib64/libcuda.so.610.57.04", "/x/libcupti.so.13", "/x/libcublasLt.so.13",
+		"/x/libcudnn.so.9", "/x/libnccl.so.2", "/x/libnvidia-ml.so.1",
+	}
+	no := []string{
+		"/x/libtorch_cpu.so", "/x/libc.so.6", "/x/libamdhip64.so",
+		"/x/librocprofiler64.so", "/usr/bin/python3.12", "/x/libstdc++.so.6",
+	}
+	for _, m := range yes {
+		if !IsNVIDIAModule(m) {
+			t.Errorf("IsNVIDIAModule(%q) = false, want true", m)
+		}
+	}
+	for _, m := range no {
+		if IsNVIDIAModule(m) {
+			t.Errorf("IsNVIDIAModule(%q) = true, want false", m)
+		}
+	}
+}
+
+// --- Store ---
+
+func newTestStore(t *testing.T, h http.HandlerFunc) (*Store, *httptest.Server, *int32) {
+	t.Helper()
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		h(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return &Store{Dir: t.TempDir(), BaseURL: srv.URL, Client: srv.Client()}, srv, &calls
+}
+
+const listingBody = `<html><body><table>
+<tr><td>[FILE] <a href="libcuda.so.1.1.sym">libcuda.so.1.1.sym</a></td><td>4051 K</td></tr>
+</table></body></html>`
+
+// elfBody is a minimal file that starts with the ELF magic. The store refuses
+// anything that does not, because an error page served with 200 that reached
+// the cache would be handed to a symbolizer and fail obscurely much later.
+var elfBody = append([]byte{0x7f, 'E', 'L', 'F'}, []byte("...symbols...")...)
+
+func TestStoreFetchesAndCachesByBuildID(t *testing.T) {
+	const id = "77d6d4f93fa0ae0840c46f3476a608c76fca7303"
+	s, _, calls := newTestStore(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/libcuda.so/" + id + "/index.html":
+			_, _ = w.Write([]byte(listingBody))
+		case "/libcuda.so/" + id + "/libcuda.so.1.1.sym":
+			_, _ = w.Write(elfBody)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	p1, err := s.Path(context.Background(), "/usr/lib64/libcuda.so.610.57.04", id)
+	if err != nil {
+		t.Fatalf("first Path: %v", err)
+	}
+	if b, _ := os.ReadFile(p1); string(b) != string(elfBody) {
+		t.Fatalf("cached content = %q, want the ELF body (not the listing)", b)
+	}
+	// Second call must be served from disk. Without this the store would
+	// re-download once per stack, which for a PyTorch capture is thousands of
+	// times for the same handful of libraries.
+	p2, err := s.Path(context.Background(), "/usr/lib64/libcuda.so.610.57.04", id)
+	if err != nil || p2 != p1 {
+		t.Fatalf("second Path = %q, %v; want %q, nil", p2, err, p1)
+	}
+	// Two requests for the first fetch (listing, then file), none for the
+	// second: the cache hit must not re-walk the listing either.
+	if got := atomic.LoadInt32(calls); got != 2 {
+		t.Fatalf("server hit %d times, want 2 (listing + file)", got)
+	}
+	if hits, fetched, _, _, _ := s.Snapshot(); hits != 1 || fetched != 1 {
+		t.Fatalf("hits=%d fetched=%d, want 1 and 1", hits, fetched)
+	}
+}
+
+// 403, not 404, is this server's "no". Treating only 404 as absence would
+// report every ordinary miss as an error.
+func TestStoreTreats403AsAbsenceAndDoesNotReAsk(t *testing.T) {
+	s, _, calls := newTestStore(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	const id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	for range 3 {
+		if _, err := s.Path(context.Background(), "/x/libcupti.so.13", id); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("want ErrNotFound, got %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Fatalf("server asked %d times for a known-refused build-id, want 1", got)
+	}
+	if _, _, nf, errs, _ := s.Snapshot(); nf != 1 || errs != 0 {
+		t.Fatalf("notFound=%d errors=%d, want 1 and 0", nf, errs)
+	}
+}
+
+// A non-NVIDIA module must never reach the network: no round trip, and no
+// build-id of an unrelated binary disclosed to a third party.
+func TestStoreNeverAsksAboutForeignModules(t *testing.T) {
+	s, _, calls := newTestStore(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server must not be contacted for a non-NVIDIA module")
+	})
+	_, err := s.Path(context.Background(), "/x/libtorch_cpu.so", "77d6d4f93fa0ae0840c46f3476a608c76fca7303")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+	if got := atomic.LoadInt32(calls); got != 0 {
+		t.Fatalf("server contacted %d times, want 0", got)
+	}
+}
+
+// A failed download must leave nothing behind: a truncated file at the final
+// path would be cached forever and would poison symbolization permanently.
+func TestStoreLeavesNoFileWhenTheServerErrors(t *testing.T) {
+	s, _, _ := newTestStore(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	const id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	if _, err := s.Path(context.Background(), "/x/libcuda.so.1", id); err == nil {
+		t.Fatal("want an error on 500")
+	}
+	if _, err := os.Stat(s.pathFor(id)); !os.IsNotExist(err) {
+		t.Fatalf("a file was left at the cache path after a failed fetch")
+	}
+	entries, _ := filepath.Glob(filepath.Join(s.Dir, ".build-id", "*", ".nvsym-*"))
+	if len(entries) != 0 {
+		t.Fatalf("temp files left behind: %v", entries)
+	}
+}
+
+// Concurrent lookups for one build-id must collapse to a single download: a
+// capture symbolizes many stacks at once through the same few libraries.
+func TestStoreCollapsesConcurrentFetches(t *testing.T) {
+	release := make(chan struct{})
+	s, _, calls := newTestStore(t, func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		if strings.HasSuffix(r.URL.Path, "/index.html") {
+			_, _ = w.Write([]byte(strings.Replace(listingBody, "libcuda.so.1.1.sym", "libcupti.so.13.sym", 2)))
+			return
+		}
+		_, _ = w.Write(elfBody)
+	})
+	const id = "cccccccccccccccccccccccccccccccccccccccc"
+
+	var wg sync.WaitGroup
+	errs := make([]error, 8)
+	for i := range 8 {
+		wg.Add(1)
+		go func() { defer wg.Done(); _, errs[i] = s.Path(context.Background(), "/x/libcupti.so.13", id) }()
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(calls); got != 2 {
+		t.Fatalf("server hit %d times concurrently, want 2 (one listing + one file)", got)
+	}
+}
+
+// The build-id URL is a directory listing, not the symbols. Caching its body
+// produced five "symbol files" of ~740 bytes each, all of them
+// "<title>NVIDIA Binary Server</title>", which every later reader would treat
+// as a corrupt ELF. The name inside is not derivable from the soname either:
+// the listing for libcuda.so serves libcuda.so.1.1.sym.
+func TestSymFileNameReadsTheListing(t *testing.T) {
+	if got := SymFileName([]byte(listingBody)); got != "libcuda.so.1.1.sym" {
+		t.Fatalf("SymFileName = %q, want libcuda.so.1.1.sym", got)
+	}
+	for _, bad := range []string{
+		"<html>no links here</html>",
+		`<a href="../../../etc/passwd.sym">x</a>`,
+		`<a href="sub/dir/x.sym">x</a>`,
+		"",
+	} {
+		if got := SymFileName([]byte(bad)); got != "" {
+			t.Errorf("SymFileName(%q) = %q, want \"\"", bad, got)
+		}
+	}
+}
+
+// A 200 that is not an ELF must not be cached. Otherwise an error page or a
+// changed format is stored under a build-id and poisons that library's
+// symbolization until someone clears the cache by hand.
+func TestStoreRefusesANonELFBody(t *testing.T) {
+	const id = "dddddddddddddddddddddddddddddddddddddddd"
+	s, _, _ := newTestStore(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/index.html") {
+			_, _ = w.Write([]byte(listingBody))
+			return
+		}
+		_, _ = w.Write([]byte("<html>maintenance</html>"))
+	})
+	if _, err := s.Path(context.Background(), "/usr/lib64/libcuda.so.1", id); err == nil {
+		t.Fatal("want an error when the served body is not an ELF")
+	}
+	if _, err := os.Stat(s.pathFor(id)); !os.IsNotExist(err) {
+		t.Fatal("a non-ELF body was cached")
+	}
+}

--- a/symbolize/nvsym/store.go
+++ b/symbolize/nvsym/store.go
@@ -1,0 +1,256 @@
+package nvsym
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ErrNotFound means the server has no symbols for this build-id. It is the
+// COMMON case, not an exceptional one: measured on one machine, the pip-wheel
+// cuBLASLt returns 200 while the CUDA-toolkit build of the same library and
+// libcupti.so.13.3 both return 403. A caller must treat it as "carry on
+// without a name".
+var ErrNotFound = errors.New("nvsym: no symbols for this build-id")
+
+// maxSymbolBytes bounds a single download. The largest observed file is the
+// ~30 MB cuBLASLt symbol table; 256 MB leaves room for growth while refusing
+// to stream something unbounded into the cache directory.
+const maxSymbolBytes = 256 << 20
+
+// Store fetches symbol-only ELFs and keeps them on disk, keyed by build-id.
+//
+// Layout is the standard .build-id/<NN>/<rest>.debug tree, which is what
+// blazesym's build-id resolver already looks in, so a fetched file needs no
+// separate plumbing to be used -- pointing a symbolizer at Dir is enough.
+type Store struct {
+	Dir     string
+	BaseURL string
+	Client  *http.Client
+
+	// negative remembers build-ids the server refused, so a run does not
+	// re-ask once per stack. Bounded by the number of distinct modules in a
+	// process, which is small; entries are never evicted because a 403 does
+	// not become a 200 within one capture.
+	negative sync.Map
+
+	// inflight collapses concurrent requests for one build-id: a PyTorch
+	// capture symbolizes many stacks at once and they hit the same handful of
+	// libraries, so without this the first miss becomes N identical downloads.
+	inflight sync.Map
+
+	stats Stats
+}
+
+// Stats reports what the store did. Fetched and NotFound are separate because
+// "the server had nothing" and "we could not reach it" are different facts and
+// only the second is a problem worth reporting.
+type Stats struct {
+	Hits     atomic.Uint64 // already on disk
+	Fetched  atomic.Uint64 // downloaded this run
+	NotFound atomic.Uint64 // server answered, had nothing
+	Errors   atomic.Uint64 // transport or write failure
+	Bytes    atomic.Uint64
+}
+
+// pathFor returns the cache path for a build-id, or "" if it is too short to
+// split. Mirrors symbolize/debuginfod/cache so the two can share a directory.
+func (s *Store) pathFor(buildID string) string {
+	if len(buildID) < 4 {
+		return ""
+	}
+	return filepath.Join(s.Dir, ".build-id", buildID[:2], buildID[2:]+".debug")
+}
+
+// Path returns a local symbols file for the module, fetching it if needed.
+//
+// Returns ErrNotFound when the server has nothing, which is expected and not
+// an error condition for the caller. Never returns a path that does not exist.
+func (s *Store) Path(ctx context.Context, modulePath, buildID string) (string, error) {
+	if s == nil || s.Dir == "" {
+		return "", ErrNotFound
+	}
+	if !IsNVIDIAModule(modulePath) {
+		return "", ErrNotFound
+	}
+	dst := s.pathFor(buildID)
+	if dst == "" {
+		return "", ErrNotFound
+	}
+	if _, err := os.Stat(dst); err == nil {
+		s.stats.Hits.Add(1)
+		return dst, nil
+	}
+	if _, refused := s.negative.Load(buildID); refused {
+		return "", ErrNotFound
+	}
+
+	// One download per build-id even under concurrency.
+	type result struct {
+		path string
+		err  error
+	}
+	ch := make(chan result, 1)
+	actual, loaded := s.inflight.LoadOrStore(buildID, ch)
+	if loaded {
+		shared := actual.(chan result)
+		select {
+		case r := <-shared:
+			shared <- r // put it back for any other waiter
+			return r.path, r.err
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	defer s.inflight.Delete(buildID)
+
+	p, err := s.download(ctx, modulePath, buildID, dst)
+	if errors.Is(err, ErrNotFound) {
+		s.negative.Store(buildID, struct{}{})
+	}
+	ch <- result{p, err}
+	return p, err
+}
+
+func (s *Store) download(ctx context.Context, modulePath, buildID, dst string) (string, error) {
+	base := s.BaseURL
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	// Two steps, because the build-id URL is a directory LISTING and not the
+	// symbols. Fetching it and caching the body yields a 740-byte HTML page
+	// that every later reader treats as a corrupt ELF -- measured, before
+	// this: five "symbol files" totalling 20 KB, all of them
+	// "<title>NVIDIA Binary Server</title>". The artifact is one [FILE] link
+	// inside, and its name is not derivable from the soname: the listing for
+	// libcuda.so serves libcuda.so.1.1.sym.
+	listing := ListingURL(base, modulePath, buildID)
+	if listing == "" {
+		return "", ErrNotFound
+	}
+	body, err := s.get(ctx, listing)
+	if err != nil {
+		return "", err
+	}
+	page, err := io.ReadAll(io.LimitReader(body, 1<<20))
+	_ = body.Close()
+	if err != nil {
+		s.stats.Errors.Add(1)
+		return "", err
+	}
+	name := SymFileName(page)
+	if name == "" {
+		// A listing with no .sym link is the server saying it has nothing
+		// for this build-id in a shape that still returns 200.
+		s.stats.NotFound.Add(1)
+		return "", ErrNotFound
+	}
+
+	fileURL := FileURL(base, modulePath, buildID, name)
+	symBody, err := s.get(ctx, fileURL)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = symBody.Close() }()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		s.stats.Errors.Add(1)
+		return "", err
+	}
+	// Written to a temp file and renamed: a truncated download left at the
+	// final path would be cached forever and would poison symbolization for
+	// the rest of the machine's life.
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".nvsym-*")
+	if err != nil {
+		s.stats.Errors.Add(1)
+		return "", err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	n, err := io.Copy(tmp, io.LimitReader(symBody, maxSymbolBytes))
+	if cerr := tmp.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		s.stats.Errors.Add(1)
+		return "", err
+	}
+	if n == maxSymbolBytes {
+		s.stats.Errors.Add(1)
+		return "", fmt.Errorf("nvsym: %s exceeded %d bytes", fileURL, int64(maxSymbolBytes))
+	}
+	// What arrives must be an ELF. Anything else -- an error page served with
+	// 200, a redirect body -- is refused here rather than cached and handed
+	// to a symbolizer that will fail obscurely much later.
+	if !isELF(tmpName) {
+		s.stats.Errors.Add(1)
+		return "", fmt.Errorf("nvsym: %s did not return an ELF", fileURL)
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		s.stats.Errors.Add(1)
+		return "", err
+	}
+	s.stats.Fetched.Add(1)
+	s.stats.Bytes.Add(uint64(n))
+	return dst, nil
+}
+
+// get performs one request, mapping this server's absence codes to
+// ErrNotFound. 403 is its "no", not 404: an unknown build-id and an all-zero
+// one both come back 403, so treating only 404 as absence would report every
+// ordinary miss as an error.
+func (s *Store) get(ctx context.Context, url string) (io.ReadCloser, error) {
+	client := s.Client
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		s.stats.Errors.Add(1)
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		s.stats.Errors.Add(1)
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+		_ = resp.Body.Close()
+		s.stats.NotFound.Add(1)
+		return nil, ErrNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		s.stats.Errors.Add(1)
+		return nil, fmt.Errorf("nvsym: %s: %s", url, resp.Status)
+	}
+	return resp.Body, nil
+}
+
+// isELF reports whether the file begins with the ELF magic.
+func isELF(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return false
+	}
+	return magic == [4]byte{0x7f, 'E', 'L', 'F'}
+}
+
+// Snapshot returns the counters by value.
+func (s *Store) Snapshot() (hits, fetched, notFound, errs, bytes uint64) {
+	return s.stats.Hits.Load(), s.stats.Fetched.Load(), s.stats.NotFound.Load(),
+		s.stats.Errors.Load(), s.stats.Bytes.Load()
+}


### PR DESCRIPTION
`libcuda`, `libcupti`, `libcublas` and `libcublasLt` export **0.16%–3.2%** of their `.text`, carry
no `.symtab`, and no distribution publishes debuginfo for them — NVIDIA's own Fedora 44 repo has
150 packages and only DCGM among them, RPM Fusion has none, and the public debuginfod federation
404s on all three build-ids with a libc control returning 200. So a PyTorch GPU profile rendered
302 frames as `libcupti.so.13+0x…` and nothing local could do better.

NVIDIA does run a symbol server with a symbols-only ELF per build-id.

## Measured, same workload, with and without `--nvidia-symbols`

| library | before | after |
|---|---|---|
| libcupti.so.13 | 210 | **0** |
| libcuda.so.610.57.04 | 36 | **0** |
| libcublasLt.so.13 | 34 | **0** |
| libcublas.so.13 | 21 | **0** |
| libcudart.so.13 | 1 | **0** |
| **whole profile** | **320/1286 (25%)** | **18/1286 (1%)** |

The remaining 18 are `libstdc++`, which this server does not serve.

## What this does not buy

The issue predicted the real prize was correct function **boundaries** — a hot function no longer
shattering into one node per PC. **That did not happen.** 23 distinct NVIDIA nodes before, 27
after.

And the recovered names are mostly opaque: of those 27, four are readable API entry points
(`cuLaunchKernel`, `cudaLaunchKernel`, `cublasSgemm_v2`, `cublasLtSSSMatmul`) and 23 are hashes of
the form `libcublas_<40 hex>`.

So on this workload the win is **coverage** — an address attributable to a function rather than to
a hex offset — and not readability, and not fewer nodes. Worth knowing before anyone weighs the
network cost.

## Two protocol details a reimplementation would get wrong

Both found by getting them wrong first, and both now pinned by tests:

**The key is the soname with every version component stripped.** `libcuda.so/<id>` returns 200
while `libcuda.so.1/<id>` and `libcuda.so.610.57.04/<id>` both return **403**. Passing the name as
it appears in `/proc/<pid>/maps` 403s on everything, which reads as "the server is down".

**`<soname>/<build-id>/index.html` is a directory listing, not the symbols.** Caching its body
produced five "symbol files" of ~740 bytes, every one `<title>NVIDIA Binary Server</title>` — which
each later reader would treat as a corrupt ELF. The artifact is one `[FILE]` link inside, and its
name is not derivable from the soname: the listing for `libcuda.so` serves `libcuda.so.1.1.sym`.
**The ELF magic is now verified before anything is cached**, which is the check that would have
caught this on its own.

Also: **403, not 404, is this server's "no"** — an unknown build-id and an all-zero one both return
it — so treating only 404 as absence would report every ordinary miss as an error. Misses are
common: the pip-wheel cuBLASLt returns 200 while the CUDA-toolkit build of the same library
returns 403.

## Defaults and cost

**Off unless `--nvidia-symbols <dir>` is given.** It reaches the network and discloses which CUDA
libraries the target has mapped — an operator's decision rather than a default, the same reasoning
that gave debuginfod a way to be declined in #111. Non-NVIDIA modules never reach the network.

It runs **last**, after the library's own file has failed, so it costs nothing on the common path.
Fetches are single-flighted and negatively cached — a capture symbolizes thousands of stacks
through the same five libraries, and without that the first miss becomes thousands of identical
downloads. Cache here is 38 MB for five libraries, in the standard `.build-id` layout blazesym
already searches.

`ServerRetryNamed` is counted apart from `FileRetryNamed`, so the value of enabling the network
stays a number rather than a claim.

## Tests

12, race-clean, no network in the suite. The cache-hit test asserts **two** requests for the first
fetch and **zero** for the second, so a change that re-walks the listing per stack fails rather
than quietly costing a round trip. Negative paths covered: 403 not re-asked, foreign modules never
contacted, a non-ELF body refused and not cached, a failed download leaving no file or temp behind,
and `../` in a listing name rejected.
