### PR TITLE
symbolize: never fetch symbols on the capture path (#122)

### DIFF
--- a/symbolize/local.go
+++ b/symbolize/local.go
@@ -2,7 +2,6 @@ package symbolize
 
 import (
 	"bufio"
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -480,10 +479,11 @@ func (s *LocalSymbolizer) retryAgainstSymbolServer(frames []Frame, mod string, i
 	if buildID == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	path, err := s.symbols.Path(ctx, mod, buildID)
-	if err != nil {
+	// Cache-only: this runs on the GPU consumer's capture path, and a
+	// blocking fetch here loses GPU executions rather than merely delaying
+	// them. A miss warms the cache in the background for the next run.
+	path, ok := s.symbols.Cached(mod, buildID)
+	if !ok {
 		return
 	}
 	syms, err := s.bz.SymbolizeElfVirtOffsets(offs, path, blazesym.ElfSourceWithDebugSyms(true))

--- a/symbolize/nvsym/nvsym_test.go
+++ b/symbolize/nvsym/nvsym_test.go
@@ -286,3 +286,65 @@ func TestStoreRefusesANonELFBody(t *testing.T) {
 		t.Fatal("a non-ELF body was cached")
 	}
 }
+
+// The hot-path contract: Cached must never block on the network. The GPU
+// consumer calls it on the goroutine draining the USDT ring buffer, and a
+// blocking fetch there does not merely delay the profile, it loses GPU
+// executions -- measured, 32,000 all-matched became 11,920 with 1,095
+// unmatched when the fetch was synchronous.
+func TestCachedNeverBlocksOnTheNetwork(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	s, _, _ := newTestStore(t, func(w http.ResponseWriter, r *http.Request) {
+		<-block // a server that never answers
+	})
+	const id = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if p, ok := s.Cached("/x/libcupti.so.13", id); ok {
+			t.Errorf("Cached reported a hit for an unfetched build-id: %q", p)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Cached blocked on the network; it must return immediately")
+	}
+}
+
+// A miss must warm the cache for next time, exactly once per build-id however
+// many stacks miss on it.
+func TestCachedPrefetchesOncePerBuildID(t *testing.T) {
+	var served int32
+	s, _, _ := newTestStore(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&served, 1)
+		if strings.HasSuffix(r.URL.Path, "/index.html") {
+			_, _ = w.Write([]byte(listingBody))
+			return
+		}
+		_, _ = w.Write(elfBody)
+	})
+	const id = "ffffffffffffffffffffffffffffffffffffffff"
+
+	for range 50 {
+		if _, ok := s.Cached("/usr/lib64/libcuda.so.1", id); ok {
+			t.Fatal("first lookups must miss")
+		}
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := s.Cached("/usr/lib64/libcuda.so.1", id); ok {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, ok := s.Cached("/usr/lib64/libcuda.so.1", id); !ok {
+		t.Fatal("background prefetch never populated the cache")
+	}
+	// listing + file, once -- not once per missing stack.
+	if got := atomic.LoadInt32(&served); got != 2 {
+		t.Fatalf("server served %d requests, want 2 (one prefetch)", got)
+	}
+}

--- a/symbolize/nvsym/store.go
+++ b/symbolize/nvsym/store.go
@@ -41,6 +41,10 @@ type Store struct {
 	// not become a 200 within one capture.
 	negative sync.Map
 
+	// prefetching records build-ids a background fill has been started for,
+	// so a miss on every stack does not spawn a goroutine per stack.
+	prefetching sync.Map
+
 	// inflight collapses concurrent requests for one build-id: a PyTorch
 	// capture symbolizes many stacks at once and they hit the same handful of
 	// libraries, so without this the first miss becomes N identical downloads.
@@ -69,7 +73,55 @@ func (s *Store) pathFor(buildID string) string {
 	return filepath.Join(s.Dir, ".build-id", buildID[:2], buildID[2:]+".debug")
 }
 
+// Cached returns a symbols file for the module ONLY if it is already on disk,
+// and never touches the network.
+//
+// This is what a caller on a latency-sensitive path must use. The GPU consumer
+// symbolizes DURING the capture, on the goroutine draining the USDT ring
+// buffer, so a blocking HTTP request there stalls the drain and executions are
+// lost: measured, the same Rust CUDA workload recorded 32,000 executions all
+// matched with the network path disabled, and 11,920 with 1,095 unmatched with
+// it enabled -- two thirds of the GPU work simply missing from the profile.
+//
+// A miss schedules a background fetch, so the cache is warm for the next run
+// and the cost is paid once, off the hot path, by nobody who is waiting.
+func (s *Store) Cached(modulePath, buildID string) (string, bool) {
+	if s == nil || s.Dir == "" || !IsNVIDIAModule(modulePath) {
+		return "", false
+	}
+	dst := s.pathFor(buildID)
+	if dst == "" {
+		return "", false
+	}
+	if _, err := os.Stat(dst); err == nil {
+		s.stats.Hits.Add(1)
+		return dst, true
+	}
+	s.prefetch(modulePath, buildID)
+	return "", false
+}
+
+// prefetch fills the cache in the background, at most once per build-id per
+// process. Errors are silent by design: nothing is waiting on the result, and
+// a miss simply means this run renders module+offset as it did before.
+func (s *Store) prefetch(modulePath, buildID string) {
+	if _, refused := s.negative.Load(buildID); refused {
+		return
+	}
+	if _, started := s.prefetching.LoadOrStore(buildID, struct{}{}); started {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+		_, _ = s.Path(ctx, modulePath, buildID)
+	}()
+}
+
 // Path returns a local symbols file for the module, fetching it if needed.
+//
+// BLOCKING. Callers on a capture path must use Cached instead; see its comment
+// for what a blocking fetch there costs.
 //
 // Returns ErrNotFound when the server has nothing, which is expected and not
 // an error condition for the caller. Never returns a path that does not exist.


### PR DESCRIPTION
#128 put a **blocking HTTP fetch inside `SymbolizeProcess`**. The GPU consumer calls that on the
goroutine draining the USDT ring buffer, *during* the capture — so the fetch did not merely delay
the profile, it lost GPU work.

Same Rust CUDA workload, same binary, flag toggled:

| | executions | matched |
|---|---|---|
| without `--nvidia-symbols` | 32,000 | all exact, all matched |
| with `--nvidia-symbols` | 11,920 | **1,095 unmatched** |
| with `--nvidia-symbols` (again) | 20,216 | **2,579 unmatched** |

Two thirds of the device time absent from the profile, with nothing in the output saying so beyond
an `unmatched` count that reads like ordinary sampling. The signal was present in the run that
measured the naming win too — `829 unmatched` — and I took the naming number and moved on.

## Fix

The hot path is now `Cached()`: a disk check that never touches the network. A miss schedules **one
background prefetch per build-id**, so the cache warms for the next run and nothing on the capture
path waits. `Path()` keeps the blocking behaviour for callers that are not on a capture path, and
its doc now says which callers those are.

After the fix, all three configurations: **32,000 executions, all exact, all matched.**

## The trade, stated

A **first** run against a cold cache now gets no symbols and renders `module+offset` exactly as
before. The **second** run gets the full recovery (25% → 1%).

That is deliberate. A profile that looks complete while missing two thirds of its GPU time is worse
than one that is honestly unsymbolized for one run.

## Tests

Both halves of the contract:

- `Cached` returns immediately against a server that never answers — the property that broke.
- Fifty missing lookups produce **one** prefetch (listing + file), not one per stack.
