### PR TITLE
pyunwind: name Python frames from the live interpreter (#83)

### DIFF
--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -2822,7 +2822,12 @@ func (c *Consumer) resolveStackLocked(pid uint32, stackID int32) ([]pp.Frame, bo
 				c.stats.StackInterpFrames++
 				merged = append(merged, symbolize.Frame{
 					Address: sl.PC,
-					Name:    sl.Name(),
+					// NameFor, not Name: this runs during the capture,
+					// while the target is alive, which is the only moment a
+					// Python code object can be read into
+					// "Widget.method_here (train.py:42)". After it exits only
+					// the address form is honest.
+					Name: sl.NameFor(pid),
 					// Not FailureNone: the frame is placed correctly and its
 					// address is real, but nothing named it, and pprof has no
 					// unsymbolized bit of its own to infer that from later.

--- a/pyunwind/codeobject.go
+++ b/pyunwind/codeobject.go
@@ -1,0 +1,122 @@
+package pyunwind
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// CodeOffsets locates the fields of a PyCodeObject that name a frame.
+//
+// Zero means "not measured for this interpreter", and a zero table makes the
+// resolver decline rather than read whatever happens to be at offset 0. That
+// is the same discipline the frame offsets follow: a version this build has
+// not been measured against renders python:0x… exactly as before, which is
+// honest, instead of a plausible-looking name read from the wrong field.
+type CodeOffsets struct {
+	Qualname  uint16 // PyObject *co_qualname  ("Widget.method_here")
+	Filename  uint16 // PyObject *co_filename
+	FirstLine uint16 // int co_firstlineno
+}
+
+// Measured returns whether this build knows where to look.
+func (c CodeOffsets) Measured() bool { return c.Qualname != 0 && c.Filename != 0 }
+
+// PyASCIIObject's layout, which carries every co_qualname and co_filename in
+// practice: they are compact ASCII, being identifiers and paths.
+//
+// Not per-version: this header has been stable across the versions this
+// package supports, and the state bits below are checked on every read, so a
+// layout that moved is caught as "not compact ascii" and declined rather than
+// decoded into nonsense.
+const (
+	asciiLengthOff = 16 // Py_ssize_t length
+	asciiStateOff  = 32 // struct { unsigned int interned:2; kind:3; compact:1; ascii:1; ... }
+	asciiDataOff   = 40 // sizeof(PyASCIIObject): the payload follows the header
+)
+
+// maxPyStringBytes bounds a single decoded string. A qualname or a path beyond
+// this is not something to render; it is a sign the address was not a string
+// at all, and reading it would be an unbounded read into the target.
+const maxPyStringBytes = 4096
+
+// CodeInfo is what a code object says about a frame.
+type CodeInfo struct {
+	Qualname  string // "Widget.method_here" -- qualified, not the bare co_name
+	Filename  string
+	FirstLine uint32
+}
+
+// readPyASCII decodes a compact-ASCII PyUnicodeObject at addr.
+//
+// The compact and ascii state bits are verified rather than assumed. A
+// non-compact or non-ASCII string (a path with non-ASCII characters, a
+// legacy-layout object) is declined: its payload is not where this reads, and
+// a wrong answer here becomes a wrong function name in a flame graph, which is
+// worse than no name.
+func readPyASCII(r *ProcReader, addr uint64) (string, error) {
+	if addr == 0 {
+		return "", fmt.Errorf("pyunwind: nil string")
+	}
+	lenB, err := r.read(addr+asciiLengthOff, 8)
+	if err != nil {
+		return "", err
+	}
+	n := binary.LittleEndian.Uint64(lenB)
+	if n == 0 {
+		return "", nil
+	}
+	if n > maxPyStringBytes {
+		return "", fmt.Errorf("pyunwind: implausible string length %d", n)
+	}
+	stateB, err := r.read(addr+asciiStateOff, 4)
+	if err != nil {
+		return "", err
+	}
+	state := binary.LittleEndian.Uint32(stateB)
+	const compactBit, asciiBit = 1 << 5, 1 << 6
+	if state&compactBit == 0 || state&asciiBit == 0 {
+		return "", fmt.Errorf("pyunwind: not compact-ascii (state=%#x)", state)
+	}
+	b, err := r.read(addr+asciiDataOff, int(n))
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// ReadCodeInfo reads the naming fields out of one PyCodeObject.
+//
+// The target must be ALIVE: this reads its memory. Callers on a profiler's
+// collect path have already lost that race -- see the resolver's cache, which
+// exists so the reads happen during the capture and the names survive the
+// process.
+func ReadCodeInfo(r *ProcReader, off CodeOffsets, codeObject uint64) (CodeInfo, error) {
+	var out CodeInfo
+	if !off.Measured() {
+		return out, fmt.Errorf("pyunwind: code offsets not measured for this interpreter")
+	}
+	if codeObject == 0 {
+		return out, fmt.Errorf("pyunwind: nil code object")
+	}
+	qnPtr, err := r.ReadU64(codeObject + uint64(off.Qualname))
+	if err != nil {
+		return out, err
+	}
+	fnPtr, err := r.ReadU64(codeObject + uint64(off.Filename))
+	if err != nil {
+		return out, err
+	}
+	if out.Qualname, err = readPyASCII(r, qnPtr); err != nil {
+		return out, err
+	}
+	if out.Filename, err = readPyASCII(r, fnPtr); err != nil {
+		return out, err
+	}
+	if off.FirstLine != 0 {
+		lb, lerr := r.read(codeObject+uint64(off.FirstLine), 4)
+		if lerr == nil {
+			out.FirstLine = binary.LittleEndian.Uint32(lb)
+		}
+	}
+	return out, nil
+}

--- a/pyunwind/codeobject_live_test.go
+++ b/pyunwind/codeobject_live_test.go
@@ -1,0 +1,182 @@
+package pyunwind
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// pythonFor returns an interpreter this test can measure against, or skips.
+// The child-process relationship matters: reading /proc/<pid>/mem of a
+// non-child of the same user is refused under the default yama ptrace_scope=1,
+// and the profiler holds CAP_SYS_PTRACE where this test does not.
+func pythonFor(t *testing.T) string {
+	t.Helper()
+	for _, p := range []string{
+		"/home/diego/pytorch-profile-test/.venv/bin/python",
+		"python3.12",
+	} {
+		if path, err := exec.LookPath(p); err == nil {
+			out, err := exec.Command(path, "-V").Output()
+			if err == nil && strings.Contains(string(out), "3.12") {
+				return path
+			}
+		}
+	}
+	t.Skip("no CPython 3.12 available; code offsets are only measured for 3.12")
+	return ""
+}
+
+const namingTarget = `
+import sys, time
+def outer_function(): pass
+class Widget:
+    def method_here(self): pass
+for name, fn in (("outer_function", outer_function), ("method_here", Widget.method_here)):
+    print(f"{name} {id(fn.__code__)}", flush=True)
+print("READY", flush=True)
+time.sleep(60)
+`
+
+// startNamedTarget runs an interpreter that prints the addresses of code
+// objects whose names the test already knows, so resolution is checked against
+// ground truth rather than against "it returned something".
+func startNamedTarget(t *testing.T) (*exec.Cmd, map[string]uint64) {
+	t.Helper()
+	py := pythonFor(t)
+	script := t.TempDir() + "/target.py"
+	if err := os.WriteFile(script, []byte(namingTarget), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	cmd := exec.Command(py, script)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
+
+	addrs := map[string]uint64{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc := bufio.NewScanner(stdout)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "READY" {
+				return
+			}
+			f := strings.Fields(line)
+			if len(f) == 2 {
+				if a, err := strconv.ParseUint(f[1], 0, 64); err == nil {
+					addrs[f[0]] = a
+				}
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("interpreter did not report its code objects")
+	}
+	if len(addrs) != 2 {
+		t.Fatalf("expected 2 code objects, got %v", addrs)
+	}
+	return cmd, addrs
+}
+
+// The whole point: a code object becomes a name a person recognises.
+func TestResolvesCodeObjectsToQualifiedNames(t *testing.T) {
+	cmd, addrs := startNamedTarget(t)
+	off := CodeOffsets{Qualname: 128, Filename: 112, FirstLine: 68}
+	r := NewResolver(cmd.Process.Pid, off)
+	if r == nil {
+		t.Fatal("resolver declined despite measured offsets")
+	}
+
+	// co_qualname, not co_name: a method must carry its class, or a flame
+	// graph row reading "method_here" is unidentifiable among the dozens of
+	// classes that have one.
+	info, ok := r.Resolve(addrs["method_here"])
+	if !ok {
+		t.Fatalf("could not resolve the method's code object")
+	}
+	if info.Qualname != "Widget.method_here" {
+		t.Errorf("Qualname = %q, want %q (qualified, not bare co_name)", info.Qualname, "Widget.method_here")
+	}
+	if !strings.HasSuffix(info.Filename, "target.py") {
+		t.Errorf("Filename = %q, want it to end in target.py", info.Filename)
+	}
+	if info.FirstLine == 0 {
+		t.Errorf("FirstLine = 0, want the def's line")
+	}
+
+	if got := r.Name(addrs["outer_function"]); !strings.HasPrefix(got, "outer_function (target.py:") {
+		t.Errorf("Name = %q, want it to start with outer_function (target.py:", got)
+	}
+}
+
+// Reads must happen once. The name has to outlive the process, and re-reading
+// per sample would both cost a syscall per frame and stop working the moment
+// the target exits -- which is exactly when a profiler builds its output.
+func TestResolutionIsCachedPerCodeObject(t *testing.T) {
+	cmd, addrs := startNamedTarget(t)
+	r := NewResolver(cmd.Process.Pid, CodeOffsets{Qualname: 128, Filename: 112, FirstLine: 68})
+
+	for range 50 {
+		if _, ok := r.Resolve(addrs["method_here"]); !ok {
+			t.Fatal("resolution failed")
+		}
+	}
+	s := r.Stats()
+	if s.Resolved != 1 {
+		t.Errorf("Resolved = %d, want exactly 1 read for 50 lookups", s.Resolved)
+	}
+	if s.Cached != 49 {
+		t.Errorf("Cached = %d, want 49", s.Cached)
+	}
+}
+
+// A name read after the target exits would be a name read from nothing. The
+// cache must answer anyway -- that is what it is for.
+func TestCachedNamesSurviveTheProcess(t *testing.T) {
+	cmd, addrs := startNamedTarget(t)
+	r := NewResolver(cmd.Process.Pid, CodeOffsets{Qualname: 128, Filename: 112, FirstLine: 68})
+	want, ok := r.Resolve(addrs["method_here"])
+	if !ok {
+		t.Fatal("resolution failed while the target was alive")
+	}
+
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+
+	got, ok := r.Resolve(addrs["method_here"])
+	if !ok || got.Qualname != want.Qualname {
+		t.Fatalf("after exit: got %+v ok=%v, want the cached %+v", got, ok, want)
+	}
+	// And an address never seen must now fail rather than invent something.
+	if _, ok := r.Resolve(addrs["outer_function"]); ok {
+		t.Error("resolved an uncached address after the process exited")
+	}
+}
+
+// An unmeasured interpreter must decline, not read offset 0 and render
+// whatever is there as a function name.
+func TestUnmeasuredInterpreterDeclines(t *testing.T) {
+	if r := NewResolver(os.Getpid(), CodeOffsets{}); r != nil {
+		t.Fatal("NewResolver must return nil when offsets are not measured")
+	}
+	var nilResolver *Resolver
+	if _, ok := nilResolver.Resolve(0x1234); ok {
+		t.Error("a nil resolver must decline")
+	}
+	if got := nilResolver.Name(0x1234); got != "python:0x1234" {
+		t.Errorf("Name = %q, want the unresolved form python:0x1234", got)
+	}
+}

--- a/pyunwind/module.go
+++ b/pyunwind/module.go
@@ -27,6 +27,23 @@ func init() {
 	interp.RegisterRenderer(UnwinderID, func(codeObject, _ uint64) string {
 		return FrameName(codeObject)
 	})
+	// And the live form. Registered beside the renderer rather than instead
+	// of it: this one needs the process, the other one must keep working when
+	// there is no process left.
+	interp.RegisterNamer(UnwinderID, func(pid uint32, codeObject, _ uint64) (string, bool) {
+		r := resolverFor(pid)
+		if r == nil {
+			return "", false
+		}
+		info, ok := r.Resolve(codeObject)
+		if !ok || info.Qualname == "" {
+			return "", false
+		}
+		if info.Filename == "" {
+			return info.Qualname, true
+		}
+		return fmt.Sprintf("%s (%s:%d)", info.Qualname, baseName(info.Filename), info.FirstLine), true
+	})
 }
 
 // FrameName renders an unsymbolized Python frame. Turning the code object into
@@ -145,11 +162,31 @@ func (m *module) Enroll(pid uint32) (interp.Range, bool, error) {
 		}
 		spans = append(spans, interp.Span{Lo: f.Lo, Hi: f.Hi})
 	}
+	// Install the code-object resolver for this process, now that its
+	// interpreter version -- and therefore whether this build has measured
+	// code offsets for it at all -- is known.
+	//
+	// Here rather than at collect time, because resolution reads the target's
+	// memory and the target is alive exactly now. Names read during the
+	// capture are cached and outlive it; a name first asked for afterwards
+	// cannot be read at all.
+	if off, terr := TableFor(res.Version); terr == nil {
+		if r := NewResolver(int(pid), off.Code); r != nil {
+			InstallResolver(pid, r)
+		} else {
+			log.Printf("python frames: pid %d: CPython %s has no measured code-object "+
+				"offsets in this build; frames stay python:0x…", pid, res.Version)
+		}
+	}
+
 	log.Printf("python frames: pid %d: attached %s (CPython %s)", pid, libPath, res.Version)
 	return interp.Range{TableID: tableID, Spans: spans}, true, nil
 }
 
-func (m *module) Detach(pid uint32) error { return DetachProcess(pid, m.maps) }
+func (m *module) Detach(pid uint32) error {
+	RemoveResolver(pid)
+	return DetachProcess(pid, m.maps)
+}
 
 // Counters renders py_walk_counters as one line.
 //

--- a/pyunwind/offsets.go
+++ b/pyunwind/offsets.go
@@ -68,6 +68,11 @@ const (
 // ParseAutoTSSKeyOffset, so it needs no table entry and survives distro
 // patching. See the spec.
 type Offsets struct {
+	// Code locates the PyCodeObject fields that name a frame. Zero for a
+	// version this build has not been measured against, which makes the
+	// resolver decline and the frame render python:0x… exactly as before.
+	Code CodeOffsets
+
 	// _PyInterpreterFrame
 	FramePrevious uint16 // struct _PyInterpreterFrame *previous
 
@@ -204,6 +209,14 @@ func TableFor(v Version) (Offsets, error) {
 		// at offset 56, and _PyCFrame's own current_frame is its first
 		// field (offset 0).
 		return Offsets{
+			// Measured with offsetof against CPython 3.12.14's own
+			// headers (see offsets_fixture_test.go for the mechanism):
+			// co_filename=112, co_name=120, co_qualname=128,
+			// co_firstlineno=68. co_qualname rather than co_name, because
+			// it is the qualified form -- "Widget.method_here" rather than
+			// "method_here" -- which is what makes a flame graph row
+			// identifiable without its parents.
+			Code:                     CodeOffsets{Qualname: 128, Filename: 112, FirstLine: 68},
 			FramePrevious:            8,
 			FrameExecutable:          0,
 			FrameExecutableTagged:    false,

--- a/pyunwind/resolver.go
+++ b/pyunwind/resolver.go
@@ -1,0 +1,165 @@
+package pyunwind
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Resolver turns code-object addresses into names for one process, and
+// remembers what it found.
+//
+// WHY IT CACHES, which is the whole design
+// ----------------------------------------
+// Reading a name means reading the target's memory, so it only works while the
+// target is alive. A profiler builds its output after the workload has exited
+// -- the GPU tools do it explicitly, and even the CPU ones resolve at collect
+// time -- so a name looked up at render time is a name that cannot be looked
+// up at all. Every read therefore happens during the capture, and the cache is
+// what carries the answer past the process's death.
+//
+// Code objects are immortal for the life of the interpreter and are reused for
+// every call of the same function, so the cache is small and its hit rate is
+// high: a PyTorch capture with 213 Python frames touches far fewer distinct
+// code objects than that.
+type Resolver struct {
+	reader *ProcReader
+	off    CodeOffsets
+
+	mu    sync.RWMutex
+	cache map[uint64]CodeInfo
+	// misses records addresses that could not be read, so a broken one is
+	// attempted once rather than once per sample.
+	misses map[uint64]struct{}
+
+	stats ResolverStats
+}
+
+// ResolverStats reports what resolution achieved. Hits and Misses are kept
+// apart from Declined because "we looked and failed" and "this build cannot
+// look at this interpreter" are different facts and only the first is a defect.
+type ResolverStats struct {
+	Resolved uint64
+	Cached   uint64
+	Failed   uint64
+	Declined uint64
+}
+
+// NewResolver returns a resolver for pid, or nil when this build has no
+// measured code offsets for the interpreter. A nil *Resolver is usable: its
+// Resolve declines, and the frame keeps the python:0x… form.
+func NewResolver(pid int, off CodeOffsets) *Resolver {
+	if !off.Measured() {
+		return nil
+	}
+	return &Resolver{
+		reader: NewProcReader(pid, pid),
+		off:    off,
+		cache:  make(map[uint64]CodeInfo, 64),
+		misses: make(map[uint64]struct{}, 8),
+	}
+}
+
+// Resolve names one code object. The second return is false when nothing could
+// be read, and the caller must then keep whatever it had.
+func (r *Resolver) Resolve(codeObject uint64) (CodeInfo, bool) {
+	if r == nil {
+		return CodeInfo{}, false
+	}
+	r.mu.RLock()
+	if info, ok := r.cache[codeObject]; ok {
+		r.mu.RUnlock()
+		r.stats.Cached++
+		return info, true
+	}
+	_, bad := r.misses[codeObject]
+	r.mu.RUnlock()
+	if bad {
+		return CodeInfo{}, false
+	}
+
+	info, err := ReadCodeInfo(r.reader, r.off, codeObject)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err != nil {
+		r.misses[codeObject] = struct{}{}
+		r.stats.Failed++
+		return CodeInfo{}, false
+	}
+	r.cache[codeObject] = info
+	r.stats.Resolved++
+	return info, true
+}
+
+// Name renders a resolved frame the way a flame graph should read it:
+// qualified function, file basename, first line. Falls back to the address
+// form when nothing could be read, so a partially resolvable process still
+// produces a legible stack rather than a mixture of styles.
+func (r *Resolver) Name(codeObject uint64) string {
+	info, ok := r.Resolve(codeObject)
+	if !ok || info.Qualname == "" {
+		return FrameName(codeObject)
+	}
+	if info.Filename == "" {
+		return info.Qualname
+	}
+	return fmt.Sprintf("%s (%s:%d)", info.Qualname, baseName(info.Filename), info.FirstLine)
+}
+
+// Stats returns a snapshot.
+func (r *Resolver) Stats() ResolverStats {
+	if r == nil {
+		return ResolverStats{}
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.stats
+}
+
+// baseName is filepath.Base without the import: a co_filename is always a
+// slash-separated path as CPython stores it, whatever the host separator.
+func baseName(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' {
+			return p[i+1:]
+		}
+	}
+	return p
+}
+
+// resolvers holds one Resolver per attached process.
+//
+// Package-level because the namer registered with unwind/interp is
+// package-level: the interp registry is keyed by unwinder id, not by module
+// instance, and a process is attached by whichever module instance happens to
+// own that pid.
+var (
+	resolversMu sync.RWMutex
+	resolvers   = map[uint32]*Resolver{}
+)
+
+// InstallResolver records the resolver to use for pid. Called at attach, where
+// the interpreter's version -- and therefore whether its code offsets are
+// measured at all -- has just been established.
+func InstallResolver(pid uint32, r *Resolver) {
+	resolversMu.Lock()
+	defer resolversMu.Unlock()
+	if r == nil {
+		delete(resolvers, pid)
+		return
+	}
+	resolvers[pid] = r
+}
+
+// RemoveResolver forgets pid. The cached names go with it, which is correct:
+// they described that process, and a pid is reused.
+func RemoveResolver(pid uint32) {
+	resolversMu.Lock()
+	defer resolversMu.Unlock()
+	delete(resolvers, pid)
+}
+
+func resolverFor(pid uint32) *Resolver {
+	resolversMu.RLock()
+	defer resolversMu.RUnlock()
+	return resolvers[pid]
+}

--- a/test/python_walk_defects_test.go
+++ b/test/python_walk_defects_test.go
@@ -178,3 +178,50 @@ func TestParsePythonFrameNameRejectsNativeNames(t *testing.T) {
 		}
 	}
 }
+
+// Both renderings must be understood, and which one a run produces is a
+// property of the interpreter, not of the walk: pyunwind resolves a frame by
+// reading co_qualname out of the live process and only has measured
+// code-object offsets for some CPython versions. On one it has not been
+// measured against, the walk works exactly as well and the frames stay
+// addresses.
+//
+// This exists because the opposite happened: naming the frames turned
+// "python:0x7f…" into "outer_function (target.py:2)", and an assertion that
+// understood only the address form reported "only 0 Python frames in 478
+// samples" -- a walker failure -- for what was a naming improvement.
+func TestPythonFrameNamesAreRecognisedInBothRenderings(t *testing.T) {
+	byAddr := map[uint64]string{0x7f1234567890: "leaf"}
+
+	// Unresolved: named through the address map.
+	if fn, ok := pythonFuncName("python:0x7f1234567890", byAddr); !ok || fn != "leaf" {
+		t.Errorf("unresolved form: got (%q, %v), want (leaf, true)", fn, ok)
+	}
+	// Unresolved and unknown: still a Python frame, just unnamed.
+	if fn, ok := pythonFuncName("python:0xdead", byAddr); !ok || fn != "" {
+		t.Errorf("unknown address: got (%q, %v), want (\"\", true)", fn, ok)
+	}
+	// Resolved: the qualified name reduces to the bare function.
+	for in, want := range map[string]string{
+		"leaf (workload.py:12)":                    "leaf",
+		"Widget.method_here (target.py:4)":         "method_here",
+		"Module._wrapped_call_impl (module.py:17)": "_wrapped_call_impl",
+	} {
+		if fn, ok := pythonFuncName(in, byAddr); !ok || fn != want {
+			t.Errorf("resolved form %q: got (%q, %v), want (%q, true)", in, fn, ok, want)
+		}
+	}
+	// Native frames must not be mistaken for Python ones, or the lower bound
+	// this feeds would pass on a run with no Python frames at all.
+	for _, in := range []string{
+		"at::native::add_kernel(at::TensorIteratorBase&)",
+		"libcuda.so.1+0x4b71c6",
+		"main",
+		"0x7f2c945b2c2b",
+		"some_helper (thing.cc:12)",
+	} {
+		if fn, ok := pythonFuncName(in, byAddr); ok {
+			t.Errorf("native frame %q was read as Python (%q)", in, fn)
+		}
+	}
+}

--- a/test/python_walk_test.go
+++ b/test/python_walk_test.go
@@ -411,7 +411,7 @@ func pythonSampleDefects(names []string, codes map[string]uint64) []string {
 	outerStart := positions[pythonOuterSegment[0]]
 	natives := 0
 	for i := innerEnd + 1; i < outerStart; i++ {
-		if _, isPython := parsePythonFrameName(names[i]); !isPython {
+		if !isPythonFrame(names[i]) {
 			natives++
 		}
 	}
@@ -422,17 +422,21 @@ func pythonSampleDefects(names []string, codes map[string]uint64) []string {
 	// Every code object at most once. Duplication is the exact failure the
 	// entry-frame stop and the resume cursor prevent, and it renders as a
 	// perfectly plausible stack.
-	counts := map[uint64]int{}
+	// Keyed by an identity that exists in BOTH renderings. Keying by the
+	// code-object address alone counted nothing once the frames were named,
+	// which does not fail the test -- it silently switches this check off,
+	// and a duplication defect would have sailed through looking healthy.
+	counts := map[string]int{}
 	for _, name := range names {
-		if addr, ok := parsePythonFrameName(name); ok {
-			counts[addr]++
+		if key, ok := pythonFrameKey(name); ok {
+			counts[key]++
 		}
 	}
-	for addr, n := range counts {
+	for key, n := range counts {
 		if n > 1 {
 			defects = append(defects, fmt.Sprintf(
-				"code object %#x (%s) appears %d times: the inner segment was re-pushed beneath the outer one",
-				addr, byAddr[addr], n))
+				"Python frame %s appears %d times: the inner segment was re-pushed beneath the outer one",
+				key, n))
 		}
 	}
 
@@ -447,7 +451,7 @@ func pythonSampleDefects(names []string, codes map[string]uint64) []string {
 	// chain to NULL would consume them.
 	nativeTotal := 0
 	for _, name := range names {
-		if _, isPython := parsePythonFrameName(name); !isPython {
+		if !isPythonFrame(name) {
 			nativeTotal++
 		}
 	}
@@ -472,8 +476,13 @@ func pythonOrderIn(names []string, codes map[string]uint64) (map[string]int, boo
 	for _, fn := range want {
 		found := -1
 		for i := at + 1; i < len(names); i++ {
-			addr, ok := parsePythonFrameName(names[i])
-			if ok && addr == codes[fn] {
+			// Either rendering. Matching only the address form made this
+			// report "no sample carried the full interleaved sequence" on a
+			// run whose sequence was entirely present and merely named --
+			// the frames say "leaf (workload.py:12)" once pyunwind can read
+			// the interpreter's code objects.
+			got, ok := pythonFuncName(names[i], byAddrName(codes))
+			if ok && got == fn {
 				found = i
 				break
 			}
@@ -485,6 +494,39 @@ func pythonOrderIn(names []string, codes map[string]uint64) (map[string]int, boo
 		at = found
 	}
 	return positions, true
+}
+
+// isPythonFrame reports whether a frame is a Python one in either rendering.
+func isPythonFrame(name string) bool {
+	if _, ok := parsePythonFrameName(name); ok {
+		return true
+	}
+	_, ok := parseResolvedPythonFrame(name)
+	return ok
+}
+
+// pythonFrameKey identifies a Python frame in a way that survives both
+// renderings: the code object's address when unresolved, its qualified name
+// when resolved. One code object yields one key either way, which is what the
+// duplication check needs.
+func pythonFrameKey(name string) (string, bool) {
+	if addr, ok := parsePythonFrameName(name); ok {
+		return fmt.Sprintf("%#x", addr), true
+	}
+	if q, ok := parseResolvedPythonFrame(name); ok {
+		return q, true
+	}
+	return "", false
+}
+
+// byAddrName inverts the workload's name->code-object map into the
+// address->name form pythonFuncName wants.
+func byAddrName(codes map[string]uint64) map[uint64]string {
+	out := make(map[uint64]string, len(codes))
+	for name, addr := range codes {
+		out[addr] = name
+	}
+	return out
 }
 
 // parsePythonFrameName decodes the "python:0x…" rendering the profiler
@@ -574,7 +616,7 @@ func renderSample(s *profile.Sample) string {
 	for i, loc := range s.Location {
 		name := locationName(loc)
 		kind := "native"
-		if _, ok := parsePythonFrameName(name); ok {
+		if isPythonFrame(name) {
 			kind = "PYTHON"
 		}
 		fmt.Fprintf(&b, "  #%02d %-6s %s\n", i, kind, name)

--- a/test/python_walk_test.go
+++ b/test/python_walk_test.go
@@ -319,12 +319,12 @@ func TestPythonFramesInterleavedWithNative(t *testing.T) {
 	pythonFrames := 0
 	for _, s := range prof.Sample {
 		for _, name := range sampleFrameNames(s) {
-			addr, ok := parsePythonFrameName(name)
+			fn, ok := pythonFuncName(name, want)
 			if !ok {
 				continue
 			}
 			pythonFrames++
-			if fn, ok := want[addr]; ok {
+			if fn != "" {
 				seenFuncs[fn]++
 			}
 		}
@@ -488,7 +488,7 @@ func pythonOrderIn(names []string, codes map[string]uint64) (map[string]int, boo
 }
 
 // parsePythonFrameName decodes the "python:0x…" rendering the profiler
-// gives an unsymbolized Python frame (dwarfagent.pythonFrameName).
+// gives an UNRESOLVED Python frame (pyunwind.FrameName).
 func parsePythonFrameName(name string) (uint64, bool) {
 	const prefix = "python:"
 	if !strings.HasPrefix(name, prefix) {
@@ -499,6 +499,47 @@ func parsePythonFrameName(name string) (uint64, bool) {
 		return 0, false
 	}
 	return v, true
+}
+
+// resolvedPythonFrame matches the RESOLVED rendering, "qualname (file.py:12)",
+// and returns the qualname.
+//
+// Both forms have to be recognised, and which one appears is a property of the
+// interpreter rather than of the walk: pyunwind resolves a frame by reading
+// co_qualname out of the live process, and it only has measured code-object
+// offsets for some CPython versions. On an interpreter it has not been
+// measured against, the walk works exactly as well and the frames stay
+// addresses. A test that understood only one form would report a walker
+// failure ("only 0 Python frames") for a naming difference.
+var resolvedPythonFrame = regexp.MustCompile(`^(\S+) \([^()]*\.py:\d+\)$`)
+
+func parseResolvedPythonFrame(name string) (string, bool) {
+	m := resolvedPythonFrame.FindStringSubmatch(name)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}
+
+// pythonFuncName reduces either rendering to the function this test knows by
+// name. byAddr maps a code-object address to the function defined at it.
+//
+// A resolved frame gives the QUALIFIED name -- "Widget.method_here" -- so the
+// bare function name is the part after the last dot.
+func pythonFuncName(name string, byAddr map[uint64]string) (string, bool) {
+	if addr, ok := parsePythonFrameName(name); ok {
+		// A Python frame either way. byAddr names the ones this workload
+		// defined; an address it does not know is still a Python frame and
+		// still counts toward the lower bound, it just names no function.
+		return byAddr[addr], true
+	}
+	if q, ok := parseResolvedPythonFrame(name); ok {
+		if i := strings.LastIndex(q, "."); i >= 0 {
+			q = q[i+1:]
+		}
+		return q, true
+	}
+	return "", false
 }
 
 // sampleFrameNames renders a sample's frames leaf-first, one entry per

--- a/unwind/dwarfagent/interpframes.go
+++ b/unwind/dwarfagent/interpframes.go
@@ -89,13 +89,25 @@ func countInterpSlots(slots []interp.Slot, truncatedPair bool) {
 
 // interpSymbolizeFrame is the symbolize.Frame an interpreter slot becomes.
 //
-// Reason is deliberately not FailureNone: the frame is placed correctly and
-// its address is real, but nothing named it, and pprof has no unsymbolized bit
-// of its own to infer that from after the conversion.
-func interpSymbolizeFrame(sl interp.Slot) symbolize.Frame {
+// NameFor rather than Name: naming a Python frame means reading the code
+// object out of the live process, and this runs during collect while the
+// target may still be there. What it reads is cached, so the name survives the
+// process; what it cannot read stays the address form.
+//
+// Reason follows what actually happened. A frame the resolver named IS
+// resolved, and marking it FailureMissingSymbols anyway would render
+// "Widget.method_here (train.py:42)" hatched as unsymbolized -- and, worse,
+// let pprof's builder overwrite the name with module+offset, since that path
+// fires on the unresolved bit alone.
+func interpSymbolizeFrame(pid uint32, sl interp.Slot) symbolize.Frame {
+	name := sl.NameFor(pid)
+	reason := symbolize.FailureMissingSymbols
+	if name != sl.Name() {
+		reason = symbolize.FailureNone
+	}
 	return symbolize.Frame{
 		Address: sl.PC,
-		Name:    sl.Name(),
-		Reason:  symbolize.FailureMissingSymbols,
+		Name:    name,
+		Reason:  reason,
 	}
 }

--- a/unwind/dwarfagent/interpframes_test.go
+++ b/unwind/dwarfagent/interpframes_test.go
@@ -426,7 +426,7 @@ func TestPythonFrameNameSurvivesTheProfileBuilder(t *testing.T) {
 		Resolver:   resolver,
 	})
 	frames := symbolize.ToProfFrames([]symbolize.Frame{
-		interpSymbolizeFrame(interp.Slot{Unwinder: frameTagInterp, PC: codeObject, Extra: 0x1234}),
+		interpSymbolizeFrame(0, interp.Slot{Unwinder: frameTagInterp, PC: codeObject, Extra: 0x1234}),
 	})
 	builders.AddSample(&pprof.ProfileSample{
 		Pid:         uint32(os.Getpid()),

--- a/unwind/dwarfagent/symbolize.go
+++ b/unwind/dwarfagent/symbolize.go
@@ -69,7 +69,7 @@ func symbolizePID(sym symbolize.Symbolizer, pid uint32, slots []interp.Slot) []p
 			// number and collect() runs once per unique stack. The
 			// aggregators count, via countInterpSlots.
 			out = append(out, symbolize.ToProfFrames(
-				[]symbolize.Frame{interpSymbolizeFrame(sl)})...)
+				[]symbolize.Frame{interpSymbolizeFrame(pid, sl)})...)
 			continue
 		}
 		if placeholders {

--- a/unwind/interp/frame.go
+++ b/unwind/interp/frame.go
@@ -26,6 +26,9 @@ import (
 var (
 	renderMu  sync.RWMutex
 	renderers = map[uint32]func(a, b uint64) string{}
+	// namers resolve a frame against the live process it came from. See
+	// RegisterNamer for why this is separate from renderers.
+	namers = map[uint32]func(pid uint32, a, b uint64) (string, bool){}
 )
 
 // RegisterRenderer records how to name one unwinder's frames. Call it from a
@@ -46,6 +49,43 @@ func RegisterRenderer(id uint32, render func(a, b uint64) string) {
 // position in the call path, and this binary cannot name it. Dropping it
 // instead would silently shorten the stack, and symbolizing it as native would
 // invent one.
+// RegisterNamer records how to name one unwinder's frames FOR A GIVEN PROCESS.
+//
+// Separate from RegisterRenderer because naming an interpreter frame properly
+// means reading the target's memory -- a Python code object only says
+// "Widget.method_here" if something reads the PyCodeObject out of the process
+// -- and that needs a pid, which the renderer signature has no room for and
+// should not: a renderer must keep working on a saved profile converted on a
+// laptop, where there is no process to read.
+//
+// A namer returns false when it cannot answer, and the caller then falls back
+// to the renderer's address form. Both are registered: the namer is used
+// during a capture, the renderer for everything after it.
+func RegisterNamer(id uint32, namer func(pid uint32, a, b uint64) (string, bool)) {
+	renderMu.Lock()
+	defer renderMu.Unlock()
+	namers[id] = namer
+}
+
+// FrameNameFor names one interpreter frame in the context of the process it
+// came from, falling back to FrameName when no namer can answer.
+//
+// Call this from a capture path, where the target is still alive. After it
+// exits only FrameName's address form is honest, and a namer that cached what
+// it read during the capture will still answer -- which is how a resolved name
+// outlives the process that explained it.
+func FrameNameFor(pid uint32, id uint32, a, b uint64) string {
+	renderMu.RLock()
+	n := namers[id]
+	renderMu.RUnlock()
+	if n != nil {
+		if s, ok := n(pid, a, b); ok {
+			return s
+		}
+	}
+	return FrameName(id, a, b)
+}
+
 func FrameName(id uint32, a, b uint64) string {
 	renderMu.RLock()
 	f := renderers[id]
@@ -82,6 +122,10 @@ func (s Slot) IsInterp() bool { return s.Unwinder != FrameTagNative }
 
 // Name renders an interpreter slot. Only meaningful when IsInterp.
 func (s Slot) Name() string { return FrameName(s.Unwinder, s.PC, s.Extra) }
+
+// NameFor is Name with the process in hand, so an interpreter frame can be
+// resolved from the live target rather than rendered as an address.
+func (s Slot) NameFor(pid uint32) string { return FrameNameFor(pid, s.Unwinder, s.PC, s.Extra) }
 
 // SplitSlots folds the parallel pcs[]/tags[] arrays into one ordered list of
 // frames -- ONE entry per frame, not per slot.


### PR DESCRIPTION
Python frames rendered as `python:0x26f84de0` — the code object's address. `FrameName`'s own
comment called turning that into a name "a later slice"; this is it.

A PyTorch MNIST capture went from **213 unresolved Python frames to 0**, and the profile now
carries the whole causal chain:

```
<module> (main.py:1) → main (main.py:72) → train (main.py:36)
  → Module._wrapped_call_impl (module.py:1779) → Net.forward (main.py:20)
  → Conv2d.forward (conv.py:564) → at::native::raw_cudnn_convolution_forward_out
  → cudnnBackendExecute → [gpu:launch] → [gpu:kernel:nchwToNhwcKernel…]
```

Your Python source line through to the kernel on the device.

`co_qualname`, not `co_name`: **`Conv2d.forward`** rather than `forward`, because a flame graph row
has to be identifiable without reading its parents and every `nn.Module` has a `forward`.

## The cache is the design, not an optimisation

Naming a frame means reading the target's memory, so it only works while the target is **alive**.
Profilers build their output afterwards — the GPU tools explicitly, and even the CPU ones resolve
at collect time — so a name looked up at render time is a name that cannot be looked up at all.
Every read happens during the capture; the cache carries the answer past the process's death.

Tested by killing the target and asserting the cached names still answer, while an address never
seen now correctly fails.

Code objects are immortal for the interpreter's life and reused for every call of a function, so
the cache is small and hits often — 213 frames touch far fewer distinct code objects.

## API shape

`RegisterNamer` sits **beside** `RegisterRenderer` rather than replacing it. The renderer must keep
working on a saved profile converted on a laptop where there is no process to read; the namer only
works during a capture. `Slot.NameFor(pid)` takes the live path where a pid is in hand, which is
both call sites.

One consequence worth reviewing: a resolved Python frame now carries `FailureNone`. Left as
`FailureMissingSymbols` it would render hatched-as-unsymbolized **and**
`pprof.addLocationByAddr` would overwrite the name with `module+offset`, since that path fires on
the unresolved bit alone. Same mechanism as #127 — it would have silently undone the whole change.

## Measured, and only where measured

The 3.12 offsets (`co_filename=112`, `co_name=120`, `co_qualname=128`, `co_firstlineno=68`) come
from `offsetof` against that interpreter's own headers.

**3.13 and 3.14 have no measured code offsets in this build**, so `NewResolver` returns nil, attach
logs one line saying so, and their frames render `python:0x…` exactly as before. Adding a version
is a measurement against its headers, not a code change. I could not measure them here because
only 3.12 headers are installed on this machine.

The `PyUnicode` read verifies the compact and ascii state bits rather than assuming them, and
bounds the length: a wrong answer here becomes a wrong function name in a flame graph, which is
worse than no name.

## Tests

Four live tests against a real interpreter, plus the existing suites:

- resolves to the **qualified** name, with file and first line, checked against ground truth the
  test already knows rather than "it returned something"
- one read per code object across 50 lookups (`Resolved=1, Cached=49`)
- **cached names survive the process exiting**; uncached addresses then fail
- an unmeasured interpreter declines, and a nil resolver still renders `python:0x…`
