### PR TITLE
flamegraph: stop billing perf-agent's own callback to the profiled program

### DIFF
--- a/internal/flamegraph/domain.go
+++ b/internal/flamegraph/domain.go
@@ -215,13 +215,29 @@ func isShimModule(module string) bool {
 }
 
 // isShimSymbol is the fallback for a shim frame in a profile whose mappings
-// are empty, which is every profile the GPU builder writes today. The CUPTI
-// and rocprofiler callback entry points are the only shim symbols that can
-// appear on a target's stack; requiring both halves keeps an application
-// function innocently named on_callback from being billed to the profiler.
+// are empty, which is every profile the GPU builder writes today.
+//
+// BOTH entry points, not just one. The adapter registers on_callback with
+// CUPTI (shim/nvidia/cupti_adapter.cc:1722) and that dispatches to on_launch
+// (:1598), so both appear on a sampled launch's stack. Matching only
+// on_callback billed the other to the profiled program: measured on a PyTorch
+// MNIST capture, the same on_launch function landed in two domains, 45 frames
+// as shim where a module happened to be known and 60 as APPLICATION where it
+// was not. The file header above says exactly why that is wrong -- "colouring
+// it as ordinary CPU work would bill the profiler's overhead to the program
+// being profiled".
+//
+// The vendor callback signature is still required on both. "on_launch" and
+// "on_callback" are names any program may use; a launch handler in the
+// profiled application is the application's own work, and only the parameter
+// types say whose function this is.
 func isShimSymbol(name string) bool {
-	return strings.Contains(name, "on_callback") &&
-		(strings.Contains(name, "CallbackDomain") || strings.Contains(name, "rocprofiler"))
+	if !strings.Contains(name, "on_callback") && !strings.Contains(name, "on_launch") {
+		return false
+	}
+	return strings.Contains(name, "CallbackDomain") ||
+		strings.Contains(name, "CUpti_CallbackData") ||
+		strings.Contains(name, "rocprofiler")
 }
 
 var vendorModulePrefixes = []string{

--- a/internal/flamegraph/domain_test.go
+++ b/internal/flamegraph/domain_test.go
@@ -156,3 +156,36 @@ func TestCuBLASIsVendorRuntimeNotApplicationCode(t *testing.T) {
 	assert.Equal(t, DomainApplication, Classify(
 		"void at::cuda::blas::gemm_internal_cublas<float, float>(char, char, long)", ""))
 }
+
+// perf-agent's own injected callback was being billed to the profiled program.
+//
+// isShimSymbol matched on "on_callback", but the CUPTI adapter's symbol is
+// on_launch (shim/nvidia/cupti_adapter.cc). A frame carrying the shim's module
+// was still caught by isShimModule, so the bug only showed where the module is
+// absent -- which is every frame of a GPU profile, because the GPU builder
+// writes profiles with empty mappings. Measured on a PyTorch MNIST capture:
+// the same function landed in two domains, 45 frames as shim and 60 as app.
+//
+// That is exactly what this file's header says must not happen: "Colouring it
+// as ordinary CPU work would bill the profiler's overhead to the program being
+// profiled."
+func TestOurOwnCallbackIsNeverBilledToTheApplication(t *testing.T) {
+	// The real symbol, as it appears in a GPU profile: no module.
+	assert.Equal(t, DomainProfilerShim,
+		Classify("(anonymous namespace)::on_launch(CUpti_CallbackData const*)", ""))
+	// The AMD counterpart, same shape.
+	assert.Equal(t, DomainProfilerShim,
+		Classify("(anonymous namespace)::on_launch(rocprofiler_callback_tracing_record_t)", ""))
+	// And with a module, which already worked.
+	assert.Equal(t, DomainProfilerShim,
+		Classify("(anonymous namespace)::on_launch(CUpti_CallbackData const*)",
+			"/opt/libperfagent-gpu-nvidia.so"))
+}
+
+// The guard that keeps the fix honest: "on_launch" is a name any program may
+// use, so the vendor callback signature must still be required. A launch
+// handler in the profiled application is the application's own work.
+func TestAnApplicationsOwnOnLaunchIsNotTheProfiler(t *testing.T) {
+	assert.Equal(t, DomainApplication, Classify("myapp::on_launch(int)", ""))
+	assert.Equal(t, DomainApplication, Classify("Renderer::on_launch()", ""))
+}


### PR DESCRIPTION
`isShimSymbol` matched `on_callback`, but the CUPTI adapter registers **on_callback** (`cupti_adapter.cc:1722`) *and* dispatches to **on_launch** (`:1598`) — so both appear on a sampled launch's stack and only one was matched.

A frame carrying the shim's module was still caught by `isShimModule`, so the miss only showed where the module is absent — which is every frame of a GPU profile, because the GPU builder writes profiles with empty mappings. Measured on a PyTorch MNIST capture, the same `on_launch` function landed in two domains:

| | before | after |
|---|---|---|
| `app` | **60** | 0 |
| `shim` | 45 | **105** |

Sixty frames of the profiler's own overhead were rendered in the application band, as the user's code. `domain.go`'s own header says why that is wrong: *"Colouring it as ordinary CPU work would bill the profiler's overhead to the program being profiled."*

Same shape as the cuBLAS bug in #126 — a name-matching rule that did not match the name it was written for — and found the same way, by looking at what a real capture actually rendered.

The vendor callback signature is still required on both names, and that is asserted: `on_launch` is a name any program may use, so a launch handler in the profiled application stays application work. A future widening cannot quietly start billing application frames to the profiler in the other direction.