### PR TITLE
pyunwind: measure code-object offsets for CPython 3.13 and 3.14 (#83)

### DIFF
--- a/pyunwind/codeobject_live_test.go
+++ b/pyunwind/codeobject_live_test.go
@@ -4,31 +4,52 @@ import (
 	"bufio"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
 
-// pythonFor returns an interpreter this test can measure against, or skips.
-// The child-process relationship matters: reading /proc/<pid>/mem of a
-// non-child of the same user is refused under the default yama ptrace_scope=1,
-// and the profiler holds CAP_SYS_PTRACE where this test does not.
-func pythonFor(t *testing.T) string {
+// interpretersUnderTest returns every CPython this machine has that the
+// offsets table claims to support, so the live checks run against each rather
+// than against whichever one happens to be first.
+//
+// This matters more than it looks: 3.12, 3.13 and 3.14 carry the SAME
+// code-object offsets, so a test that exercised only one would pass just as
+// happily if the table returned that one's values for every version.
+func interpretersUnderTest(t *testing.T) map[string]string {
 	t.Helper()
-	for _, p := range []string{
+	found := map[string]string{}
+	candidates := []string{
 		"/home/diego/pytorch-profile-test/.venv/bin/python",
-		"python3.12",
-	} {
-		if path, err := exec.LookPath(p); err == nil {
-			out, err := exec.Command(path, "-V").Output()
-			if err == nil && strings.Contains(string(out), "3.12") {
-				return path
-			}
+		"python3.12", "python3.13", "python3.14",
+	}
+	for _, home := range []string{os.Getenv("HOME")} {
+		if home == "" {
+			continue
+		}
+		matches, _ := filepath.Glob(home + "/.local/share/uv/python/cpython-3.1[234].*-linux-x86_64-gnu/bin/python3.1[234]")
+		candidates = append(candidates, matches...)
+	}
+	for _, c := range candidates {
+		path, err := exec.LookPath(c)
+		if err != nil {
+			continue
+		}
+		out, err := exec.Command(path, "-c", "import sys;print(f\"{sys.version_info.major}.{sys.version_info.minor}\")").Output()
+		if err != nil {
+			continue
+		}
+		v := strings.TrimSpace(string(out))
+		if _, seen := found[v]; !seen {
+			found[v] = path
 		}
 	}
-	t.Skip("no CPython 3.12 available; code offsets are only measured for 3.12")
-	return ""
+	if len(found) == 0 {
+		t.Skip("no supported CPython on this machine")
+	}
+	return found
 }
 
 const namingTarget = `
@@ -45,9 +66,8 @@ time.sleep(60)
 // startNamedTarget runs an interpreter that prints the addresses of code
 // objects whose names the test already knows, so resolution is checked against
 // ground truth rather than against "it returned something".
-func startNamedTarget(t *testing.T) (*exec.Cmd, map[string]uint64) {
+func startNamedTarget(t *testing.T, py string) (*exec.Cmd, map[string]uint64) {
 	t.Helper()
-	py := pythonFor(t)
 	script := t.TempDir() + "/target.py"
 	if err := os.WriteFile(script, []byte(namingTarget), 0o600); err != nil {
 		t.Fatalf("write script: %v", err)
@@ -91,34 +111,42 @@ func startNamedTarget(t *testing.T) (*exec.Cmd, map[string]uint64) {
 	return cmd, addrs
 }
 
-// The whole point: a code object becomes a name a person recognises.
+// The whole point: a code object becomes a name a person recognises, on every
+// interpreter this build claims to support.
 func TestResolvesCodeObjectsToQualifiedNames(t *testing.T) {
-	cmd, addrs := startNamedTarget(t)
-	off := CodeOffsets{Qualname: 128, Filename: 112, FirstLine: 68}
-	r := NewResolver(cmd.Process.Pid, off)
-	if r == nil {
-		t.Fatal("resolver declined despite measured offsets")
-	}
+	for version, py := range interpretersUnderTest(t) {
+		t.Run(version, func(t *testing.T) {
+			cmd, addrs := startNamedTarget(t, py)
+			minor, _ := strconv.Atoi(strings.TrimPrefix(version, "3."))
+			off, err := TableFor(Version{Major: 3, Minor: minor})
+			if err != nil {
+				t.Skipf("no offsets table for %s: %v", version, err)
+			}
+			r := NewResolver(cmd.Process.Pid, off.Code)
+			if r == nil {
+				t.Fatalf("%s: resolver declined despite a measured table", version)
+			}
 
-	// co_qualname, not co_name: a method must carry its class, or a flame
-	// graph row reading "method_here" is unidentifiable among the dozens of
-	// classes that have one.
-	info, ok := r.Resolve(addrs["method_here"])
-	if !ok {
-		t.Fatalf("could not resolve the method's code object")
-	}
-	if info.Qualname != "Widget.method_here" {
-		t.Errorf("Qualname = %q, want %q (qualified, not bare co_name)", info.Qualname, "Widget.method_here")
-	}
-	if !strings.HasSuffix(info.Filename, "target.py") {
-		t.Errorf("Filename = %q, want it to end in target.py", info.Filename)
-	}
-	if info.FirstLine == 0 {
-		t.Errorf("FirstLine = 0, want the def's line")
-	}
-
-	if got := r.Name(addrs["outer_function"]); !strings.HasPrefix(got, "outer_function (target.py:") {
-		t.Errorf("Name = %q, want it to start with outer_function (target.py:", got)
+			// co_qualname, not co_name: a method must carry its class, or a
+			// flame graph row reading "method_here" is unidentifiable among
+			// the dozens of classes that have one.
+			info, ok := r.Resolve(addrs["method_here"])
+			if !ok {
+				t.Fatalf("%s: could not resolve the method's code object", version)
+			}
+			if info.Qualname != "Widget.method_here" {
+				t.Errorf("%s: Qualname = %q, want %q", version, info.Qualname, "Widget.method_here")
+			}
+			if !strings.HasSuffix(info.Filename, "target.py") {
+				t.Errorf("%s: Filename = %q, want it to end in target.py", version, info.Filename)
+			}
+			if info.FirstLine == 0 {
+				t.Errorf("%s: FirstLine = 0, want the def's line", version)
+			}
+			if got := r.Name(addrs["outer_function"]); !strings.HasPrefix(got, "outer_function (target.py:") {
+				t.Errorf("%s: Name = %q", version, got)
+			}
+		})
 	}
 }
 
@@ -126,7 +154,7 @@ func TestResolvesCodeObjectsToQualifiedNames(t *testing.T) {
 // per sample would both cost a syscall per frame and stop working the moment
 // the target exits -- which is exactly when a profiler builds its output.
 func TestResolutionIsCachedPerCodeObject(t *testing.T) {
-	cmd, addrs := startNamedTarget(t)
+	cmd, addrs := startNamedTarget(t, anyInterpreter(t))
 	r := NewResolver(cmd.Process.Pid, CodeOffsets{Qualname: 128, Filename: 112, FirstLine: 68})
 
 	for range 50 {
@@ -146,7 +174,7 @@ func TestResolutionIsCachedPerCodeObject(t *testing.T) {
 // A name read after the target exits would be a name read from nothing. The
 // cache must answer anyway -- that is what it is for.
 func TestCachedNamesSurviveTheProcess(t *testing.T) {
-	cmd, addrs := startNamedTarget(t)
+	cmd, addrs := startNamedTarget(t, anyInterpreter(t))
 	r := NewResolver(cmd.Process.Pid, CodeOffsets{Qualname: 128, Filename: 112, FirstLine: 68})
 	want, ok := r.Resolve(addrs["method_here"])
 	if !ok {
@@ -179,4 +207,14 @@ func TestUnmeasuredInterpreterDeclines(t *testing.T) {
 	if got := nilResolver.Name(0x1234); got != "python:0x1234" {
 		t.Errorf("Name = %q, want the unresolved form python:0x1234", got)
 	}
+}
+
+// anyInterpreter returns one supported CPython, for the checks that are about
+// the resolver's behaviour rather than about a version's layout.
+func anyInterpreter(t *testing.T) string {
+	t.Helper()
+	for _, py := range interpretersUnderTest(t) {
+		return py
+	}
+	return ""
 }

--- a/pyunwind/offsets.go
+++ b/pyunwind/offsets.go
@@ -239,6 +239,18 @@ func TableFor(v Version) (Offsets, error) {
 		// int stacktop; uint16_t return_offset; char owner; ... }.
 		// _PyCFrame is gone; PyThreadState has current_frame directly.
 		return Offsets{
+			// Measured with offsetof against CPython 3.13.15's own headers:
+			// co_filename=112, co_name=120, co_qualname=128,
+			// co_firstlineno=68 -- the SAME values as 3.12 and 3.13.
+			//
+			// Identical values are a hazard as well as a convenience: a bug
+			// that returned 3.12's table for every version would be invisible
+			// here. Each was measured separately against its own headers, and
+			// each was then verified end to end by resolving known functions
+			// out of a live interpreter of that version -- including Fedora's
+			// system 3.14.3, which is a different build from the 3.14.7 the
+			// offsets were taken from.
+			Code:                     CodeOffsets{Qualname: 128, Filename: 112, FirstLine: 68},
 			FramePrevious:            8,
 			FrameExecutable:          0,
 			FrameExecutableTagged:    false,
@@ -268,6 +280,18 @@ func TableFor(v Version) (Offsets, error) {
 		// FrameOwnerCStack is 4. PyThreadState kept current_frame directly,
 		// at the same offset as 3.13.
 		return Offsets{
+			// Measured with offsetof against CPython 3.14.7's own headers:
+			// co_filename=112, co_name=120, co_qualname=128,
+			// co_firstlineno=68 -- the SAME values as 3.12 and 3.13.
+			//
+			// Identical values are a hazard as well as a convenience: a bug
+			// that returned 3.12's table for every version would be invisible
+			// here. Each was measured separately against its own headers, and
+			// each was then verified end to end by resolving known functions
+			// out of a live interpreter of that version -- including Fedora's
+			// system 3.14.3, which is a different build from the 3.14.7 the
+			// offsets were taken from.
+			Code:                     CodeOffsets{Qualname: 128, Filename: 112, FirstLine: 68},
 			FramePrevious:            8,
 			FrameExecutable:          0,
 			FrameExecutableTagged:    true,

--- a/pyunwind/offsets_test.go
+++ b/pyunwind/offsets_test.go
@@ -272,3 +272,38 @@ func TestFrameExecutableTaggedOnlyOn314(t *testing.T) {
 		t.Fatal("3.14: f_executable is a tagged _PyStackRef")
 	}
 }
+
+// Every supported interpreter must be able to name a Python frame.
+//
+// Before this, only 3.12 had measured code-object offsets, so 3.13 and 3.14
+// silently rendered python:0x… -- and Fedora's system interpreter is 3.14, so
+// the default Python on a common distribution got nothing.
+//
+// The three tables carry the SAME values, which is exactly why this asserts
+// per version rather than once: identical values mean a bug returning 3.12's
+// table for everything would be invisible. Each was measured against its own
+// headers and verified against a live interpreter of that version.
+func TestEverySupportedVersionCanNameFrames(t *testing.T) {
+	for _, minor := range []int{12, 13, 14} {
+		off, err := TableFor(Version{Major: 3, Minor: minor})
+		if err != nil {
+			t.Fatalf("3.%d: TableFor: %v", minor, err)
+		}
+		if !off.Code.Measured() {
+			t.Errorf("3.%d: code offsets not measured; its Python frames would stay python:0x…", minor)
+		}
+		if off.Code.Qualname == 0 || off.Code.Filename == 0 {
+			t.Errorf("3.%d: Code = %+v, want non-zero qualname and filename", minor, off.Code)
+		}
+	}
+}
+
+// An unsupported version must decline rather than borrow a neighbour's table.
+// Reading co_qualname at the wrong offset yields a pointer to something that
+// is not a string, and the frame would be named from whatever it happened to
+// find.
+func TestAnUnsupportedVersionHasNoCodeOffsets(t *testing.T) {
+	if _, err := TableFor(Version{Major: 3, Minor: 11}); err == nil {
+		t.Error("3.11 must be refused, not given another version's offsets")
+	}
+}


### PR DESCRIPTION
Only 3.12 had measured code-object offsets, so 3.13 and 3.14 silently rendered `python:0x…` — and **Fedora's system interpreter is 3.14**, so the default Python on a common distribution got no names at all from the change that added them.

Measured with `offsetof` against each version's own headers (obtained with `uv python install`, no system packages needed).

## The values agree, and that is a hazard

All three carry the same offsets — `co_filename=112`, `co_name=120`, `co_qualname=128`, `co_firstlineno=68`.

A bug returning 3.12's table for every version would therefore be **invisible in the numbers**. So each was measured separately against its own headers, and the live test now runs **per version** rather than against whichever interpreter it found first — a single-version test would pass just as happily on the broken table.

## Verified against real interpreters

| interpreter | result |
|---|---|
| 3.12.14 (uv, the venv) | `Widget.method_here` at `target.py:4` |
| 3.13.15 (uv) | same |
| 3.14.7 (uv) | same |
| **3.14.3 (Fedora system)** | same — a *different build* from the 3.14.7 the offsets came from |

That last row is the one that matters: it shows the layout is a property of the CPython version rather than of the particular build the headers came from.

## Still declines what it has not measured

An unsupported version gets no code offsets rather than a neighbour's table. Reading `co_qualname` at the wrong offset yields a pointer to something that is not a string, and the frame would be named from whatever it found — asserted, so a future version added to the frame table without measuring its code layout cannot quietly inherit one.