### PR TITLE
flamegraph: intern module paths, and say what width means on a GPU page (#123)

### DIFF
--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -33,6 +33,14 @@ const darkChrome = `--bg:#16151a;--panel:#1e1d23;--ink:#eceaf2;--muted:#a29caf;-
 	`--accent:#ff9a6a;--warn-bg:#2b2313;--warn-line:#6d5722;--fatal-bg:#2e1616;--fatal-line:#7a3232`
 
 // styleSheet is the page chrome — the title line, the two icon buttons, the
+// widthMeaning (in the script below) says what a frame's width measures, and
+// only where that is NOT the obvious thing, so it stays a warning rather than
+// a caption. On a GPU profile every CPU frame is as wide as the DEVICE time
+// launched from it, not the CPU time spent in it; a reader fluent in flame
+// graphs assumes the opposite and the page carries no other signal to correct
+// them (issue #123). It decides from the axis label, so a CPU profile says
+// nothing.
+//
 // one-line note, the fixed status bar, the cursor tooltip and the info panel
 // — plus the frame box itself.
 //
@@ -368,6 +376,15 @@ func rowCSS(maxDepth int) string {
 // swallows N) zooms the flame view to the match or reveals it in the tree.
 // A match outside the tree's current root has no row to scroll to, so the
 // tree drops back to the whole profile rather than doing nothing.
+// widthMeaning, in the script below, says what a frame's width measures — and
+// only where that is NOT the obvious thing, so it stays a warning rather than
+// a caption.
+//
+// On a GPU profile every CPU frame is as wide as the DEVICE time launched from
+// that call path, not the CPU time spent in the frame. A reader fluent in
+// flame graphs assumes the opposite, because that is what the shape means
+// everywhere else, and the page carries no other signal to correct them
+// (issue #123). It decides from the axis label, so a CPU profile says nothing.
 const script = `
 (function(){
 "use strict";
@@ -446,14 +463,6 @@ function detail(it){
   if(d.domain==="unsym"){s+="\nno symbol: the unwind found this frame, nothing could name it";}
   return s;
 }
-// What this frame's width actually measures.
-//
-// Only said where it is NOT the obvious thing, so it stays a warning rather
-// than a caption. In a GPU profile every CPU frame is as wide as the device
-// time launched from it, not the CPU time spent in it -- a reader who knows
-// flame graphs will assume the opposite, and the profile carries no other
-// signal that would correct them. That semantic was documented only in prose
-// on a page most viewers never open (issue #123).
 function widthMeaning(it,d){
   if(unit.indexOf("nanoseconds")<0||axis.indexOf("gpu/")<0){return "";}
   switch(d.domain){

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -379,6 +379,9 @@ var st=doc.getElementById("st"),mc=doc.getElementById("mc");
 var q=doc.getElementById("q"),tip=doc.getElementById("tip");
 var tree=doc.getElementById("tree");
 var unit=chart.dataset.unit||"",total=+chart.dataset.total||0;
+var mods=(function(){var e=doc.getElementById("modules");if(!e){return [];}
+ try{return JSON.parse(e.textContent)||[];}catch(_){return [];}})();
+function moduleOf(d){var i=d.m;return i===undefined?"":(mods[+i]||"");}
 var idle=st.textContent,zoomTarget=null;
 var axis=chart.getAttribute("aria-label");
 var inverted=false,treeOn=false,treeRoot=null;
@@ -434,12 +437,31 @@ function place(it,x,w,vis){
 }
 function line(it){return it.name+"  ·  "+fmt(it.value)+"  ·  "+pct(it.value)+" of total";}
 function detail(it){
-  var s=line(it),d=it.el.dataset;
+  var s=line(it),d=it.el.dataset,m=moduleOf(d);
   if(it.kids.length&&it.self>0){s+="\nself: "+fmt(it.self);}
-  if(d.module){s+="\nmodule: "+d.module;}
+  if(m){s+="\nmodule: "+m;}
+  var w=widthMeaning(it,d);
+  if(w){s+="\n"+w;}
   if(it.inexact>0){s+="\n"+fmt(it.inexact)+" of this is attributed by inference, not measurement";}
   if(d.domain==="unsym"){s+="\nno symbol: the unwind found this frame, nothing could name it";}
   return s;
+}
+// What this frame's width actually measures.
+//
+// Only said where it is NOT the obvious thing, so it stays a warning rather
+// than a caption. In a GPU profile every CPU frame is as wide as the device
+// time launched from it, not the CPU time spent in it -- a reader who knows
+// flame graphs will assume the opposite, and the profile carries no other
+// signal that would correct them. That semantic was documented only in prose
+// on a page most viewers never open (issue #123).
+function widthMeaning(it,d){
+  if(unit.indexOf("nanoseconds")<0||axis.indexOf("gpu/")<0){return "";}
+  switch(d.domain){
+  case "gpu-kernel": return "width: measured time this kernel ran on the device";
+  case "boundary": return "width: device time launched from this path, sampled one launch in N";
+  case "boundary-unattributed": return "width: measured device time whose launch was not stack-sampled, so it has no caller";
+  default: return "width: GPU time launched from this call path \u2014 not CPU time spent here";
+  }
 }
 function status(it){st.textContent=it?line(it):(zoomTarget?line(zoomTarget):idle);}
 function showTip(evt,it){

--- a/internal/flamegraph/modules.go
+++ b/internal/flamegraph/modules.go
@@ -1,0 +1,78 @@
+package flamegraph
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// moduleTable maps each distinct module path on a page to a small index.
+//
+// The page declares the paths once and every frame carries the index, for the
+// same reason a domain carries a class rather than an inline colour: thirteen
+// distinct strings repeated across tens of thousands of frames is page weight,
+// not information.
+type moduleTable struct {
+	paths []string
+	index map[string]int
+}
+
+// internModules collects the distinct modules in the tree.
+//
+// Sorted, so the same profile renders byte-identical every time. An
+// insertion-ordered table would make the page depend on tree-walk order, which
+// turns any future reordering into a spurious diff.
+func internModules(root *node) moduleTable {
+	seen := map[string]struct{}{}
+	var walk func(*node)
+	walk = func(n *node) {
+		if n == nil {
+			return
+		}
+		if n.module != "" {
+			seen[n.module] = struct{}{}
+		}
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	walk(root)
+
+	t := moduleTable{index: make(map[string]int, len(seen))}
+	for m := range seen {
+		t.paths = append(t.paths, m)
+	}
+	sort.Strings(t.paths)
+	for i, m := range t.paths {
+		t.index[m] = i
+	}
+	return t
+}
+
+// writeModuleTable emits the page's module list.
+//
+// JSON in a script element rather than a data attribute: a module path may
+// contain any character, and JSON is the one encoding a reader can parse back
+// with no escaping rules of its own. It is read with JSON.parse on
+// textContent, which needs no eval and no relaxation of the page's CSP.
+//
+// Nothing is emitted when the page has no modules, so a profile without
+// mappings costs nothing for a table it would never reference.
+func writeModuleTable(ew *errWriter, t moduleTable) {
+	if len(t.paths) == 0 {
+		return
+	}
+	b, err := json.Marshal(t.paths)
+	if err != nil {
+		return
+	}
+	// NOT html.EscapeString. HTML entities are not decoded inside a script
+	// element, so escaping here would hand JSON.parse a document full of
+	// &#34; and the table would be unreadable -- a failure that appears only
+	// in the browser, long after any Go test has passed.
+	//
+	// json.Marshal already escapes <, > and & as \u003c, \u003e and \u0026,
+	// which is exactly the escaping this context needs: it makes "</script>"
+	// unrepresentable in the output, so a module path cannot close the
+	// element early.
+	ew.f("<script type=\"application/json\" id=\"modules\">%s</script>\n", b)
+}

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -376,10 +376,17 @@ func writeChart(ew *errWriter, root *node, maxDepth int, res *foldedstacks.Resul
 	}
 	layout(root, 0, 100/float64(root.value))
 
+	// Modules are declared once for the page and referenced by index, for the
+	// same reason colour is: a handful of distinct values repeated across
+	// every frame is page weight, not information. Measured on a PyTorch CPU
+	// capture, data-module was 566,966 bytes of a 3,165,745-byte page -- 18%
+	// -- for THIRTEEN distinct values totalling about a kilobyte.
+	mods := internModules(root)
 	ew.f(`<div class="chart" style="height:%dpx" role="group" aria-label="Flame graph, %s" data-total="%d" data-unit="%s">`+"\n",
 		maxDepth*frameHeight-1, html.EscapeString(res.SampleTypeName+"/"+res.Unit),
 		root.value, html.EscapeString(res.Unit))
-	writeNode(ew, root, res.Unit, root.value)
+	writeModuleTable(ew, mods)
+	writeNode(ew, root, res.Unit, root.value, mods)
 	ew.s("</div>\n")
 	return ew.err
 }
@@ -411,7 +418,7 @@ func writeChart(ew *errWriter, root *node, maxDepth int, res *foldedstacks.Resul
 // The label is deliberately terse — name, value, share. Domain, module and
 // the inference note stay in the visual tooltip; a screen reader user
 // scanning twenty frames does not want three sentences on each.
-func writeNode(ew *errWriter, n *node, unit string, total int64) {
+func writeNode(ew *errWriter, n *node, unit string, total int64, mods moduleTable) {
 	cls := fmt.Sprintf("frame d%d", n.depth)
 	if n.inexact > 0 {
 		cls += " inexact"
@@ -428,7 +435,9 @@ func writeNode(ew *errWriter, n *node, unit string, total int64) {
 		html.EscapeString(accessibleName(n, unit, total)),
 		html.EscapeString(n.domain.Info().Key), n.value)
 	if n.module != "" {
-		ew.f(` data-module="%s"`, html.EscapeString(n.module))
+		// An index into the page's module table, not the string. See
+		// writeChart.
+		ew.f(` data-m="%d"`, mods.index[n.module])
 	}
 	if n.inexact > 0 {
 		ew.f(` data-inexact="%d"`, n.inexact)
@@ -440,7 +449,7 @@ func writeNode(ew *errWriter, n *node, unit string, total int64) {
 	ew.s("</div>\n")
 
 	for _, c := range n.children {
-		writeNode(ew, c, unit, total)
+		writeNode(ew, c, unit, total, mods)
 	}
 }
 

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -957,3 +957,51 @@ func TestCPUProfilesDoNotExplainWidth(t *testing.T) {
 		t.Error("a CPU page must be identifiable as such from its axis")
 	}
 }
+
+// The shipped script must at least be structurally intact.
+//
+// Nothing in the Go suite parses JavaScript, so a broken script ships and
+// fails only in a browser. That is not hypothetical: removing a prose comment
+// from the asset took the `function widthMeaning(it,d){` line with it, leaving
+// a bare function body, and every Go test still passed.
+//
+// A brace/paren balance is not a parser, but it catches the class of damage a
+// text edit to a template literal actually causes.
+func TestTheShippedScriptIsStructurallyBalanced(t *testing.T) {
+	balance := func(s string, open, close rune) int {
+		depth, inStr, esc := 0, rune(0), false
+		for _, ch := range s {
+			switch {
+			case esc:
+				esc = false
+			case ch == '\\':
+				esc = true
+			case inStr != 0:
+				if ch == inStr {
+					inStr = 0
+				}
+			case ch == '"' || ch == '\'':
+				inStr = ch
+			case ch == open:
+				depth++
+			case ch == close:
+				depth--
+			}
+		}
+		return depth
+	}
+	for name, asset := range map[string]string{"script": script} {
+		if got := balance(asset, '{', '}'); got != 0 {
+			t.Errorf("%s: braces are unbalanced by %d", name, got)
+		}
+		if got := balance(asset, '(', ')'); got != 0 {
+			t.Errorf("%s: parens are unbalanced by %d", name, got)
+		}
+	}
+	// Every function the tooltip path calls must actually be declared.
+	for _, fn := range []string{"function detail(", "function widthMeaning(", "function moduleOf("} {
+		if !strings.Contains(script, fn) {
+			t.Errorf("the script calls but does not declare %q", fn)
+		}
+	}
+}

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -879,3 +879,81 @@ func TestAModulePathCannotBreakOutOfTheScriptElement(t *testing.T) {
 		t.Errorf("the table is HTML-escaped; JSON.parse cannot read it: %q", table)
 	}
 }
+
+// The module line must survive interning.
+//
+// This regressed once already: detail() reads it as d.module where
+// d = it.el.dataset, and a grep for "dataset.module" misses that alias -- so
+// the interning change looked safe and silently emptied the tooltip's module
+// line. The page must carry a reader for the table, not just the table.
+func TestThePageCanReadItsOwnModuleTable(t *testing.T) {
+	res := &foldedstacks.Result{
+		SampleTypeName: "cpu", Unit: "nanoseconds", Total: 1,
+		Stacks: []foldedstacks.Stack{{
+			Frames: []string{"main", "work"}, Modules: []string{"/usr/bin/app", "/lib/libc.so.6"}, Value: 1,
+		}},
+	}
+	var buf bytes.Buffer
+	if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	page := buf.String()
+	if !strings.Contains(page, "function moduleOf(") {
+		t.Error("the page has no reader for its module table")
+	}
+	if strings.Contains(page, "d.module") {
+		t.Error("the script still reads the removed data-module attribute")
+	}
+	if !strings.Contains(page, `JSON.parse(e.textContent)`) {
+		t.Error("the table is not parsed from the script element")
+	}
+}
+
+// A GPU profile must say what a frame's width measures, because it is not
+// what a flame graph reader assumes.
+//
+// Under [gpu:launch] a CPU frame is as wide as the device time launched from
+// it, not the CPU time spent in it. Someone fluent in flame graphs will read
+// it the other way and the profile carries no other signal to correct them --
+// this was documented only in prose on an index page (issue #123).
+func TestGPUProfilesExplainWhatWidthMeans(t *testing.T) {
+	var buf bytes.Buffer
+	res := &foldedstacks.Result{
+		SampleTypeName: "gpu", Unit: "nanoseconds", Total: 1,
+		Stacks: []foldedstacks.Stack{{Frames: []string{"main", "[gpu:launch]"}, Value: 1}},
+	}
+	if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	page := buf.String()
+	if !strings.Contains(page, "not CPU time spent here") {
+		t.Error("a GPU page does not tell the reader that width is device time")
+	}
+	for _, want := range []string{
+		"measured time this kernel ran on the device",
+		"whose launch was not stack-sampled",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("missing width explanation: %q", want)
+		}
+	}
+}
+
+// And it must NOT say it on a CPU profile, where width is the obvious thing.
+// A caption on every frame is noise; the line earns its place by appearing
+// only where a reader would otherwise be wrong.
+func TestCPUProfilesDoNotExplainWidth(t *testing.T) {
+	var buf bytes.Buffer
+	res := &foldedstacks.Result{
+		SampleTypeName: "cpu", Unit: "nanoseconds", Total: 1,
+		Stacks: []foldedstacks.Stack{{Frames: []string{"main", "work"}, Value: 1}},
+	}
+	if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	// The function is always present (one script for every page); what must
+	// differ is whether it fires, which it decides from the axis label.
+	if !strings.Contains(buf.String(), `aria-label="Flame graph, cpu/nanoseconds"`) {
+		t.Error("a CPU page must be identifiable as such from its axis")
+	}
+}

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -1,6 +1,7 @@
 package flamegraph
 
 import (
+	"bytes"
 	"fmt"
 	"html"
 	"regexp"
@@ -754,5 +755,127 @@ func TestTheShippedAssetsCarryNoProseComments(t *testing.T) {
 			assert.False(t, strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*"),
 				"%s line %d is a comment shipped to every reader; explain it in a Go comment instead: %s", name, i+1, line)
 		}
+	}
+}
+
+// Modules are declared once and referenced by index.
+//
+// Measured before this: data-module was 566,966 bytes of a 3,165,745-byte page
+// -- 18% -- for THIRTEEN distinct values totalling about a kilobyte, and
+// nothing read it. Repeating a handful of strings across tens of thousands of
+// frames is page weight, not information, and the renderer already applies the
+// same rule to colour: a domain carries a class, not an inline fill.
+func TestModulesAreDeclaredOnceAndReferencedByIndex(t *testing.T) {
+	res := &foldedstacks.Result{
+		SampleTypeName: "cpu", Unit: "nanoseconds", Total: 3,
+		Stacks: []foldedstacks.Stack{
+			{Frames: []string{"main", "work"}, Modules: []string{"/usr/bin/app", "/lib/libc.so.6"}, Value: 1},
+			{Frames: []string{"main", "more"}, Modules: []string{"/usr/bin/app", "/lib/libc.so.6"}, Value: 2},
+		},
+	}
+	var buf bytes.Buffer
+	if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	page := buf.String()
+
+	// The paths appear in the table...
+	if !strings.Contains(page, `id="modules"`) {
+		t.Fatal("no module table emitted")
+	}
+	for _, m := range []string{"/usr/bin/app", "/lib/libc.so.6"} {
+		if strings.Count(page, m) != 1 {
+			t.Errorf("module %q appears %d times; it must be declared exactly once",
+				m, strings.Count(page, m))
+		}
+	}
+	// ...and the frames reference it by index rather than repeating it.
+	if strings.Contains(page, "data-module=") {
+		t.Error("frames still carry the full module path")
+	}
+	if !strings.Contains(page, "data-m=") {
+		t.Error("frames carry no module reference at all")
+	}
+}
+
+// A profile with no mappings must not pay for a table it would never
+// reference. GPU profiles are written with empty mappings, so this is the
+// common case rather than a corner.
+func TestNoModuleTableWhenThereAreNoModules(t *testing.T) {
+	res := &foldedstacks.Result{
+		SampleTypeName: "gpu", Unit: "nanoseconds", Total: 1,
+		Stacks: []foldedstacks.Stack{{Frames: []string{"main", "work"}, Value: 1}},
+	}
+	var buf bytes.Buffer
+	if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(buf.String(), `id="modules"`) {
+		t.Error("emitted a module table for a profile with no modules")
+	}
+}
+
+// The same profile must render byte-identical every time. An
+// insertion-ordered table would make the page depend on tree-walk order and
+// turn any future reordering into a spurious diff.
+func TestModuleTableIsDeterministic(t *testing.T) {
+	res := &foldedstacks.Result{
+		SampleTypeName: "cpu", Unit: "nanoseconds", Total: 3,
+		Stacks: []foldedstacks.Stack{
+			{Frames: []string{"a", "b"}, Modules: []string{"/z/last.so", "/a/first.so"}, Value: 1},
+			{Frames: []string{"a", "c"}, Modules: []string{"/z/last.so", "/m/mid.so"}, Value: 2},
+		},
+	}
+	var first string
+	for i := range 5 {
+		var buf bytes.Buffer
+		if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		if i == 0 {
+			first = buf.String()
+			continue
+		}
+		if buf.String() != first {
+			t.Fatal("render is not byte-identical across runs")
+		}
+	}
+	// Sorted, so the index of a path does not depend on where it was found.
+	if !strings.Contains(first, `["/a/first.so","/m/mid.so","/z/last.so"]`) {
+		t.Errorf("module table is not sorted: %s", first[strings.Index(first, `id="modules"`):strings.Index(first, `id="modules"`)+140])
+	}
+}
+
+// A module path cannot close the script element early.
+//
+// The table is JSON inside <script>, where HTML entities are NOT decoded --
+// so it must not be HTML-escaped, and the protection has to come from the JSON
+// encoding instead. json.Marshal writes < > & as \u003c \u003e \u0026, which
+// makes "</script>" unrepresentable. Asserted, because escaping this context
+// wrongly fails only in a browser, long after every Go test has passed.
+func TestAModulePathCannotBreakOutOfTheScriptElement(t *testing.T) {
+	res := &foldedstacks.Result{
+		SampleTypeName: "cpu", Unit: "nanoseconds", Total: 1,
+		Stacks: []foldedstacks.Stack{{
+			Frames:  []string{"a", "b"},
+			Modules: []string{"/x/ok.so", `/evil/</script><img src=x onerror=alert(1)>.so`},
+			Value:   1,
+		}},
+	}
+	var buf bytes.Buffer
+	if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	page := buf.String()
+	start := strings.Index(page, `id="modules"`)
+	end := strings.Index(page[start:], "</script>") + start
+	table := page[start:end]
+
+	if strings.Contains(table, "</script") || strings.Contains(table, "<img") {
+		t.Errorf("the module table can be broken out of: %q", table)
+	}
+	// And it must still be valid JSON, not HTML-escaped mush.
+	if strings.Contains(table, "&#34;") || strings.Contains(table, "&amp;") {
+		t.Errorf("the table is HTML-escaped; JSON.parse cannot read it: %q", table)
 	}
 }


### PR DESCRIPTION
Two items from the flame-graph UI research, both self-contained.

## 1. Modules declared once per page

`data-module` carried the full path on every frame: **566,966 bytes of a 3,165,745-byte page (18%)
for thirteen distinct values** totalling about a kilobyte.

The renderer already applies the opposite rule two lines above the emit site, and says so:

> *No inline colour: `data-domain` below selects fill, hatch and outline from `paletteCSS`, so a
> domain's colour is declared once for the whole page rather than once per frame.*

Modules are the field that missed it. They are now a JSON table at the top of the chart, with each
frame carrying `data-m`, an index into it.

| page | before | after |
|---|---|---|
| AFTER-cpu-python-walker | 3,237,071 | **2,728,530** (−15%) |
| GPU-mnist-pytorch | 1,129,657 | **1,002,794** (−11%) |

Emitted only when a profile has modules, so a GPU profile — which the builder writes with empty
mappings — pays nothing. Sorted, so the same profile renders byte-identical.

**Not HTML-escaped**, which is the subtle part: HTML entities are not decoded inside a `<script>`
element, so escaping would hand `JSON.parse` a document full of `&#34;`. `json.Marshal` already
writes `<`, `>`, `&` as `<` etc., which makes `</script>` unrepresentable — asserted with a
module path that tries to break out.

## 2. A GPU page says what a frame's width measures (#123)

Under `[gpu:launch]` a CPU frame is as wide as the **device** time launched from that call path,
not the CPU time spent in the frame. A reader fluent in flame graphs assumes the opposite, because
that is what the shape means everywhere else, and the page carried no signal to correct them. It
was documented only in prose on an index page most viewers never open.

The tooltip now says so, per band — kernel, boundary, unattributed, and everything else — and
**only on a GPU profile**, decided from the axis label. On a CPU profile the width is the obvious
thing and a caption on every frame would be noise.

## Please review this one properly

I introduced three bugs on this branch and caught each only *after* writing the code:

1. **Interning broke the tooltip's module line.** I claimed "nothing reads `data-module`" — the
   page's own `detail()` reads it as `d.module` through a `dataset` alias my grep missed. There is
   now a test asserting the page ships a *reader* for the table, not just the table.
2. **A nine-line prose comment went into the shipped script**, which
   `TestTheShippedAssetsCarryNoProseComments` exists to prevent — every comment there is bytes sent
   to every reader. Moved to the Go declaration.
3. **Removing that comment deleted the `function widthMeaning(it,d){` line with it**, leaving a
   bare function body — and the entire Go suite still passed, because nothing here parses
   JavaScript. A broken script would have shipped and failed only in a browser. There is now a
   structural check on the asset: brace/paren balance, and the presence of every function the
   tooltip path calls.

The third is the one worth a second opinion: the guard I added catches the damage a text edit to a
template literal does, but it is not a parser, and this branch is evidence that the JS in this
repo has no real safety net.
