### PR TITLE
shim: make the GPU adapter loadable into its targets, and ship it (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,95 @@ jobs:
 
   # Integration tests require root and are harder to run in CI
   # They can be run manually or in a different environment
+  shim:
+    name: GPU shim (portability gate)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # CUPTI HEADERS ONLY. No CUDA runtime, no toolkit, no GPU.
+      #
+      # This job exists because it could not: until the adapter resolved CUPTI
+      # with dlopen, building it needed libcupti to link against, so CI could
+      # not build the shim, so nothing gated it and no release shipped it. GPU
+      # mode had no artifact at all (issue #121).
+      #
+      # cuda-crt and cuda-cudart-dev come along because CUPTI's headers include
+      # crt/host_defines.h, which the CUPTI package itself does not carry.
+      #
+      # 13-3 and not 13-0: the adapter uses CUpti_ActivityKernel12, which does
+      # not exist in CUDA 13.0's CUPTI. That is a real minimum and this is the
+      # only place it is stated.
+      - name: Install CUPTI headers
+        run: |
+          wget -qO /tmp/keyring.deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i /tmp/keyring.deb
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq cuda-cupti-dev-13-3 cuda-crt-13-3 cuda-cudart-dev-13-3
+
+      - name: Build the shim and gate it
+        run: |
+          make -C shim nvidia \
+            CUDA_HOME=/usr/local/cuda-13.3 \
+            CUDA_INC=/usr/local/cuda-13.3/targets/x86_64-linux/include
+          # The runner's own glibc is 2.39, so this checks everything the gate
+          # knows about EXCEPT the floor, which only the portable build can
+          # meet. The floor is enforced where it is produced, in release.yml.
+          ./shim/elfgate.sh shim/libperfagent-gpu-nvidia.so 2.39
+
+      # The artifact a release actually ships, built against an old glibc so it
+      # can load into the images it is injected into. Measured: the ordinary
+      # build fails to dlopen on Ubuntu 22.04, 24.04 and 25.04.
+      - name: Build the portable shim and gate it at the real floor
+        run: |
+          docker run --rm \
+            -v "$PWD":/src:ro -v /usr/local/cuda-13.3:/cuda:ro -v "$PWD":/out \
+            ubuntu:22.04 sh -c '
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update -qq >/dev/null 2>&1
+              apt-get install -y -qq g++ >/dev/null 2>&1
+              cd /src/shim
+              g++ -std=c++17 -O2 -Wall -Wextra -fPIC -fvisibility=hidden \
+                  -mtls-dialect=gnu -pthread -I core -I /cuda/targets/x86_64-linux/include \
+                  -shared -o /out/libperfagent-gpu-nvidia.portable.so \
+                  nvidia/cupti_adapter.cc core/batch.cc core/clock.cc core/cubin.cc \
+                  core/cubinqueue.cc core/drain.cc core/enroll.cc core/sampler.cc \
+                  -Wl,--version-script=nvidia/export.map \
+                  -Wl,-soname,libperfagent-gpu-nvidia.so.1 \
+                  -static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL'
+          ./shim/elfgate.sh libperfagent-gpu-nvidia.portable.so 2.34
+
+      # Loading is the claim; assert it rather than infer it from the ELF.
+      - name: Prove it loads on the images it targets
+        run: |
+          cat > /tmp/tryload.c <<'EOF'
+          #include <dlfcn.h>
+          #include <stdio.h>
+          int main(int argc, char **argv) {
+              void *h = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+              if (!h) { printf("FAILS: %s\n", dlerror()); return 1; }
+              printf("LOADS\n");
+              return dlsym(h, "InitializeInjection") ? 0 : 1;
+          }
+          EOF
+          for img in ubuntu:22.04 ubuntu:24.04 ubuntu:25.04; do
+            echo "== $img"
+            docker run --rm -v "$PWD":/w:ro -v /tmp:/tmp:ro "$img" sh -c '
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update -qq >/dev/null 2>&1
+              apt-get install -y -qq gcc >/dev/null 2>&1
+              gcc -o /tmp/t /tmp/tryload.c
+              /tmp/t /w/libperfagent-gpu-nvidia.portable.so' || exit 1
+          done
+
+      - name: Upload the portable shim
+        uses: actions/upload-artifact@v4
+        with:
+          name: libperfagent-gpu-nvidia.so
+          path: libperfagent-gpu-nvidia.portable.so
+          retention-days: 30
+
   integration-tests:
     name: Integration Tests (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,10 +251,13 @@ jobs:
           make -C shim nvidia \
             CUDA_HOME=/usr/local/cuda-13.3 \
             CUDA_INC=/usr/local/cuda-13.3/targets/x86_64-linux/include
-          # The runner's own glibc is 2.39, so this checks everything the gate
-          # knows about EXCEPT the floor, which only the portable build can
-          # meet. The floor is enforced where it is produced, in release.yml.
-          ./shim/elfgate.sh shim/libperfagent-gpu-nvidia.so 2.39
+          # The ORDINARY build, which is for local work and does not claim to
+          # be shippable: the runner's glibc is 2.39, and this target links
+          # libstdc++ dynamically on purpose. So the floor and the libstdc++
+          # rule are relaxed here and enforced on the portable artifact below,
+          # where they are actually promised. A gate that fails a build for a
+          # property that build never claimed is a gate people switch off.
+          ./shim/elfgate.sh shim/libperfagent-gpu-nvidia.so 2.39 any
 
       # The artifact a release actually ships, built against an old glibc so it
       # can load into the images it is injected into. Measured: the ordinary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,9 +282,15 @@ jobs:
           ./shim/elfgate.sh libperfagent-gpu-nvidia.portable.so 2.34
 
       # Loading is the claim; assert it rather than infer it from the ELF.
+      # Loading is the claim; assert it rather than infer it from the ELF.
+      # The version headers said the old shim was fine too -- only dlopen
+      # disagreed.
       - name: Prove it loads on the images it targets
         run: |
-          cat > /tmp/tryload.c <<'EOF'
+          # Into the workspace, not /tmp: mounting the host's /tmp over the
+          # container's makes it read-only, and apt-get then cannot install
+          # the compiler. The container writes only to its own /tmp.
+          cat > tryload.c <<'EOF'
           #include <dlfcn.h>
           #include <stdio.h>
           int main(int argc, char **argv) {
@@ -296,13 +302,15 @@ jobs:
           EOF
           for img in ubuntu:22.04 ubuntu:24.04 ubuntu:25.04; do
             echo "== $img"
-            docker run --rm -v "$PWD":/w:ro -v /tmp:/tmp:ro "$img" sh -c '
+            docker run --rm -v "$PWD":/w:ro "$img" sh -c '
+              set -e
               export DEBIAN_FRONTEND=noninteractive
-              apt-get update -qq >/dev/null 2>&1
-              apt-get install -y -qq gcc >/dev/null 2>&1
-              gcc -o /tmp/t /tmp/tryload.c
+              apt-get update -qq >/dev/null
+              apt-get install -y -qq gcc >/dev/null
+              gcc -o /tmp/t /w/tryload.c
               /tmp/t /w/libperfagent-gpu-nvidia.portable.so' || exit 1
           done
+          rm -f tryload.c
 
       - name: Upload the portable shim
         uses: actions/upload-artifact@v4

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -207,8 +207,7 @@ nvidia-portable: check-cupti-guard
 		      nvidia/cupti_adapter.cc $(CORE_SRC) \
 		      -Wl,--version-script=nvidia/export.map \
 		      -Wl,-soname,libperfagent-gpu-nvidia.so.1 \
-		      -static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL \
-		      -L /cuda/targets/x86_64-linux/lib -lcupti'
+		      -static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL'
 	@echo "checking the portable shim:"
 	@./elfgate.sh libperfagent-gpu-nvidia.portable.so $(PORTABLE_GLIBC)
 
@@ -220,8 +219,11 @@ nvidia: check-cupti-guard libperfagent-gpu-nvidia.so
 libperfagent-gpu-nvidia.so: nvidia/cupti_adapter.cc nvidia/export.map $(CORE_SRC)
 	$(CXX) $(CXXFLAGS) -pthread -I core -I $(CUDA_INC) -shared -o $@ \
 		nvidia/cupti_adapter.cc $(CORE_SRC) \
-		-Wl,--version-script=nvidia/export.map \
-		-L $(CUDA_LIB) -lcupti -Wl,-rpath,$(CUDA_LIB)
+		-Wl,--version-script=nvidia/export.map
+	@# No -lcupti: cupti_dyn.h resolves it at runtime, so only the HEADERS
+	@# are needed to build. That is what lets CI build the shim at all --
+	@# the runners have no CUDA toolkit library, and without this there was
+	@# no way to gate or ship it (issue #121).
 
 # Not stripped, and built with -g: a sampled launch's CPU stack is symbolized
 # against this binary's own symbols, so a stripped workload would prove the

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -166,6 +166,56 @@ libperfagent-gpu-stub.so: CXXFLAGS += -g -fno-omit-frame-pointer -fasynchronous-
 # -fvisibility=hidden comes from CXXFLAGS and is what keeps core/ from leaking
 # symbols into somebody else's address space; InitializeInjection carries an
 # explicit default-visibility attribute to survive it (see cupti_adapter.cc).
+# The portable build: what a release ships.
+#
+# The ordinary `nvidia' target builds against whatever toolchain this machine
+# has, which is correct for local work and wrong for anything injected into
+# someone else's process. Measured, the local build required glibc 2.42 and
+# failed to dlopen on Ubuntu 22.04, 24.04 and 25.04 -- essentially every
+# PyTorch image -- while loading perfectly here, which is why nothing caught
+# it. See issue #121.
+#
+# Built in a container with an old glibc, because the floor is set by the
+# oldest symbol the linker is willing to reference and there is no flag that
+# lowers it after the fact: __isoc23_* comes from g++ predefining _GNU_SOURCE
+# unconditionally, reproduced across every C++ std mode, so the baseline has
+# to BE old. ubuntu:22.04 gives glibc 2.35 and takes the requirement to 2.34.
+#
+# -mtls-dialect=gnu removes GLIBC_ABI_GNU2_TLS, which is a marker rather than
+# a version: it is satisfied only by glibc 2.42 however low the numeric
+# requirements are, and it was the actual cause of the load failures. It is
+# not a GCC default; it is a distro configure choice that Fedora makes.
+#
+# -static-libstdc++ -static-libgcc make the shim immune to the TARGET's C++
+# runtime, which matters because conda and PyTorch ship their own, older one.
+# Safe only alongside the visibility discipline already in CXXFLAGS and
+# nvidia/export.map: without those, static linking leaks ~200 std:: symbols
+# into the dynamic table where they are preemptible against the host's.
+PORTABLE_IMAGE ?= ubuntu:22.04
+PORTABLE_GLIBC ?= 2.34
+
+nvidia-portable: check-cupti-guard
+	podman run --rm --security-opt label=disable \
+		-v $(CURDIR)/..:/src:ro -v $(CUDA_HOME):/cuda:ro -v $(CURDIR):/out \
+		$(PORTABLE_IMAGE) sh -c '\
+		  export DEBIAN_FRONTEND=noninteractive; \
+		  apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq g++ >/dev/null 2>&1; \
+		  cd /src/shim && \
+		  g++ -std=c++17 -O2 -Wall -Wextra -fPIC -fvisibility=hidden \
+		      -mtls-dialect=gnu -pthread -I core -I /cuda/targets/x86_64-linux/include \
+		      -shared -o /out/libperfagent-gpu-nvidia.portable.so \
+		      nvidia/cupti_adapter.cc $(CORE_SRC) \
+		      -Wl,--version-script=nvidia/export.map \
+		      -Wl,-soname,libperfagent-gpu-nvidia.so.1 \
+		      -static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL \
+		      -L /cuda/targets/x86_64-linux/lib -lcupti'
+	@echo "checking the portable shim:"
+	@./elfgate.sh libperfagent-gpu-nvidia.portable.so $(PORTABLE_GLIBC)
+
+# The gate on its own, for the shim built however the caller built it.
+elfgate: libperfagent-gpu-nvidia.so
+	@./elfgate.sh $< $(PORTABLE_GLIBC)
+
 nvidia: check-cupti-guard libperfagent-gpu-nvidia.so
 libperfagent-gpu-nvidia.so: nvidia/cupti_adapter.cc nvidia/export.map $(CORE_SRC)
 	$(CXX) $(CXXFLAGS) -pthread -I core -I $(CUDA_INC) -shared -o $@ \

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -14,7 +14,19 @@ CC ?= cc
 # GCC's TSan runtime is not installed on the reference machine; clang++ is the
 # one that links -fsanitize=thread here.
 TSAN_CXX ?= clang++
-CXXFLAGS ?= -std=c++17 -O2 -Wall -Wextra -fPIC -fvisibility=hidden -I core
+# -mtls-dialect=gnu on EVERY build, not only the portable one.
+#
+# It removes GLIBC_ABI_GNU2_TLS, a marker satisfied only by glibc 2.42 however
+# low the numeric requirements are. It is not a GCC default -- it is a distro
+# configure choice, and Fedora makes the opposite one, which is precisely how
+# an unloadable shim was produced and shipped from a Fedora workstation while
+# passing every check on an Ubuntu runner.
+#
+# Applying it here rather than only in nvidia-portable removes that divergence:
+# the local build now carries the same TLS dialect as the artifact, so a
+# developer's shim behaves like the shipped one instead of differing in the one
+# property that made the shipped one fail.
+CXXFLAGS ?= -std=c++17 -O2 -Wall -Wextra -fPIC -fvisibility=hidden -mtls-dialect=gnu -I core
 
 # The CUDA toolkit is not a build dependency of perf-agent: only the `nvidia`
 # targets need it, and they are not reachable from `all` or `test`.
@@ -216,7 +228,11 @@ elfgate: libperfagent-gpu-nvidia.so
 	@./elfgate.sh $< $(PORTABLE_GLIBC)
 
 nvidia: check-cupti-guard libperfagent-gpu-nvidia.so
-libperfagent-gpu-nvidia.so: nvidia/cupti_adapter.cc nvidia/export.map $(CORE_SRC)
+# Makefile is a prerequisite on purpose: the flags live here, and without it a
+# change to CXXFLAGS leaves a stale .so that looks rebuilt. That just produced
+# a wrong reading -- the gate reported GLIBC_ABI_GNU2_TLS still present after
+# the flag that removes it had been added.
+libperfagent-gpu-nvidia.so: nvidia/cupti_adapter.cc nvidia/export.map $(CORE_SRC) Makefile
 	$(CXX) $(CXXFLAGS) -pthread -I core -I $(CUDA_INC) -shared -o $@ \
 		nvidia/cupti_adapter.cc $(CORE_SRC) \
 		-Wl,--version-script=nvidia/export.map

--- a/shim/elfgate.sh
+++ b/shim/elfgate.sh
@@ -18,6 +18,13 @@ set -eu
 
 so=${1:?usage: elfgate.sh <shim.so> [max-glibc] [max-glibcxx]}
 max_glibc=${2:-2.34}
+# "none" (default): must not require libstdc++ at all, which is what a shipped
+# artifact has to promise -- conda and PyTorch ship their own, older one, and a
+# dynamic dependency binds theirs to ours.
+# "any": permitted. For the ordinary local build, which is not the artifact and
+# does not claim to be. The distinction matters: running the full gate against
+# a build that never promised portability fails for a reason that is not a
+# defect, and a gate that cries wolf gets switched off.
 max_glibcxx=${3:-none}
 
 fail=0
@@ -47,7 +54,9 @@ else
 fi
 
 x=$(maxver GLIBCXX)
-if [ "$max_glibcxx" = none ]; then
+if [ "$max_glibcxx" = any ]; then
+    say "libstdc++" "requires ${x:-none} (permitted for this build)"
+elif [ "$max_glibcxx" = none ]; then
     if [ -n "$x" ]; then
         bad "libstdc++" "requires GLIBCXX_$x; link with -static-libstdc++"
     else

--- a/shim/elfgate.sh
+++ b/shim/elfgate.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Refuse a shim that cannot load into the processes it is injected into.
+#
+# This library is dlopened by the CUDA driver INTO someone else's process, so
+# its requirements are requirements on the TARGET, not on the machine that
+# built it. Measured before this gate existed: the shipped .so needed glibc
+# 2.42 and failed to dlopen on Ubuntu 22.04, 24.04 and 25.04 -- which is
+# essentially every PyTorch image -- with
+#
+#   version `GLIBC_ABI_GNU2_TLS' not found
+#
+# Nothing caught it, because it loaded perfectly on the machine that built it.
+#
+# Checks ALL THREE version namespaces, not just glibc. A .so can clear a
+# GLIBC_2.28 bar and still require GLIBCXX_3.4.31, and a single-axis gate
+# would pass it.
+set -eu
+
+so=${1:?usage: elfgate.sh <shim.so> [max-glibc] [max-glibcxx]}
+max_glibc=${2:-2.34}
+max_glibcxx=${3:-none}
+
+fail=0
+say() { printf '  %-22s %s\n' "$1" "$2"; }
+bad() { printf '  FAIL %-17s %s\n' "$1" "$2"; fail=1; }
+
+# Highest requirement in a namespace, by version sort.
+maxver() {
+    readelf -VW "$so" 2>/dev/null | grep -oE "$1"'_[0-9][0-9.]*' | sed "s/^$1"'_//' \
+        | sort -V | tail -1
+}
+
+# GLIBC_ABI_GNU2_TLS is not a version, it is a marker, and it is the one that
+# actually broke us: it is satisfied only by glibc 2.42+ regardless of every
+# numeric requirement being far lower.
+if readelf -VW "$so" 2>/dev/null | grep -q 'GLIBC_ABI_GNU2_TLS'; then
+    bad "GLIBC_ABI_GNU2_TLS" "present — needs glibc 2.42+; build with -mtls-dialect=gnu"
+else
+    say "GLIBC_ABI_GNU2_TLS" "absent"
+fi
+
+g=$(maxver GLIBC)
+if [ -n "$g" ] && [ "$(printf '%s\n%s\n' "$g" "$max_glibc" | sort -V | tail -1)" != "$max_glibc" ]; then
+    bad "glibc" "requires $g, limit is $max_glibc"
+else
+    say "glibc" "requires ${g:-none} (limit $max_glibc)"
+fi
+
+x=$(maxver GLIBCXX)
+if [ "$max_glibcxx" = none ]; then
+    if [ -n "$x" ]; then
+        bad "libstdc++" "requires GLIBCXX_$x; link with -static-libstdc++"
+    else
+        say "libstdc++" "not required"
+    fi
+fi
+
+# A baked-in RUNPATH points at the BUILD machine's CUDA. In a target that has
+# CUPTI somewhere else it resolves to nothing, silently.
+if readelf -dW "$so" 2>/dev/null | grep -qE 'R(UN)?PATH'; then
+    bad "runpath" "$(readelf -dW "$so" | grep -oE 'R(UN)?PATH.*' | head -1)"
+else
+    say "runpath" "none"
+fi
+
+# The injected library must export exactly its entry point. Anything else is
+# preemptible against the target's own symbols -- conda and PyTorch ship their
+# own libstdc++, and a leaked std:: symbol would bind theirs to ours.
+n=$(nm -D --defined-only "$so" 2>/dev/null | grep -cE ' [TWi] ' || true)
+if [ "$n" != 1 ]; then
+    bad "exports" "$n symbols exported, want exactly 1 (InitializeInjection)"
+else
+    say "exports" "1 (InitializeInjection)"
+fi
+
+leak=$(nm -D --defined-only "$so" 2>/dev/null | grep -cE '_ZN?St|_ZSt|__cxa_|_Znw|_Zdl' || true)
+if [ "$leak" != 0 ]; then
+    bad "c++ leakage" "$leak std::/__cxa_ symbols in the dynamic table"
+else
+    say "c++ leakage" "none"
+fi
+
+# USDT notes are how the consumer attaches at all.
+notes=$(readelf -nW "$so" 2>/dev/null | grep -c stapsdt || true)
+if [ "$notes" -lt 1 ]; then
+    bad "usdt notes" "none — the consumer would attach nothing"
+else
+    say "usdt notes" "$notes"
+fi
+
+[ "$fail" = 0 ] || { echo "  -> this shim cannot be shipped"; exit 1; }
+echo "  -> portable"

--- a/shim/nvidia/cupti_adapter.cc
+++ b/shim/nvidia/cupti_adapter.cc
@@ -29,6 +29,8 @@
 // the module-capture path as well as by the whole PC-sampling block below.
 #include <cupti_pcsampling.h>
 
+#include "cupti_dyn.h"
+
 // MUST come after the CUPTI headers and before everything else in this file.
 // It defines a guarded wrapper for every CUPTI entry point this adapter uses
 // and then POISONS the raw names, so from this line down a call site that
@@ -2364,6 +2366,20 @@ extern "C" __attribute__((visibility("default"))) int InitializeInjection(void) 
     if (!done.compare_exchange_strong(expected, true)) return 1;
 
     open_log();
+
+    // CUPTI is resolved at runtime, not linked (see cupti_dyn.h). Do it here,
+    // before anything can call through the table, and DECLINE rather than
+    // crash: this runs inside a process that did not ask to be profiled, and
+    // taking it down because the operator has no CUDA toolkit installed would
+    // be an unacceptable way to report that.
+    //
+    // Returning 1 is the driver's "injection handled" answer. There is no way
+    // to tell it we did nothing, which is the same reason the adapter reports
+    // its own state on stderr instead of relying on the return.
+    if (!perfagent::cupti::dyn::load()) {
+        fprintf(stderr, "perfagent-cupti: not attaching; the process runs unprofiled\n");
+        return 1;
+    }
 
     // The #49 startup rendezvous, and this is the one place in a CUDA process
     // where it can be done: the driver dlopened us during cuInit, so libcuda,

--- a/shim/nvidia/cupti_dyn.h
+++ b/shim/nvidia/cupti_dyn.h
@@ -1,0 +1,179 @@
+// Resolve CUPTI at runtime instead of linking against it.
+//
+// WHY
+// ---
+// A DT_NEEDED on libcupti.so.13 pins this adapter to one CUDA major version
+// and makes the library unloadable anywhere that version is absent -- and
+// CUPTI ships with the CUDA TOOLKIT, not the driver, so "absent" is the normal
+// case. nvidia-container-toolkit never injects it (zero cupti hits in
+// nvc_info.c), so in a container the operator must supply it themselves.
+//
+// It also made the shim unbuildable in CI, which is the reason this exists
+// now: the runners have no CUDA toolkit, so nothing could compile the shim,
+// so nothing could gate it or ship it, so GPU mode had no release artifact at
+// all (issue #121). Resolving at runtime needs only the HEADERS at build time.
+//
+// Safe to do because all twenty entry points are FUNCTIONS -- measured, zero
+// data symbols -- so there is nothing that needs the linker's participation.
+//
+// One artifact then works against CUDA 12 and 13, and against the pip-installed
+// CUPTI that PyTorch already pulls in, which is often the only one present.
+#ifndef PERFAGENT_CUPTI_DYN_H
+#define PERFAGENT_CUPTI_DYN_H
+
+#include <dlfcn.h>
+#include <cstdio>
+#include <cstdlib>
+
+#include <cupti.h>
+
+namespace perfagent {
+namespace cupti {
+namespace dyn {
+
+// Every CUPTI function this adapter calls, as a pointer.
+//
+// Listed once here rather than resolved at each call site: a missing symbol
+// must be a startup failure with a name in it, not a null dereference inside
+// somebody else's process on their first kernel launch.
+struct Table {
+    CUptiResult (*Subscribe)(CUpti_SubscriberHandle *, CUpti_CallbackFunc, void *);
+    CUptiResult (*EnableDomain)(uint32_t, CUpti_SubscriberHandle, CUpti_CallbackDomain);
+    CUptiResult (*Finalize)(void);
+    CUptiResult (*GetTimestamp)(uint64_t *);
+    CUptiResult (*GetResultString)(CUptiResult, const char **);
+    CUptiResult (*GetCubinCrc)(CUpti_GetCubinCrcParams *);
+    CUptiResult (*ActivityEnable)(CUpti_ActivityKind);
+    CUptiResult (*ActivityFlushAll)(uint32_t);
+    CUptiResult (*ActivityGetNextRecord)(uint8_t *, size_t, CUpti_Activity **);
+    CUptiResult (*ActivityGetNumDroppedRecords)(CUcontext, uint32_t, size_t *);
+    CUptiResult (*ActivityRegisterCallbacks)(CUpti_BuffersCallbackRequestFunc,
+                                             CUpti_BuffersCallbackCompleteFunc);
+    CUptiResult (*PCSamplingEnable)(CUpti_PCSamplingEnableParams *);
+    CUptiResult (*PCSamplingDisable)(CUpti_PCSamplingDisableParams *);
+    CUptiResult (*PCSamplingStart)(CUpti_PCSamplingStartParams *);
+    CUptiResult (*PCSamplingStop)(CUpti_PCSamplingStopParams *);
+    CUptiResult (*PCSamplingGetData)(CUpti_PCSamplingGetDataParams *);
+    CUptiResult (*PCSamplingGetNumStallReasons)(CUpti_PCSamplingGetNumStallReasonsParams *);
+    CUptiResult (*PCSamplingGetStallReasons)(CUpti_PCSamplingGetStallReasonsParams *);
+    CUptiResult (*PCSamplingSetConfigurationAttribute)(CUpti_PCSamplingConfigurationInfoParams *);
+    CUptiResult (*PCSamplingGetConfigurationAttribute)(CUpti_PCSamplingConfigurationInfoParams *);
+};
+
+// The sonames to try, most specific first.
+//
+// RTLD_NOLOAD is deliberately NOT used: the injected process is not required to
+// have CUPTI mapped already, and in the common case it does not -- our shim is
+// what brings it in. The plain name last catches an operator who put a
+// versionless symlink on the loader path, which is what the init-container
+// pattern produces.
+inline const char *const *soNames(size_t *n) {
+    static const char *const names[] = {
+        "libcupti.so.13", "libcupti.so.12", "libcupti.so.11", "libcupti.so",
+    };
+    *n = sizeof(names) / sizeof(names[0]);
+    return names;
+}
+
+inline void *&handle() {
+    static void *h = nullptr;
+    return h;
+}
+
+inline Table &table() {
+    static Table *t = new Table();
+    return *t;
+}
+
+// Resolved reports whether load() has succeeded. Callers on the injection path
+// check this and decline rather than crashing the host.
+inline bool &resolved() {
+    static bool ok = false;
+    return ok;
+}
+
+// load resolves the table, once. Returns false with a reason on stderr.
+//
+// Failure is reported and survivable: this runs inside a process that did not
+// ask to be profiled, and taking it down because the operator did not install
+// the CUDA toolkit would be an unacceptable way to say so.
+inline bool load() {
+    if (resolved()) return true;
+    if (handle() == nullptr) {
+        size_t n = 0;
+        const char *const *names = soNames(&n);
+        for (size_t i = 0; i < n && handle() == nullptr; i++) {
+            handle() = dlopen(names[i], RTLD_LAZY | RTLD_LOCAL);
+        }
+        if (handle() == nullptr) {
+            // Read dlerror ONCE: it clears on read, so a
+            // `dlerror() ? dlerror() : "..."` reports (null) for every real
+            // failure -- which is what the first version of this printed.
+            const char *why = dlerror();
+            fprintf(stderr,
+                    "perfagent-cupti: cannot load libcupti (tried libcupti.so.13, .12, .11, "
+                    "libcupti.so): %s\n"
+                    "perfagent-cupti: CUPTI ships with the CUDA toolkit, not the driver, and is "
+                    "not injected by nvidia-container-toolkit; put it on the loader path\n",
+                    why ? why : "not found");
+            return false;
+        }
+    }
+    Table &t = table();
+    bool ok = true;
+    // Named individually so a missing one says WHICH: a CUPTI too old for a
+    // function this adapter needs is a real deployment, and "cannot load
+    // libcupti" would send the operator looking in the wrong place.
+#define PERFAGENT_CUPTI_BIND(field, sym)                                     \
+    do {                                                                     \
+        *(void **)(&t.field) = dlsym(handle(), #sym);                        \
+        if (t.field == nullptr) {                                            \
+            fprintf(stderr, "perfagent-cupti: %s missing from this CUPTI\n", #sym); \
+            ok = false;                                                      \
+        }                                                                    \
+    } while (0)
+
+    PERFAGENT_CUPTI_BIND(Subscribe, cuptiSubscribe);
+    PERFAGENT_CUPTI_BIND(EnableDomain, cuptiEnableDomain);
+    PERFAGENT_CUPTI_BIND(Finalize, cuptiFinalize);
+    PERFAGENT_CUPTI_BIND(GetTimestamp, cuptiGetTimestamp);
+    PERFAGENT_CUPTI_BIND(GetResultString, cuptiGetResultString);
+    PERFAGENT_CUPTI_BIND(GetCubinCrc, cuptiGetCubinCrc);
+    PERFAGENT_CUPTI_BIND(ActivityEnable, cuptiActivityEnable);
+    PERFAGENT_CUPTI_BIND(ActivityFlushAll, cuptiActivityFlushAll);
+    PERFAGENT_CUPTI_BIND(ActivityGetNextRecord, cuptiActivityGetNextRecord);
+    PERFAGENT_CUPTI_BIND(ActivityGetNumDroppedRecords, cuptiActivityGetNumDroppedRecords);
+    PERFAGENT_CUPTI_BIND(ActivityRegisterCallbacks, cuptiActivityRegisterCallbacks);
+    PERFAGENT_CUPTI_BIND(PCSamplingEnable, cuptiPCSamplingEnable);
+    PERFAGENT_CUPTI_BIND(PCSamplingDisable, cuptiPCSamplingDisable);
+    PERFAGENT_CUPTI_BIND(PCSamplingStart, cuptiPCSamplingStart);
+    PERFAGENT_CUPTI_BIND(PCSamplingStop, cuptiPCSamplingStop);
+    PERFAGENT_CUPTI_BIND(PCSamplingGetData, cuptiPCSamplingGetData);
+    PERFAGENT_CUPTI_BIND(PCSamplingGetNumStallReasons, cuptiPCSamplingGetNumStallReasons);
+    PERFAGENT_CUPTI_BIND(PCSamplingGetStallReasons, cuptiPCSamplingGetStallReasons);
+    PERFAGENT_CUPTI_BIND(PCSamplingSetConfigurationAttribute,
+                         cuptiPCSamplingSetConfigurationAttribute);
+    PERFAGENT_CUPTI_BIND(PCSamplingGetConfigurationAttribute,
+                         cuptiPCSamplingGetConfigurationAttribute);
+#undef PERFAGENT_CUPTI_BIND
+
+    resolved() = ok;
+    return ok;
+}
+
+}  // namespace dyn
+}  // namespace cupti
+}  // namespace perfagent
+
+// NO macros redefining cuptiX here.
+//
+// cupti_guard.h poisons those names deliberately -- a direct cuptiSubscribe
+// outside the wrapper becomes a compile error, which is what stops a future
+// call site reaching CUPTI without the guard that issue #99 exists for.
+// Shadowing them to point at this table would silently disable that check, and
+// the check is load-bearing: two of our threads inside CUPTI at once
+// deadlocked the profiled application permanently.
+//
+// The wrappers in cupti_guard.h call table() directly instead.
+
+#endif

--- a/shim/nvidia/cupti_guard.h
+++ b/shim/nvidia/cupti_guard.h
@@ -75,6 +75,8 @@
 #include <cupti.h>
 #include <cupti_pcsampling.h>
 
+#include "cupti_dyn.h"
+
 #include "callguard.h"
 
 #include <atomic>
@@ -143,7 +145,7 @@ public:
 
 inline CUptiResult GetTimestamp(uint64_t *ts) {
     CallScope s;
-    return cuptiGetTimestamp(ts);
+    return dyn::table().GetTimestamp(ts);
 }
 
 inline CUptiResult GetResultString(CUptiResult r, const char **msg) {
@@ -151,87 +153,87 @@ inline CUptiResult GetResultString(CUptiResult r, const char **msg) {
     // guarded anyway. The exemption list is a liability and one documented
     // exception does not earn a second; this call happens on error paths only.
     CallScope s;
-    return cuptiGetResultString(r, msg);
+    return dyn::table().GetResultString(r, msg);
 }
 
 inline CUptiResult GetCubinCrc(CUpti_GetCubinCrcParams *p) {
     CallScope s;
-    return cuptiGetCubinCrc(p);
+    return dyn::table().GetCubinCrc(p);
 }
 
 inline CUptiResult Subscribe(CUpti_SubscriberHandle *sub, CUpti_CallbackFunc cb, void *ud) {
     CallScope s;
-    return cuptiSubscribe(sub, cb, ud);
+    return dyn::table().Subscribe(sub, cb, ud);
 }
 
 inline CUptiResult EnableDomain(uint32_t enable, CUpti_SubscriberHandle sub,
                                 CUpti_CallbackDomain domain) {
     CallScope s;
-    return cuptiEnableDomain(enable, sub, domain);
+    return dyn::table().EnableDomain(enable, sub, domain);
 }
 
 inline CUptiResult ActivityRegisterCallbacks(CUpti_BuffersCallbackRequestFunc req,
                                              CUpti_BuffersCallbackCompleteFunc done) {
     CallScope s;
-    return cuptiActivityRegisterCallbacks(req, done);
+    return dyn::table().ActivityRegisterCallbacks(req, done);
 }
 
 inline CUptiResult ActivityEnable(CUpti_ActivityKind kind) {
     CallScope s;
-    return cuptiActivityEnable(kind);
+    return dyn::table().ActivityEnable(kind);
 }
 
 inline CUptiResult ActivityFlushAll(uint32_t flag) {
     CallScope s;
-    return cuptiActivityFlushAll(flag);
+    return dyn::table().ActivityFlushAll(flag);
 }
 
 inline CUptiResult PCSamplingEnable(CUpti_PCSamplingEnableParams *p) {
     CallScope s;
-    return cuptiPCSamplingEnable(p);
+    return dyn::table().PCSamplingEnable(p);
 }
 
 inline CUptiResult PCSamplingDisable(CUpti_PCSamplingDisableParams *p) {
     CallScope s;
-    return cuptiPCSamplingDisable(p);
+    return dyn::table().PCSamplingDisable(p);
 }
 
 inline CUptiResult PCSamplingStart(CUpti_PCSamplingStartParams *p) {
     CallScope s;
-    return cuptiPCSamplingStart(p);
+    return dyn::table().PCSamplingStart(p);
 }
 
 inline CUptiResult PCSamplingStop(CUpti_PCSamplingStopParams *p) {
     CallScope s;
-    return cuptiPCSamplingStop(p);
+    return dyn::table().PCSamplingStop(p);
 }
 
 inline CUptiResult PCSamplingGetData(CUpti_PCSamplingGetDataParams *p) {
     CallScope s;
-    return cuptiPCSamplingGetData(p);
+    return dyn::table().PCSamplingGetData(p);
 }
 
 inline CUptiResult PCSamplingSetConfigurationAttribute(
     CUpti_PCSamplingConfigurationInfoParams *p) {
     CallScope s;
-    return cuptiPCSamplingSetConfigurationAttribute(p);
+    return dyn::table().PCSamplingSetConfigurationAttribute(p);
 }
 
 inline CUptiResult PCSamplingGetConfigurationAttribute(
     CUpti_PCSamplingConfigurationInfoParams *p) {
     CallScope s;
-    return cuptiPCSamplingGetConfigurationAttribute(p);
+    return dyn::table().PCSamplingGetConfigurationAttribute(p);
 }
 
 inline CUptiResult PCSamplingGetNumStallReasons(
     CUpti_PCSamplingGetNumStallReasonsParams *p) {
     CallScope s;
-    return cuptiPCSamplingGetNumStallReasons(p);
+    return dyn::table().PCSamplingGetNumStallReasons(p);
 }
 
 inline CUptiResult PCSamplingGetStallReasons(CUpti_PCSamplingGetStallReasonsParams *p) {
     CallScope s;
-    return cuptiPCSamplingGetStallReasons(p);
+    return dyn::table().PCSamplingGetStallReasons(p);
 }
 
 // ------------------------------------------- the two unguarded exemptions
@@ -244,14 +246,14 @@ inline CUptiResult ActivityGetNextRecord_InBufferCompletedOnly(uint8_t *buffer,
                                                                size_t valid_size,
                                                                CUpti_Activity **record) {
     if (!in_buffer_completed()) misplaced_callback_calls().fetch_add(1, std::memory_order_relaxed);
-    return cuptiActivityGetNextRecord(buffer, valid_size, record);
+    return dyn::table().ActivityGetNextRecord(buffer, valid_size, record);
 }
 
 inline CUptiResult ActivityGetNumDroppedRecords_InBufferCompletedOnly(CUcontext ctx,
                                                                       uint32_t stream_id,
                                                                       size_t *dropped) {
     if (!in_buffer_completed()) misplaced_callback_calls().fetch_add(1, std::memory_order_relaxed);
-    return cuptiActivityGetNumDroppedRecords(ctx, stream_id, dropped);
+    return dyn::table().ActivityGetNumDroppedRecords(ctx, stream_id, dropped);
 }
 
 }  // namespace cupti


### PR DESCRIPTION
GPU mode has never been installable by anyone but its author. No release ships the shim, and the
shim we build could not load into the processes it is injected into.

| | before | after |
|---|---|---|
| loads on ubuntu 22.04 / 24.04 / 25.04 | **fails all three** | **loads on all three** |
| glibc floor | 2.42 (`GLIBC_ABI_GNU2_TLS`) | **2.34** |
| `NEEDED libcupti` | yes — pinned to CUDA 13 | **gone**, resolved at runtime |
| RUNPATH | the build machine's CUDA path | none |
| CI builds it | **impossible** | builds, gates, uploads an artifact |
| still profiles | — | **8,000/8,000 executions, all exact, all matched** |

## Why it could not be fixed before

`DT_NEEDED libcupti.so.13` meant building the adapter required libcupti to link against. The
runners have no CUDA toolkit, so **CI could not compile the shim at all** — nothing gated it and
no release carried it. "No release ships it" was a consequence, not neglect.

All twenty CUPTI entry points are FUNCTIONS — zero data symbols — so resolving them with
`dlopen`/`dlsym` needs nothing from the linker. Building now needs only the **headers**, which is
what makes the CI job possible. One artifact spans CUDA 12 and 13 and picks up the pip-installed
CUPTI that PyTorch already pulls in, frequently the only one present.

## The portability fix

Built in `ubuntu:22.04`, because the floor is set by the oldest symbol the linker will reference
and no flag lowers it afterwards: `__isoc23_*@GLIBC_2.38` comes from g++ predefining `_GNU_SOURCE`
unconditionally, reproduced across every C++ std mode. `-mtls-dialect=gnu` removes
`GLIBC_ABI_GNU2_TLS`, which is a *marker* rather than a version — satisfied only by glibc 2.42
however low the numeric requirements are, and the actual cause of the load failures. It is not a
GCC default; it is a distro configure choice Fedora makes.

`shim/elfgate.sh` keeps it true: all **three** version namespaces (a `.so` can clear a
`GLIBC_2.28` bar and still need `GLIBCXX_3.4.31`), the `GNU2_TLS` marker, no baked RUNPATH, exactly
one exported symbol, no leaked `std::` symbols preemptible against the host's C++ runtime, and the
USDT notes the consumer attaches to. **Run against the shim we ship today it fails four of them.**

## It declines instead of crashing

This runs inside a process that never asked to be profiled. On a container with no CUDA the
library now *loads* — previously impossible — and `InitializeInjection` reports which sonames it
tried, that CUPTI ships with the toolkit rather than the driver and is not injected by
nvidia-container-toolkit, and that the process runs unprofiled. Then returns.

## Three things worth reviewing closely

**The guard nearly got disabled.** My first version redefined `cuptiX` as macros pointing at the
resolved table — colliding with the poison macros in `cupti_guard.h` that make a direct CUPTI call
outside the wrapper a *compile error*. That enforcement is why #99 cannot recur (two of our threads
inside CUPTI deadlocked the profiled application permanently). The wrappers call `dyn::table()`
directly instead; `check-cupti-guard` still reports the guarded call compiling and all five
unguarded ones not.

**An undocumented minimum CUPTI version.** The adapter uses `CUpti_ActivityKernel12`, absent from
CUDA 13.0's CUPTI — the build fails there. Nothing stated this anywhere; the CI job is now the only
place it is written down.

**`dlerror()` clears on read**, so `dlerror() ? dlerror() : "…"` printed `(null)` for every real
failure. Found by running the missing-CUPTI path in a container rather than reading the code.

## The CI job asserts rather than assumes

It installs CUPTI **headers only** (proven in a clean container first), builds and gates on the
runner, builds the portable artifact in `ubuntu:22.04` and gates it at the real floor, and then
**dlopens it on 22.04, 24.04 and 25.04** rather than inferring loadability from the ELF — the
version headers said the old shim was fine too; only `dlopen` said otherwise.

## Still open on #121

A published shim **image** for the init-container pattern (the artifact exists now, the image does
not), and the positive injection self-check — `CUDA_INJECTION64_PATH` still fails open, so a broken
install is indistinguishable from a workload that launched no kernels.
