### PR TITLE
gpu: say whether the injection happened, and document how to install it (#121)

### DIFF
--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -236,6 +236,16 @@ func main() {
 		log.Fatalf("workload: %v", err)
 	}
 
+	// Did the injection actually happen?
+	//
+	// CUDA_INJECTION64_PATH fails OPEN and SILENT: a driver that cannot load
+	// the library carries on as though the variable were unset, so a broken
+	// shim and a workload that launched no kernels produce identical output --
+	// an empty profile and no error. The mapping is the one observable that
+	// separates them. Watched here, while the workload is alive, because
+	// /proc/<pid>/maps is gone the moment it is not.
+	injected := waitForInjection(cmd.Process.Pid, shimPath, 10*time.Second)
+
 	deadline := time.Now().Add(time.Duration(*linger) * time.Millisecond)
 	for c.Stats().SampledLaunches < uint64(wantSampled) {
 		if time.Now().After(deadline) {
@@ -246,6 +256,7 @@ func main() {
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+	reportInjection(injected, shimPath, cmd.Process.Pid, c.Stats().SampledLaunches)
 	if err := release.Close(); err != nil {
 		log.Fatalf("release workload: %v", err)
 	}
@@ -310,4 +321,47 @@ func main() {
 	// (the CRCs the PC records join on are not the CRCs the cubins arrived
 	// under, which is hardware assertion 13).
 	log.Printf("module store: %+v", store.Stats())
+}
+
+// waitForInjection watches for the shim appearing in the workload's mappings.
+//
+// Bounded, and a miss is not an error: the driver loads the library during
+// cuInit, which a workload may not reach for some time, and a workload started
+// through a wrapper script does its CUDA work in a CHILD whose mappings this
+// does not inspect. The answer feeds a diagnostic, never a failure.
+func waitForInjection(pid int, shimPath string, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if ok, err := gpuprobe.ShimIsMappedIn(pid, shimPath); err == nil && ok {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// reportInjection turns "an empty profile" into a statement about which of the
+// two possible causes it was.
+//
+// Says nothing when there is nothing to say: a run that sampled launches
+// plainly injected, whatever the mapping check saw, and a line confirming the
+// obvious on every successful run is noise that trains people to skip the
+// output.
+func reportInjection(mapped bool, shimPath string, pid int, sampled uint64) {
+	if sampled > 0 {
+		return
+	}
+	if mapped {
+		log.Printf("no launches were sampled, but the shim IS mapped into the workload: " +
+			"injection worked and the adapter did not report launches. Look at the " +
+			"perfagent-cupti lines above for why -- a missing CUPTI is reported there.")
+		return
+	}
+	log.Printf("no launches were sampled and %s is NOT mapped into pid %d. "+
+		"CUDA_INJECTION64_PATH fails open and silent, so this is exactly what a shim the "+
+		"driver could not load looks like: check that the workload is a CUDA program that "+
+		"reached cuInit, and that the shim loads in ITS environment "+
+		"(`make -C shim nvidia-portable` builds one that does). If the workload is a wrapper "+
+		"script the CUDA process is a child, and this check does not see it.",
+		shimPath, pid)
 }

--- a/docs/gpu-injection.md
+++ b/docs/gpu-injection.md
@@ -1,0 +1,158 @@
+<!-- docs/gpu-injection.md -->
+# Installing the GPU adapter with CUDA injection
+
+perf-agent profiles GPU work by getting a small shared library -- the *shim* --
+loaded into the application's own process, where it subscribes to CUPTI and
+emits USDT probes the agent consumes. The application is not rebuilt, not
+relinked, and not otherwise modified.
+
+This document is how to deliver that library, and how to tell whether it
+actually arrived.
+
+## The mechanism
+
+The CUDA driver loads whatever `CUDA_INJECTION64_PATH` names, during `cuInit`,
+and calls its `InitializeInjection`:
+
+```
+CUDA_INJECTION64_PATH=/path/to/libperfagent-gpu-nvidia.so ./your-cuda-app
+```
+
+Two properties of this mechanism drive everything below.
+
+**It fails open and silent.** If the driver cannot load the library -- wrong
+path, wrong architecture, a glibc the process does not have -- it carries on
+exactly as though the variable were never set. Nothing is logged by the driver,
+the application runs normally, and the profile comes out empty. *"The shim is
+broken"* and *"this workload launched no kernels"* produce identical output.
+Verifying injection is therefore not optional; see **Did it work?** below.
+
+**`CUDA_INJECTION64_PATH` is absent from NVIDIA's public CUPTI documentation**
+(only `NVTX_INJECTION64_PATH` is). It is the mechanism NVIDIA's own tools use
+and that other profilers depend on, but treat it as semi-official surface.
+
+## Which shim to use
+
+Build the **portable** one for anything that leaves your machine:
+
+```bash
+make -C shim nvidia-portable      # needs podman/docker and CUPTI headers
+```
+
+`make -C shim nvidia` is for local work on the machine that built it. The
+difference is not cosmetic: the shim is loaded into *someone else's* process, so
+its requirements are requirements on the **target**.
+
+| | `nvidia` (local) | `nvidia-portable` |
+|---|---|---|
+| glibc floor | your build machine's | **2.34** |
+| libstdc++ | dynamic | statically linked in |
+| RUNPATH | your CUDA path | none |
+| loads on ubuntu 22.04 / 24.04 / 25.04 | not necessarily | **yes, asserted in CI** |
+
+Both resolve CUPTI at **runtime**, so neither is tied to a CUDA major version
+and neither needs the toolkit present in order to build.
+
+`shim/elfgate.sh` checks a shim against those requirements and names any it
+fails:
+
+```bash
+./shim/elfgate.sh shim/libperfagent-gpu-nvidia.portable.so 2.34
+```
+
+CI runs it on every change and additionally `dlopen`s the artifact inside
+Ubuntu 22.04, 24.04 and 25.04 -- because the ELF version headers said an
+unloadable shim was fine, and only `dlopen` disagreed.
+
+## CUPTI is yours to supply
+
+CUPTI ships with the **CUDA toolkit**, not the driver, and
+`nvidia-container-toolkit` never injects it. The shim `dlopen`s
+`libcupti.so.13`, `.12`, `.11`, then the bare soname; if none is present it says
+so and lets the process run unprofiled rather than taking it down.
+
+In a PyTorch image the pip-installed CUPTI is usually already present, under
+`site-packages/nvidia/*/lib`. Put that directory on `LD_LIBRARY_PATH` if the
+loader does not find it.
+
+## Delivering it
+
+### Bare metal
+
+```bash
+CUDA_INJECTION64_PATH=/opt/perf-agent/libperfagent-gpu-nvidia.so ./your-app
+```
+
+### A container
+
+The library must be inside the container and readable by the process:
+
+```bash
+podman run --rm \
+  -v /opt/perf-agent/libperfagent-gpu-nvidia.so:/opt/pa/shim.so:ro \
+  -e CUDA_INJECTION64_PATH=/opt/pa/shim.so \
+  your-cuda-image
+```
+
+### Kubernetes
+
+An init container copies the shim onto a shared volume, the application
+container mounts it and sets the environment variable. See
+[`examples/kubernetes/`](../examples/kubernetes/) for a full manifest and for
+what does and does not work today.
+
+**The agent must open the same inode**, not a copy of the same bytes: uprobe
+attachment keys on `(dev, ino)`. Two copies of an identical file produce zero
+probe fires and no error message.
+
+## Did it work?
+
+The single most useful check, because the failure is silent:
+
+```bash
+grep libperfagent /proc/<pid>/maps
+```
+
+Several file-backed mappings, `r-xp` among them, all sharing one inode. **No
+output means injection did not happen** -- do not read the resulting empty
+profile as "this workload used no GPU".
+
+`cmd/gpu-cuda-profile` performs this check itself, and when a run samples no
+launches it says which of the two causes it was: the shim mapped but the adapter
+reported nothing, or the shim never mapped at all. It says nothing on a healthy
+run.
+
+The shim also reports its own state on stderr:
+
+```
+perfagent-cupti: initialized pid=26 sample_period=8 ... enroll=confirmed
+```
+
+and when it cannot find CUPTI:
+
+```
+perfagent-cupti: cannot load libcupti (tried libcupti.so.13, .12, .11, libcupti.so): ...
+perfagent-cupti: CUPTI ships with the CUDA toolkit, not the driver ...
+perfagent-cupti: not attaching; the process runs unprofiled
+```
+
+## Capabilities
+
+The agent -- not the shim -- needs `CAP_BPF`, `CAP_PERFMON`, `CAP_SYS_PTRACE`,
+`CAP_CHECKPOINT_RESTORE`, and `CAP_SYSLOG` for kernel stacks. It does **not**
+need `CAP_SYS_ADMIN`, and that is a deliberate constraint rather than an
+accident: the USDT consumer attaches through the `uprobe_multi` BPF link,
+because the `perf_uprobe` PMU path requires `CAP_SYS_ADMIN` and that is what
+gets a per-pod agent rejected by admission policy. It costs a **Linux 6.6**
+floor.
+
+## What this does not yet cover
+
+- **No published container image** for the init-container pattern. CI uploads
+  the portable shim as a build artifact; there is no registry image to name in
+  a pod spec yet.
+- **The agent cannot attach to an already-running process** on the GPU path:
+  `cmd/gpu-cuda-profile` launches the workload itself. A Kubernetes sidecar has
+  to attach to a container the kubelet started, so the sidecar shape in
+  `examples/kubernetes/` cannot run end to end until that exists. Tracked in
+  issue #124.

--- a/gpuprobe/injectcheck.go
+++ b/gpuprobe/injectcheck.go
@@ -1,0 +1,28 @@
+package gpuprobe
+
+// ShimIsMappedIn reports whether pid has the shim at shimPath mapped.
+//
+// WHY THIS IS NEEDED AT ALL
+// -------------------------
+// CUDA_INJECTION64_PATH fails OPEN and SILENT. If the driver cannot load the
+// library -- wrong path, wrong architecture, a glibc the target does not have
+// (issue #121) -- it carries on exactly as if the variable had never been set.
+// Nothing is logged by the driver, the workload runs normally, and the profile
+// comes out empty. "The shim is broken" and "this workload launched no kernels"
+// produce identical output.
+//
+// The mapping is the one observable that separates them, and it is the same
+// fact enrolment already keys on: the shim appears in the victim's maps as
+// file-backed segments carrying the inode of the file on disk.
+//
+// Answers only for THIS pid, not its descendants. A workload launched through
+// a wrapper script does its CUDA work in a child, and the shim will be mapped
+// there rather than here -- so a false answer is possible and callers must say
+// so rather than assert injection failed.
+func ShimIsMappedIn(pid int, shimPath string) (bool, error) {
+	dev, ino, err := enrollShimIdentity(shimPath)
+	if err != nil {
+		return false, err
+	}
+	return procMapsHaveInode("/proc", uint32(pid), dev, ino) //nolint:gosec // a pid from exec.Cmd
+}

--- a/gpuprobe/injectcheck_test.go
+++ b/gpuprobe/injectcheck_test.go
@@ -1,0 +1,56 @@
+package gpuprobe
+
+import (
+	"os"
+	"testing"
+)
+
+// The check has to answer both ways for the SAME process, or it cannot
+// distinguish a shim the driver loaded from one it silently refused -- which
+// is the entire reason it exists. CUDA_INJECTION64_PATH fails open: a driver
+// that cannot load the library carries on as though the variable were unset,
+// so "the shim is broken" and "this workload launched no kernels" produce
+// identical output, and only the mapping tells them apart.
+func TestShimIsMappedInAnswersBothWaysForOneProcess(t *testing.T) {
+	// libc is mapped into this test binary by construction.
+	mapped := "/lib64/libc.so.6"
+	if _, err := os.Stat(mapped); err != nil {
+		mapped = "/lib/x86_64-linux-gnu/libc.so.6"
+		if _, err := os.Stat(mapped); err != nil {
+			t.Skip("no libc at a known path on this machine")
+		}
+	}
+	ok, err := ShimIsMappedIn(os.Getpid(), mapped)
+	if err != nil {
+		t.Fatalf("ShimIsMappedIn(libc): %v", err)
+	}
+	if !ok {
+		t.Errorf("libc is not reported as mapped into this process; the check cannot " +
+			"confirm an injection that DID happen, so it would report every run as broken")
+	}
+
+	// A real ELF that this process certainly has not loaded. Using a file
+	// rather than a fabricated path keeps the negative honest: the identity
+	// is resolved from a genuine dev/ino, exactly as the positive case is.
+	notMapped := "/bin/true"
+	if _, err := os.Stat(notMapped); err != nil {
+		t.Skip("no /bin/true")
+	}
+	ok, err = ShimIsMappedIn(os.Getpid(), notMapped)
+	if err != nil {
+		t.Fatalf("ShimIsMappedIn(/bin/true): %v", err)
+	}
+	if ok {
+		t.Errorf("/bin/true is reported as mapped into this process; the check would " +
+			"confirm an injection that never happened, which is worse than not checking")
+	}
+}
+
+// A path that is not a file must be an error rather than a confident "no":
+// answering "not injected" because the shim path was mistyped would send the
+// reader looking at the driver instead of at their own command line.
+func TestShimIsMappedInRefusesAPathItCannotIdentify(t *testing.T) {
+	if _, err := ShimIsMappedIn(os.Getpid(), "/nonexistent/shim.so"); err == nil {
+		t.Error("a missing shim path must be an error, not a negative answer")
+	}
+}


### PR DESCRIPTION
`CUDA_INJECTION64_PATH` fails **open and silent**. A driver that cannot load the library carries on
as though the variable were never set: nothing logged, workload runs normally, profile comes out
empty. *"The shim is broken"* and *"this workload launched no kernels"* are indistinguishable in the
output — which is how a shim requiring glibc 2.42, unloadable in every mainstream PyTorch image,
went unnoticed.

## The check

The mapping is the one observable that separates the two, and it is the same fact enrolment already
keys on. `gpuprobe.ShimIsMappedIn` exports it; the tool watches for the shim appearing in the
workload's maps **while the workload is alive**, and when a run samples no launches it says which
cause it was:

| | reported |
|---|---|
| launches > 0 | **nothing** — a line confirming the obvious on every healthy run trains people to skip the output |
| none, shim mapped | injection worked, the adapter reported nothing → points at the `perfagent-cupti` lines |
| none, shim absent | names the file and pid, says this is what a failed injection looks like, suggests `nvidia-portable` |

Two limits are stated rather than hidden: it inspects **this** pid, so a workload launched through a
wrapper script does its CUDA work in a child it cannot see; and it only ever produces a diagnostic,
never a failure. A malformed shim is caught earlier still, at attach, with its own message.

## Tested both ways, deliberately

A check that can only answer "no" would report every run as broken; one that can only answer "yes"
would confirm injections that never happened, which is worse than not checking. So the test asserts
both against the *same* process. A path that is not a file is an **error**, not a confident
negative — answering "not injected" for a mistyped path sends the reader to the driver instead of
to their own command line.

## Docs

`docs/gpu-injection.md` is the install guide this issue implied but never had: the mechanism and
its two dangerous properties, which shim to build and why that distinction is not cosmetic, that
CUPTI is the operator's to supply and where it usually already is, delivery on bare metal / in a
container / in Kubernetes, how to verify, and the capability set including why `CAP_SYS_ADMIN` is
absent by design.

It also states what is **still missing** rather than implying completeness: no published image for
the init-container pattern, and no attach-to-running-process mode — which is what stops the
Kubernetes sidecar shape from working at all (#124).
