### PR TITLE
gpu: find the targets instead of being handed a pid (#124)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Local build outputs. Copying these into the build context is slow (hundreds
+# of MB of binaries) and pointless: the image builds its own.
+bin-*
+gpu-cuda-profile
+perf-agent
+*.pb.gz
+*.so
+.git
+.worktrees

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,55 @@ jobs:
 
   # Integration tests require root and are harder to run in CI
   # They can be run manually or in a different environment
+  images:
+    name: Container images
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Built, not just linted. The failures these images have are BUILD-time
+      # failures -- an unshippable shim, a dynamically linked blazesym that
+      # kills file capabilities -- and both are caught by gates inside the
+      # Dockerfiles. A workflow that only ran hadolint would pass while
+      # shipping neither.
+      - name: Build the shim image
+        run: docker build -f Dockerfile.shim -t perf-agent-shim:ci .
+
+      - name: The shim image carries a loadable shim
+        # elfgate already ran inside the build; this checks the FILE made it
+        # into the final stage, which a bad COPY would silently skip.
+        run: |
+          docker run --rm --entrypoint sh perf-agent-shim:ci -c \
+            'test -s /usr/local/lib/libperfagent-gpu-nvidia.so && echo present'
+
+      - name: Build the agent image
+        run: docker build -f Dockerfile.agent -t perf-agent:ci .
+
+      - name: The agent refuses without capabilities, and says which
+        # The bare failure here is an EPERM at exec that names nothing. If the
+        # entrypoint check regresses, this catches it.
+        run: |
+          out=$(docker run --rm perf-agent:ci -discover 2>&1 || true)
+          echo "$out"
+          echo "$out" | grep -q CAP_BPF \
+            || (echo "the capability refusal no longer names what is missing" && exit 1)
+
+      - name: The agent starts with the four documented capabilities
+        # The regression this pins: setcap'ing a capability onto the binary
+        # that the documented deployment does not grant makes the image fail
+        # to exec, because file capabilities must be a subset of the bounding
+        # set. It is invisible until someone deploys it.
+        run: |
+          out=$(docker run --rm \
+            --cap-add=BPF --cap-add=PERFMON --cap-add=SYS_PTRACE --cap-add=CHECKPOINT_RESTORE \
+            perf-agent:ci -discover -wait-for-shim 200ms -shim /nonexistent.so 2>&1 || true)
+          echo "$out"
+          echo "$out" | grep -q "Operation not permitted" \
+            && (echo "the image cannot exec under the capabilities it documents" && exit 1)
+          echo "$out" | grep -q "adapter /nonexistent.so" \
+            || (echo "the agent did not reach its own argument handling" && exit 1)
+
   shim:
     name: GPU shim (portability gate)
     runs-on: ubuntu-24.04

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,0 +1,133 @@
+# The GPU profiler: the consumer half, which attaches to processes the shim was
+# injected into.
+#
+# Separate from Dockerfile.shim, and the split is not tidiness. The shim is
+# dlopened into the APPLICATION's process and must satisfy its loader, so it is
+# built against an old-glibc baseline and carries no dependencies. This binary
+# runs in its OWN container, where the base is ours to choose. Merging them
+# would force the shim's constraints onto the agent or the agent's onto the
+# shim, and the shim's are the ones that cannot bend.
+FROM ubuntu:24.04 AS build
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GO_VERSION=1.26.0
+
+RUN apt-get update -qq \
+ && apt-get install -y -qq --no-install-recommends \
+      ca-certificates wget git build-essential libelf-dev zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN wget -qO /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+ && tar -C /usr/local -xzf /tmp/go.tgz && rm /tmp/go.tgz
+ENV PATH=/usr/local/go/bin:/root/.cargo/bin:$PATH
+
+# blazesym does the symbolization. Built here rather than vendored because it
+# is Rust and the Go binding links its C API.
+RUN wget -qO /tmp/rust.sh https://sh.rustup.rs \
+ && sh /tmp/rust.sh -y --profile minimal --default-toolchain stable \
+ && rm /tmp/rust.sh
+RUN git clone --depth 1 https://github.com/libbpf/blazesym.git /blazesym \
+ && cd /blazesym && cargo build --release --package blazesym-c
+
+# STATIC blazesym, in a directory holding ONLY the archive.
+#
+# Both halves matter. A binary that loads libblazesym_c.so at runtime cannot be
+# given file capabilities: secure-execution mode ignores LD_LIBRARY_PATH, so
+# the loader will not find it and the process dies before main. And -Bstatic
+# alone is not enough -- with the .so beside the .a in the same -L directory
+# the link still records a NEEDED entry for it. Isolating the archive is what
+# actually produces a self-contained binary.
+RUN mkdir -p /blazeonly && cp /blazesym/target/release/libblazesym_c.a /blazeonly/
+
+WORKDIR /src
+COPY go.mod go.sum ./
+
+# The committed go.mod carries an ABSOLUTE-PATH replace for the blazesym Go
+# binding, pointing at a checkout on a developer's machine. Nothing outside
+# that machine can resolve it -- CI rewrites it with the same `go mod edit`
+# before every build, and this image has to as well. Repointing it at the
+# checkout above is what makes this Dockerfile buildable by anyone.
+RUN go mod edit -replace github.com/libbpf/blazesym/go=/blazesym/go \
+ && go mod download
+
+COPY . .
+# COPY brought the committed go.mod back with its unusable absolute path, so
+# the rewrite has to happen again. Cheap, and the alternative -- excluding
+# go.mod from the copy -- silently diverges the build from the source tree.
+RUN go mod edit -replace github.com/libbpf/blazesym/go=/blazesym/go
+
+# No clang and no `go generate`: the BPF objects are committed and embedded
+# with //go:embed, so this image does not need the eBPF toolchain to exist.
+# Regenerating them here would also make the image's behaviour depend on a
+# clang version nothing in the manifest pins -- see issue #117 on why those
+# objects are not reproducible across machines that agree on every visible
+# input.
+RUN CGO_CFLAGS="-I /blazesym/capi/include" \
+    CGO_LDFLAGS="-L /blazeonly -lblazesym_c" \
+    go build -trimpath -o /gpu-cuda-profile ./cmd/gpu-cuda-profile
+
+# Proof, in the build, that the static link actually took. The failure it
+# prevents is a container that starts, is granted its capabilities, and then
+# cannot exec -- which reads as a Kubernetes problem rather than a link
+# problem.
+RUN ! ldd /gpu-cuda-profile | grep -q blazesym \
+    || (echo "blazesym linked dynamically: file capabilities will not survive exec" && exit 1)
+
+FROM ubuntu:24.04
+
+RUN apt-get update -qq \
+ && apt-get install -y -qq --no-install-recommends libcap2-bin ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /gpu-cuda-profile /usr/local/bin/gpu-cuda-profile
+COPY build/agent-entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# FILE CAPABILITIES, so the container does not have to run as root.
+#
+# securityContext.capabilities.add puts capabilities in the container's
+# BOUNDING set. A root process gets them in its effective set from there; a
+# non-root process does NOT -- it needs them on the file. Setting them here is
+# what makes runAsNonRoot possible, and a pod that runs as root gets the same
+# capabilities either way, so this is strictly the safer default.
+#
+# The four, and why each: CAP_BPF loads programs and creates maps and links;
+# CAP_PERFMON opens perf events; CAP_SYS_PTRACE reads another process's memory;
+# CAP_CHECKPOINT_RESTORE dereferences /proc/<pid>/map_files, without which
+# every user-space frame resolves to a bare hex address.
+#
+# CAP_SYSLOG IS DELIBERATELY NOT AMONG THEM, and this is a trade-off rather
+# than an oversight. It would buy kernel-frame symbolization: without it
+# /proc/kallsyms reads zeros and kernel symbolization is silently skipped. But
+# the kernel refuses to exec a file whose file capabilities are not a SUBSET of
+# the bounding set, so a binary carrying five would fail to start -- with a
+# bare EPERM -- in the four-capability deployment this project documents and
+# examples/kubernetes ships. Measured, not reasoned about: granting exactly
+# BPF, PERFMON, SYS_PTRACE and CHECKPOINT_RESTORE to a five-capability binary
+# fails at exec.
+#
+# So the image is built for the deployment that exists, and kernel frames are
+# unavailable in it. Adding SYSLOG to a securityContext will NOT enable them
+# either: for a non-root process the permitted set comes from the file
+# capabilities, so a capability the binary does not carry cannot be gained by
+# granting it. Kernel stacks need a build that setcaps five and a manifest that
+# grants five, together.
+#
+# CAP_SYS_ADMIN is deliberately ABSENT. It is near-root and is what gets a
+# per-pod agent rejected by admission policy. Staying without it is why the
+# USDT consumer attaches through the uprobe_multi BPF link rather than the
+# perf_uprobe PMU, and it costs a Linux 6.6 floor on the NODE.
+RUN setcap cap_bpf,cap_perfmon,cap_sys_ptrace,cap_checkpoint_restore+ep \
+      /usr/local/bin/gpu-cuda-profile \
+ && getcap /usr/local/bin/gpu-cuda-profile
+
+# An unprivileged uid, which the capabilities above are what make workable.
+RUN useradd --uid 65532 --no-create-home --shell /usr/sbin/nologin perfagent
+USER 65532
+
+LABEL org.opencontainers.image.title="perf-agent GPU profiler" \
+      org.opencontainers.image.description="Attaches to CUDA processes carrying the perf-agent CUPTI shim" \
+      org.opencontainers.image.source="https://github.com/dpsoft/perf-agent"
+
+# Not the binary directly: see build/agent-entrypoint.sh for why an
+# unexplained EPERM at exec is the failure this wrapper exists to prevent.
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.shim
+++ b/Dockerfile.shim
@@ -1,0 +1,80 @@
+# The CUPTI adapter, and nothing else.
+#
+# This image exists to be an INIT CONTAINER: it starts, copies one .so onto a
+# shared volume, and exits. The application container then loads that file
+# through CUDA_INJECTION64_PATH. Nothing in this image ever runs alongside the
+# workload, which is why it carries no agent, no Go binary and no CUDA runtime.
+#
+# WHY THE BUILD BASE IS OLD ON PURPOSE
+# ------------------------------------
+# The shim is dlopened by the CUDA driver into somebody else's process, so it
+# has to satisfy THEIR loader, not ours. Built on a current distro it acquires
+# a GLIBC_ABI_GNU2_TLS marker (glibc 2.42) and __isoc23_* symbols (glibc 2.38)
+# and then fails to load into every mainstream PyTorch image -- silently, since
+# CUDA_INJECTION64_PATH fails open. Ubuntu 22.04 is the baseline that clears
+# Ubuntu 22.04, 24.04 and 25.04, which is essentially the whole PyTorch fleet.
+#
+# -mtls-dialect=gnu is not optional: GCC on some distros defaults to gnu2,
+# which is what emits the 2.42 marker. It is set here rather than inherited.
+FROM ubuntu:22.04 AS build
+
+ARG CUDA_MAJOR_MINOR=13-3
+ARG DEBIAN_FRONTEND=noninteractive
+
+# CUPTI HEADERS ONLY. The shim does not link against libcupti and must not:
+# libcupti ships with the CUDA TOOLKIT, not the driver, and an image that
+# linked it would refuse to load in any container that has only the runtime.
+# The adapter resolves every CUPTI entry point with dlopen/dlsym at
+# InitializeInjection and reports its absence instead of dying.
+RUN apt-get update -qq \
+ && apt-get install -y -qq --no-install-recommends g++ ca-certificates wget \
+ && wget -qO /tmp/keyring.deb \
+      https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb \
+ && dpkg -i /tmp/keyring.deb \
+ && apt-get update -qq \
+ && apt-get install -y -qq --no-install-recommends \
+      cuda-cupti-dev-${CUDA_MAJOR_MINOR} \
+      cuda-crt-${CUDA_MAJOR_MINOR} \
+      cuda-cudart-dev-${CUDA_MAJOR_MINOR} \
+ && rm -rf /var/lib/apt/lists/* /tmp/keyring.deb
+
+WORKDIR /src
+COPY shim/ /src/shim/
+
+# The same command line as `make -C shim nvidia-portable`, deliberately spelled
+# out rather than invoking make: this image must not depend on the host's
+# CUDA_HOME, which that target bind-mounts.
+RUN cd /src/shim \
+ && CUDA_INC=$(ls -d /usr/local/cuda-*/targets/x86_64-linux/include | head -1) \
+ && g++ -std=c++17 -O2 -Wall -Wextra -fPIC -fvisibility=hidden \
+      -mtls-dialect=gnu -pthread -I core -I "$CUDA_INC" \
+      -shared -o /libperfagent-gpu-nvidia.so \
+      nvidia/cupti_adapter.cc core/batch.cc core/clock.cc core/cubin.cc \
+      core/cubinqueue.cc core/drain.cc core/enroll.cc core/sampler.cc \
+      -Wl,--version-script=nvidia/export.map \
+      -Wl,-soname,libperfagent-gpu-nvidia.so.1 \
+      -static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL
+
+# THE GATE RUNS IN THE BUILD, so an unshippable shim cannot become an image.
+#
+# This is the whole point of publishing rather than hand-copying: the failure
+# it catches is invisible at runtime. A shim that requires a glibc the target
+# does not have produces an empty profile and no error anywhere, so "it built"
+# is not evidence of anything. Failing here is the only place the mistake is
+# cheap.
+RUN cd /src/shim && ./elfgate.sh /libperfagent-gpu-nvidia.so 2.34
+
+# busybox for `cp`: the init container's whole job is one copy, and the
+# manifest invokes it through `sh -c`. Nothing here is ever executed in the
+# same process as the workload.
+FROM busybox:stable
+COPY --from=build /libperfagent-gpu-nvidia.so /usr/local/lib/libperfagent-gpu-nvidia.so
+
+LABEL org.opencontainers.image.title="perf-agent CUDA shim" \
+      org.opencontainers.image.description="CUPTI adapter for CUDA_INJECTION64_PATH; init-container payload" \
+      org.opencontainers.image.source="https://github.com/dpsoft/perf-agent"
+
+# Not an entrypoint that runs the shim -- it is a library and cannot be run.
+# The default command states what the image is FOR, so `docker run` on it
+# produces an explanation rather than a crash.
+CMD ["sh", "-c", "echo 'This image carries /usr/local/lib/libperfagent-gpu-nvidia.so for an init container to copy onto a shared volume. It is a library; there is nothing here to execute.'; exit 1"]

--- a/build/agent-entrypoint.sh
+++ b/build/agent-entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Turn one opaque EPERM into a sentence naming what is missing.
+#
+# gpu-cuda-profile carries file capabilities, which is what lets it run as a
+# non-root uid. The kernel refuses to exec a file whose file capabilities are
+# not a subset of the process's BOUNDING set -- and it refuses with a bare
+# EPERM, before any of the program's own code runs. So a container started
+# without the capabilities does not report a missing capability: it reports
+#
+#   exec container process `/usr/local/bin/gpu-cuda-profile`: Operation not permitted
+#
+# which names neither the capability nor the securityContext that should have
+# granted it, and in Kubernetes surfaces as a CrashLoopBackOff with nothing in
+# it. This script checks the bounding set FIRST, so the common misconfiguration
+# explains itself instead.
+set -eu
+
+BIN=/usr/local/bin/gpu-cuda-profile
+
+# CapBnd is the bounding set as a hex mask in /proc/self/status. Bit N is
+# capability N; the numbers below are from <linux/capability.h> and are spelled
+# out because a wrong one here would report a capability the agent does not
+# actually need.
+bnd=$(awk '/^CapBnd:/ {print $2}' /proc/self/status)
+missing=""
+check() { # name bit
+    if [ $(( (0x${bnd} >> $2) & 1 )) -eq 0 ]; then
+        missing="${missing} $1"
+    fi
+}
+check CAP_BPF 39                # load programs, create maps and links
+check CAP_PERFMON 38            # perf_event_open
+check CAP_SYS_PTRACE 19         # read another process's memory
+check CAP_CHECKPOINT_RESTORE 40 # /proc/<pid>/map_files
+
+if [ -n "${missing}" ]; then
+    cat >&2 <<EOF
+perf-agent: refusing to start -- these capabilities are not in this container's
+bounding set:${missing}
+
+The binary carries them as FILE capabilities so it can run as a non-root uid,
+and the kernel will not exec such a file unless the same capabilities are in
+the bounding set. Without this check the failure is a bare "Operation not
+permitted" at exec, naming nothing.
+
+In Kubernetes, grant them in the container's securityContext:
+
+  securityContext:
+    capabilities:
+      drop: ["ALL"]
+      add: ["BPF", "PERFMON", "SYS_PTRACE", "CHECKPOINT_RESTORE"]
+
+With docker or podman: --cap-add=BPF,PERFMON,SYS_PTRACE,CHECKPOINT_RESTORE
+
+CAP_SYS_ADMIN is deliberately NOT required and must not be added to work
+around this -- it is near-root and is what gets a per-pod agent rejected by
+admission policy.
+EOF
+    exit 1
+fi
+
+# CAP_SYSLOG is not in this binary's file capabilities and cannot be gained by
+# granting it -- see Dockerfile.agent for why five would make the documented
+# four-capability deployment fail to exec. Kernel frames are therefore not
+# symbolized in this image. Said once, at start, because the profile it
+# produces looks perfectly healthy without them.
+if [ $(( (0x${bnd} >> 34) & 1 )) -eq 1 ]; then
+    echo "perf-agent: CAP_SYSLOG is in the bounding set but this image's binary does not" >&2
+    echo "  carry it as a file capability, so kernel frames still will not be symbolized." >&2
+fi
+
+exec "${BIN}" "$@"

--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -44,6 +44,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -72,20 +73,22 @@ import (
 // exists to prevent; a test enumerates the registered set and fails until
 // every name is on one side or the other.
 type options struct {
-	shim        *string
-	workload    *string
-	iters       *int
-	sleepUs     *int
-	period      *int
-	linger      *int
-	out         *string
-	pid         *int
-	duration    *time.Duration
-	drainEvery  *time.Duration
-	waitForShim *time.Duration
-	nvSymbols   *string
-	pcSampling  *string
-	pcAck       *bool
+	shim            *string
+	workload        *string
+	iters           *int
+	sleepUs         *int
+	period          *int
+	linger          *int
+	out             *string
+	pid             *int
+	discover        *bool
+	rediscoverEvery *time.Duration
+	duration        *time.Duration
+	drainEvery      *time.Duration
+	waitForShim     *time.Duration
+	nvSymbols       *string
+	pcSampling      *string
+	pcAck           *bool
 }
 
 func defineFlags(fs *flag.FlagSet) *options {
@@ -107,6 +110,16 @@ func defineFlags(fs *flag.FlagSet) *options {
 			"profile this already-running process instead of launching a workload. It must "+
 				"have been started with CUDA_INJECTION64_PATH pointing at -shim; injection "+
 				"happens during cuInit and cannot be added to a live process"),
+		discover: fs.Bool("discover", false,
+			"profile EVERY process that maps -shim, found by scanning /proc, instead of "+
+				"being handed one with -pid. This is the shape a sidecar and a node "+
+				"collector need: neither is the application's parent and neither is told "+
+				"its pid"),
+		rediscoverEvery: fs.Duration("rediscover-every", 5*time.Second,
+			"in -discover mode, how often to rescan for targets that appeared or left. "+
+				"Processes that start normally enrol themselves during cuInit and do not "+
+				"need this; the rescan is for ones already past that point, and for "+
+				"noticing when every target has gone"),
 		duration: fs.Duration("duration", 30*time.Second,
 			"how long to profile in -pid mode. The run also ends early on SIGINT or when the "+
 				"target exits"),
@@ -180,13 +193,15 @@ var launchOnlyInAttachMode = map[string]string{
 // configure THIS process -- where the shim is, where the profile goes, how
 // long to run, how symbols are resolved -- rather than the profiled one.
 var attachSafeFlags = map[string]bool{
-	"shim":           true,
-	"out":            true,
-	"nvidia-symbols": true,
-	"pid":            true,
-	"duration":       true,
-	"wait-for-shim":  true,
-	"drain-every":    true,
+	"shim":             true,
+	"out":              true,
+	"nvidia-symbols":   true,
+	"pid":              true,
+	"duration":         true,
+	"wait-for-shim":    true,
+	"drain-every":      true,
+	"discover":         true,
+	"rediscover-every": true,
 }
 
 // refusedLaunchFlags reports the launch-only flags the operator actually set,
@@ -207,6 +222,17 @@ func refusedLaunchFlags(fs *flag.FlagSet) []string {
 // in it, so "evicted 10198 launches" and "evicted 20824 launches" are
 // recognised as one ongoing condition rather than two events.
 var anomalyDigits = regexp.MustCompile(`[0-9]+`)
+
+// describeTargets names what a run covered, in the singular or the plural as
+// the run actually was. "pid 1234" and "3 pids [12 34 56]" are different
+// facts, and a message that said "pid 12" for a three-process collector would
+// misreport the scope of everything else on the line.
+func describeTargets(targets []int) string {
+	if len(targets) == 1 {
+		return fmt.Sprintf("pid %d", targets[0])
+	}
+	return fmt.Sprintf("%d pids %v", len(targets), targets)
+}
 
 func main() {
 	opt := defineFlags(flag.CommandLine)
@@ -229,7 +255,12 @@ func main() {
 	// applied. The profile would then be interpreted at a sampling rate it
 	// was not taken at. Every flag below has that shape: it configures a
 	// process this mode does not create.
-	attach := *opt.pid != 0
+	attach := *opt.pid != 0 || *opt.discover
+	if *opt.pid != 0 && *opt.discover {
+		log.Fatalf("-pid and -discover both name what to profile and disagree about how: " +
+			"-pid is one process you already know, -discover is every process that maps " +
+			"the shim. Pick one")
+	}
 	if attach {
 		if refused := refusedLaunchFlags(flag.CommandLine); len(refused) > 0 {
 			log.Fatalf("-pid was given, so these flags cannot take effect and are refused "+
@@ -322,10 +353,20 @@ func main() {
 	// The wait is for one case only: a process attached to in the seconds
 	// after it started, which has not reached cuInit yet. It is not a retry
 	// loop for a target that will never load the shim.
-	if attach {
+	var targets []int
+	switch {
+	case *opt.discover:
+		var derr error
+		targets, derr = waitForTargets(shimPath, *opt.waitForShim)
+		if derr != nil {
+			log.Fatalf("discover targets: %v", derr)
+		}
+		log.Printf("discovered %d process(es) mapping %s: %v", len(targets), shimPath, targets)
+	case *opt.pid != 0:
 		if err := waitForShimIn(*opt.pid, shimPath, *opt.waitForShim); err != nil {
 			log.Fatalf("attach to pid %d: %v", *opt.pid, err)
 		}
+		targets = []int{*opt.pid}
 		log.Printf("pid %d maps %s; attaching", *opt.pid, shimPath)
 	}
 
@@ -414,7 +455,20 @@ func main() {
 		// tables, which is exactly the ~38% loss issue #49 measured. Here
 		// the window is not merely narrowed but absent: the tables are in
 		// before the first probe exists.
-		PID:        *opt.pid,
+		//
+		// Discovery leaves this ZERO on purpose. PID 0 is not a weaker
+		// attachment than a specific pid, it is the broader one: the
+		// uprobe_multi link then fires in EVERY process mapping the file,
+		// which is precisely the set discovery just enumerated -- and it
+		// keeps covering processes that map it later, which a pid filter
+		// fixed at startup could never do. The narrowing that a pid does buy
+		// is not wanted here; what a specific pid ALSO does -- eager CFI
+		// registration -- is, and that is what EagerPIDs carries.
+		PID: *opt.pid,
+		// Every already-running target, whose tables must exist before the
+		// link does. None of them can use the startup rendezvous: all of them
+		// went past cuInit before this process started.
+		EagerPIDs:  targets,
 		Backend:    gpu.BackendCUPTI,
 		Sink:       timeline,
 		Symbolizer: sym,
@@ -514,7 +568,12 @@ func main() {
 	// it is doing.
 	var launches, wantSampled int
 	if attach {
-		profileAttached(c, *opt.pid, *opt.duration, *opt.drainEvery, collect)
+		targets = profileAttached(c, targets, attachConfig{
+			duration:   *opt.duration,
+			drainEvery: *opt.drainEvery,
+			rediscover: rediscoverInterval(*opt.discover, *opt.rediscoverEvery),
+			shimPath:   shimPath,
+		}, collect)
 	} else {
 		// The sampler jitters each gap around the period so it cannot lock phase
 		// against the workload's alternating axpy/scale pair (issue #50), but the
@@ -609,10 +668,11 @@ func main() {
 		// often a fact about the target -- a process that was idle for the
 		// whole window launches nothing, and there is no defect to report.
 		if attach {
-			log.Fatalf("no samples projected: pid %d launched no kernels in %s. The shim is "+
-				"mapped (checked at startup), so the probes were live; the target was "+
-				"idle, or its CUDA work happens in a different process. stats=%+v",
-				*opt.pid, *opt.duration, c.Stats())
+			log.Fatalf("no samples projected: %v launched no kernels in %s. The shim is "+
+				"mapped (checked at startup), so the probes were live; the targets were "+
+				"idle, or the CUDA work happens in a process that does not map this shim. "+
+				"stats=%+v",
+				describeTargets(targets), *opt.duration, c.Stats())
 		}
 		log.Fatal("no samples projected; the pipeline produced nothing")
 	}
@@ -638,8 +698,8 @@ func main() {
 	// expected_sampled=0 beside a healthy attached run would read as a
 	// shortfall rather than as an inapplicable number.
 	if attach {
-		log.Printf("wrote %s: %d samples from pid %d over %d drain intervals, stats=%+v",
-			*opt.out, totalSamples, *opt.pid, snapshots, st)
+		log.Printf("wrote %s: %d samples from %v over %d drain intervals, stats=%+v",
+			*opt.out, totalSamples, describeTargets(targets), snapshots, st)
 	} else {
 		log.Printf("wrote %s: %d samples, launches=%d expected_sampled=%d stats=%+v",
 			*opt.out, totalSamples, launches, wantSampled, st)
@@ -787,88 +847,128 @@ func waitForShimIn(pid int, shimPath string, within time.Duration) error {
 	}
 }
 
+// attachConfig is how an attached run is bounded and, in discovery mode, kept
+// current. Grouped rather than passed as five positional arguments, because
+// four of them are durations and a transposition would compile.
+type attachConfig struct {
+	duration   time.Duration
+	drainEvery time.Duration
+	// rediscover is zero when there is nothing to rediscover: a -pid run
+	// profiles the one process it was given, and rescanning /proc for it would
+	// be work in service of an answer that cannot change.
+	rediscover time.Duration
+	shimPath   string
+}
+
+// rediscoverInterval is zero unless discovery is actually in use.
+func rediscoverInterval(discover bool, every time.Duration) time.Duration {
+	if !discover || every <= 0 {
+		return 0
+	}
+	return every
+}
+
+// waitForTargets is discovery's precondition, and it is the same refusal
+// waitForShimIn makes, asked of a set rather than of one process.
+//
+// Bounded and then an error, for the same reason: a collector that attaches to
+// nothing and says nothing spends its whole -duration producing an empty
+// profile, which is indistinguishable from a workload that launched no
+// kernels. The wait covers the one legitimate case -- starting alongside an
+// application that has not reached cuInit yet, which is the NORMAL case for a
+// sidecar, since both containers start together.
+func waitForTargets(shimPath string, within time.Duration) ([]int, error) {
+	deadline := time.Now().Add(within)
+	for {
+		found, err := gpuprobe.ProcessesMappingShim(shimPath)
+		if err != nil {
+			return nil, err
+		}
+		if len(found) > 0 {
+			return found, nil
+		}
+		if !time.Now().Before(deadline) {
+			return nil, fmt.Errorf(
+				"no process on this host maps %s after %s. The CUDA driver loads the shim "+
+					"during cuInit, from CUDA_INJECTION64_PATH in each process's own "+
+					"environment, so a process not started with it pointing at THIS FILE "+
+					"can never be a target -- and a copy of the shim at another path is a "+
+					"different file to a uprobe, however identical its bytes. Check that "+
+					"the application was started with CUDA_INJECTION64_PATH=%s, that it "+
+					"has reached cuInit, and that this process can see it (a sidecar needs "+
+					"shareProcessNamespace, a node agent needs hostPID)",
+				shimPath, within, shimPath)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 // profileAttached bounds a run this command did not start.
 //
-// Three things can end it, and the third is the one that matters for
-// correctness rather than convenience. The duration is the operator's budget.
-// SIGINT is the operator changing their mind, and it must produce the profile
-// collected so far rather than discarding it -- a collector killed at the end
-// of a scrape window that wrote nothing would be worse than useless.
+// Four things can end it, and the last is the one that matters for correctness
+// rather than convenience. The duration is the operator's budget. SIGINT is
+// the operator changing their mind, and it must produce the profile collected
+// so far rather than discarding it -- a collector killed at the end of a
+// scrape window that wrote nothing would be worse than useless.
 //
-// The target exiting ends the run IMMEDIATELY, and not as a courtesy: a
-// sampled launch's stack is symbolized against /proc/<pid>/maps, which the
-// kernel destroys the instant the process leaves. Every second spent
-// collecting after that point produces records whose stacks can no longer be
-// resolved. Launch mode solves this by holding the workload's stdin open;
-// attach mode has no such handle on a process it did not create, so the best
-// it can do is notice and stop.
+// Every target exiting ends the run, and not as a courtesy: a sampled launch's
+// stack is symbolized against /proc/<pid>/maps, which the kernel destroys the
+// instant the process leaves. Every second spent collecting after the last one
+// has gone produces records whose stacks can no longer be resolved. Launch
+// mode solves this by holding the workload's stdin open; attach mode has no
+// such handle on processes it did not create, so the best it can do is notice.
 //
-// A pidfd rather than polling /proc/<pid>: the pid is not ours, so it can be
-// reaped and reused by an unrelated process while we watch. A pidfd is bound
-// to the process, not to the number, and it becomes readable exactly once,
-// when that process dies.
-func profileAttached(c *gpuprobe.Consumer, pid int, d, drainEvery time.Duration, collect func()) {
+// EVERY target, not any: with several processes under one attachment, one
+// exiting is an ordinary event -- pods restart -- and ending the run there
+// would throw away the profiling of everything still running.
+//
+// A pidfd per target rather than polling /proc/<pid>: the pids are not ours,
+// so they can be reaped and reused by unrelated processes while we watch. A
+// pidfd is bound to the process, not to the number.
+func profileAttached(c *gpuprobe.Consumer, targets []int, cfg attachConfig, collect func()) []int {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sig)
 
-	gone := make(chan struct{})
-	if fd, err := unix.PidfdOpen(pid, 0); err == nil {
-		go func() {
-			defer func() { _ = unix.Close(fd) }()
-			defer close(gone)
-			fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}} //nolint:gosec // a pidfd is well inside int32
-			for {
-				n, err := unix.Poll(fds, -1)
-				// Poll is interruptible by any signal the runtime delivers,
-				// and the Go runtime delivers plenty. EINTR here means
-				// "nothing happened yet", not "the process is gone", and
-				// treating it as the latter would end every attached run at
-				// the first GC-related signal.
-				if errors.Is(err, unix.EINTR) {
-					continue
-				}
-				if n > 0 || err != nil {
-					return
-				}
-			}
-		}()
-	} else {
-		// No pidfd (pre-5.3, or the process left between the mapping check
-		// and here). The run still works; it just cannot shorten itself when
-		// the target exits, so stacks arriving after that point fail to
-		// symbolize and are counted as such.
-		log.Printf("cannot watch pid %d for exit (%v); the run will not end early if it exits, "+
-			"and stacks captured after that point cannot be symbolized", pid, err)
-	}
+	live := newLiveSet(targets)
+	defer live.close()
+	// Every return below reports what was ACTUALLY covered, which under
+	// rediscovery is not what the run started with.
+	covered := func() []int { return live.all() }
 
-	log.Printf("profiling pid %d for %s (ctrl-c to stop early)", pid, d)
-	// A progress line, because the alternative is an operator watching an
-	// idle terminal for the length of the budget with no way to tell a
-	// working attach from a dead one. Coarse on purpose: it is a sign of
-	// life, not a metric.
+	log.Printf("profiling %d process(es) for %s (ctrl-c to stop early)", len(targets), cfg.duration)
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	// The drain is what keeps the timeline's rings holding an interval rather
 	// than a run. It is deliberately separate from the progress ticker above:
 	// one is for the operator watching, the other is load-bearing.
-	drain := time.NewTicker(drainEvery)
+	drain := time.NewTicker(cfg.drainEvery)
 	defer drain.Stop()
-	deadline := time.After(d)
+
+	// A ticker that never fires when rediscovery is off, so the select below
+	// does not need a second shape for the -pid case.
+	rescan := make(<-chan time.Time)
+	if cfg.rediscover > 0 {
+		t := time.NewTicker(cfg.rediscover)
+		defer t.Stop()
+		rescan = t.C
+	}
+
+	deadline := time.After(cfg.duration)
 	for {
 		select {
 		case <-deadline:
 			log.Printf("-duration elapsed")
-			return
+			return covered()
 		case s := <-sig:
 			log.Printf("%s: stopping early and writing what was collected", s)
-			return
-		case <-gone:
+			return covered()
+		case <-live.allGone:
 			st := c.Stats()
-			log.Printf("pid %d exited after %d sampled launches; stopping now, because its "+
-				"/proc maps are gone and any stack arriving from here on cannot be "+
-				"symbolized", pid, st.SampledLaunches)
-			return
+			log.Printf("every target has exited after %d sampled launches; stopping now, "+
+				"because their /proc maps are gone and any stack arriving from here on "+
+				"cannot be symbolized", st.SampledLaunches)
+			return covered()
 		case <-drain.C:
 			// Deliberately NOT c.Flush() here, though the end-of-run path
 			// does exactly that. Flush releases every launch being held for a
@@ -881,9 +981,165 @@ func profileAttached(c *gpuprobe.Consumer, pid int, d, drainEvery time.Duration,
 			// in the NEXT snapshot. Only the last one, where nothing more is
 			// coming, has to force the issue.
 			collect()
+		case <-rescan:
+			found, err := gpuprobe.ProcessesMappingShim(cfg.shimPath)
+			if err != nil {
+				// Not fatal: the run in progress is unaffected by a failed
+				// rescan, and ending it would throw away a working profile
+				// over a transient /proc read.
+				log.Printf("rediscovery failed (continuing with the targets already found): %v", err)
+				continue
+			}
+			for _, pid := range found {
+				if !live.add(pid) {
+					continue
+				}
+				// New target, and it is here rather than in the rendezvous
+				// because the rendezvous already had its chance: a process
+				// that could use it never reaches this line.
+				n, rerr := c.RegisterTarget(pid)
+				log.Printf("new target pid %d (%d binaries registered, err=%v)", pid, n, rerr)
+			}
 		case <-ticker.C:
 			st := c.Stats()
-			log.Printf("... sampled_launches=%d batches=%d", st.SampledLaunches, st.Batches)
+			log.Printf("... targets=%d sampled_launches=%d batches=%d",
+				live.count(), st.SampledLaunches, st.Batches)
 		}
 	}
+}
+
+// liveSet watches a set of processes and closes allGone when the last one
+// leaves.
+//
+// The edge is ALL-GONE rather than any-gone, and that distinction is the whole
+// reason this is a type instead of a channel. Under discovery a run covers
+// several processes; one of them exiting is an ordinary event -- pods restart,
+// jobs finish -- and treating it as the end of the run would discard the
+// profiling of everything still running. Under -pid the set has one member and
+// all-gone is any-gone, so the single-target case falls out rather than being
+// special-cased.
+//
+// A pidfd per target rather than polling /proc/<pid>: these pids belong to
+// other people, so the kernel may reap and reuse the number while we watch. A
+// pidfd is bound to the process itself and becomes readable exactly once, when
+// that process dies. A pid that cannot be opened is treated as ALREADY GONE
+// rather than as live-forever: it exited between the scan and here, or we may
+// not see it, and either way waiting for it to die would hold the run open on
+// something we can never observe.
+type liveSet struct {
+	allGone chan struct{}
+
+	mu      sync.Mutex
+	watched map[int]bool
+	alive   int
+	closed  bool
+	fds     []int
+}
+
+func newLiveSet(pids []int) *liveSet {
+	// alive starts at 1 for a CONSTRUCTION TOKEN, released once every member
+	// has been added. Without it the set can report all-gone before it is
+	// fully built: the first target's watcher goroutine is running the moment
+	// add returns, so a process that exits during construction takes alive
+	// from 1 to 0 and closes allGone while the remaining pids have not been
+	// added yet. The run would end immediately, having profiled nothing,
+	// on a set where all but one process was perfectly healthy.
+	l := &liveSet{allGone: make(chan struct{}), watched: map[int]bool{}, alive: 1}
+	for _, p := range pids {
+		l.add(p)
+	}
+	// Releasing the token is itself a death for counting purposes, which
+	// gives the degenerate cases the right answer for free: a set where every
+	// pidfd failed to open drops straight to zero and reports all-gone, rather
+	// than holding the run open on processes nothing can observe.
+	l.died()
+	return l
+}
+
+// add starts watching pid and reports whether it was new to this set.
+func (l *liveSet) add(pid int) bool {
+	l.mu.Lock()
+	if l.closed || l.watched[pid] {
+		l.mu.Unlock()
+		return false
+	}
+	l.watched[pid] = true
+	fd, err := unix.PidfdOpen(pid, 0)
+	if err != nil {
+		// Not watchable: gone already, or invisible to us. Recorded as seen so
+		// rediscovery does not retry it every interval, but never counted as
+		// alive -- a target we cannot observe dying must not be able to hold
+		// the run open forever.
+		l.mu.Unlock()
+		return true
+	}
+	l.alive++
+	l.fds = append(l.fds, fd)
+	l.mu.Unlock()
+
+	go func() {
+		fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}} //nolint:gosec // a pidfd is well inside int32
+		for {
+			n, err := unix.Poll(fds, -1)
+			// Poll is interruptible by any signal the runtime delivers, and
+			// the Go runtime delivers plenty. EINTR means "nothing happened
+			// yet", not "the process is gone", and treating it as the latter
+			// would end every attached run at the first GC-related signal.
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			if n > 0 || err != nil {
+				break
+			}
+		}
+		l.died()
+	}()
+	return true
+}
+
+func (l *liveSet) died() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return
+	}
+	l.alive--
+	if l.alive <= 0 {
+		l.closed = true
+		close(l.allGone)
+	}
+}
+
+// all returns every pid this set ever watched, including ones that have since
+// exited and ones found by rediscovery.
+//
+// It is what the end-of-run summary must report, and NOT the set discovery
+// started with. Under -discover the covered set grows during the run, so a
+// summary built from the startup list understates what is in the profile --
+// it would name two processes for a profile containing four, which is a
+// false statement about the scope of every other number on the line.
+func (l *liveSet) all() []int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]int, 0, len(l.watched))
+	for pid := range l.watched {
+		out = append(out, pid)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func (l *liveSet) count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.alive
+}
+
+func (l *liveSet) close() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, fd := range l.fds {
+		_ = unix.Close(fd)
+	}
+	l.fds = nil
 }

--- a/cmd/gpu-cuda-profile/main_test.go
+++ b/cmd/gpu-cuda-profile/main_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -179,5 +180,178 @@ func TestAnOngoingConditionIsOneAnomalyAndNotOnePerInterval(t *testing.T) {
 	c := "gpu join ANOMALY: 353 of 65536 executions unmatched — GPU time arrived with no launch"
 	if kind(a) == kind(c) {
 		t.Errorf("two unrelated anomalies collapsed to one kind: %q", kind(a))
+	}
+}
+
+// The edge is ALL-gone, not ANY-gone. Under discovery a run covers several
+// processes and one exiting is ordinary -- pods restart, jobs finish -- so
+// ending the run there would discard the profiling of everything still alive.
+func TestTheRunEndsWhenTheLASTTargetExitsAndNotTheFirst(t *testing.T) {
+	a, b := startSleeper(t), startSleeper(t)
+	live := newLiveSet([]int{a.Pid, b.Pid})
+	defer live.close()
+
+	if got := live.count(); got != 2 {
+		t.Fatalf("want 2 live targets, got %d", got)
+	}
+	_ = a.Kill()
+	_, _ = a.Wait()
+
+	select {
+	case <-live.allGone:
+		t.Fatal("one of two targets exited and the run was told every target had gone")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	_ = b.Kill()
+	_, _ = b.Wait()
+	select {
+	case <-live.allGone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("both targets exited and the run was never told")
+	}
+}
+
+// The construction race, which is why alive starts at 1.
+//
+// The hazard: a target's watcher goroutine is running the moment add returns,
+// so a process that exits while the set is STILL BEING BUILT can take alive
+// from 1 to 0 and close allGone before the remaining pids have been added. A
+// run covering many healthy processes would end immediately, having profiled
+// nothing.
+//
+// Driven through the token directly rather than through newLiveSet, because
+// the natural-looking version of this test does not reproduce it: a process
+// that has already been reaped cannot be pidfd-opened at all, so it spawns no
+// watcher and there is nothing to race. Reproducing it by timing would be
+// flaky in the direction that matters least -- passing when the bug is
+// present. So the invariant is exercised where it actually lives: while the
+// token is held, deaths must not close the channel.
+func TestADeathWhileTheSetIsBeingBuiltDoesNotEndTheRun(t *testing.T) {
+	doomed, survivor := startSleeper(t), startSleeper(t)
+
+	// Mid-construction: the token is held and nothing has been released.
+	l := &liveSet{allGone: make(chan struct{}), watched: map[int]bool{}, alive: 1}
+	defer l.close()
+
+	if !l.add(doomed.Pid) {
+		t.Fatal("the first target was not added")
+	}
+	_ = doomed.Kill()
+	_, _ = doomed.Wait()
+
+	// Its watcher fires here. Without the token alive is now 0 and allGone is
+	// closed -- with the survivor not yet added, and the run over.
+	deadline := time.After(3 * time.Second)
+	for l.count() > 1 {
+		select {
+		case <-deadline:
+			t.Fatal("the killed target's watcher never fired")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	select {
+	case <-l.allGone:
+		t.Fatal("a death during construction ended the run before the set was built")
+	default:
+	}
+
+	l.add(survivor.Pid)
+	l.died() // construction complete: release the token
+
+	select {
+	case <-l.allGone:
+		t.Fatal("the run ended with a healthy target still in the set")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// A set nothing could be watched in must not hold the run open forever waiting
+// for deaths it can never observe.
+func TestASetWithNothingWatchableReportsAllGone(t *testing.T) {
+	live := newLiveSet([]int{1 << 21}) // no such process
+	defer live.close()
+	select {
+	case <-live.allGone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no target could be watched, so no death can ever be observed; the run " +
+			"must not wait for one")
+	}
+}
+
+func TestATargetIsOnlyAddedOnce(t *testing.T) {
+	p := startSleeper(t)
+	defer func() { _ = p.Kill(); _, _ = p.Wait() }()
+	live := newLiveSet([]int{p.Pid})
+	defer live.close()
+
+	if live.add(p.Pid) {
+		t.Error("rediscovery re-adding a known target must report it as not new, or every " +
+			"rescan would re-register and re-log every process")
+	}
+	if got := live.count(); got != 1 {
+		t.Errorf("a duplicate add changed the live count to %d", got)
+	}
+}
+
+func TestDescribeTargetsSaysSingularOrPluralAsTheRunActuallyWas(t *testing.T) {
+	if got := describeTargets([]int{1234}); got != "pid 1234" {
+		t.Errorf("one target: got %q", got)
+	}
+	got := describeTargets([]int{12, 34, 56})
+	if !strings.Contains(got, "3 pids") {
+		t.Errorf("three targets must not be reported as one: got %q", got)
+	}
+}
+
+func startSleeper(t *testing.T) *os.Process {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start a helper process: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
+	return cmd.Process
+}
+
+// The end-of-run summary must name what was actually covered, and under
+// rediscovery that is not the set the run started with.
+//
+// The bug this pins: a 25s discovery run on the 3090 started with 2 targets,
+// picked up 2 more, profiled all of them -- and reported "276042 samples from
+// 2 pids [...]". The sample count was right and the scope was a false
+// statement about it. Exited targets must stay in the answer too: their
+// samples are in the profile, so a summary that dropped them would understate
+// the scope just as badly in the other direction.
+func TestTheSummaryNamesEveryTargetEverCoveredNotJustTheFirstOnes(t *testing.T) {
+	first, second := startSleeper(t), startSleeper(t)
+	live := newLiveSet([]int{first.Pid})
+	defer live.close()
+
+	if got := live.all(); len(got) != 1 || got[0] != first.Pid {
+		t.Fatalf("the initial target is missing from the covered set: %v", got)
+	}
+
+	// Rediscovery finds another one mid-run.
+	live.add(second.Pid)
+	got := live.all()
+	if len(got) != 2 {
+		t.Fatalf("a rediscovered target is not in the covered set: %v", got)
+	}
+
+	// And one of them exits. Its GPU time is already in the profile, so it
+	// must not vanish from the run's description of itself.
+	_ = first.Kill()
+	_, _ = first.Wait()
+	deadline := time.After(3 * time.Second)
+	for live.count() > 1 {
+		select {
+		case <-deadline:
+			t.Fatal("the killed target's watcher never fired")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if got := live.all(); len(got) != 2 {
+		t.Errorf("an exited target was dropped from the covered set: %v", got)
 	}
 }

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -282,6 +282,29 @@ type Config struct {
 	ShimPath string
 	// PID restricts the attachment to one process; zero is system-wide.
 	PID int
+
+	// EagerPIDs are processes ALREADY RUNNING that map ShimPath, whose CFI
+	// tables must be compiled before the uprobe link exists.
+	//
+	// It is the multi-target form of what a non-zero PID does, and it exists
+	// because the two ways a target can reach this consumer need opposite
+	// treatment. A process that starts LATER is served by the startup
+	// rendezvous: it blocks in its own cuInit until its tables are in, which
+	// is earlier than any poll could manage. A process already past cuInit
+	// can never use that path -- it went through it before this consumer
+	// existed -- so unless its tables are installed here, its first stacks are
+	// walked without them (issue #49 measured that loss at ~38%).
+	//
+	// Left empty for a system-wide attach that is not discovering anything, so
+	// the ordinary launch path is unchanged: there is nothing running to
+	// register, which is exactly why the rendezvous exists.
+	//
+	// Registration is best-effort per pid and never fails the attach, for the
+	// same reason the single-PID path is: a consumer with no CFI tables still
+	// profiles with frame-pointer stacks and says so in
+	// Stats.StacksWalkedNoTables. Refusing to attach would turn a degraded
+	// profile into no profile.
+	EagerPIDs []int
 	// Backend labels the correlation IDs the consumer produces.
 	Backend gpu.GPUBackendID
 	// Sink receives the normalized events.
@@ -1641,6 +1664,16 @@ func Attach(cfg Config) (c *Consumer, err error) {
 		// This is what unwind/dwarfagent does for a per-PID profiler, where
 		// ModeLazy is forced back to ModeEager for the same reason.
 		_, _ = c.unwind.registerNow(uint32(cfg.PID))
+	}
+	// The same thing for a discovered SET of already-running targets. A
+	// system-wide attach that found its targets by scanning still has to
+	// install their tables here: none of them can use the rendezvous, because
+	// all of them are already past the point where it would have caught them.
+	for _, p := range cfg.EagerPIDs {
+		if p <= 0 || p == cfg.PID {
+			continue
+		}
+		_, _ = c.unwind.registerNow(uint32(p)) //nolint:gosec // bounds-checked above
 	}
 	// For a system-wide attach (cfg.PID == 0) there is nothing to register
 	// yet — the target may not even be running, which is exactly the gate's

--- a/gpuprobe/discover.go
+++ b/gpuprobe/discover.go
@@ -1,0 +1,118 @@
+package gpuprobe
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+)
+
+// ProcessesMappingShim returns every process on this host that has the shim at
+// shimPath mapped, which is the set of processes whose probes an attachment to
+// that file can ever fire in.
+//
+// WHY DISCOVERY IS A SEPARATE PROBLEM FROM ATTACHMENT
+// ---------------------------------------------------
+// Attaching to one process needs a pid, and the deployments that need this
+// most are the ones with no way to learn it. A sidecar shares a process
+// namespace with the application container; it is not the application's
+// parent, nothing hands it a pid, and the kubelet -- which does know -- has no
+// channel to tell it. A node collector has the same problem multiplied by
+// every pod on the node. Asking an operator to supply -pid in a pod spec is
+// asking them for a number that does not exist until after the pod is
+// scheduled.
+//
+// The shim's own mapping answers it without asking anybody. A process that
+// maps the shim inode was started with CUDA_INJECTION64_PATH pointing at it
+// and reached cuInit; a process that does not, was not, and no probe attached
+// to that file can ever fire in it. So the mapping is not a heuristic for
+// "is this a target" -- it is the definition of one.
+//
+// IDENTITY IS (dev, ino), NOT THE PATH
+// ------------------------------------
+// The same rule the uprobe itself follows, and it is the reason discovery
+// cannot be done by matching path strings out of /proc/<pid>/maps. A uprobe
+// attaches to an inode. Two byte-identical copies of the shim at two paths are
+// two files, and a process mapping the second one will never fire probes
+// attached to the first, however identical its maps line looks. Conversely a
+// process that mapped this exact inode still counts after the file is renamed
+// or deleted, and its maps line then says something else entirely.
+//
+// This has a direct consequence for Kubernetes that belongs in the caller's
+// documentation rather than being discovered later: an emptyDir per pod gives
+// every pod its OWN copy of the shim and therefore its own inode, so one
+// attachment covers one pod. Covering a whole node from one attachment
+// requires the pods to share one file.
+//
+// WHAT IT DOES NOT DO
+// -------------------
+// It reads what is mapped now. A process that starts later will not be in the
+// answer, and does not need to be: the startup rendezvous (enroll.go) catches
+// a process during its own cuInit, which is strictly better than any poll
+// could be. Rediscovery exists for the ones the rendezvous could not serve --
+// a process already past cuInit when this agent arrived -- and for noticing
+// that every target has gone.
+//
+// Processes that cannot be read are SKIPPED rather than failing the scan. A
+// host runs processes belonging to other users, and a scan that gave up on the
+// first EACCES would report no targets on any machine with a second tenant --
+// the failure would look exactly like "nothing is being profiled".
+func ProcessesMappingShim(shimPath string) ([]int, error) {
+	return processesMappingShimIn("/proc", shimPath)
+}
+
+func processesMappingShimIn(procRoot, shimPath string) ([]int, error) {
+	dev, ino, err := enrollShimIdentity(shimPath)
+	if err != nil {
+		return nil, fmt.Errorf("identify shim: %w", err)
+	}
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", procRoot, err)
+	}
+	var found []int
+	for _, e := range entries {
+		pid, err := strconv.ParseUint(e.Name(), 10, 32)
+		if err != nil {
+			continue // not a pid directory
+		}
+		// Errors are the normal case here, not the exception: a process that
+		// exits between ReadDir and this read is gone (ESRCH/ENOENT), and one
+		// owned by another user without ptrace access is unreadable (EACCES).
+		// Neither says anything about whether it was a target, and neither may
+		// stop the scan.
+		ok, err := procMapsHaveInode(procRoot, uint32(pid), dev, ino) //nolint:gosec // bounded by ParseUint above
+		if err != nil || !ok {
+			continue
+		}
+		found = append(found, int(pid)) //nolint:gosec // bounded by ParseUint above
+	}
+	// Sorted so a caller's log, and a test's expectation, do not depend on
+	// readdir order.
+	sort.Ints(found)
+	return found, nil
+}
+
+// RegisterTarget installs CFI tables for a process discovered after Attach.
+//
+// Rediscovery needs it, and only rediscovery: a process that starts normally
+// enrols itself during cuInit, which is earlier and more reliable than any
+// scan. What this covers is the process a scan finds that the rendezvous could
+// not serve -- one already past cuInit when this agent arrived, or one whose
+// rendezvous was refused or throttled.
+//
+// Idempotent: the registry never recompiles a pid it already holds, so calling
+// this on every rescan for every target costs a map lookup per pid rather than
+// a CFI compile. That is what makes a polling caller cheap enough to be
+// correct.
+//
+// Returns how many binaries were registered for the pid and any error. Zero
+// with no error is the ordinary answer for a pid already held -- not a
+// failure, and a caller that logged it as one would report every rescan as
+// broken.
+func (c *Consumer) RegisterTarget(pid int) (int, error) {
+	if c == nil || c.unwind == nil || pid <= 0 {
+		return 0, nil
+	}
+	return c.unwind.registerNow(uint32(pid)) //nolint:gosec // bounds-checked above
+}

--- a/gpuprobe/discover_test.go
+++ b/gpuprobe/discover_test.go
@@ -1,0 +1,135 @@
+package gpuprobe
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// A fake /proc whose maps files can be written per pid, plus a real file on
+// disk to stand in for the shim -- real, because identity comes from stat(2)
+// and a fixture cannot fake an inode.
+func fakeProcWithShim(t *testing.T) (procRoot, shimPath string, maj, min uint32, ino uint64) {
+	t.Helper()
+	dir := t.TempDir()
+	shimPath = filepath.Join(dir, "libperfagent-gpu-nvidia.so")
+	require.NoError(t, os.WriteFile(shimPath, []byte("\x7fELF not really"), 0o755))
+	var st unix.Stat_t
+	require.NoError(t, unix.Stat(shimPath, &st))
+	return t.TempDir(), shimPath, unix.Major(st.Dev), unix.Minor(st.Dev), st.Ino
+}
+
+func writeMaps(t *testing.T, procRoot string, pid int, lines string) {
+	t.Helper()
+	d := filepath.Join(procRoot, fmt.Sprint(pid))
+	require.NoError(t, os.MkdirAll(d, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "maps"), []byte(lines), 0o600))
+}
+
+func mapsLine(maj, min uint32, ino uint64, path string) string {
+	return fmt.Sprintf("7fc9a0a00000-7fc9a0a21000 r-xp 00001000 %02x:%02x %d %s\n", maj, min, ino, path)
+}
+
+// The whole point: find the targets without being told what they are.
+func TestDiscoveryFindsExactlyTheProcessesMappingTheShim(t *testing.T) {
+	procRoot, shim, maj, min, ino := fakeProcWithShim(t)
+
+	writeMaps(t, procRoot, 101, mapsLine(maj, min, ino, shim))
+	writeMaps(t, procRoot, 202, mapsLine(maj, min, ino+1, "/lib/libsomethingelse.so"))
+	writeMaps(t, procRoot, 303, mapsLine(maj, min, ino, shim))
+	// A non-pid entry: /proc is full of them (self, sys, meminfo) and a scan
+	// that tried to read them all as pids would be noisy at best.
+	require.NoError(t, os.MkdirAll(filepath.Join(procRoot, "sys"), 0o755))
+
+	got, err := processesMappingShimIn(procRoot, shim)
+	require.NoError(t, err)
+	assert.Equal(t, []int{101, 303}, got,
+		"discovery must return every process mapping the shim inode and no others")
+}
+
+// A host runs other people's processes. If a single unreadable one aborted the
+// scan, discovery would report no targets on any multi-tenant machine -- and
+// "nothing is being profiled" is what that failure would look like.
+func TestAnUnreadableProcessDoesNotHideTheReadableOnes(t *testing.T) {
+	procRoot, shim, maj, min, ino := fakeProcWithShim(t)
+
+	// 111 sorts first and cannot be read at all: no maps file, exactly as a
+	// process that exited between readdir and open presents.
+	require.NoError(t, os.MkdirAll(filepath.Join(procRoot, "111"), 0o755))
+	writeMaps(t, procRoot, 222, mapsLine(maj, min, ino, shim))
+
+	got, err := processesMappingShimIn(procRoot, shim)
+	require.NoError(t, err)
+	assert.Equal(t, []int{222}, got,
+		"an unreadable pid must be skipped, not abort the scan")
+}
+
+// Identity is the inode, not the path, because that is what a uprobe attaches
+// to. A second copy of the shim is a second file: a process mapping it will
+// never fire probes attached to the first, however identical the maps line
+// reads. Getting this wrong would make a sidecar attach confidently to a pod
+// running a different build and report nothing, forever, with no error.
+func TestASecondCopyOfTheShimIsADifferentTarget(t *testing.T) {
+	procRoot, shim, maj, min, ino := fakeProcWithShim(t)
+
+	copyPath := filepath.Join(filepath.Dir(shim), "copy-of-shim.so")
+	orig, err := os.ReadFile(shim)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(copyPath, orig, 0o755))
+	var st unix.Stat_t
+	require.NoError(t, unix.Stat(copyPath, &st))
+	require.NotEqual(t, ino, st.Ino, "the fixture must actually be a second inode")
+
+	// 404 maps the copy. Its maps line even NAMES a path ending in .so from
+	// the same directory -- a path-matching implementation would take it.
+	writeMaps(t, procRoot, 404, mapsLine(maj, min, st.Ino, copyPath))
+	writeMaps(t, procRoot, 505, mapsLine(maj, min, ino, shim))
+
+	got, err := processesMappingShimIn(procRoot, shim)
+	require.NoError(t, err)
+	assert.Equal(t, []int{505}, got,
+		"byte-identical copies are different files to a uprobe and must be to discovery")
+
+	got, err = processesMappingShimIn(procRoot, copyPath)
+	require.NoError(t, err)
+	assert.Equal(t, []int{404}, got, "and the reverse must hold, or the test proves nothing")
+}
+
+// No targets is an ANSWER, not an error. A collector that starts before any
+// GPU pod is scheduled is in a normal state, and the caller decides what to do
+// about it; a scan that errored could not tell that apart from a broken /proc.
+func TestNoTargetsIsAnEmptyAnswerRatherThanAnError(t *testing.T) {
+	procRoot, shim, maj, min, ino := fakeProcWithShim(t)
+	writeMaps(t, procRoot, 999, mapsLine(maj, min, ino+7, "/lib/libc.so.6"))
+
+	got, err := processesMappingShimIn(procRoot, shim)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// A shim path that cannot be stat'd is a different failure from one nothing
+// maps, and callers route them to different fixes: the operator's command line
+// versus how the target was started.
+func TestAnUnidentifiableShimIsAnError(t *testing.T) {
+	procRoot := t.TempDir()
+	_, err := processesMappingShimIn(procRoot, filepath.Join(procRoot, "does-not-exist.so"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identify shim")
+}
+
+// The exported entry point reads the real /proc, and this process maps its own
+// libraries -- so a library out of our own maps must find at least us. Guards
+// against the whole thing being wired to a procRoot that does not exist.
+func TestTheExportedScanReadsTheRealProc(t *testing.T) {
+	self, err := os.Readlink("/proc/self/exe")
+	require.NoError(t, err)
+	got, err := ProcessesMappingShim(self)
+	require.NoError(t, err)
+	assert.Contains(t, got, os.Getpid(),
+		"this process maps its own executable; the real /proc scan must find it")
+}


### PR DESCRIPTION
`-pid` needs a number, and the deployments that need attach most have no way to learn one. A sidecar
shares a process namespace with the application; it is not the application's parent, nothing hands
it a pid, and the kubelet — which knows — has no channel to tell it.

`examples/kubernetes` guessed `--pid=1  # PID 1 in the shared namespace`. That is **wrong**: under
`shareProcessNamespace` pid 1 is the *pause* container, so the manifest would have attached to
pause, found no shim, and profiled nothing.

## Discovery, and why scanning /proc is acceptable here

The shim's own mapping answers it without asking anyone. A process that maps the shim inode was
started with `CUDA_INJECTION64_PATH` pointing at it and reached `cuInit`; one that does not, was
not, and no probe attached to that file can ever fire in it.

So the mapping is not a heuristic for "is this a target" — it is the definition of one. And since
the operator is who sets that variable, discovery finds **exactly the processes somebody opted in**.
It cannot find anything else.

**Identity is `(dev, ino)`**, the same rule the uprobe follows, and the reason this cannot match path
strings: two byte-identical copies of the shim are two files, and a process mapping the second will
never fire probes attached to the first however identical its maps line looks. That makes the shim
*file* the scope knob — an `emptyDir` copy per pod covers one pod, a shared `hostPath` covers every
opted-in pod on the node — which settles #124's "one inode per node or per pod" as an access-control
question rather than a packaging one.

Discovery attaches with `PID: 0`, which is the **broader** attachment rather than the weaker one:
`uprobe_multi` then fires in every process mapping the file, including ones that map it *after* we
started. What a specific pid also buys — eager CFI registration — is what `Config.EagerPIDs` now
carries for the whole discovered set.

**All-gone, not any-gone.** With several processes under one attachment, one exiting is ordinary —
pods restart, jobs finish — and ending the run there would discard the profiling of everything still
alive.

## Three bugs found in the writing

**A construction race.** A target's watcher goroutine runs the moment `add` returns, so a process
exiting mid-construction took `alive` from 1 to 0 and closed all-gone *before the remaining pids were
added* — ending a run over many healthy processes having profiled nothing.

**A test that did not test what its name said.** The first version of that race test passed with the
fix removed: a reaped process cannot be pidfd-opened, so it spawns no watcher and there is nothing to
race. Rewritten to drive the token directly, and confirmed to fail without it.

**A false summary.** The first 3090 run started with 2 targets, picked up 2 more, profiled all of
them, and reported `276042 samples from 2 pids`. The count was right and the scope was a lie about
it.

## Verified on the 3090

Two workloads discovered at startup, two more picked up mid-run by rediscovery, 276,042 samples. The
profile separates by `gpu_pid`, so a multi-target run is not an undifferentiated blob:

```
gpu_pid: 158.10ms (39.80%): 1930956
         156.44ms (39.38%): 1930954
          82.70ms (20.82%): 1931080
```

The late target's smaller share is the time it was actually present for.

Both refusal paths check out too: an empty discovery names the three things to check, and
`-pid` with `-discover` is refused rather than one silently winning.
