### PR TITLE
gpu: raise the launch-cache anomaly on the loss, not on the bound (#137)

### DIFF
--- a/gpu/crossprocess_test.go
+++ b/gpu/crossprocess_test.go
@@ -590,3 +590,38 @@ func TestJoinHealthSurfacesTheHeuristicProcessGuard(t *testing.T) {
 	require.Len(t, cleanLines, 1, "a healthy snapshot must stay one line: %v", cleanLines)
 	assert.Contains(t, cleanLines[0], "no anomalies")
 }
+
+// The heuristic join must tell the CACHE it used the launch, not just the
+// snapshot.
+//
+// The join happens by scanning Entries() rather than by looking a correlation
+// up, so nothing informs the cache which entry was chosen. Without that,
+// every heuristically-joined launch looks unused for the rest of its life and
+// its eventual capacity eviction is counted as a lost attribution — the exact
+// false alarm issue #137 is about, reintroduced through the one join path that
+// does not go through Get.
+//
+// Driven through Timeline rather than by calling MarkJoined directly: the
+// method working is not the property at risk, the CALL SITE existing is.
+func TestAHeuristicJoinMarksTheLaunchAsUsedInTheCache(t *testing.T) {
+	tl := NewTimeline(TimelineConfig{LaunchCache: LaunchCacheConfig{Capacity: 1}})
+	require.NoError(t, tl.EmitLaunch(taggedLaunchIn(4242, "7", 10, "a_work", "pod-a")))
+	require.NoError(t, tl.EmitExec(heurExecIn(4242, 20, 30)))
+
+	snap := tl.Snapshot()
+	require.Len(t, snap.Executions, 1)
+	require.Equal(t, JoinHeuristic, snap.Executions[0].Join,
+		"the fixture must actually take the heuristic path or this test proves nothing")
+
+	// A second launch evicts the first at capacity 1. Because the first was
+	// joined — heuristically — that eviction cost nothing and must not be
+	// counted as a loss.
+	require.NoError(t, tl.EmitLaunch(taggedLaunchIn(4242, "8", 40, "b_work", "pod-a")))
+
+	lc := tl.Snapshot().LaunchCache
+	require.Equal(t, uint64(1), lc.EvictedCapacity,
+		"the fixture must actually evict, or the assertion below is vacuous")
+	assert.Zero(t, lc.EvictedCapacityUnjoined,
+		"the evicted launch had already been joined heuristically, so its eviction lost "+
+			"nothing — counting it would put a permanent false anomaly on every long run")
+}

--- a/gpu/joinhealth.go
+++ b/gpu/joinhealth.go
@@ -415,10 +415,34 @@ func joinAnomalies(snap Snapshot, proj ProjectionStats) []string {
 			"LaunchEventJoinWindowNs — widen that window or snapshot more often",
 			js.OutOfWindowDropCount)
 	}
-	if lc.EvictedCapacity > 0 {
-		add("launch cache evicted %s at capacity (%d live) — too small for the launch rate, "+
-			"so their executions cannot join; raise TimelineConfig.LaunchCache.Capacity",
-			plural(lc.EvictedCapacity, "launch", "launches"), lc.Live)
+	// The capacity anomaly fires on the LOSS, not on the bound being reached.
+	//
+	// It used to fire on EvictedCapacity alone and assert "their executions
+	// cannot join", which is untrue of most of them: LaunchCache.Get does not
+	// delete, so a launch stays live long after its execution has joined, and
+	// capacity eviction reaches it eventually on any run with more than
+	// Capacity launches. Measured on an RTX 3090: a 20 s attach reported
+	// 45,172 such evictions while projecting 111,056 samples from ~110,851
+	// launches and joining every execution in its final snapshot exactly. The
+	// alarm was describing a bounded LRU doing its job.
+	//
+	// That mattered more than noise. Attach mode has no natural end, so the
+	// line fired on every long run forever, and an operator who sees the same
+	// alarm every interval learns to skip it — along with the next one, which
+	// is real. The advice was also actively wrong: raising Capacity moves the
+	// cliff and makes resident memory grow with the length of the run, which
+	// for a collector is unbounded by construction.
+	//
+	// EvictedCapacityUnjoined counts only launches evicted before any
+	// execution found them, which is the population that genuinely reaches the
+	// profile as GPU time with no CPU stack.
+	if lc.EvictedCapacityUnjoined > 0 {
+		add("launch cache evicted %s at capacity BEFORE their execution arrived (%d live, "+
+			"%d evicted in total) — that GPU time is in the profile with no CPU stack. The "+
+			"cache is too small for the launch-to-execution latency at this rate: raise "+
+			"TimelineConfig.LaunchCache.Capacity, or snapshot more often so executions "+
+			"join sooner",
+			plural(lc.EvictedCapacityUnjoined, "launch", "launches"), lc.Live, lc.EvictedCapacity)
 	}
 	if lc.EvictedHorizon > 0 {
 		add("launch cache evicted %s past HorizonNs — they aged out before their execution "+

--- a/gpu/joinhealth_test.go
+++ b/gpu/joinhealth_test.go
@@ -45,11 +45,15 @@ func anomalousSnapshot() Snapshot {
 			OutOfWindowDropCount:         7,
 		},
 		LaunchCache: LaunchCacheStats{
-			Live:               250,
-			EvictedCapacity:    47,
-			EvictedHorizon:     3,
-			Replaced:           2,
-			AnomalousTimestamp: 1,
+			Live:            250,
+			EvictedCapacity: 47,
+			// The subset that actually lost an attribution. Set here so the
+			// many-anomalies fixture still exercises the capacity line: it now
+			// fires on the loss rather than on the eviction total (#137).
+			EvictedCapacityUnjoined: 47,
+			EvictedHorizon:          3,
+			Replaced:                2,
+			AnomalousTimestamp:      1,
 		},
 		Dropped: TimelineDropStats{
 			EvictedExecutions:     9,
@@ -115,7 +119,7 @@ func TestJoinHealthAnomaliesEachGetTheirOwnLine(t *testing.T) {
 		"22 of 512 executions joined heuristically",
 		"4 heuristic joins flagged ambiguous",
 		"7 of the unmatched executions had a candidate launch",
-		"launch cache evicted 47 launches at capacity",
+		"launch cache evicted 47 launches at capacity BEFORE",
 		"launch cache evicted 3 launches past HorizonNs",
 		"launch cache replaced 2 live entries",
 		"1 launch carried an out-of-range timestamp",
@@ -249,17 +253,72 @@ func TestJoinHealthEmptySnapshotIsAnAnomalyNotAllExact(t *testing.T) {
 // A run whose executions all joined but whose cache was thrashing is the
 // case the summary line alone would call fine; the eviction lines are what
 // make it visible.
-func TestJoinHealthEvictionsAreRaisedEvenWhenEveryJoinWasExact(t *testing.T) {
+// A LOST launch is raised even when every join in this snapshot was exact.
+//
+// The original point of this test stands and is the reason it is not simply
+// deleted: eviction health must not be inferred from the join outcomes of the
+// snapshot in front of us. A launch evicted before its execution arrived is a
+// loss whether or not the executions that DID arrive all joined perfectly --
+// the execution that lost its launch is in a later snapshot, or was never
+// counted here at all.
+//
+// What changed is which counter carries that meaning. It is now a property of
+// the evicted ENTRIES (were they ever joined?) rather than the raw eviction
+// total, which on any long run is dominated by entries that had already done
+// their job. See TestABoundedCacheReachingItsBoundIsNotAnAnomaly.
+func TestJoinHealthLostLaunchesAreRaisedEvenWhenEveryJoinWasExact(t *testing.T) {
 	snap := healthySnapshot()
 	snap.LaunchCache.EvictedCapacity = 47
+	snap.LaunchCache.EvictedCapacityUnjoined = 47
+	snap.LaunchCache.EvictedCapacityUnjoined = 47
 
 	lines := JoinHealth(snap)
 
 	require.Len(t, lines, 2)
 	assert.Contains(t, lines[0], "512 executions, all exact")
 	assert.Contains(t, lines[0], "; 1 anomaly")
-	assert.Contains(t, lines[1], "launch cache evicted 47 launches at capacity")
+	assert.Contains(t, lines[1], "launch cache evicted 47 launches at capacity BEFORE")
 	assert.Contains(t, lines[1], "TimelineConfig.LaunchCache.Capacity")
+}
+
+// The regression this pins (issue #137): a bounded LRU reaching its bound is
+// what the bound is FOR, and is not by itself a defect.
+//
+// LaunchCache.Get does not delete -- the cache serves repeated correlations --
+// so a launch stays live long after its execution has joined, and capacity
+// eviction reaches it eventually on any run with more than Capacity launches.
+// Firing on the raw total made the alarm permanent on long runs: measured on
+// an RTX 3090, a 20 s attach reported 45,172 capacity evictions while
+// projecting 111,056 samples from ~110,851 launches and joining every
+// execution in its final snapshot exactly.
+//
+// A permanent alarm is worse than a missing one. An operator who sees the same
+// line every interval learns to skip it, and skips the next one with it.
+func TestABoundedCacheReachingItsBoundIsNotAnAnomaly(t *testing.T) {
+	snap := healthySnapshot()
+	snap.LaunchCache.EvictedCapacity = 45172 // every one of them already joined
+	snap.LaunchCache.EvictedCapacityUnjoined = 0
+
+	lines := JoinHealth(snap)
+
+	require.Len(t, lines, 1, "a healthy run must produce the summary line and nothing else")
+	assert.Contains(t, lines[0], "no anomalies")
+}
+
+// And the total is still reported when there IS a loss, because the ratio is
+// what tells an operator whether the cache is marginally or wildly too small.
+func TestTheLossIsReportedAgainstTheTotalItCameFrom(t *testing.T) {
+	snap := healthySnapshot()
+	snap.LaunchCache.EvictedCapacity = 45172
+	snap.LaunchCache.EvictedCapacityUnjoined = 12
+
+	lines := JoinHealth(snap)
+
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[1], "12 launches")
+	assert.Contains(t, lines[1], "45172 evicted in total",
+		"without the denominator, 12 lost launches reads the same whether the cache "+
+			"missed by a hair or by an order of magnitude")
 }
 
 // The summary line quotes len(snap.Executions) as its denominator so the

--- a/gpu/launchcache.go
+++ b/gpu/launchcache.go
@@ -36,8 +36,20 @@ type LaunchCacheConfig struct {
 // eviction path is counted: a cache that loses attributions silently is
 // indistinguishable from a correlation bug.
 type LaunchCacheStats struct {
-	Live               int    `json:"live"`
-	EvictedCapacity    uint64 `json:"evicted_capacity,omitempty"`
+	Live int `json:"live"`
+
+	// EvictedCapacity is every eviction at the capacity bound, and on a long
+	// run it is mostly a NON-EVENT: a bounded LRU reaching its bound is what
+	// the bound is for, and an entry evicted after its execution already
+	// joined cost nothing at all.
+	//
+	// EvictedCapacityUnjoined is the subset that actually lost an
+	// attribution -- launches evicted before any execution found them. It is
+	// always <= EvictedCapacity, and it is the one worth raising an anomaly
+	// about. Their executions reach the profile as unmatched GPU time with no
+	// CPU stack.
+	EvictedCapacity         uint64 `json:"evicted_capacity,omitempty"`
+	EvictedCapacityUnjoined uint64 `json:"evicted_capacity_unjoined,omitempty"`
 	EvictedHorizon     uint64 `json:"evicted_horizon,omitempty"`
 	Replaced           uint64 `json:"replaced,omitempty"`
 	AnomalousTimestamp uint64 `json:"anomalous_timestamp,omitempty"`
@@ -61,6 +73,22 @@ const defaultMaxAdvanceNs = 60 * 1e9 // 60s
 type cacheEntry struct {
 	launch GPUKernelLaunch
 	seq    uint64
+	// joined records that an execution has already found this launch.
+	//
+	// It exists to make eviction legible. Get does not delete -- the cache
+	// serves repeated correlations -- so a launch stays live long after it has
+	// done its job, and capacity eviction reaches it eventually on any run
+	// with more than Capacity launches. Without this flag the two eviction
+	// outcomes are indistinguishable:
+	//
+	//	evicted AFTER joining   free. The entry had already been used.
+	//	evicted BEFORE joining  a lost attribution: its execution can no
+	//	                        longer find it, and that GPU time reaches the
+	//	                        profile with no CPU stack.
+	//
+	// Reporting the first as the second is what made the capacity anomaly fire
+	// on healthy runs (issue #137).
+	joined bool
 }
 
 // LaunchCache is a bounded FIFO of recent launches indexed by correlation ID.
@@ -154,7 +182,36 @@ func (c *LaunchCache) Get(id CorrelationID) (GPUKernelLaunch, bool) {
 	if !ok {
 		return GPUKernelLaunch{}, false
 	}
+	// A successful Get IS the join: this is the exact-correlation path, and
+	// the caller uses what it returns. Marking here rather than asking the
+	// caller to call back keeps the flag true by construction -- a join that
+	// forgot to report itself would make its own eviction look like a loss.
+	if !e.joined {
+		e.joined = true
+		c.byCorr[id] = e
+	}
 	return e.launch, true
+}
+
+// MarkJoined records that a launch was joined through a path that does not go
+// through Get.
+//
+// The heuristic join is that path: it scans Entries() for a candidate rather
+// than looking one up by correlation, so nothing tells the cache which entry
+// it settled on. Without this call every heuristic join would leave its launch
+// looking unjoined, and its eventual eviction would be counted as a lost
+// attribution that had in fact been attributed.
+//
+// A correlation the cache no longer holds is not an error: the entry may have
+// been evicted between the scan and here, and the join still happened -- it
+// used the copy Entries returned.
+func (c *LaunchCache) MarkJoined(id CorrelationID) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.byCorr[id]; ok && !e.joined {
+		e.joined = true
+		c.byCorr[id] = e
+	}
 }
 
 // Entries returns a snapshot of the launches currently live in the cache, in
@@ -210,6 +267,11 @@ func (c *LaunchCache) evictLocked() {
 		id, ok := c.order.evictOldestLive(c.isLiveLocked)
 		if !ok {
 			break
+		}
+		// Read BEFORE the delete: the entry is what says whether this
+		// eviction cost anything.
+		if e, present := c.byCorr[id]; present && !e.joined {
+			c.stats.EvictedCapacityUnjoined++
 		}
 		delete(c.byCorr, id)
 		c.stats.EvictedCapacity++

--- a/gpu/launchcache_test.go
+++ b/gpu/launchcache_test.go
@@ -218,3 +218,70 @@ func TestLaunchCacheEntriesIsACopyNotAView(t *testing.T) {
 	assert.Equal(t, "k_a", got.KernelName, "mutating the returned slice must not affect the cache's stored value")
 	assert.Equal(t, 1, c.Len(), "appending to the returned slice must not grow the cache")
 }
+
+// Issue #137: an eviction only costs an attribution if nothing had joined the
+// entry yet, and the cache is the only thing that can tell the two apart.
+func TestEvictingAJoinedLaunchIsNotCountedAsALoss(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 2})
+
+	put := func(id string, ns uint64) CorrelationID {
+		corr := CorrelationID{Backend: BackendCUPTI, PID: 7, Value: id}
+		c.Put(GPUKernelLaunch{Correlation: corr, TimeNs: ns})
+		return corr
+	}
+	a := put("a", 1000)
+	b := put("b", 2000)
+
+	// Its execution arrives and joins. From here on the entry has done its
+	// job and its eviction costs nothing.
+	if _, ok := c.Get(a); !ok {
+		t.Fatal("the launch should be live")
+	}
+
+	// Two more launches push both originals out at capacity.
+	put("c", 3000)
+	put("d", 4000)
+
+	st := c.Stats()
+	if st.EvictedCapacity != 2 {
+		t.Fatalf("want 2 capacity evictions, got %d", st.EvictedCapacity)
+	}
+	if st.EvictedCapacityUnjoined != 1 {
+		t.Errorf("only the launch that never joined lost an attribution: want 1 unjoined "+
+			"eviction, got %d", st.EvictedCapacityUnjoined)
+	}
+	_ = b
+}
+
+// The heuristic join does not go through Get, so without MarkJoined every
+// heuristically-joined launch would look unused and its eviction would be
+// reported as a lost attribution that had in fact been attributed.
+func TestAHeuristicallyJoinedLaunchIsAlsoNotALoss(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 1})
+	corr := CorrelationID{Backend: BackendCUPTI, PID: 7, Value: "a"}
+	c.Put(GPUKernelLaunch{Correlation: corr, TimeNs: 1000})
+
+	c.MarkJoined(corr)
+
+	c.Put(GPUKernelLaunch{Correlation: CorrelationID{Backend: BackendCUPTI, PID: 7, Value: "b"}, TimeNs: 2000})
+
+	st := c.Stats()
+	if st.EvictedCapacity != 1 {
+		t.Fatalf("want 1 capacity eviction, got %d", st.EvictedCapacity)
+	}
+	if st.EvictedCapacityUnjoined != 0 {
+		t.Errorf("a launch the heuristic path joined must not be counted as lost: got %d",
+			st.EvictedCapacityUnjoined)
+	}
+}
+
+// A correlation the cache no longer holds is not an error: the entry may have
+// been evicted between the heuristic scan and the mark, and the join still
+// happened against the copy Entries returned.
+func TestMarkingAnEvictedLaunchIsHarmless(t *testing.T) {
+	c := NewLaunchCache(LaunchCacheConfig{Capacity: 4})
+	c.MarkJoined(CorrelationID{Backend: BackendCUPTI, PID: 7, Value: "absent"})
+	if st := c.Stats(); st.EvictedCapacity != 0 || st.EvictedCapacityUnjoined != 0 {
+		t.Errorf("marking an absent correlation changed the counters: %+v", st)
+	}
+}

--- a/gpu/timeline.go
+++ b/gpu/timeline.go
@@ -1710,6 +1710,11 @@ func (t *Timeline) Snapshot() Snapshot {
 			view.Heuristic = true
 			view.Ambiguous = match.ambiguous
 			stats.HeuristicExecutionJoinCount++
+			// The heuristic path found its launch by scanning rather than by
+			// lookup, so the cache does not otherwise learn that this entry
+			// was used -- and an entry that looks unused is counted as a lost
+			// attribution when it is eventually evicted (issue #137).
+			t.cache.MarkJoined(match.launch.Correlation)
 			if match.ambiguous {
 				stats.AmbiguousHeuristicMatchCount++
 			}


### PR DESCRIPTION
Closes #137.

The capacity anomaly fired on `EvictedCapacity > 0` and asserted *"so their executions cannot
join"*. Measured on an RTX 3090, on the run that produced that exact line: **111,056 samples from
~110,851 launches**, final snapshot joining every execution exactly. The only unmatched executions
in the whole run were 414 at the attach boundary — launches that predate the consumer, which no
cache size can fix. The stated consequence had not happened.

## Why it was wrong, not merely noisy

`LaunchCache.Get` does not delete — the cache serves repeated correlations — so a launch stays live
long after its execution has joined, and capacity eviction reaches it eventually on any run with
more than `Capacity` launches. `EvictedCapacity` counted both:

| | cost |
|---|---|
| evicted **after** joining | nothing — the entry had done its job |
| evicted **before** joining | a real lost attribution |

and reported both as the second, with the first the overwhelming majority. Its advice made things
worse: raising `Capacity` moves the cliff and makes resident memory grow with the length of the run,
which for a collector is unbounded by construction.

It also mattered more than a stray line. Attach mode has no natural end, so it fired every interval
forever — and an operator who sees the same alarm ten times learns to skip it, and skips the next
one, which is real.

## The fix

`cacheEntry` records whether anything joined it; `EvictedCapacityUnjoined` counts the evictions that
actually cost an attribution. The anomaly fires on that. The raw total is still reported beside it,
because without the denominator "12 lost launches" reads the same whether the cache missed by a hair
or by an order of magnitude.

**Two join paths, and the second is the one that bites.** The exact path marks in `Get`, where a
successful lookup *is* the join — true by construction, since a caller that had to remember to
report back eventually would not. The heuristic path finds its launch by *scanning* `Entries()`, so
nothing tells the cache which entry it chose; `MarkJoined` is that call. Without it every
heuristically-joined launch looks unused for life and its eviction is reported as a loss that had in
fact been attributed.

## On the test that defended the old behaviour

`TestJoinHealthEvictionsAreRaisedEvenWhenEveryJoinWasExact` is **updated, not deleted** — its
original point stands. Eviction health must not be inferred from the join outcomes of the snapshot
in front of us: the execution that lost its launch is in a later snapshot, or was never counted here
at all. What changed is that the judgement is now a property of the evicted *entries* rather than of
the eviction total.

Both call sites are mutation-tested. The first attempt at the heuristic one **did not hold**: a test
calling `MarkJoined` directly passed with the timeline's call site deleted, because it exercised the
method rather than its use. It is driven through `Timeline` now, and fails without the call.
