### PR TITLE
gpu: elide the profiler's own delivery path from every stack (#122)

### DIFF
--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -1069,6 +1069,18 @@ type Stats struct {
 	// where the shim IS the program and there is no boundary to cross. See
 	// shimScope for how the two deployment shapes are told apart.
 	StacksProfilerOnly uint64
+
+	// StackFramesElided counts frames removed as the profiler's own delivery
+	// path, and StacksWithInstrumentationBand the stacks that had one.
+	//
+	// Both are reported because they answer different questions. The first is
+	// how much of the profile was the measurement apparatus -- ~19% of all
+	// frames in a measured PyTorch capture. The second is how many stacks were
+	// touched at all: if it is near zero on a CUDA run something has changed
+	// about where CUPTI delivers callbacks, and the elision is quietly doing
+	// nothing.
+	StackFramesElided             uint64
+	StacksWithInstrumentationBand uint64
 	// StacksProfilerOnlyUncertain is the SUBSET of StacksProfilerOnly
 	// rejected without proof: no frame was provably outside the shim, but at
 	// least one frame's module was unknown (the symbolizer named the frame
@@ -1540,6 +1552,10 @@ type Consumer struct {
 	// and which module paths are the shim's own. Immutable after
 	// newConsumer; see shimScope.
 	shim shimScope
+	// instr collapses the profiler's own delivery path out of a stack. It
+	// shares shimScope's classification because the shim's frames are the
+	// innermost end of every such band.
+	instr instrumentationBand
 
 	// sawKernelName records whether this producer emits kernel names at
 	// all. Holding an event for a name that is never coming would delay
@@ -1560,6 +1576,7 @@ func newConsumer(cfg Config) *Consumer {
 	return &Consumer{
 		cfg:         cfg,
 		shim:        newShimScope(cfg.ShimPath),
+		instr:       newInstrumentationBand(newShimScope(cfg.ShimPath)),
 		seqByStream: map[seqKey]uint64{},
 		pending:     newPendingStacks(cfg.SampledStackCapacity),
 		deferred:    newDeferredLaunches(cfg.DeferredLaunchCapacity),
@@ -2527,6 +2544,17 @@ func (c *Consumer) attachSampledStackLocked(pid uint32, stackID int32, sl gpuabi
 		c.stats.StacksProfilerOnly++
 		return
 	case stackAttributable:
+	}
+
+	// The profiler's own delivery path is not the workload's call path.
+	// Measured at ~7 frames in every stack -- 19% of all frames -- of CUPTI
+	// callback machinery between the application's cuLaunchKernel and our own
+	// callback. Collapsed to one marker rather than deleted, so the profile
+	// still says a band was there. See instrumentationBand.
+	if collapsed, removed := c.instr.collapse(frames); removed > 0 {
+		frames = collapsed
+		c.stats.StackFramesElided += uint64(removed) //nolint:gosec // a frame count
+		c.stats.StacksWithInstrumentationBand++
 	}
 
 	// Built through the same correlationOf as the batched twin's, from the

--- a/gpuprobe/instrumentation.go
+++ b/gpuprobe/instrumentation.go
@@ -1,0 +1,201 @@
+package gpuprobe
+
+import (
+	"path/filepath"
+	"strings"
+
+	pp "github.com/dpsoft/perf-agent/pprof"
+)
+
+// The profiler's own delivery path is not the workload's call path.
+//
+// # What this removes, and why it is not cosmetic
+//
+// Every sampled launch's stack passes through the machinery that told us
+// about the launch. Measured on a PyTorch capture of 47,204 stacks:
+//
+//	avg frames per stack                       37.5
+//	avg UNNAMED vendor frames per stack        10.1   (28.6% of all frames)
+//	longest consecutive unnamed run             7 frames in 40,646 stacks
+//	                                           13 frames in  6,378 stacks
+//
+// and the band looks like this, every time:
+//
+//	libcublasLt.so.13+0x3279bb4        <- real work
+//	cuLaunchKernel                     <- named, and the meaningful boundary
+//	  libcuda.so.610.57.04+0x3d8947    ┐
+//	  libcupti.so.13+0x11667f          │  CUPTI's callback machinery
+//	  libcupti.so.13+0x116485          │  delivering the event to us
+//	  ... four more ...                ┘
+//	  (anonymous namespace)::on_launch <- the shim
+//
+// Across the whole capture, libcupti accounts for 5.98 frames per stack and
+// the driver's dispatch frame for 1.00 -- 69% of all unnamed vendor frames,
+// about 19% of EVERY frame in EVERY stack. None of it is the application. It
+// exists because we subscribed a callback, and it would not be in the profile
+// if the profiler were not there.
+//
+// Leaving it in is not neutral. It pushes the application's own frames a
+// quarter of the way down every flame graph, it makes the deepest common
+// prefix of every stack a stretch of the profiler, and it does so with
+// addresses no local symbol table can name -- so the reader cannot even tell
+// what they are looking at without knowing CUPTI's internals.
+//
+// # Collapsed, not deleted
+//
+// One marker frame replaces the run. The instrumentation WAS on the stack and
+// a profile that silently omitted it would be claiming a call path the process
+// never had; `[gpu:instrumentation]` says a band was elided and how many
+// frames it held. It is the same shape as [gpu:launch] -- a synthetic frame
+// that names something real about how the measurement was made.
+//
+// # The rule, and why it is anchored rather than pattern-matched
+//
+// A maximal contiguous run whose every frame is either the SHIM's own module
+// or libcupti collapses. The run may then extend across immediately adjacent
+// UNNAMED libcuda frames, but only if it already contains a shim or libcupti
+// frame.
+//
+// That last condition is the whole of the care here. libcuda is the CUDA
+// driver: most of its frames are the application's work and eliding them would
+// be deleting the measurement's subject. The single dispatch frame that hands
+// control to a CUPTI callback is different, and the only thing that
+// distinguishes it is that it sits directly against the callback machinery. So
+// the run is anchored on frames that are provably ours, and libcuda is only
+// ever absorbed inward from such an anchor -- never matched on its own.
+//
+// A NAMED libcuda frame is never absorbed either: cuLaunchKernel is the
+// boundary a reader needs, it is the last thing the application actually
+// called, and it must survive.
+type instrumentationBand struct {
+	// shim is the same predicate shimScope polices whole stacks with; the
+	// shim's own frames are the innermost end of every band.
+	shim shimScope
+	// enabled is false when there is no shim to anchor on. Without an anchor
+	// the rule would have to match libcupti alone, which is a guess about
+	// somebody else's process rather than a fact about ours.
+	enabled bool
+}
+
+func newInstrumentationBand(s shimScope) instrumentationBand {
+	return instrumentationBand{shim: s, enabled: s.guarded}
+}
+
+// InstrumentationFrameName is the marker left in place of an elided band.
+// Bracketed like [gpu:launch] so it cannot collide with a real symbol, and
+// deliberately not shaped like a module name: stackcollapse-perf.pl reads
+// bracketed .so names as kernel frames.
+const InstrumentationFrameName = "[gpu:instrumentation]"
+
+// isInstrumentation reports whether a frame both belongs to the delivery path
+// -- the shim itself, or CUPTI -- and carries no name.
+//
+// A NAMED frame is never elided, whoever owns it. The shim's own callback
+// arrives as "(anonymous namespace)::on_launch(CUpti_CallbackData const*)",
+// which tells a reader exactly what it is and where the boundary lies;
+// replacing that with a generic marker would trade information for tidiness.
+// What is worth removing is the run of addresses no symbol table can name, and
+// that is precisely the population this predicate selects.
+func (b instrumentationBand) isInstrumentation(f pp.Frame) bool {
+	if !f.Unresolved {
+		return false
+	}
+	if b.shim.isShimModule(f.Module) {
+		return true
+	}
+	return isCUPTIModule(f.Module)
+}
+
+// absorbable frames join a band that already has an anchor, but can never
+// start one.
+//
+// An UNNAMED driver frame sitting against the callback machinery is the
+// driver's dispatch into it -- in the measured band it is the single
+// libcuda frame between CUPTI and cuLaunchKernel. The same frame with no
+// anchor beside it is the application's own work and is left alone, which is
+// what `absorbable` never starting a band guarantees.
+//
+// Named-ness is what protects the boundary, not position. An earlier version
+// tried to keep driver frames at the "outer edge" of a band on the theory that
+// those were the application calling in; the measured stacks refute it -- the
+// dispatch frame IS at the outer edge, immediately before cuLaunchKernel. What
+// must survive is every frame that carries a NAME, and cuLaunchKernel does.
+func absorbable(f pp.Frame) bool {
+	return f.Unresolved && isDriverModule(f.Module)
+}
+
+func isCUPTIModule(module string) bool {
+	return strings.HasPrefix(filepath.Base(module), "libcupti.so")
+}
+
+func isDriverModule(module string) bool {
+	return strings.HasPrefix(filepath.Base(module), "libcuda.so")
+}
+
+// collapse rewrites frames in place, replacing each instrumentation band with
+// a single marker, and reports how many frames were removed.
+//
+// Returns the (possibly shorter) slice. A stack that is ENTIRELY
+// instrumentation is left untouched: shimScope has already refused those as
+// unattributable, and collapsing one to a lone marker would turn a stack the
+// consumer withheld into one that looks like an attribution.
+func (b instrumentationBand) collapse(frames []pp.Frame) ([]pp.Frame, int) {
+	if !b.enabled || len(frames) == 0 {
+		return frames, 0
+	}
+	// A mask first, and the reason is a bug this replaced: a single forward
+	// scan that only ever extended a band FORWARD was order-dependent. Frames
+	// arrive outermost-first, so the driver's dispatch frame is reached before
+	// the CUPTI frames that anchor it -- and since an absorbable frame may
+	// never start a band, it was passed over and kept. It stayed in every
+	// stack (1.00 frames per stack, measured) while the rule's comment claimed
+	// it did not.
+	//
+	// Marking anchors first and then growing over absorbable frames in BOTH
+	// directions makes the result the same whichever end of the stack the
+	// slice starts at, which is the property the rule was supposed to have.
+	mark := make([]bool, len(frames))
+	anchored := false
+	for i, f := range frames {
+		if b.isInstrumentation(f) {
+			mark[i] = true
+			anchored = true
+		}
+	}
+	if !anchored {
+		return frames, 0
+	}
+	for i := 0; i < len(frames); i++ {
+		if !mark[i] {
+			continue
+		}
+		for j := i - 1; j >= 0 && !mark[j] && absorbable(frames[j]); j-- {
+			mark[j] = true
+		}
+		for j := i + 1; j < len(frames) && !mark[j] && absorbable(frames[j]); j++ {
+			mark[j] = true
+		}
+	}
+
+	out := frames[:0]
+	removed := 0
+	for i := 0; i < len(frames); {
+		if !mark[i] {
+			out = append(out, frames[i])
+			i++
+			continue
+		}
+		j := i
+		for j < len(frames) && mark[j] {
+			j++
+		}
+		out = append(out, pp.Frame{Name: InstrumentationFrameName})
+		removed += j - i - 1
+		i = j
+	}
+	if len(out) == 1 && out[0].Name == InstrumentationFrameName {
+		// Every frame was ours. Not this function's call to make.
+		return frames, 0
+	}
+	return out, removed
+}

--- a/gpuprobe/instrumentation_test.go
+++ b/gpuprobe/instrumentation_test.go
@@ -1,0 +1,206 @@
+package gpuprobe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pp "github.com/dpsoft/perf-agent/pprof"
+)
+
+const testShimPath = "/opt/perfagent/libperfagent-gpu-nvidia.so"
+
+func testBand(t *testing.T) instrumentationBand {
+	t.Helper()
+	return newInstrumentationBand(shimScope{
+		guarded: true,
+		paths:   map[string]struct{}{testShimPath: {}},
+		base:    "libperfagent-gpu-nvidia.so",
+	})
+}
+
+func named(name, module string) pp.Frame {
+	return pp.Frame{Name: name, Module: module}
+}
+func raw(module string) pp.Frame {
+	return pp.Frame{Name: "0xdead", Module: module, Unresolved: true}
+}
+
+func names(frames []pp.Frame) []string {
+	out := make([]string, len(frames))
+	for i, f := range frames {
+		out[i] = f.Name
+	}
+	return out
+}
+
+// The measured band, verbatim from a PyTorch capture: one driver dispatch
+// frame and six CUPTI frames between the application's cuLaunchKernel and the
+// shim's own callback.
+func TestTheMeasuredBandCollapsesToOneMarker(t *testing.T) {
+	b := testBand(t)
+	frames := []pp.Frame{
+		named("(anonymous namespace)::on_launch(CUpti_CallbackData const*)", testShimPath),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcuda.so.610.57.04"),
+		named("cuLaunchKernel", "/usr/lib/libcuda.so.610.57.04"),
+		raw("/usr/lib/libcublasLt.so.13"),
+		named("torch::autograd::Engine::execute", "/usr/lib/libtorch_cuda.so"),
+	}
+
+	got, removed := b.collapse(frames)
+
+	assert.Equal(t, []string{
+		"(anonymous namespace)::on_launch(CUpti_CallbackData const*)", // named: kept
+		InstrumentationFrameName,
+		"cuLaunchKernel",
+		"0xdead", // the cuBLASLt frame: real work, untouched
+		"torch::autograd::Engine::execute",
+	}, names(got))
+	assert.Equal(t, 6, removed, "seven unnamed frames became one; every name survives")
+}
+
+// cuLaunchKernel is the last thing the application actually called and the
+// boundary a reader needs. A rule that ate named driver frames along with the
+// unnamed ones would remove the only landmark in the region.
+func TestANamedDriverFrameIsNeverElided(t *testing.T) {
+	b := testBand(t)
+	frames := []pp.Frame{
+		named("on_launch", testShimPath),
+		raw("/usr/lib/libcupti.so.13"),
+		named("cuLaunchKernel", "/usr/lib/libcuda.so.610.57.04"),
+		named("app_main", "/opt/app"),
+	}
+	got, _ := b.collapse(frames)
+	assert.Contains(t, names(got), "cuLaunchKernel")
+	assert.Contains(t, names(got), "on_launch", "a named shim frame says more than the marker does")
+}
+
+// The care in the rule. libcuda is the CUDA driver and most of its frames are
+// the application's own work; only the dispatch frame wedged against the
+// callback machinery is ours. Driver frames with no instrumentation anchor
+// beside them must survive, or the profile would be deleting its own subject.
+func TestDriverFramesAloneAreNeverABand(t *testing.T) {
+	b := testBand(t)
+	frames := []pp.Frame{
+		raw("/usr/lib/libcuda.so.610.57.04"),
+		raw("/usr/lib/libcuda.so.610.57.04"),
+		named("cuMemcpyAsync", "/usr/lib/libcuda.so.610.57.04"),
+		named("app_main", "/opt/app"),
+	}
+	got, removed := b.collapse(frames)
+	assert.Equal(t, 4, len(got), "no anchor, so nothing may be elided: %v", names(got))
+	assert.Zero(t, removed)
+}
+
+// Unnamed driver frames adjacent to an anchor are the dispatch path and are
+// absorbed wherever in the band they sit. This fixture is the shape that
+// refuted the first version of the rule, which tried to protect driver frames
+// at the band's outer edge: in the real stacks the dispatch frame IS at the
+// outer edge, immediately before cuLaunchKernel, so position cannot be what
+// distinguishes it. Having a NAME is.
+func TestUnnamedDriverFramesAgainstTheBandAreAbsorbed(t *testing.T) {
+	b := testBand(t)
+	frames := []pp.Frame{
+		named("on_launch", testShimPath),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcuda.so.610.57.04"),
+		raw("/usr/lib/libcuda.so.610.57.04"),
+		named("cuLaunchKernel", "/usr/lib/libcuda.so.610.57.04"),
+		named("app_main", "/opt/app"),
+	}
+	got, removed := b.collapse(frames)
+	require.Equal(t, 4, len(got), "%v", names(got))
+	assert.Equal(t, "on_launch", got[0].Name)
+	assert.Equal(t, InstrumentationFrameName, got[1].Name)
+	assert.Equal(t, "cuLaunchKernel", got[2].Name, "the named boundary always survives")
+	assert.Equal(t, 2, removed)
+}
+
+// A stack that is ENTIRELY instrumentation is shimScope's business, and it
+// has already refused those as unattributable. Collapsing one to a lone marker
+// would turn a stack the consumer withheld into something that looks like an
+// attribution.
+func TestAStackThatIsAllInstrumentationIsLeftAlone(t *testing.T) {
+	b := testBand(t)
+	frames := []pp.Frame{
+		raw(testShimPath),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcupti.so.13"),
+	}
+	got, removed := b.collapse(frames)
+	assert.Equal(t, 3, len(got))
+	assert.Zero(t, removed)
+}
+
+// Without a shim there is no anchor, and matching libcupti on its own would be
+// a guess about somebody else's process rather than a fact about ours.
+func TestWithNoShimNothingIsElided(t *testing.T) {
+	b := newInstrumentationBand(shimScope{})
+	frames := []pp.Frame{
+		raw("/usr/lib/libcupti.so.13"),
+		named("app_main", "/opt/app"),
+	}
+	got, removed := b.collapse(frames)
+	assert.Equal(t, 2, len(got))
+	assert.Zero(t, removed)
+}
+
+// Two separate bands in one stack each collapse; they must not be merged
+// across the application frames between them.
+func TestTwoBandsCollapseSeparately(t *testing.T) {
+	b := testBand(t)
+	frames := []pp.Frame{
+		raw(testShimPath),
+		raw("/usr/lib/libcupti.so.13"),
+		named("app_middle", "/opt/app"),
+		raw("/usr/lib/libcupti.so.13"),
+		named("app_main", "/opt/app"),
+	}
+	got, removed := b.collapse(frames)
+	assert.Equal(t, []string{
+		InstrumentationFrameName, "app_middle", InstrumentationFrameName, "app_main",
+	}, names(got))
+	assert.Equal(t, 1, removed)
+}
+
+// The rule must not depend on which end of the stack the slice starts at.
+//
+// The bug this pins: a forward-only scan passed over the driver's dispatch
+// frame when the frames arrived outermost-first, because an absorbable frame
+// may not START a band and its anchor had not been seen yet. Measured on a real
+// capture, that left 1.00 libcuda frames per stack in every profile while the
+// implementation's own comment said they were absorbed.
+func TestTheBandIsTheSameFromEitherEndOfTheStack(t *testing.T) {
+	b := testBand(t)
+	inner := []pp.Frame{
+		raw(testShimPath),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcuda.so.610.57.04"), // the dispatch frame
+		named("cuLaunchKernel", "/usr/lib/libcuda.so.610.57.04"),
+		named("app_main", "/opt/app"),
+	}
+	outer := make([]pp.Frame, len(inner))
+	for i := range inner {
+		outer[i] = inner[len(inner)-1-i]
+	}
+
+	gotInner, removedInner := b.collapse(append([]pp.Frame(nil), inner...))
+	gotOuter, removedOuter := b.collapse(append([]pp.Frame(nil), outer...))
+
+	assert.Equal(t, []string{
+		InstrumentationFrameName, "cuLaunchKernel", "app_main",
+	}, names(gotInner))
+	assert.Equal(t, []string{
+		"app_main", "cuLaunchKernel", InstrumentationFrameName,
+	}, names(gotOuter))
+	assert.Equal(t, removedInner, removedOuter,
+		"the same stack read from the other end must lose the same frames")
+	assert.Equal(t, 2, removedInner)
+}


### PR DESCRIPTION
Part of #122.

Measured before touching anything, on a 47,204-stack PyTorch capture: **10.08 unnamed vendor frames
per stack, 26.9% of all frames**, in an unbroken run of 7 (40,646 stacks) or 13 (6,378) — from only
22 distinct addresses. The band is always this:

```
libcublasLt.so.13+0x3279bb4        <- real work
cuLaunchKernel                     <- named, and the meaningful boundary
  libcuda.so.610.57.04+0x3d8947    ┐
  libcupti.so.13+0x11667f          │  CUPTI's callback machinery
  ... five more libcupti ...       ┘  delivering the event to us
(anonymous namespace)::on_launch   <- the shim
```

libcupti accounts for 5.98 frames per stack and the driver's dispatch frame for 1.00 — **69% of all
unnamed vendor frames, ~19% of every frame in every stack**. None of it is the application. It is in
the profile because we subscribed a callback.

## Result

| | before | after |
|---|---:|---:|
| frames per stack | 37.5 | **30.0** |
| unnamed vendor per stack | 10.08 | **2.94** |
| share of all frames | 26.9% | **9.8%** |
| most common longest run | 7 | **0** (26,658 stacks have no band at all) |
| libcupti per stack | 5.98 | **gone** |
| libcuda per stack | 1.00 | **gone** |

What remains — 1.79 libcublasLt and 1.15 libcublas per stack — is genuine cuBLAS internals doing the
workload's work.

## This is not where the issue pointed

Item 2 proposed grafting the CUDA API name onto these frames. Measuring first showed that aims at
the wrong ones: **`cuLaunchKernel` is already symbolized and sits immediately above the band**, so
there is no naming gap to fill. The band is not unnamed application code — it is the measurement
apparatus, and the answer is to remove it rather than label it.

## Design

**Collapsed, not deleted.** One `[gpu:instrumentation]` marker replaces the run, so the profile
never claims a call path the process did not have.

**Named frames are never elided**, whoever owns them. The shim's callback arrives as
`(anonymous namespace)::on_launch(CUpti_CallbackData const*)`, which tells a reader exactly where
the boundary is; a generic marker would trade information for tidiness. An existing shimscope test
caught the first version doing precisely that.

## Two bugs found by measurement, not foresight

Both in rules whose own comments described behaviour the code did not have.

**An invented distinction.** Driver frames were protected at the "outer edge" of a band, on the
theory that those were the application calling in. The real stacks refute it — the dispatch frame
*is* at the outer edge, immediately before `cuLaunchKernel`. Position cannot distinguish it; having
a name can.

**An order dependence.** A forward-only scan passed over the dispatch frame because frames arrive
outermost-first, so the absorbable frame is reached before the anchor that would justify absorbing
it — and an absorbable frame may not *start* a band. It survived in every stack, visible in the
first post-change capture as 4.05 remaining instead of the predicted 3.1. Anchors are marked first
now and grown in **both** directions; the test feeds one stack forwards and reversed and asserts
both lose the same frames.

## Tested where eliding would be wrong

Driver frames with no anchor beside them (the application's own work), named driver frames, a stack
that is entirely instrumentation (shimScope has already refused those — collapsing one to a lone
marker would turn a withheld stack into something that looks like an attribution), and no shim at
all: without an anchor, matching libcupti alone would be a guess about somebody else's process
rather than a fact about ours.
