### PR TITLE
flamegraph: collapse runs of vendor frames that say nothing (#122)

### DIFF
--- a/cmd/flamegraph/main.go
+++ b/cmd/flamegraph/main.go
@@ -31,6 +31,11 @@ func main() {
 		folded     = flag.Bool("folded", false, "write folded stacks to stdout instead of HTML")
 		sampleIdx  = flag.Int("sample-index", -1, "which sample type to fold; -1 chooses automatically")
 		stackOrder = flag.String("stack-order", "root-first", "how the profile stores Sample.Location: root-first (perf-agent) | leaf-first (pprof proto)")
+		rawVendor  = flag.Bool("raw-vendor-frames", false,
+			"draw every vendor frame separately instead of merging runs whose names say "+
+				"nothing (an address, or the CUDA symbol server's obfuscated libfoo_<hex>). "+
+				"The profile always contains them either way; this decides what the PICTURE "+
+				"shows")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: %s [flags] <profile.pb.gz>\n\n", os.Args[0])
@@ -63,7 +68,8 @@ func main() {
 		dst = in + ".html"
 	}
 	res, err := flamegraph.FromProfileFile(in, dst, flamegraph.Options{
-		Title: *title,
+		Title:           *title,
+		RawVendorFrames: *rawVendor,
 	})
 	if err != nil {
 		fatalf("%v", err)

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -461,6 +461,7 @@ function detail(it){
   if(w){s+="\n"+w;}
   if(it.inexact>0){s+="\n"+fmt(it.inexact)+" of this is attributed by inference, not measurement";}
   if(d.domain==="unsym"){s+="\nno symbol: the unwind found this frame, nothing could name it";}
+  if(d.collapsed){s+="\nmerged: consecutive frames in this library whose names carry no information (an address, or an obfuscated vendor symbol) are drawn as one. The profile still holds every frame; re-render with -raw-vendor-frames to see them.";}
   return s;
 }
 function widthMeaning(it,d){

--- a/internal/flamegraph/file.go
+++ b/internal/flamegraph/file.go
@@ -43,7 +43,7 @@ func FromProfileFile(profilePath, htmlPath string, opts Options) (*foldedstacks.
 		// changing what those stacks contain would alter somebody else's
 		// pipeline. A picture is the one consumer that is read by a person,
 		// and the one where three unreadable rows cost more than they carry.
-		CollapseVendorRuns: true,
+		CollapseVendorRuns: !opts.RawVendorFrames,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("fold %s: %w", profilePath, err)

--- a/internal/flamegraph/file.go
+++ b/internal/flamegraph/file.go
@@ -38,6 +38,12 @@ func FromProfileFile(profilePath, htmlPath string, opts Options) (*foldedstacks.
 	res, err := foldedstacks.Fold(p, foldedstacks.Options{
 		SampleIndex: -1,
 		StackOrder:  foldedstacks.RootFirst,
+		// The RENDERER opts in, and only the renderer. Folding is also how
+		// `flamegraph -folded` produces text for other tools, and quietly
+		// changing what those stacks contain would alter somebody else's
+		// pipeline. A picture is the one consumer that is read by a person,
+		// and the one where three unreadable rows cost more than they carry.
+		CollapseVendorRuns: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("fold %s: %w", profilePath, err)

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -78,6 +78,10 @@ type Options struct {
 	Subtitle string
 	// Meta are extra provenance items, listed in the info panel.
 	Meta []MetaItem
+	// RawVendorFrames draws every vendor frame separately instead of merging
+	// runs whose names say nothing. The profile contains them either way --
+	// this only decides what the picture shows. See foldedstacks.
+	RawVendorFrames bool
 }
 
 // MetaItem is one provenance item.
@@ -87,12 +91,16 @@ type MetaItem struct {
 }
 
 type node struct {
-	name    string
-	module  string
-	modSet  bool
-	domain  Domain
-	value   int64
-	inexact int64
+	name   string
+	module string
+	modSet bool
+	// collapsed marks a frame that stands for a run of merged frames. It is
+	// carried from the fold rather than inferred here; see
+	// foldedstacks.Stack.Collapsed.
+	collapsed bool
+	domain    Domain
+	value     int64
+	inexact   int64
 	// jitter is this frame's step on the shade ladder — see assignJitter.
 	jitter int
 
@@ -227,11 +235,12 @@ func buildTree(res *foldedstacks.Result) (*node, int) {
 			child := cur.index[frame]
 			if child == nil {
 				child = &node{
-					name:   frame,
-					module: mod,
-					modSet: true,
-					index:  map[string]*node{},
-					depth:  cur.depth + 1,
+					name:      frame,
+					module:    mod,
+					modSet:    true,
+					collapsed: i < len(st.Collapsed) && st.Collapsed[i],
+					index:     map[string]*node{},
+					depth:     cur.depth + 1,
 				}
 				cur.index[frame] = child
 				cur.children = append(cur.children, child)
@@ -441,6 +450,12 @@ func writeNode(ew *errWriter, n *node, unit string, total int64, mods moduleTabl
 	}
 	if n.inexact > 0 {
 		ew.f(` data-inexact="%d"`, n.inexact)
+	}
+	// Read by detail() in the page script, which is what makes this attribute
+	// worth emitting at all. A data attribute nothing reads is dead weight
+	// that looks like a feature.
+	if n.collapsed {
+		ew.s(` data-collapsed="1"`)
 	}
 	ew.s(">")
 	// No whitespace around the name: the script reads this back as the

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -1005,3 +1005,49 @@ func TestTheShippedScriptIsStructurallyBalanced(t *testing.T) {
 		}
 	}
 }
+
+// A collapsed frame must both BE marked and be EXPLAINED.
+//
+// Two halves, and shipping either alone is the failure this pins. An attribute
+// nothing reads is dead weight that looks like a feature; a tooltip branch with
+// no attribute to trigger it is a comment. The module-table regression above is
+// the same shape and is why this is asserted rather than assumed: the reader
+// side is d.collapsed via the `d = it.el.dataset` alias, which a grep for
+// "dataset.collapsed" would miss entirely.
+func TestACollapsedFrameIsMarkedAndTheScriptExplainsIt(t *testing.T) {
+	res := &foldedstacks.Result{
+		SampleTypeName: "gpu", Unit: "nanoseconds", Total: 1,
+		VendorFramesCollapsed: 3,
+		Stacks: []foldedstacks.Stack{{
+			Frames:    []string{"main", "libcublasLt.so.13", "cuLaunchKernel"},
+			Modules:   []string{"/usr/bin/app", "/lib/libcublasLt.so.13", "/lib/libcuda.so.610"},
+			Collapsed: []bool{false, true, false},
+			Value:     1,
+		}},
+	}
+	var buf bytes.Buffer
+	if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	page := buf.String()
+
+	if !strings.Contains(page, `data-collapsed="1"`) {
+		t.Error("the collapsed frame carries no marking, so the page cannot tell a merged " +
+			"frame from a library that really exports a symbol named after itself")
+	}
+	if strings.Count(page, `data-collapsed="1"`) != 1 {
+		t.Errorf("want exactly one marked frame, got %d",
+			strings.Count(page, `data-collapsed="1"`))
+	}
+	if !strings.Contains(page, "d.collapsed") {
+		t.Error("the script never reads data-collapsed: the attribute is shipped to every " +
+			"reader of every page and does nothing")
+	}
+	if !strings.Contains(page, "-raw-vendor-frames") {
+		t.Error("the explanation does not say how to see the merged frames")
+	}
+	// The banner that carries the count is produced by Fold, not by this
+	// function, so it is asserted there -- see
+	// TestFoldSaysWhenItMergedVendorRuns. Asserting it here against a
+	// hand-built Result would only prove that the fixture set the field.
+}

--- a/internal/foldedstacks/fold.go
+++ b/internal/foldedstacks/fold.go
@@ -82,6 +82,18 @@ type Options struct {
 	// MaxLabelValues caps how many distinct values are retained per label
 	// key in the summary. Zero means DefaultMaxLabelValues.
 	MaxLabelValues int
+
+	// CollapseVendorRuns merges each run of consecutive frames from one
+	// vendor library whose names say nothing -- pprof's `module+0xHEX`, or
+	// the CUDA symbol server's obfuscated `libfoo_<40 hex>` -- into a single
+	// frame named after the module. See vendorruns.go.
+	//
+	// OFF by default, and the default is the conservative one on purpose:
+	// folding is also how `flamegraph -folded` produces text other tools
+	// consume, and silently changing what those stacks contain would alter
+	// somebody else's pipeline. The renderer opts in; a caller who wants the
+	// raw stacks gets them by doing nothing.
+	CollapseVendorRuns bool
 }
 
 // InexactRule flags samples whose stack is attributed by inference.
@@ -198,6 +210,11 @@ type Result struct {
 	EmptyStackSamples int
 	// Frames is the number of frame slots emitted across all folded stacks.
 	Frames int
+	// VendorFramesCollapsed counts frames merged away by
+	// Options.CollapseVendorRuns. Reported rather than silent: a reader
+	// comparing a rendered page against the profile it came from must be able
+	// to see that the two do not have the same number of frames, and why.
+	VendorFramesCollapsed int
 	// AddressOnlyFrames is how many of those carry no symbol — a bare
 	// address, or UnknownFrame. A flame graph that quietly dropped these
 	// would look cleaner precisely when symbolization worked worst.
@@ -301,6 +318,18 @@ func Fold(p *profile.Profile, opts Options) (*Result, error) {
 		res.InlinedFrames += stats.inlined
 		if len(frames) > res.MaxDepth {
 			res.MaxDepth = len(frames)
+		}
+
+		// BEFORE the aggregation key, which is the whole mechanism: two
+		// stacks that differ only in how many uninformative vendor frames
+		// they contain must collapse to the SAME key so they merge into one
+		// node. Collapsing after the key was computed would leave them as
+		// separate nodes wearing the same label, which looks identical in a
+		// list and is wrong in a flame graph.
+		if opts.CollapseVendorRuns {
+			var dropped int
+			frames, mods, dropped = collapseVendorRuns(frames, mods)
+			res.VendorFramesCollapsed += dropped
 		}
 
 		key := strings.Join(frames, "\x00")
@@ -544,6 +573,23 @@ func buildWarnings(res *Result, p *profile.Profile) []string {
 	if res.AddressOnlyFrames > 0 {
 		w = append(w, fmt.Sprintf("%d of %d frame slots (%.1f%%) have no symbol and are drawn as a raw address or %s.",
 			res.AddressOnlyFrames, res.Frames, pct(int64(res.AddressOnlyFrames), int64(res.Frames)), UnknownFrame))
+	}
+	// TOP LEVEL, not nested under AddressOnlyFrames. The collapse can remove
+	// every address-only frame there was -- that is what it is for -- and
+	// nesting this inside that branch would silence the note in exactly the
+	// case where the picture diverged from the profile the most.
+	//
+	// Said at all because the picture and the profile no longer have the same
+	// number of frames, and a reader comparing them is entitled to know why.
+	// It is not a warning about the data: nothing was lost, the pprof file
+	// still holds every frame. It is a warning about the PICTURE.
+	if res.VendorFramesCollapsed > 0 {
+		w = append(w, fmt.Sprintf(
+			"%d frame slots were merged: runs of consecutive frames from one vendor library "+
+				"whose names say nothing (an address, or the CUDA symbol server's obfuscated "+
+				"libfoo_<hex>) are drawn as a single frame named after the library. The "+
+				"profile itself is unchanged.",
+			res.VendorFramesCollapsed))
 	}
 	if res.InexactTotal > 0 {
 		w = append(w, fmt.Sprintf("%.1f%% of the total is attributed to its CPU call path by inference, not measurement (gpu_join is heuristic or unmatched, or the join was ambiguous). Those frames name a plausible caller, not an observed one.",

--- a/internal/foldedstacks/fold.go
+++ b/internal/foldedstacks/fold.go
@@ -144,6 +144,16 @@ type Stack struct {
 	// name. Consumers must tolerate "" everywhere: the GPU builder emits
 	// a single empty mapping for every location.
 	Modules []string
+	// Collapsed is parallel to Frames: true where the frame stands for a run
+	// of consecutive frames that CollapseVendorRuns merged. Nil when nothing
+	// was collapsed, so a consumer that does not care pays nothing.
+	//
+	// Carried explicitly rather than re-derived by the renderer from "the name
+	// equals the module's basename". That test would be a guess: a library
+	// really can export a symbol spelled like its own file, and a frame is
+	// either the product of a merge or it is not -- which is a fact the fold
+	// knows and nothing downstream can recover.
+	Collapsed []bool
 	// Value is the summed value at the chosen sample index.
 	Value int64
 	// Inexact is the part of Value contributed by samples matched by
@@ -326,16 +336,17 @@ func Fold(p *profile.Profile, opts Options) (*Result, error) {
 		// node. Collapsing after the key was computed would leave them as
 		// separate nodes wearing the same label, which looks identical in a
 		// list and is wrong in a flame graph.
+		var collapsed []bool
 		if opts.CollapseVendorRuns {
 			var dropped int
-			frames, mods, dropped = collapseVendorRuns(frames, mods)
+			frames, mods, collapsed, dropped = collapseVendorRuns(frames, mods)
 			res.VendorFramesCollapsed += dropped
 		}
 
 		key := strings.Join(frames, "\x00")
 		st := agg[key]
 		if st == nil {
-			st = &Stack{Frames: frames, Modules: mods}
+			st = &Stack{Frames: frames, Modules: mods, Collapsed: collapsed}
 			agg[key] = st
 			order = append(order, key)
 		}

--- a/internal/foldedstacks/vendorruns.go
+++ b/internal/foldedstacks/vendorruns.go
@@ -106,12 +106,13 @@ func isHex(s string) bool {
 //
 // Same module, because two adjacent vendor libraries are two different places
 // and merging them would invent a call path through neither.
-func collapseVendorRuns(frames, modules []string) ([]string, []string, int) {
+func collapseVendorRuns(frames, modules []string) ([]string, []string, []bool, int) {
 	if len(frames) == 0 {
-		return frames, modules, 0
+		return frames, modules, nil, 0
 	}
 	outF := make([]string, 0, len(frames))
 	outM := make([]string, 0, len(frames))
+	outC := make([]bool, 0, len(frames))
 	removed := 0
 	for i := 0; i < len(frames); {
 		m := ""
@@ -121,6 +122,7 @@ func collapseVendorRuns(frames, modules []string) ([]string, []string, int) {
 		if !uninformative(frames[i], m) {
 			outF = append(outF, frames[i])
 			outM = append(outM, m)
+			outC = append(outC, false)
 			i++
 			continue
 		}
@@ -135,13 +137,20 @@ func collapseVendorRuns(frames, modules []string) ([]string, []string, int) {
 		if j-i == 1 {
 			outF = append(outF, frames[i])
 			outM = append(outM, m)
+			outC = append(outC, false)
 			i++
 			continue
 		}
 		outF = append(outF, filepath.Base(m))
 		outM = append(outM, m)
+		outC = append(outC, true)
 		removed += j - i - 1
 		i = j
 	}
-	return outF, outM, removed
+	if removed == 0 {
+		// Nothing merged: hand back nil rather than a slice of falses, so a
+		// consumer can test the field itself instead of scanning it.
+		return outF, outM, nil, 0
+	}
+	return outF, outM, outC, removed
 }

--- a/internal/foldedstacks/vendorruns.go
+++ b/internal/foldedstacks/vendorruns.go
@@ -1,0 +1,147 @@
+package foldedstacks
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// A run of frames that each say nothing is worth less than one frame that says
+// where they were.
+//
+// # What this collapses
+//
+// After the profiler's own delivery path is elided (gpuprobe's
+// instrumentationBand), a measured PyTorch capture still carries fixed runs of
+// vendor frames between the application and the kernel:
+//
+//	libcublas.so.13     run of 3   in 16,658 stacks
+//	libcublasLt.so.13   run of 4   in 11,222 stacks
+//	libcublasLt.so.13   run of 6   in  5,436 stacks
+//
+// and only THIRTEEN distinct addresses produce all of them. So this is not
+// horizontal fragmentation, it is vertical depth: three to six rows of
+// `libcublas.so.13+0x2cc690` in every stack, pushing everything beneath them
+// down and telling the reader nothing about any of it.
+//
+// # Why not in the profile, the way the instrumentation band was
+//
+// Because these frames are REAL. The instrumentation band existed only because
+// something was watching; removing it from the profile removed a call path the
+// process would not have had unprofiled. cuBLAS frames are work the
+// application actually did, and deleting them would discard something true.
+//
+// So this happens at the folding step, and the pprof file is untouched. The
+// picture becomes readable; anyone who wants the individual addresses still
+// has them.
+//
+// # "Uninformative" is two exact spellings, not a judgement
+//
+// A frame is collapsible only when its name is one of the two ways a name can
+// be present and still say nothing:
+//
+//	module+0xHEX               pprof's own rendering of an address that no
+//	                           symbol table could name (pprof.Frame.Unresolved,
+//	                           applied by addLocationByAddr)
+//	libfoo_<40 hex>            NVIDIA's CUDA Toolkit Symbol Server serves
+//	                           OBFUSCATED names for internal functions. They
+//	                           are stable and distinguish one function from
+//	                           another, which is why they are worth fetching --
+//	                           but `libcublasLt_c44dd15e5b30f7ac…` is no more
+//	                           legible than the offset it replaced.
+//
+// The second is the reason this cannot key on "unsymbolized", as issue #122
+// originally proposed. With the symbol server attached -- the configuration we
+// recommend -- these frames ARE symbolized, and a rule testing for a missing
+// name would never fire in the setup it was written for.
+//
+// Everything else survives. A run of five named frames from libtorch_cuda.so is
+// five things the reader can look up, and merging them would destroy exactly
+// the information a flame graph exists to show.
+//
+// # The frame count is deliberately NOT in the result
+//
+// A collapsed frame is the bare module name. Writing `libcublasLt.so.13 (4
+// frames)` would put the run length into the merge key, so the run-of-4 and
+// run-of-6 paths above would become two nodes instead of one -- which is the
+// whole thing this is trying to undo. The count is a property of one stack;
+// the node has to be a property of the module.
+//
+// Square brackets are avoided for the same class of reason: stackcollapse-perf
+// reads a bracketed name as a kernel frame, and these are anything but.
+
+// obfuscatedVendorName matches the symbol server's internal names:
+// a library-ish prefix, an underscore, and a 40-character hex digest.
+var obfuscatedVendorName = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*_[0-9a-f]{40}$`)
+
+// uninformative reports whether a frame name carries nothing a reader can act
+// on, given the module it came from.
+func uninformative(frame, module string) bool {
+	if frame == "" || module == "" {
+		return false
+	}
+	base := filepath.Base(module)
+	// pprof's module+0xHEX spelling. Anchored on the module's own basename so
+	// a genuine symbol that merely contains "+0x" cannot match.
+	if rest, ok := strings.CutPrefix(frame, base+"+0x"); ok && rest != "" {
+		return isHex(rest)
+	}
+	return obfuscatedVendorName.MatchString(frame)
+}
+
+func isHex(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// collapseVendorRuns rewrites one stack, replacing each maximal run of
+// consecutive uninformative frames from the SAME module with a single frame
+// named after that module. Returns the stack and how many frames were removed.
+//
+// Same module, because two adjacent vendor libraries are two different places
+// and merging them would invent a call path through neither.
+func collapseVendorRuns(frames, modules []string) ([]string, []string, int) {
+	if len(frames) == 0 {
+		return frames, modules, 0
+	}
+	outF := make([]string, 0, len(frames))
+	outM := make([]string, 0, len(frames))
+	removed := 0
+	for i := 0; i < len(frames); {
+		m := ""
+		if i < len(modules) {
+			m = modules[i]
+		}
+		if !uninformative(frames[i], m) {
+			outF = append(outF, frames[i])
+			outM = append(outM, m)
+			i++
+			continue
+		}
+		j := i + 1
+		for j < len(frames) && j < len(modules) && modules[j] == m && uninformative(frames[j], m) {
+			j++
+		}
+		// A run of one is left exactly as it is. Renaming a lone
+		// `libcublas.so.13+0x2cc690` to `libcublas.so.13` would discard the
+		// address without collapsing anything -- strictly less information for
+		// no gain in readability.
+		if j-i == 1 {
+			outF = append(outF, frames[i])
+			outM = append(outM, m)
+			i++
+			continue
+		}
+		outF = append(outF, filepath.Base(m))
+		outM = append(outM, m)
+		removed += j - i - 1
+		i = j
+	}
+	return outF, outM, removed
+}

--- a/internal/foldedstacks/vendorruns_test.go
+++ b/internal/foldedstacks/vendorruns_test.go
@@ -1,0 +1,146 @@
+package foldedstacks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const lt = "/usr/lib/python3/site-packages/nvidia/cu13/lib/libcublasLt.so.13"
+const bl = "/usr/lib/python3/site-packages/nvidia/cu13/lib/libcublas.so.13"
+
+// The measured shape: a fixed run of address-only frames from one library,
+// which after the profiler's own band is elided is what still stands between
+// the application and the kernel.
+func TestARunOfAddressOnlyVendorFramesBecomesTheModule(t *testing.T) {
+	frames := []string{
+		"torch::autograd::Engine::execute",
+		"libcublasLt.so.13+0xf8e200",
+		"libcublasLt.so.13+0xe2b573",
+		"libcublasLt.so.13+0x1df0eb0",
+		"cuLaunchKernel",
+	}
+	mods := []string{"/usr/lib/libtorch_cuda.so", lt, lt, lt, "/usr/lib/libcuda.so.610"}
+
+	gotF, gotM, removed := collapseVendorRuns(frames, mods)
+
+	assert.Equal(t, []string{
+		"torch::autograd::Engine::execute",
+		"libcublasLt.so.13",
+		"cuLaunchKernel",
+	}, gotF)
+	assert.Equal(t, lt, gotM[1], "the collapsed frame keeps the module it came from")
+	assert.Equal(t, 2, removed)
+}
+
+// The symbol server serves OBFUSCATED names for internal functions, so the
+// frames are symbolized and a rule testing for a missing name would never fire
+// in the configuration this project recommends. That is the whole reason the
+// rule cannot key on "unsymbolized" as #122 originally proposed.
+func TestObfuscatedSymbolServerNamesAreCollapsedToo(t *testing.T) {
+	frames := []string{
+		"main",
+		"libcublasLt_82ed00161d0a6b6290add9bc600fcefbbf94f832",
+		"libcublasLt_c44dd15e5b30f7ac1684653f64405e357708e83b",
+		"cuLaunchKernel",
+	}
+	mods := []string{"/app/main", lt, lt, "/usr/lib/libcuda.so.610"}
+
+	gotF, _, removed := collapseVendorRuns(frames, mods)
+
+	assert.Equal(t, []string{"main", "libcublasLt.so.13", "cuLaunchKernel"}, gotF)
+	assert.Equal(t, 1, removed)
+}
+
+// The thing this must never do. Real names are what a flame graph exists to
+// show, and a run of them from one library is a call path, not noise.
+func TestNamedFramesFromOneLibraryAreNeverMerged(t *testing.T) {
+	torch := "/usr/lib/libtorch_cuda.so"
+	frames := []string{
+		"at::native::add_kernel",
+		"at::TensorIteratorBase::build",
+		"at::native::gpu_kernel_impl",
+		"c10::cuda::CUDAStream::synchronize",
+	}
+	mods := []string{torch, torch, torch, torch}
+
+	gotF, _, removed := collapseVendorRuns(frames, mods)
+
+	assert.Equal(t, frames, gotF, "four things a reader can look up must stay four")
+	assert.Zero(t, removed)
+}
+
+// Two adjacent vendor libraries are two different places; merging them would
+// invent a call path through neither.
+func TestAdjacentDifferentModulesDoNotMerge(t *testing.T) {
+	frames := []string{
+		"libcublas.so.13+0x2cc690",
+		"libcublas.so.13+0x1c6b85",
+		"libcublasLt.so.13+0xf8e200",
+		"libcublasLt.so.13+0xe2b573",
+	}
+	mods := []string{bl, bl, lt, lt}
+
+	gotF, _, removed := collapseVendorRuns(frames, mods)
+
+	assert.Equal(t, []string{"libcublas.so.13", "libcublasLt.so.13"}, gotF)
+	assert.Equal(t, 2, removed)
+}
+
+// A lone uninformative frame is left exactly as it is: renaming it would
+// discard the address without collapsing anything, which is strictly less
+// information for no gain.
+func TestALoneUninformativeFrameKeepsItsAddress(t *testing.T) {
+	frames := []string{"main", "libcublasLt.so.13+0xf8e200", "cuLaunchKernel"}
+	mods := []string{"/app/main", lt, "/usr/lib/libcuda.so.610"}
+
+	gotF, _, removed := collapseVendorRuns(frames, mods)
+
+	assert.Equal(t, frames, gotF)
+	assert.Zero(t, removed)
+}
+
+// The "+0x" test is anchored on the module's own basename, so a genuine symbol
+// that merely contains the substring cannot be mistaken for an address.
+func TestASymbolContainingPlus0xIsNotAnAddress(t *testing.T) {
+	mods := []string{lt, lt}
+	frames := []string{"operator+0x_helper", "another+0x_helper"}
+
+	gotF, _, removed := collapseVendorRuns(frames, mods)
+
+	assert.Equal(t, frames, gotF, "these are names, however unusual")
+	assert.Zero(t, removed)
+}
+
+func TestAFrameWithNoModuleIsNeverCollapsed(t *testing.T) {
+	frames := []string{"libcublasLt.so.13+0xf8e200", "libcublasLt.so.13+0xe2b573"}
+	mods := []string{"", ""}
+
+	gotF, _, removed := collapseVendorRuns(frames, mods)
+
+	assert.Equal(t, frames, gotF, "with no module there is nothing to name the merge after")
+	assert.Zero(t, removed)
+}
+
+// The constraint from #122's research, and the one that decides whether any of
+// this achieves anything: the run LENGTH must not reach the merge key. Two
+// stacks differing only in how many uninformative frames they carry have to
+// become the same node.
+func TestRunsOfDifferentLengthCollapseToTheSameFrame(t *testing.T) {
+	four := []string{"main", "libcublasLt.so.13+0x1", "libcublasLt.so.13+0x2",
+		"libcublasLt.so.13+0x3", "libcublasLt.so.13+0x4", "cuLaunchKernel"}
+	six := []string{"main", "libcublasLt.so.13+0x1", "libcublasLt.so.13+0x2",
+		"libcublasLt.so.13+0x3", "libcublasLt.so.13+0x4",
+		"libcublasLt.so.13+0x5", "libcublasLt.so.13+0x6", "cuLaunchKernel"}
+	mods4 := []string{"/app/main", lt, lt, lt, lt, "/usr/lib/libcuda.so.610"}
+	mods6 := []string{"/app/main", lt, lt, lt, lt, lt, lt, "/usr/lib/libcuda.so.610"}
+
+	got4, _, _ := collapseVendorRuns(four, mods4)
+	got6, _, _ := collapseVendorRuns(six, mods6)
+
+	require.Equal(t, got4, got6,
+		"a run of 4 and a run of 6 must fold to the identical stack, or they stay two "+
+			"nodes and the collapse has achieved nothing")
+	assert.Equal(t, []string{"main", "libcublasLt.so.13", "cuLaunchKernel"}, got4)
+}

--- a/internal/foldedstacks/vendorruns_test.go
+++ b/internal/foldedstacks/vendorruns_test.go
@@ -1,7 +1,10 @@
 package foldedstacks
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/google/pprof/profile"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,7 +26,7 @@ func TestARunOfAddressOnlyVendorFramesBecomesTheModule(t *testing.T) {
 	}
 	mods := []string{"/usr/lib/libtorch_cuda.so", lt, lt, lt, "/usr/lib/libcuda.so.610"}
 
-	gotF, gotM, removed := collapseVendorRuns(frames, mods)
+	gotF, gotM, _, removed := collapseVendorRuns(frames, mods)
 
 	assert.Equal(t, []string{
 		"torch::autograd::Engine::execute",
@@ -47,7 +50,7 @@ func TestObfuscatedSymbolServerNamesAreCollapsedToo(t *testing.T) {
 	}
 	mods := []string{"/app/main", lt, lt, "/usr/lib/libcuda.so.610"}
 
-	gotF, _, removed := collapseVendorRuns(frames, mods)
+	gotF, _, _, removed := collapseVendorRuns(frames, mods)
 
 	assert.Equal(t, []string{"main", "libcublasLt.so.13", "cuLaunchKernel"}, gotF)
 	assert.Equal(t, 1, removed)
@@ -65,7 +68,7 @@ func TestNamedFramesFromOneLibraryAreNeverMerged(t *testing.T) {
 	}
 	mods := []string{torch, torch, torch, torch}
 
-	gotF, _, removed := collapseVendorRuns(frames, mods)
+	gotF, _, _, removed := collapseVendorRuns(frames, mods)
 
 	assert.Equal(t, frames, gotF, "four things a reader can look up must stay four")
 	assert.Zero(t, removed)
@@ -82,7 +85,7 @@ func TestAdjacentDifferentModulesDoNotMerge(t *testing.T) {
 	}
 	mods := []string{bl, bl, lt, lt}
 
-	gotF, _, removed := collapseVendorRuns(frames, mods)
+	gotF, _, _, removed := collapseVendorRuns(frames, mods)
 
 	assert.Equal(t, []string{"libcublas.so.13", "libcublasLt.so.13"}, gotF)
 	assert.Equal(t, 2, removed)
@@ -95,7 +98,7 @@ func TestALoneUninformativeFrameKeepsItsAddress(t *testing.T) {
 	frames := []string{"main", "libcublasLt.so.13+0xf8e200", "cuLaunchKernel"}
 	mods := []string{"/app/main", lt, "/usr/lib/libcuda.so.610"}
 
-	gotF, _, removed := collapseVendorRuns(frames, mods)
+	gotF, _, _, removed := collapseVendorRuns(frames, mods)
 
 	assert.Equal(t, frames, gotF)
 	assert.Zero(t, removed)
@@ -107,7 +110,7 @@ func TestASymbolContainingPlus0xIsNotAnAddress(t *testing.T) {
 	mods := []string{lt, lt}
 	frames := []string{"operator+0x_helper", "another+0x_helper"}
 
-	gotF, _, removed := collapseVendorRuns(frames, mods)
+	gotF, _, _, removed := collapseVendorRuns(frames, mods)
 
 	assert.Equal(t, frames, gotF, "these are names, however unusual")
 	assert.Zero(t, removed)
@@ -117,7 +120,7 @@ func TestAFrameWithNoModuleIsNeverCollapsed(t *testing.T) {
 	frames := []string{"libcublasLt.so.13+0xf8e200", "libcublasLt.so.13+0xe2b573"}
 	mods := []string{"", ""}
 
-	gotF, _, removed := collapseVendorRuns(frames, mods)
+	gotF, _, _, removed := collapseVendorRuns(frames, mods)
 
 	assert.Equal(t, frames, gotF, "with no module there is nothing to name the merge after")
 	assert.Zero(t, removed)
@@ -136,11 +139,60 @@ func TestRunsOfDifferentLengthCollapseToTheSameFrame(t *testing.T) {
 	mods4 := []string{"/app/main", lt, lt, lt, lt, "/usr/lib/libcuda.so.610"}
 	mods6 := []string{"/app/main", lt, lt, lt, lt, lt, lt, "/usr/lib/libcuda.so.610"}
 
-	got4, _, _ := collapseVendorRuns(four, mods4)
-	got6, _, _ := collapseVendorRuns(six, mods6)
+	got4, _, _, _ := collapseVendorRuns(four, mods4)
+	got6, _, _, _ := collapseVendorRuns(six, mods6)
 
 	require.Equal(t, got4, got6,
 		"a run of 4 and a run of 6 must fold to the identical stack, or they stay two "+
 			"nodes and the collapse has achieved nothing")
 	assert.Equal(t, []string{"main", "libcublasLt.so.13", "cuLaunchKernel"}, got4)
+}
+
+// The count must reach the page, not only the tooltip. A reader who never
+// hovers anything still has to be able to see that the picture and the profile
+// do not have the same number of frames.
+func TestFoldSaysWhenItMergedVendorRuns(t *testing.T) {
+	p := profileWithVendorRun(t)
+
+	on, err := Fold(p, Options{SampleIndex: -1, StackOrder: RootFirst, CollapseVendorRuns: true})
+	require.NoError(t, err)
+	require.Positive(t, on.VendorFramesCollapsed, "the fixture must actually collapse something")
+	require.Contains(t, joined(on.Warnings), "frame slots were merged")
+	assert.Contains(t, joined(on.Warnings), "profile itself is unchanged",
+		"the note must say the data is intact, or it reads as a loss")
+
+	off, err := Fold(p, Options{SampleIndex: -1, StackOrder: RootFirst})
+	require.NoError(t, err)
+	assert.Zero(t, off.VendorFramesCollapsed)
+	assert.NotContains(t, joined(off.Warnings), "frame slots were merged",
+		"nothing was merged, so nothing may be claimed")
+}
+
+func joined(w []string) string { return strings.Join(w, "\n") }
+
+// A profile whose stack carries a run of three address-only frames from one
+// vendor library, which is the measured shape this collapse exists for.
+func profileWithVendorRun(t *testing.T) *profile.Profile {
+	t.Helper()
+	m := &profile.Mapping{ID: 1, File: lt}
+	at := func(name string, mapping *profile.Mapping) *profile.Location {
+		l := &profile.Location{Address: 1, Mapping: mapping}
+		l.Line = append(l.Line, profile.Line{Function: &profile.Function{Name: name}})
+		return l
+	}
+	app := &profile.Mapping{ID: 2, File: "/usr/bin/app"}
+	return &profile.Profile{
+		SampleType: []*profile.ValueType{{Type: "gpu", Unit: "nanoseconds"}},
+		Mapping:    []*profile.Mapping{m, app},
+		Sample: []*profile.Sample{{
+			Value: []int64{5},
+			Location: []*profile.Location{
+				at("main", app),
+				at("libcublasLt.so.13+0xf8e200", m),
+				at("libcublasLt.so.13+0xe2b573", m),
+				at("libcublasLt.so.13+0x1df0eb0", m),
+				at("cuLaunchKernel", app),
+			},
+		}},
+	}
 }


### PR DESCRIPTION
Part of #122 — the last of its ranked items.

After #141 elided the profiler's own delivery path, a measured PyTorch capture still carries fixed
runs of vendor frames between the application and the kernel:

| module | run length | stacks |
|---|---:|---:|
| `libcublas.so.13` | 3 | 16,658 |
| `libcublasLt.so.13` | 4 | 11,222 |
| `libcublasLt.so.13` | 6 | 5,436 |

and only **thirteen** distinct addresses produce all of them. So this is not horizontal
fragmentation — it is vertical depth: three to six rows of `libcublas.so.13+0x2cc690` in every
stack, pushing everything beneath them down and saying nothing about any of it.

**94,162 frame slots merged** on that capture.

## Not in the profile — the difference from #141

The instrumentation band was removed from the *profile* because those frames existed only because
something was watching; unprofiled, the process would not have had them. **cuBLAS frames are work
the application actually did**, and deleting them would discard something true.

So this happens at the folding step. The pprof file is untouched, and the page says what the picture
did:

```
note  94162 frame slots were merged: runs of consecutive frames from one vendor
      library whose names say nothing (an address, or the CUDA symbol server's
      obfuscated libfoo_<hex>) are drawn as a single frame named after the
      library. The profile itself is unchanged.
```

**Off by default, and only the renderer opts in.** Folding is also how `flamegraph -folded` produces
text other tools consume, and quietly changing what those stacks contain would alter somebody else's
pipeline.

## "Uninformative" is two exact spellings, not a judgement

| | |
|---|---|
| `module+0xHEX` | pprof's rendering of an address no symbol table could name |
| `libfoo_<40 hex>` | the CUDA Toolkit Symbol Server's **obfuscated** internal names |

The second is why this cannot key on *"unsymbolized"*, as the issue originally proposed. With the
symbol server attached — the configuration this project recommends — these frames **are** symbolized,
and a rule testing for a missing name would never fire in the setup it was written for. Measured: the
server carries 194,704 symbols against the wheel's 184 and names 9 of 9 residual addresses, every one
as `libcublasLt_<hash>`. Total coverage, zero meaning.

## The constraint that decides whether any of this works

**The run length must not reach the merge key.** A collapsed frame is the bare module name;
`libcublasLt.so.13 (4 frames)` would make the run-of-4 and run-of-6 paths two nodes instead of one,
which is the whole thing this undoes. So the collapse runs *before* the aggregation key is computed —
after it, the stacks would stay separate while wearing the same label, which looks identical in a
list and is wrong in a flame graph. There is a test that folds a run of 4 and a run of 6 and requires
them to produce the identical stack.

## What deliberately survives

- **Named frames from one library.** A run of five `at::native::…` frames is five things a reader can
  look up; merging them destroys exactly what a flame graph exists to show.
- **Adjacent different modules.** Two vendor libraries are two places, and merging them would invent
  a call path through neither.
- **A lone uninformative frame**, which keeps its address — renaming it would discard the offset
  while collapsing nothing.

The `+0x` test is anchored on the module's own basename so a genuine symbol containing that substring
cannot be mistaken for an address.

One bug caught in review of my own wiring: the merge note was nested under `AddressOnlyFrames > 0`.
The collapse can remove every address-only frame there was — that is its purpose — so nesting would
have silenced the note in exactly the case where the picture diverged from the profile the most.
