### PR TITLE
cpu: document the dead include flags instead of removing them (#117)

### DIFF
--- a/cpu/gen.go
+++ b/cpu/gen.go
@@ -1,4 +1,25 @@
 package cpu
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64 -cc clang -cflags "-O2 -Wall -Werror -fpie -Wno-unused-variable -Wno-unused-function" -go-package=cpu cpu ../bpf/cpu.bpf.c -- -I../bpf/libbpf -I../bpf/vmlinux/
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target arm64 -cc clang -cflags "-O2 -Wall -Werror -fpie -Wno-unused-variable -Wno-unused-function" -go-package=cpu cpu ../bpf/cpu.bpf.c -- -I../bpf/libbpf -I../bpf/vmlinux/
+// The include path is -I../bpf, the same as every other package here.
+//
+// It used to be `-I../bpf/libbpf -I../bpf/vmlinux/`, and neither directory has
+// ever existed in any branch of this repository. clang ignores a missing -I
+// silently, so the flags compiled fine and did nothing for as long as they were
+// there: `#include "vmlinux.h"` resolves relative to bpf/cpu.bpf.c on its own,
+// and `<bpf/bpf_helpers.h>` came from the system include path regardless.
+//
+// They were the residue of vendoring the libbpf headers, which issue #117
+// proposed as the durable fix for BPF objects not being byte-reproducible.
+// That is NOT the fix and the investigation settled it: the divergence is
+// clang's BTF forward-declaration ordering, which follows the malloc addresses
+// of debug-info nodes (a pointer-keyed std::map in BTFDebug::endModule), and
+// what actually determines it is the BUILD DIRECTORY STRING. See the
+// generate-container target in the Makefile, which reproduces CI's objects
+// byte for byte by building at CI's checkout path.
+//
+// Left in place, dead flags that name a vendoring directory are worse than
+// nothing: the next person to read #117 would see them and conclude the
+// vendoring had been done.
+//
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64 -cc clang -cflags "-O2 -Wall -Werror -fpie -Wno-unused-variable -Wno-unused-function" -go-package=cpu cpu ../bpf/cpu.bpf.c -- -I../bpf
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target arm64 -cc clang -cflags "-O2 -Wall -Werror -fpie -Wno-unused-variable -Wno-unused-function" -go-package=cpu cpu ../bpf/cpu.bpf.c -- -I../bpf

--- a/cpu/gen.go
+++ b/cpu/gen.go
@@ -1,25 +1,35 @@
 package cpu
 
-// The include path is -I../bpf, the same as every other package here.
+// DO NOT "CLEAN UP" THE INCLUDE FLAGS BELOW. They are dead, and removing them
+// costs a day.
 //
-// It used to be `-I../bpf/libbpf -I../bpf/vmlinux/`, and neither directory has
-// ever existed in any branch of this repository. clang ignores a missing -I
-// silently, so the flags compiled fine and did nothing for as long as they were
-// there: `#include "vmlinux.h"` resolves relative to bpf/cpu.bpf.c on its own,
-// and `<bpf/bpf_helpers.h>` came from the system include path regardless.
+// `-I../bpf/libbpf -I../bpf/vmlinux/` name two directories that have never
+// existed in any branch of this repository. clang ignores a missing -I
+// silently, so they have never affected include resolution: `#include
+// "vmlinux.h"` resolves relative to bpf/cpu.bpf.c on its own, and
+// `<bpf/bpf_helpers.h>` comes from the system include path. This package has no
+// working include path of its own and never has. They are residue of vendoring
+// the libbpf headers, which #117 proposed as the durable fix for BPF objects
+// not being byte-reproducible and which is not the fix.
 //
-// They were the residue of vendoring the libbpf headers, which issue #117
-// proposed as the durable fix for BPF objects not being byte-reproducible.
-// That is NOT the fix and the investigation settled it: the divergence is
-// clang's BTF forward-declaration ordering, which follows the malloc addresses
-// of debug-info nodes (a pointer-keyed std::map in BTFDebug::endModule), and
-// what actually determines it is the BUILD DIRECTORY STRING. See the
-// generate-container target in the Makefile, which reproduces CI's objects
-// byte for byte by building at CI's checkout path.
+// The obvious tidy-up -- replace both with -I../bpf, what every other package
+// passes -- was tried on 2026-09-08 and REVERTED, because it broke CI:
 //
-// Left in place, dead flags that name a vendoring directory are worse than
-// nothing: the next person to read #117 would see them and conclude the
-// vendoring had been done.
+//	make generate-container   all 14 objects byte-identical, before and after
+//	CI (ubuntu-24.04, clang-18)   cpu_{x86,arm64} differ, 47128 both sides
 //
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64 -cc clang -cflags "-O2 -Wall -Werror -fpie -Wno-unused-variable -Wno-unused-function" -go-package=cpu cpu ../bpf/cpu.bpf.c -- -I../bpf
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target arm64 -cc clang -cflags "-O2 -Wall -Werror -fpie -Wno-unused-variable -Wno-unused-function" -go-package=cpu cpu ../bpf/cpu.bpf.c -- -I../bpf
+// Same source, same clang version, same flags, and the two environments landed
+// on different BTF orderings. That is #117's malloc lottery: the forward
+// declarations get their type IDs in the iteration order of a pointer-keyed
+// std::map in BTFDebug::endModule, so anything that shifts clang's allocation
+// pattern permutes them. The Makefile's generate-container reproduces CI's
+// objects for the command lines that are committed TODAY; it is not robust to
+// changing one, and there is no way to find that out except by pushing.
+//
+// So the flags stay. Their only cost is looking like vendoring that was never
+// done, which this comment fixes for free. Changing them means regenerating
+// against whatever CI produces and giving up local reproduction until the two
+// agree again -- for nothing but tidiness.
+//
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64 -cc clang -cflags "-O2 -Wall -Werror -fpie -Wno-unused-variable -Wno-unused-function" -go-package=cpu cpu ../bpf/cpu.bpf.c -- -I../bpf/libbpf -I../bpf/vmlinux/
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target arm64 -cc clang -cflags "-O2 -Wall -Werror -fpie -Wno-unused-variable -Wno-unused-function" -go-package=cpu cpu ../bpf/cpu.bpf.c -- -I../bpf/libbpf -I../bpf/vmlinux/


### PR DESCRIPTION
While verifying #117 I found `cpu/gen.go` passing `-I../bpf/libbpf -I../bpf/vmlinux/` — **two directories that have never existed in any branch**. clang ignores a missing `-I` silently, so they have never affected include resolution: `#include "vmlinux.h"` resolves relative to `bpf/cpu.bpf.c` on its own, and `<bpf/bpf_helpers.h>` comes from the system path. This package has no include path of its own while appearing to have two.

**The first version of this PR removed them. It is reverted, because it broke CI** — and that failure is the interesting part.

| | result |
|---|---|
| `make generate-container` | all 14 objects byte-identical, **before and after** |
| CI (ubuntu-24.04, clang-18) | `cpu_{x86,arm64}` **differ** — 47128 bytes both sides |

Same source, same clang version, same flags, two different BTF orderings. My claim that the flags were *"provably inert"* because the container reproduced byte-identically was wrong: they are inert for include **resolution**, not for BTF **ordering**, and one environment agreeing is not evidence about the other.

I verified the container genuinely regenerates this package rather than skipping it — a deliberately corrupted `cpu_x86_bpfel.o` was restored byte-for-byte.

## What this exposes, which matters more than the tidy-up

`generate-container` reproduces CI **for the command lines committed today**. It is not robust to changing one. Every clang command line is a fresh roll of #117's malloc lottery — BTF forward declarations take their type IDs from the iteration order of a pointer-keyed `std::map` in `BTFDebug::endModule` — so the container and the runner can land differently on a new line while agreeing on the old one. There is no way to find that out except by pushing.

That is a real qualification on #117 being "solved", and it is why I am **not** recommending closing it any more.

So the flags stay, and the comment carries what a reader needs: that they are dead, why they exist, that removing them is expensive, and what it costs. Their only harm was looking like vendoring that was never done — which the comment fixes for free, with no object churn and no lottery roll.