### PR TITLE
flamegraph: rework the page toward the mocks, keeping Gregg's palette (#123)

### DIFF
--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -85,11 +85,12 @@ h1{font-size:12.5px;font-weight:500;color:var(--muted);margin:0;flex:1;min-width
 .top button:hover,.top summary:hover{color:var(--accent);background:var(--bg)}
 .legend{display:flex;flex-wrap:wrap;align-items:center;gap:5px 14px;padding:7px 16px;border-bottom:1px solid var(--line);background:var(--panel);font-size:11.5px;color:var(--muted)}
 .legend .c{display:inline-flex;align-items:center;gap:5px;white-space:nowrap}
-.legend .c i{width:11px;height:11px;border-radius:3px;border:1px solid rgb(0 0 0/.22);display:inline-block}
+.legend .c i{width:11px;height:11px;border-radius:3px;border:1px solid rgb(0 0 0/.22);display:inline-block;background-repeat:repeat}
 .legend .sep{width:1px;height:14px;background:var(--line)}
 #info-btn.notes::after{content:"\2022";color:var(--accent);vertical-align:super;font-size:11px}
 .note{margin:8px 16px 0;padding:5px 11px;border:1px solid var(--warn-line);border-left-width:3px;border-radius:7px;background:var(--warn-bg);font-size:12px}
-.chart{position:relative;margin:10px 16px 0;padding:8px;border:1px solid var(--line);border-radius:10px;background:var(--panel)}
+.canvas{margin:10px 16px 0;padding:9px;border:1px solid var(--line);border-radius:10px;background:var(--panel);overflow:hidden}
+.chart{position:relative;margin:0}
 .frame{position:absolute;height:17px;padding:0 4px;border-radius:2px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;line-height:17px;cursor:pointer}
 .frame.dim{opacity:.15}
 #status{position:fixed;left:0;right:0;bottom:0;z-index:6;display:flex;gap:14px;align-items:center;padding:5px 16px;background:var(--panel);border-top:1px solid var(--line);font-size:12px}

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -65,28 +65,41 @@ const darkChrome = `--bg:#16151a;--panel:#1e1d23;--ink:#eceaf2;--muted:#a29caf;-
 // about 14 px they draw a lone ellipsis. Both are the browser applying the
 // rule, not a threshold anyone chose.
 const styleSheet = `
-:root{--bg:#fbf9f6;--panel:#fffefc;--ink:#1d1a17;--muted:#6b6259;--line:#e2dad0;--accent:#b4522a;--warn-bg:#fff6e8;--warn-line:#e8c88a;--fatal-bg:#fdecec;--fatal-line:#e0a3a3}
+:root{--tip-bg:#1f1d24;--tip-ink:#f2eff7;--tip-line:#3a3543;--bg:#f7f6f9;--panel:#ffffff;--ink:#1d1a17;--muted:#6b6259;--line:#e2dad0;--accent:#b4522a;--warn-bg:#fff6e8;--warn-line:#e8c88a;--fatal-bg:#fdecec;--fatal-line:#e0a3a3}
 @media (prefers-color-scheme: dark){:root:not([data-theme="light"]){` + darkChrome + `}}
 :root[data-theme="dark"]{` + darkChrome + `}
 *{box-sizing:border-box}
-body{margin:0;padding:8px 12px 30px;background:var(--bg);color:var(--ink);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5}
+body{margin:0;padding:0 0 34px;background:var(--bg);color:var(--ink);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5}
 code,kbd{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11.5px}
 .muted{color:var(--muted)}
-.top{display:flex;align-items:baseline;gap:8px}
-h1{font-size:13px;font-weight:600;margin:0;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.top button,.top summary{cursor:pointer;color:var(--muted);background:none;border:0;padding:0 2px;font-size:15px;line-height:1;list-style:none}
+.top{display:flex;align-items:center;gap:10px;padding:10px 16px;background:var(--panel);border-bottom:1px solid var(--line)}
+.brand{display:flex;align-items:baseline;gap:9px;flex:0 0 auto}
+.brand b{font-size:16px;font-weight:700;letter-spacing:-.015em}
+.brand i{font-style:italic;color:var(--muted);font-size:12.5px}
+h1{font-size:12.5px;font-weight:500;color:var(--muted);margin:0;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:center}
+.readout{display:flex;gap:6px;flex:0 0 auto}
+.readout span{padding:3px 9px;border:1px solid var(--line);border-radius:7px;background:var(--bg);font-size:12px;white-space:nowrap}
+.readout b{font-weight:600}
+.top button,.top summary{cursor:pointer;color:var(--muted);background:none;border:0;padding:2px 4px;font-size:15px;line-height:1;list-style:none;border-radius:6px}
 .top summary::-webkit-details-marker{display:none}
-.top button:hover,.top summary:hover{color:var(--accent)}
+.top button:hover,.top summary:hover{color:var(--accent);background:var(--bg)}
+.legend{display:flex;flex-wrap:wrap;align-items:center;gap:5px 14px;padding:7px 16px;border-bottom:1px solid var(--line);background:var(--panel);font-size:11.5px;color:var(--muted)}
+.legend .c{display:inline-flex;align-items:center;gap:5px;white-space:nowrap}
+.legend .c i{width:11px;height:11px;border-radius:3px;border:1px solid rgb(0 0 0/.22);display:inline-block}
+.legend .sep{width:1px;height:14px;background:var(--line)}
 #info-btn.notes::after{content:"\2022";color:var(--accent);vertical-align:super;font-size:11px}
-.note{margin:6px 0 0;padding:3px 9px;border:1px solid var(--warn-line);border-left-width:3px;border-radius:5px;background:var(--warn-bg);font-size:12px}
-.chart{position:relative;margin:8px 0 0}
+.note{margin:8px 16px 0;padding:5px 11px;border:1px solid var(--warn-line);border-left-width:3px;border-radius:7px;background:var(--warn-bg);font-size:12px}
+.chart{position:relative;margin:10px 16px 0;padding:8px;border:1px solid var(--line);border-radius:10px;background:var(--panel)}
 .frame{position:absolute;height:17px;padding:0 4px;border-radius:2px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;line-height:17px;cursor:pointer}
 .frame.dim{opacity:.15}
-#status{position:fixed;left:0;right:0;bottom:0;z-index:6;display:flex;gap:12px;align-items:center;padding:2px 12px;background:var(--panel);border-top:1px solid var(--line);font-size:12px}
+#status{position:fixed;left:0;right:0;bottom:0;z-index:6;display:flex;gap:14px;align-items:center;padding:5px 16px;background:var(--panel);border-top:1px solid var(--line);font-size:12px}
+#status b{font-weight:600}
+#status .k{color:var(--muted)}
+#brandf{color:var(--muted);font-style:italic;white-space:nowrap}
 #st{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 #mc{color:var(--muted);white-space:nowrap}
 #q{font:inherit;color:inherit;background:var(--bg);border:1px solid var(--line);border-radius:5px;padding:1px 6px;width:15em}
-#tip{position:fixed;z-index:8;left:0;top:0;max-width:46em;padding:5px 8px;border:1px solid var(--line);border-radius:6px;background:var(--panel);box-shadow:0 2px 10px rgb(0 0 0/.2);font-size:12px;line-height:1.45;white-space:pre-line;word-break:break-all;pointer-events:none}
+#tip{position:fixed;z-index:8;left:0;top:0;max-width:44em;padding:11px 14px;border:1px solid var(--tip-line);border-radius:10px;background:var(--tip-bg);color:var(--tip-ink);box-shadow:0 8px 28px rgb(0 0 0/.28);font-size:12.5px;line-height:1.5;white-space:pre-line;word-break:break-word;pointer-events:none}
 #panel{position:fixed;z-index:9;top:32px;left:50%;transform:translateX(-50%);width:min(1000px,calc(100% - 24px));max-height:calc(100vh - 72px);overflow:auto;padding:12px 16px 16px;border:1px solid var(--line);border-radius:10px;background:var(--panel);box-shadow:0 8px 34px rgb(0 0 0/.25);cursor:auto;text-align:left}
 #panel h2{font-size:10.5px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin:14px 0 6px}
 #panel h2:first-of-type{margin-top:0}

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -232,6 +232,9 @@ const paletteCSS = `
 
   --hatch-gap: repeating-linear-gradient(45deg,var(--hatch-ink) 0 2.2px,transparent 2.2px 6px);
   --hatch-inf: repeating-linear-gradient(-45deg,var(--hatch-ink) 0 1.4px,transparent 1.4px 5px);
+  --hatch-bare: repeating-linear-gradient(45deg,var(--hatch-ink) 0 3.2px,transparent 3.2px 5px);
+  --hatch-obf: radial-gradient(var(--hatch-ink) .9px,transparent 1px) 0 0/5px 5px;
+  --hatch-interp: repeating-linear-gradient(-45deg,var(--hatch-ink) 0 2.2px,transparent 2.2px 6px);
 
   --fill-app:      hsl(335 calc(78% * var(--fill-ds)) calc(79% + var(--fill-dl)));
   --fill-system:   hsl(  2 calc(68% * var(--fill-ds)) calc(78% + var(--fill-dl)));
@@ -262,13 +265,21 @@ const paletteCSS = `
 [data-domain="system"]{--fill-x:var(--fill-system)}
 [data-domain="kernel"]{--fill-x:var(--fill-kernel)}
 [data-domain="vendor"]{--fill-x:var(--fill-vendor)}
-[data-domain="unsym"]{--fill-x:var(--fill-unsym);background-image:var(--hatch-gap)}
+[data-domain="unsym"]{--fill-x:var(--fill-unsym)}
+[data-resolution="module-offset"]{background-image:var(--hatch-gap)}
+[data-resolution="bare-address"]{background-image:var(--hatch-bare)}
+[data-resolution="obfuscated"]{background-image:var(--hatch-obf)}
+[data-resolution="interpreter"]{background-image:var(--hatch-interp)}
 [data-domain="gpu-kernel"]{--fill-x:var(--fill-gpu-kernel)}
 [data-domain="shim"]{--fill-x:var(--fill-shim);box-shadow:inset 0 0 0 1px var(--edge-shim)}
 [data-domain="boundary"]{--fill-x:var(--fill-boundary);box-shadow:inset 0 0 0 1px var(--edge-boundary)}
 [data-domain="boundary-unattributed"]{--fill-x:var(--fill-boundary-unattributed);background-image:var(--hatch-gap);box-shadow:none;outline:1px dashed var(--edge-unattributed);outline-offset:-1px}
 .frame.inexact{background-image:var(--hatch-inf)}
-.frame.inexact[data-domain="unsym"],.frame.inexact[data-domain="boundary-unattributed"]{background-image:var(--hatch-gap),var(--hatch-inf)}
+.frame.inexact[data-domain="boundary-unattributed"]{background-image:var(--hatch-gap),var(--hatch-inf)}
+.frame.inexact[data-resolution="module-offset"]{background-image:var(--hatch-gap),var(--hatch-inf)}
+.frame.inexact[data-resolution="bare-address"]{background-image:var(--hatch-bare),var(--hatch-inf)}
+.frame.inexact[data-resolution="obfuscated"]{background-image:var(--hatch-obf),var(--hatch-inf)}
+.frame.inexact[data-resolution="interpreter"]{background-image:var(--hatch-interp),var(--hatch-inf)}
 
 .frame:hover{box-shadow:inset 0 0 0 1.4px var(--frame-ink);outline:none}
 .frame.match{background-color:var(--fill-match)}

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -87,6 +87,7 @@ h1{font-size:12.5px;font-weight:500;color:var(--muted);margin:0;flex:1;min-width
 .legend .c{display:inline-flex;align-items:center;gap:5px;white-space:nowrap}
 .legend .c i{width:11px;height:11px;border-radius:3px;border:1px solid rgb(0 0 0/.22);display:inline-block;background-repeat:repeat}
 .legend .sep{width:1px;height:14px;background:var(--line)}
+.legend i.res{background-color:var(--fill-root)}
 #fd{position:fixed;z-index:7;top:96px;right:14px;bottom:44px;width:378px;max-width:calc(100vw - 28px);display:flex;flex-direction:column;border:1px solid var(--line);border-radius:12px;background:var(--panel);box-shadow:0 10px 36px rgb(0 0 0/.16);overflow:hidden}
 #fd[hidden]{display:none}
 body.pinned .canvas,body.pinned .note{margin-right:406px}

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -89,6 +89,8 @@ h1{font-size:12.5px;font-weight:500;color:var(--muted);margin:0;flex:1;min-width
 .legend .sep{width:1px;height:14px;background:var(--line)}
 #fd{position:fixed;z-index:7;top:96px;right:14px;bottom:44px;width:378px;max-width:calc(100vw - 28px);display:flex;flex-direction:column;border:1px solid var(--line);border-radius:12px;background:var(--panel);box-shadow:0 10px 36px rgb(0 0 0/.16);overflow:hidden}
 #fd[hidden]{display:none}
+body.pinned .canvas,body.pinned .note{margin-right:406px}
+@media (max-width:900px){body.pinned .canvas,body.pinned .note{margin-right:16px}#fd{top:auto;height:46vh}}
 #fd .fh{display:flex;align-items:center;gap:7px;padding:9px 12px;border-bottom:1px solid var(--line)}
 #fd .fh b{flex:1;font-size:12.5px;font-weight:600}
 #fd .fh button{cursor:pointer;color:var(--muted);background:none;border:0;font-size:14px;padding:2px 4px;border-radius:6px}
@@ -105,12 +107,18 @@ h1{font-size:12.5px;font-weight:500;color:var(--muted);margin:0;flex:1;min-width
 #fd .callout{margin:11px 0;padding:8px 10px;border:1px solid var(--line);border-left-width:3px;border-radius:7px;background:var(--bg);font-size:11.5px;line-height:1.45}
 #fd .callout b{display:block;font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin-bottom:2px}
 #fd h3{font-size:10.5px;text-transform:uppercase;letter-spacing:.07em;color:var(--muted);margin:14px 0 6px}
-#fd .path{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;line-height:1.6;white-space:pre;overflow:auto;padding:8px 10px;border:1px solid var(--line);border-radius:8px;background:var(--bg)}
+#fd .path{border:1px solid var(--line);border-radius:8px;background:var(--bg);padding:4px 0;max-height:46vh;overflow:auto}
+#fd .path div{position:relative;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:10.5px;line-height:1.45;padding:2px 9px 2px 22px;word-break:break-word}
+#fd .path div::before{content:"";position:absolute;left:11px;top:0;bottom:0;width:1px;background:var(--line)}
+#fd .path div:first-child::before{top:9px}
+#fd .path div:last-child::before{bottom:auto;height:9px}
+#fd .path div::after{content:"";position:absolute;left:11px;top:9px;width:6px;height:1px;background:var(--line)}
+#fd .path div.here{background:var(--warn-bg);font-weight:600}
 #fd .dot{display:inline-block;width:9px;height:9px;border-radius:50%;border:1px solid rgb(0 0 0/.25);margin-right:5px;vertical-align:-1px}
 .frame.pinned{outline:2px solid var(--accent);outline-offset:-2px}
 #info-btn.notes::after{content:"\2022";color:var(--accent);vertical-align:super;font-size:11px}
 .note{margin:8px 16px 0;padding:5px 11px;border:1px solid var(--warn-line);border-left-width:3px;border-radius:7px;background:var(--warn-bg);font-size:12px}
-.canvas{margin:10px 16px 0;padding:9px;border:1px solid var(--line);border-radius:10px;background:var(--panel);overflow:hidden}
+.canvas{margin:10px 16px 0;transition:margin-right .12s ease;padding:9px;border:1px solid var(--line);border-radius:10px;background:var(--panel);overflow:hidden}
 .chart{position:relative;margin:0}
 .frame{position:absolute;height:17px;padding:0 4px;border-radius:2px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;line-height:17px;cursor:pointer}
 .frame.dim{opacity:.15}
@@ -676,6 +684,10 @@ function revealInTree(it){
 
 var fd=doc.getElementById("fd"),fdName=doc.getElementById("fd-name"),fdBody=doc.getElementById("fd-body");
 var pinned=null,fdTab="sum",hover=null;
+var domLabels=(function(){var e=doc.getElementById("domain-labels");
+  try{return e?JSON.parse(e.textContent):{};}catch(x){return {};}})();
+function domLabel(k){return domLabels[k]||k||"application";}
+function baseName(p){var i=p.lastIndexOf("/");return i<0?p:p.slice(i+1);}
 function esc(t){var d=doc.createElement("div");d.textContent=t;return d.innerHTML;}
 function rows(pairs){
   var h='<div class="rows">';
@@ -694,10 +706,9 @@ function pathToRoot(it){
   var chain=[],o=it;
   while(o){chain.push(o);o=o.up;}
   chain.reverse();
-  return chain.map(function(o,i){
-    var pad=i?" ".repeat((i-1)*2)+"\u2514 ":"";
-    return esc(pad+o.name);
-  }).join("\n");
+  return chain.map(function(o){
+    return '<div'+(o===it?' class="here"':'')+'>'+esc(o.name)+"</div>";
+  }).join("");
 }
 function acrossGraph(it){
   var n=0,total=0;
@@ -705,7 +716,7 @@ function acrossGraph(it){
   return {n:n,total:total};
 }
 function fdSummary(it){
-  var d=it.el.dataset,m=moduleOf(d),w=widthMeaning(it,d),r=resolutionNote(d);
+  var d=it.el.dataset,m=moduleOf(d),w=widthMeaning(it,d);
   var h=rows([
     ["Cumulative",fmt(it.value)+' <span class="muted">'+pct(it.value)+"</span>"],
     ["Self",fmt(it.self)+' <span class="muted">'+pct(it.self)+"</span>"],
@@ -714,9 +725,9 @@ function fdSummary(it){
   ]);
   if(w){h+='<div class="callout"><b>Width means</b>'+esc(w.replace(/^width: /,""))+"</div>";}
   h+=rows([
-    ["Domain",domainDot(d.domain)+esc(d.domain||"application"),true],
-    ["Resolution",r?esc(r.replace(/^[a-z ]+: /,"")):"fully resolved",true],
-    ["Module",m?esc(m):'<span class="muted">unknown</span>',true]
+    ["Domain",domainDot(d.domain)+esc(domLabel(d.domain)),true],
+    ["Resolution",d.domain==="unsym"?"no symbol":"fully resolved",true],
+    ["Module",m?'<span title="'+esc(m)+'">'+esc(baseName(m))+"</span>":'<span class="muted">unknown</span>',true]
   ]);
   if(it.inexact>0){h+='<div class="callout"><b>Attributed by inference</b>'+fmt(it.inexact)+" of this frame names a plausible caller, not an observed one.</div>";}
   if(d.collapsed){h+='<div class="callout"><b>Merged</b>Consecutive frames in this library whose names carry no information are drawn as one. The profile still holds every frame.</div>';}
@@ -751,11 +762,11 @@ function pin(it){
   if(pinned===it){unpin();return;}
   if(pinned&&pinned.el){pinned.el.classList.remove("pinned");}
   pinned=it;it.el.classList.add("pinned");
-  fd.hidden=false;fdRender();
+  fd.hidden=false;doc.body.classList.add("pinned");fdRender();
 }
 function unpin(){
   if(pinned&&pinned.el){pinned.el.classList.remove("pinned");}
-  pinned=null;fd.hidden=true;
+  pinned=null;fd.hidden=true;doc.body.classList.remove("pinned");
 }
 doc.getElementById("fd-close").addEventListener("click",unpin);
 doc.getElementById("fd-copy").addEventListener("click",function(){

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -87,6 +87,27 @@ h1{font-size:12.5px;font-weight:500;color:var(--muted);margin:0;flex:1;min-width
 .legend .c{display:inline-flex;align-items:center;gap:5px;white-space:nowrap}
 .legend .c i{width:11px;height:11px;border-radius:3px;border:1px solid rgb(0 0 0/.22);display:inline-block;background-repeat:repeat}
 .legend .sep{width:1px;height:14px;background:var(--line)}
+#fd{position:fixed;z-index:7;top:96px;right:14px;bottom:44px;width:378px;max-width:calc(100vw - 28px);display:flex;flex-direction:column;border:1px solid var(--line);border-radius:12px;background:var(--panel);box-shadow:0 10px 36px rgb(0 0 0/.16);overflow:hidden}
+#fd[hidden]{display:none}
+#fd .fh{display:flex;align-items:center;gap:7px;padding:9px 12px;border-bottom:1px solid var(--line)}
+#fd .fh b{flex:1;font-size:12.5px;font-weight:600}
+#fd .fh button{cursor:pointer;color:var(--muted);background:none;border:0;font-size:14px;padding:2px 4px;border-radius:6px}
+#fd .fh button:hover{color:var(--accent);background:var(--bg)}
+#fd .fn{padding:9px 12px;border-bottom:1px solid var(--line);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11.5px;line-height:1.45;word-break:break-word;max-height:5.4em;overflow:auto}
+#fd .tabs{display:flex;gap:2px;padding:7px 9px 0;border-bottom:1px solid var(--line)}
+#fd .tabs button{cursor:pointer;border:0;background:none;color:var(--muted);font:inherit;font-size:12px;padding:5px 10px;border-radius:7px 7px 0 0}
+#fd .tabs button[aria-selected="true"]{color:var(--ink);background:var(--bg);font-weight:600}
+#fd .body{flex:1;overflow:auto;padding:11px 12px 14px}
+#fd .rows{display:grid;grid-template-columns:auto 1fr;gap:5px 12px;font-size:12px;align-items:baseline}
+#fd .rows .k{color:var(--muted);white-space:nowrap}
+#fd .rows .v{text-align:right;font-variant-numeric:tabular-nums}
+#fd .rows .v.l{text-align:left}
+#fd .callout{margin:11px 0;padding:8px 10px;border:1px solid var(--line);border-left-width:3px;border-radius:7px;background:var(--bg);font-size:11.5px;line-height:1.45}
+#fd .callout b{display:block;font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin-bottom:2px}
+#fd h3{font-size:10.5px;text-transform:uppercase;letter-spacing:.07em;color:var(--muted);margin:14px 0 6px}
+#fd .path{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;line-height:1.6;white-space:pre;overflow:auto;padding:8px 10px;border:1px solid var(--line);border-radius:8px;background:var(--bg)}
+#fd .dot{display:inline-block;width:9px;height:9px;border-radius:50%;border:1px solid rgb(0 0 0/.25);margin-right:5px;vertical-align:-1px}
+.frame.pinned{outline:2px solid var(--accent);outline-offset:-2px}
 #info-btn.notes::after{content:"\2022";color:var(--accent);vertical-align:super;font-size:11px}
 .note{margin:8px 16px 0;padding:5px 11px;border:1px solid var(--warn-line);border-left-width:3px;border-radius:7px;background:var(--warn-bg);font-size:12px}
 .canvas{margin:10px 16px 0;padding:9px;border:1px solid var(--line);border-radius:10px;background:var(--panel);overflow:hidden}
@@ -653,8 +674,102 @@ function revealInTree(it){
   if(it.head){it.head.scrollIntoView({block:"center"});}
 }
 
+var fd=doc.getElementById("fd"),fdName=doc.getElementById("fd-name"),fdBody=doc.getElementById("fd-body");
+var pinned=null,fdTab="sum",hover=null;
+function esc(t){var d=doc.createElement("div");d.textContent=t;return d.innerHTML;}
+function rows(pairs){
+  var h='<div class="rows">';
+  pairs.forEach(function(p){
+    if(p[1]===null||p[1]===undefined||p[1]==="")return;
+    h+='<span class="k">'+esc(p[0])+'</span><span class="v'+(p[2]?" l":"")+'">'+p[1]+'</span>';
+  });
+  return h+'</div>';
+}
+function domainDot(d){
+  var e=doc.createElement("span");e.className="frame";e.setAttribute("data-domain",d||"app");
+  doc.body.appendChild(e);var bg=getComputedStyle(e).backgroundColor;e.remove();
+  return '<span class="dot" style="background:'+bg+'"></span>';
+}
+function pathToRoot(it){
+  var chain=[],o=it;
+  while(o){chain.push(o);o=o.up;}
+  chain.reverse();
+  return chain.map(function(o,i){
+    var pad=i?" ".repeat((i-1)*2)+"\u2514 ":"";
+    return esc(pad+o.name);
+  }).join("\n");
+}
+function acrossGraph(it){
+  var n=0,total=0;
+  items.forEach(function(o){if(o.name===it.name){n++;total+=o.value;}});
+  return {n:n,total:total};
+}
+function fdSummary(it){
+  var d=it.el.dataset,m=moduleOf(d),w=widthMeaning(it,d),r=resolutionNote(d);
+  var h=rows([
+    ["Cumulative",fmt(it.value)+' <span class="muted">'+pct(it.value)+"</span>"],
+    ["Self",fmt(it.self)+' <span class="muted">'+pct(it.self)+"</span>"],
+    ["Depth",it.d],
+    ["Children",it.kids.length]
+  ]);
+  if(w){h+='<div class="callout"><b>Width means</b>'+esc(w.replace(/^width: /,""))+"</div>";}
+  h+=rows([
+    ["Domain",domainDot(d.domain)+esc(d.domain||"application"),true],
+    ["Resolution",r?esc(r.replace(/^[a-z ]+: /,"")):"fully resolved",true],
+    ["Module",m?esc(m):'<span class="muted">unknown</span>',true]
+  ]);
+  if(it.inexact>0){h+='<div class="callout"><b>Attributed by inference</b>'+fmt(it.inexact)+" of this frame names a plausible caller, not an observed one.</div>";}
+  if(d.collapsed){h+='<div class="callout"><b>Merged</b>Consecutive frames in this library whose names carry no information are drawn as one. The profile still holds every frame.</div>';}
+  h+="<h3>Path to root</h3>"+'<div class="path">'+pathToRoot(it)+"</div>";
+  return h;
+}
+function fdStack(it){
+  return "<h3>Call path</h3>"+'<div class="path">'+pathToRoot(it)+"</div>";
+}
+function fdAll(it){
+  var a=acrossGraph(it);
+  return rows([
+    ["Instances",a.n],
+    ["Combined",fmt(a.total)+' <span class="muted">'+pct(a.total)+"</span>"],
+    ["This one",fmt(it.value)+' <span class="muted">'+pct(it.value)+"</span>"]
+  ])+'<div class="callout"><b>Across graph</b>The same symbol reached by different call paths is a different frame in a flame graph. These are all of them, summed.</div>';
+}
+function fdRender(){
+  if(!pinned)return;
+  fdName.textContent=pinned.name;
+  fdBody.innerHTML=fdTab==="sum"?fdSummary(pinned):fdTab==="stack"?fdStack(pinned):fdAll(pinned);
+}
+function setTab(t){
+  fdTab=t;
+  [["sum","tab-sum"],["stack","tab-stack"],["all","tab-all"]].forEach(function(p){
+    doc.getElementById(p[1]).setAttribute("aria-selected",p[0]===t?"true":"false");
+  });
+  fdRender();
+}
+function pin(it){
+  if(!it){return;}
+  if(pinned===it){unpin();return;}
+  if(pinned&&pinned.el){pinned.el.classList.remove("pinned");}
+  pinned=it;it.el.classList.add("pinned");
+  fd.hidden=false;fdRender();
+}
+function unpin(){
+  if(pinned&&pinned.el){pinned.el.classList.remove("pinned");}
+  pinned=null;fd.hidden=true;
+}
+doc.getElementById("fd-close").addEventListener("click",unpin);
+doc.getElementById("fd-copy").addEventListener("click",function(){
+  if(pinned&&navigator.clipboard){navigator.clipboard.writeText(pinned.name);}
+});
+doc.getElementById("tab-sum").addEventListener("click",function(){setTab("sum");});
+doc.getElementById("tab-stack").addEventListener("click",function(){setTab("stack");});
+doc.getElementById("tab-all").addEventListener("click",function(){setTab("all");});
+
 items.forEach(function(it){
   it.el.addEventListener("click",function(e){e.stopPropagation();zoom(it);});
+  it.el.addEventListener("click",function(e){if(e.shiftKey){e.stopPropagation();e.preventDefault();pin(it);}},true);
+  it.el.addEventListener("mouseenter",function(){hover=it;});
+  it.el.addEventListener("mouseleave",function(){if(hover===it){hover=null;}});
   it.el.addEventListener("mouseenter",function(){status(it);});
   it.el.addEventListener("mousemove",function(e){showTip(e,it);});
   it.el.addEventListener("mouseleave",function(){tip.hidden=true;status(null);});
@@ -670,6 +785,7 @@ doc.addEventListener("click",function(e){
 });
 doc.addEventListener("keydown",function(e){
   if((e.ctrlKey||e.metaKey)&&(e.key==="f"||e.key==="F")){e.preventDefault();openSearch();return;}
+  if(e.key==="Escape"&&pinned){unpin();return;}
   if(e.key==="Escape"){
     if(info.open){info.open=false;}
     else if(!q.hidden){closeSearch();}
@@ -685,6 +801,7 @@ doc.addEventListener("keydown",function(e){
   else if(e.key==="d"||e.key==="D"){toggleTheme();}
   else if(e.key==="i"||e.key==="I"){toggleInvert();}
   else if(e.key==="t"||e.key==="T"){toggleTree();}
+  else if(e.key==="p"||e.key==="P"){pin(hover||pinned);}
   else if(e.key==="n"){stepMatch(1);}
   else if(e.key==="N"){stepMatch(-1);}
   else if(e.key==="?"){toggleInfo();}

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -60,7 +60,7 @@ const darkChrome = `--bg:#16151a;--panel:#1e1d23;--ink:#eceaf2;--muted:#a29caf;-
 // text-overflow:ellipsis cuts the label to whatever the frame can hold, at
 // the reader's actual window width, in the reader's actual font — three
 // things a Go function measuring characters against a nominal 6.4 px advance
-// could only guess at. Frames narrower than the 8 px of horizontal padding
+// could only guess at. Frames narrower than the 14 px of horizontal padding
 // have a zero-width content box and draw no text at all; between there and
 // about 14 px they draw a lone ellipsis. Both are the browser applying the
 // rule, not a threshold anyone chose.
@@ -121,7 +121,7 @@ body.pinned .canvas,body.pinned .note{margin-right:406px}
 .note{margin:8px 16px 0;padding:5px 11px;border:1px solid var(--warn-line);border-left-width:3px;border-radius:7px;background:var(--warn-bg);font-size:12px}
 .canvas{margin:10px 16px 0;transition:margin-right .12s ease;padding:9px;border:1px solid var(--line);border-radius:10px;background:var(--panel);overflow:hidden}
 .chart{position:relative;margin:0}
-.frame{position:absolute;height:17px;padding:0 4px;border-radius:2px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11px;line-height:17px;cursor:pointer}
+.frame{position:absolute;height:19px;padding:0 7px;border-radius:5px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:11.5px;line-height:19px;cursor:pointer}
 .frame.dim{opacity:.15}
 #status{position:fixed;left:0;right:0;bottom:0;z-index:6;display:flex;gap:14px;align-items:center;padding:5px 16px;background:var(--panel);border-top:1px solid var(--line);font-size:12px}
 #status b{font-weight:600}

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -460,8 +460,19 @@ function detail(it){
   var w=widthMeaning(it,d);
   if(w){s+="\n"+w;}
   if(it.inexact>0){s+="\n"+fmt(it.inexact)+" of this is attributed by inference, not measurement";}
-  if(d.domain==="unsym"){s+="\nno symbol: the unwind found this frame, nothing could name it";}
+  var r=resolutionNote(d);
+  if(r){s+="\n"+r;}
   return s;
+}
+function resolutionNote(d){
+  switch(d.resolution){
+  case "module-offset": return "no symbol here, but the module is known \u2014 this offset is stable across ASLR and can be matched against symbol data for the same build";
+  case "bare-address": return "no symbol and no module: the frame's position is real, nothing else about it is known";
+  case "obfuscated": return "symbolized by NVIDIA's symbol server \u2014 a stable identifier for an internal function, not a human-readable name. Not a symbolization failure";
+  case "interpreter": return "interpreter frame placed correctly; its code object could not be read";
+  }
+  if(d.domain==="unsym"){return "no symbol: the unwind found this frame, nothing could name it";}
+  return "";
 }
 function widthMeaning(it,d){
   if(unit.indexOf("nanoseconds")<0||axis.indexOf("gpu/")<0){return "";}

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -285,6 +285,10 @@ const paletteCSS = `
 .frame.match{background-color:var(--fill-match)}
 .frame.cur{box-shadow:inset 0 0 0 1.8px var(--frame-ink);outline:none}
 .sw[data-domain]{background-color:var(--fill-x)}
+.sw.res-module-offset{background-image:var(--hatch-gap)}
+.sw.res-bare-address{background-image:var(--hatch-bare)}
+.sw.res-obfuscated{background-image:var(--hatch-obf)}
+.sw.res-interpreter{background-image:var(--hatch-interp)}
 `
 
 // The jitter ladder. jitterSteps shades per domain, evenly spaced from 0 to

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -62,8 +62,10 @@ const darkChrome = `--bg:#16151a;--panel:#1e1d23;--ink:#eceaf2;--muted:#a29caf;-
 // things a Go function measuring characters against a nominal 6.4 px advance
 // could only guess at. Frames narrower than the 14 px of horizontal padding
 // have a zero-width content box and draw no text at all; between there and
-// about 14 px they draw a lone ellipsis. Both are the browser applying the
-// rule, not a threshold anyone chose.
+// about 21 px they draw a lone ellipsis. Both are the browser applying the
+// rule, not a threshold anyone chose. (Both numbers moved with the padding
+// when the bars took the mock's shape: they were 8 px and 14 px at 4 px of
+// padding, and they are not independent of it.)
 const styleSheet = `
 :root{--tip-bg:#1f1d24;--tip-ink:#f2eff7;--tip-line:#3a3543;--bg:#f7f6f9;--panel:#ffffff;--ink:#1d1a17;--muted:#6b6259;--line:#e2dad0;--accent:#b4522a;--warn-bg:#fff6e8;--warn-line:#e8c88a;--fatal-bg:#fdecec;--fatal-line:#e0a3a3}
 @media (prefers-color-scheme: dark){:root:not([data-theme="light"]){` + darkChrome + `}}

--- a/internal/flamegraph/domain.go
+++ b/internal/flamegraph/domain.go
@@ -117,7 +117,10 @@ var domainInfo = [numDomains]DomainInfo{
 		Desc: "CUDA/HIP/HSA runtime and driver frames: the CPU path that initiates GPU work. Yellow, Gregg's C++ layer.",
 	},
 	DomainUnsymbolized: {
-		Key: "unsym", Label: "vendor, no symbols", Fill: "var(--fill-unsym)", Overlay: "var(--hatch-gap)",
+		// No Overlay: the hatch moved to the RESOLUTION axis, which says why
+		// a frame is unnamed (module+offset, bare address, obfuscated) where
+		// the domain only said that it is. See resolution.go.
+		Key: "unsym", Label: "vendor, no symbols", Fill: "var(--fill-unsym)",
 		Desc: "Unwound correctly; no symbol table could name it. The depth is real, the names are missing — usually a stripped vendor library with no exported symbols. Labelled module+offset (libcuda.so.1+0x1b71c6) where the profile knows which file the address fell in, and as a bare address where it does not. The CPU band's hue, drained: right layer, no name.",
 	},
 	DomainProfilerShim: {

--- a/internal/flamegraph/modules.go
+++ b/internal/flamegraph/modules.go
@@ -76,3 +76,36 @@ func writeModuleTable(ew *errWriter, t moduleTable) {
 	// element early.
 	ew.f("<script type=\"application/json\" id=\"modules\">%s</script>\n", b)
 }
+
+// writeDomainLabels emits the key -> human label map the details panel reads.
+//
+// The frames carry data-domain="app", which is an identifier chosen for CSS
+// selectors, not a word to show a reader. The panel used to print it raw, so a
+// frame's domain read "app" and "unsym" instead of "application" and "vendor,
+// no symbols". The labels live in Go, in domainInfo, and this is the one hop
+// that gets them to the page.
+//
+// Same escaping reasoning as writeModuleTable above: json.Marshal, not
+// html.EscapeString, because entities are not decoded inside a script element.
+func writeDomainLabels(ew *errWriter, present map[Domain]bool) {
+	// Only the domains this profile actually contains, which is the same rule
+	// the legend follows and for the same reason: naming a domain that is not
+	// on screen sends the reader looking for it. It is also what
+	// TestRenderHTMLLegendOnlyNamesDomainsThatAreActuallyPresent checks, and
+	// emitting the whole table quietly broke it.
+	m := make(map[string]string, len(present))
+	for d := range present {
+		in := d.Info()
+		if in.Key != "" {
+			m[in.Key] = in.Label
+		}
+	}
+	if len(m) == 0 {
+		return
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return
+	}
+	ew.f("<script type=\"application/json\" id=\"domain-labels\">%s</script>\n", b)
+}

--- a/internal/flamegraph/palette_test.go
+++ b/internal/flamegraph/palette_test.go
@@ -376,11 +376,56 @@ func TestEveryHatchedDomainIsActuallyHatchedByARule(t *testing.T) {
 		assert.Contains(t, paletteCSS, strings.TrimSuffix(strings.TrimPrefix(info.Overlay, "var("), ")")+":",
 			"domain %q names a hatch token the stylesheet does not declare", info.Key)
 	}
-	// A frame can be both unnamed and inferred; it must then show both
-	// hatches rather than silently losing one to the cascade.
-	assert.Contains(t, paletteCSS, `.frame.inexact[data-domain="unsym"],.frame.inexact[data-domain="boundary-unattributed"]{background-image:var(--hatch-gap),var(--hatch-inf)}`)
-	// The two hatches run opposite ways, so which uncertainty a frame
-	// carries is visible without hovering it.
+}
+
+// Texture belongs to the RESOLUTION, colour to the domain.
+//
+// They answer different questions -- what kind of code this is, and how well
+// we could name it -- and folding both into the domain meant a reader could
+// not ask the second one. Every resolution that is not plain "resolved" must
+// therefore paint something, and each must paint something DIFFERENT, or the
+// axis is decorative.
+func TestEveryUnresolvedResolutionHasItsOwnTexture(t *testing.T) {
+	seen := map[string]string{}
+	for _, r := range []Resolution{
+		ResolutionModuleOffset, ResolutionBareAddress,
+		ResolutionObfuscated, ResolutionInterpreter,
+	} {
+		key := r.Info().Key
+		rule := fmt.Sprintf(`[data-resolution="%s"]{background-image:`, key)
+		assert.Contains(t, paletteCSS, rule, "resolution %q paints nothing", key)
+
+		i := strings.Index(paletteCSS, rule)
+		tok := paletteCSS[i+len(rule):]
+		tok = tok[:strings.Index(tok, "}")]
+		assert.Contains(t, paletteCSS, strings.TrimSuffix(strings.TrimPrefix(tok, "var("), ")")+":",
+			"resolution %q names a texture token the stylesheet does not declare", key)
+		if prev, dup := seen[tok]; dup {
+			t.Errorf("resolutions %q and %q share the texture %s; they must be told apart", prev, key, tok)
+		}
+		seen[tok] = key
+	}
+	// A resolved frame must carry no texture at all: the plain case has to
+	// look plain, or every frame reads as uncertain.
+	assert.NotContains(t, paletteCSS, `[data-resolution="resolved"]`)
+}
+
+// A frame can be both unnamed AND inferred. It must show both textures rather
+// than silently losing one to the cascade -- background-image does not
+// accumulate, so each combination needs its own rule.
+func TestInferredCombinesWithEveryTexture(t *testing.T) {
+	for _, r := range []Resolution{
+		ResolutionModuleOffset, ResolutionBareAddress,
+		ResolutionObfuscated, ResolutionInterpreter,
+	} {
+		key := r.Info().Key
+		assert.Contains(t, paletteCSS,
+			fmt.Sprintf(`.frame.inexact[data-resolution="%s"]{background-image:`, key),
+			"an inferred %q frame would lose one of its two textures", key)
+	}
+	assert.Contains(t, paletteCSS, `.frame.inexact[data-domain="boundary-unattributed"]{background-image:var(--hatch-gap),var(--hatch-inf)}`)
+	// The two uncertainties run opposite ways, so which one a frame carries
+	// is visible without hovering it.
 	assert.Contains(t, paletteCSS, "--hatch-gap: repeating-linear-gradient(45deg,")
 	assert.Contains(t, paletteCSS, "--hatch-inf: repeating-linear-gradient(-45deg,")
 }

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -152,6 +152,7 @@ func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
 	}
 	writeTreeContainer(ew, res)
 	writeStatusBar(ew, res)
+	writeFrameDetails(ew)
 	ew.s("<div id=\"tip\" hidden></div>\n")
 
 	ew.s("<script>\n")
@@ -679,6 +680,34 @@ func samplePeriod(res *foldedstacks.Result) (string, bool) {
 func writeTreeContainer(ew *errWriter, res *foldedstacks.Result) {
 	ew.f("<div id=\"tree\" role=\"group\" aria-label=\"Call tree, %s\" hidden></div>\n",
 		html.EscapeString(res.SampleTypeName+"/"+res.Unit))
+}
+
+// writeFrameDetails emits the docked panel the script fills on pin.
+//
+// Empty and hidden in the markup: everything in it is derived from the frame
+// the reader pinned, and the page has no pinned frame until they pin one.
+// Emitting a skeleton rather than building the nodes in script keeps the
+// structure in the same file as the rest of the page's HTML, where the
+// balance test can see it.
+//
+// It is a PANEL, not a dialog: it does not trap focus and the graph stays
+// live behind it, because the reader's next action after pinning a frame is
+// usually to look at its neighbours. Escape closes it, which is the one
+// dialog behaviour worth keeping.
+func writeFrameDetails(ew *errWriter) {
+	ew.s("<div id=\"fd\" hidden aria-label=\"Frame details\">\n")
+	ew.s("<div class=\"fh\"><b>Frame Details</b>")
+	ew.s("<button id=\"fd-copy\" type=\"button\" title=\"Copy the frame name\" aria-label=\"Copy the frame name\">&#10697;</button>")
+	ew.s("<button id=\"fd-close\" type=\"button\" title=\"Close (Esc)\" aria-label=\"Close\">&#10005;</button>")
+	ew.s("</div>\n")
+	ew.s("<div class=\"fn\" id=\"fd-name\"></div>\n")
+	ew.s("<div class=\"tabs\" role=\"tablist\">")
+	ew.s("<button role=\"tab\" id=\"tab-sum\" aria-selected=\"true\">Summary</button>")
+	ew.s("<button role=\"tab\" id=\"tab-stack\" aria-selected=\"false\">Stack</button>")
+	ew.s("<button role=\"tab\" id=\"tab-all\" aria-selected=\"false\">Across graph</button>")
+	ew.s("</div>\n")
+	ew.s("<div class=\"body\" id=\"fd-body\"></div>\n")
+	ew.s("</div>\n")
 }
 
 // writeStatusBar emits the single permanent line of text on the page. Its

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -611,7 +611,50 @@ func writeLegendBar(ew *errWriter, root *node) {
 		ew.f("<span class=\"c\"><i style=\"%s\"></i>%s</span>",
 			html.EscapeString(style), html.EscapeString(shortLegendLabel(in.Label)))
 	}
+	writeResolutionChips(ew, root)
 	ew.s("\n</div>\n")
+}
+
+// writeResolutionChips is the legend's SECOND axis, in the same bar.
+//
+// Colour says what kind of code a frame is; texture says how well it is
+// named. One channel carrying both facts is what the old legend had to
+// apologise for, and the mock draws the two rows together.
+//
+// "resolved" is deliberately absent: it is the default, every frame that is
+// not marked has it, and a chip for it would be a key to the absence of a
+// mark. Only the resolutions this profile actually contains appear, for the
+// same reason the domain chips work that way.
+func writeResolutionChips(ew *errWriter, root *node) {
+	present := map[Resolution]bool{}
+	var walk func(*node)
+	walk = func(n *node) {
+		// Derived from the name, exactly as writeNode derives it for the
+		// frame's own data-resolution: one function decides, so the key and
+		// the frames it keys can never disagree.
+		if r := ResolutionOf(n.name); n.depth > 0 && r != ResolutionResolved {
+			present[r] = true
+		}
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	walk(root)
+	if len(present) == 0 {
+		return
+	}
+	ew.s("<span class=\"sep\"></span>")
+	for _, r := range []Resolution{
+		ResolutionModuleOffset, ResolutionObfuscated,
+		ResolutionInterpreter, ResolutionBareAddress,
+	} {
+		if !present[r] {
+			continue
+		}
+		in := r.Info()
+		ew.f("<span class=\"c\"><i class=\"res\" data-resolution=\"%s\"></i>%s</span>",
+			html.EscapeString(in.Key), html.EscapeString(in.Label))
+	}
 }
 
 // domainsPresent is the set of domains this profile actually contains. The

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -541,14 +541,82 @@ func group(v int64) string {
 // the panel one of them opens. The info button grows a dot when the profile
 // carries notes, so a page with caveats never looks like a page without.
 func writeTopBar(ew *errWriter, opts Options, res *foldedstacks.Result, root *node) {
-	ew.s("<div class=\"top\">\n<h1>")
+	ew.s("<div class=\"top\">\n")
+	// The wordmark, which is the product rather than the file. The profile's
+	// own name moves to the middle of the bar and to the status line: a page
+	// with no identity of its own reads as a debug artefact, and this one is
+	// meant to be shared.
+	ew.s("<span class=\"brand\"><b>perf-agent</b><i>Enjoy the Flames.</i></span>\n")
+	ew.s("<h1>")
 	ew.esc(opts.Title)
 	ew.s("</h1>\n")
+	// Metric and unit as READOUTS, not controls. The mock draws them as
+	// dropdowns; a dropdown that cannot switch anything is a lie about what
+	// the page can do, and this page renders exactly one sample type. They
+	// say what is on screen and nothing more.
+	ew.s("<span class=\"readout\">")
+	ew.f("<span>Metric <b>%s</b></span>", html.EscapeString(res.SampleTypeName))
+	ew.f("<span>Unit <b>%s</b></span>", html.EscapeString(res.Unit))
+	ew.s("</span>\n")
 	writeInfoPanel(ew, root, res, opts)
 	ew.s("<button id=\"inv-btn\" type=\"button\" title=\"Invert: root at top (I)\" aria-label=\"Invert the graph\">&#8645;</button>\n")
 	ew.s("<button id=\"tree-btn\" type=\"button\" title=\"Tree view (T)\" aria-label=\"Toggle the tree view\">&#9776;</button>\n")
 	ew.s("<button id=\"theme-btn\" type=\"button\" title=\"Light / dark (D)\" aria-label=\"Toggle light or dark\">&#9680;</button>\n")
 	ew.s("</div>\n")
+	writeLegendBar(ew, root)
+}
+
+// writeLegendBar puts the colour key ON the page instead of inside a panel
+// nobody opens.
+//
+// It lists only the domains this profile actually contains, for the same
+// reason the info panel's legend does: a key naming colours that are not on
+// screen sends the reader looking for them. The labels are the short form --
+// "vendor", not "CPU: GPU runtime and driver" -- because a bar is scanned and
+// the panel is read; the full description is still one click away.
+func writeLegendBar(ew *errWriter, root *node) {
+	present := map[Domain]bool{}
+	var walk func(*node)
+	walk = func(n *node) {
+		if n.depth > 0 {
+			present[n.domain] = true
+		}
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	walk(root)
+	if len(present) == 0 {
+		return
+	}
+	ew.s("<div class=\"legend\" aria-label=\"Colour key\">\n")
+	for _, d := range legendOrder {
+		if !present[d] {
+			continue
+		}
+		in := d.Info()
+		ew.f("<span class=\"c\"><i style=\"background:%s\"></i>%s</span>",
+			html.EscapeString(in.Fill), html.EscapeString(shortLegendLabel(in.Label)))
+	}
+	ew.s("\n</div>\n")
+}
+
+// legendOrder is the CPU-to-GPU reading order, not the declaration order of
+// the Domain constants: a key is a sentence about the path a launch takes.
+var legendOrder = []Domain{
+	DomainApplication, DomainSystem, DomainVendorRuntime, DomainUnsymbolized,
+	DomainKernel, DomainProfilerShim, DomainBoundary, DomainBoundaryUnattributed,
+	DomainGPUKernel, DomainRoot,
+}
+
+// shortLegendLabel trims the panel's descriptive label to a bar-sized one.
+// The long form explains; the short form identifies, and only the second fits
+// on one line beside eight others.
+func shortLegendLabel(label string) string {
+	if i := strings.Index(label, ": "); i >= 0 {
+		return label[i+2:]
+	}
+	return label
 }
 
 // writeSamplePeriodNote is the one note that stays on the page.
@@ -602,15 +670,18 @@ func writeTreeContainer(ew *errWriter, res *foldedstacks.Result) {
 // used to hold — and the script replaces it with the hovered frame.
 func writeStatusBar(ew *errWriter, res *foldedstacks.Result) {
 	ew.s("<div id=\"status\">\n<span id=\"st\">")
-	ew.esc(FormatValue(res.Total, res.Unit))
-	ew.s(" total")
-	ew.f(" &middot; %s samples", group(int64(res.Samples)))
-	ew.f(" &middot; %s stacks", group(int64(len(res.Stacks))))
-	ew.s(" &middot; ")
-	ew.esc(res.SampleTypeName + "/" + res.Unit)
+	// Labelled figures rather than a run-on sentence: the mock's status line
+	// is scanned for one number at a time, and "15.049 s total" reads as prose
+	// while "Total 15.049 s" reads as a field.
+	ew.f("<span class=\"k\">Total</span> <b>%s</b>", html.EscapeString(FormatValue(res.Total, res.Unit)))
+	ew.f(" &nbsp;<span class=\"k\">Samples</span> <b>%s</b>", group(int64(res.Samples)))
+	ew.f(" &nbsp;<span class=\"k\">Stacks</span> <b>%s</b>", group(int64(len(res.Stacks))))
+	ew.f(" &nbsp;<span class=\"k\">Metric</span> <b>%s</b>", html.EscapeString(res.SampleTypeName))
+	ew.f(" &nbsp;<span class=\"k\">Unit</span> <b>%s</b>", html.EscapeString(res.Unit))
 	ew.s("</span>\n")
 	ew.s("<input id=\"q\" type=\"search\" hidden placeholder=\"search frames\" autocomplete=\"off\" spellcheck=\"false\" aria-label=\"Search frames\">\n")
-	ew.s("<span id=\"mc\"></span>\n</div>\n")
+	ew.s("<span id=\"mc\"></span>\n")
+	ew.s("<span id=\"brandf\">Enjoy the Flames.</span>\n</div>\n")
 }
 
 // writeInfoPanel is everything that used to be permanently on screen.

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -152,6 +152,7 @@ func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
 	}
 	writeTreeContainer(ew, res)
 	writeStatusBar(ew, res)
+	writeDomainLabels(ew, domainsPresent(root))
 	writeFrameDetails(ew)
 	ew.s("<div id=\"tip\" hidden></div>\n")
 
@@ -584,17 +585,7 @@ func writeTopBar(ew *errWriter, opts Options, res *foldedstacks.Result, root *no
 // "vendor", not "CPU: GPU runtime and driver" -- because a bar is scanned and
 // the panel is read; the full description is still one click away.
 func writeLegendBar(ew *errWriter, root *node) {
-	present := map[Domain]bool{}
-	var walk func(*node)
-	walk = func(n *node) {
-		if n.depth > 0 {
-			present[n.domain] = true
-		}
-		for _, c := range n.children {
-			walk(c)
-		}
-	}
-	walk(root)
+	present := domainsPresent(root)
 	if len(present) == 0 {
 		return
 	}
@@ -616,6 +607,24 @@ func writeLegendBar(ew *errWriter, root *node) {
 			html.EscapeString(style), html.EscapeString(shortLegendLabel(in.Label)))
 	}
 	ew.s("\n</div>\n")
+}
+
+// domainsPresent is the set of domains this profile actually contains. The
+// legend and the details panel's label table both take their contents from
+// it, so neither can name a domain the other does not.
+func domainsPresent(root *node) map[Domain]bool {
+	present := map[Domain]bool{}
+	var walk func(*node)
+	walk = func(n *node) {
+		if n.depth > 0 {
+			present[n.domain] = true
+		}
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	walk(root)
+	return present
 }
 
 // legendOrder is the CPU-to-GPU reading order, not the declaration order of

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -651,10 +651,12 @@ func writeInfoPanel(ew *errWriter, root *node, res *foldedstacks.Result, opts Op
 // legend never advertises a layer the profile does not contain.
 func writeLegend(ew *errWriter, root *node) {
 	present := make([]bool, numDomains)
+	presentRes := map[Resolution]bool{}
 	var walk func(*node)
 	walk = func(n *node) {
 		if n.depth > 0 {
 			present[n.domain] = true
+			presentRes[ResolutionOf(n.name)] = true
 		}
 		for _, c := range n.children {
 			walk(c)
@@ -672,7 +674,10 @@ func writeLegend(ew *errWriter, root *node) {
 		cls := "sw"
 		if info.Overlay != "" {
 			// The swatch is hatched exactly when the frames are, so the
-			// legend row and the graph read as the same thing.
+			// legend row and the graph read as the same thing. Only domains
+			// still own a texture; the rest moved to the resolution legend
+			// below, and a swatch here that hatched without a matching frame
+			// rule would be the legend contradicting the graph.
 			cls += " hatched"
 		}
 		ew.f("<li><span class=\"%s\" style=\"background-color:%s\"", cls, info.Fill)
@@ -685,8 +690,9 @@ func writeLegend(ew *errWriter, root *node) {
 		ew.esc(info.Desc)
 		ew.s("</li>\n")
 	}
+	writeResolutionLegend(ew, presentRes)
 	if root.inexact > 0 {
-		ew.s("<li><span class=\"sw hatch\"></span><b>diagonal hatching</b> Either the frame has no symbol, or its CPU attribution was inferred rather than measured. Hover the frame for which.</li>\n")
+		ew.s("<li><span class=\"sw hatch\"></span><b>diagonal hatching, the other way</b> This frame&rsquo;s CPU attribution was inferred rather than measured. A frame can carry this and a texture above at the same time.</li>\n")
 	} else {
 		ew.s("<li><span class=\"sw hatch\"></span><b>diagonal hatching</b> The frame has no symbol, or no CPU stack stands behind it. Hover the frame for which.</li>\n")
 	}
@@ -901,4 +907,44 @@ func (e *errWriter) f(format string, args ...any) {
 		return
 	}
 	_, e.err = fmt.Fprintf(e.w, format, args...)
+}
+
+// writeResolutionLegend explains the textures.
+//
+// A second axis, because the first one could not carry it: colour says what
+// kind of code a frame is, texture says how well it could be named, and until
+// these were separated the legend had to fall back on "either the frame has no
+// symbol, or its attribution was inferred — hover the frame for which", which
+// is the legend admitting it cannot tell the reader what they are looking at.
+//
+// Only the resolutions actually present are listed, on the same principle as
+// the domain legend: never advertise a state the profile does not contain.
+func writeResolutionLegend(ew *errWriter, present map[Resolution]bool) {
+	order := []Resolution{
+		ResolutionModuleOffset, ResolutionObfuscated,
+		ResolutionBareAddress, ResolutionInterpreter,
+	}
+	any := false
+	for _, r := range order {
+		if present[r] {
+			any = true
+			break
+		}
+	}
+	if !any {
+		return
+	}
+	ew.s("</ul>\n<h2>Texture means how well it is named</h2>\n")
+	ew.s("<p class=\"muted\">Independent of the colour: a frame can be vendor code that is fully named, or application code with no symbol at all. A frame with no texture was named by a symbol table.</p>\n<ul class=\"legend-list\">\n")
+	for _, r := range order {
+		if !present[r] {
+			continue
+		}
+		info := r.Info()
+		ew.f("<li><span class=\"sw res-%s\"></span><b>", info.Key)
+		ew.esc(info.Label)
+		ew.s("</b> ")
+		ew.esc(info.Desc)
+		ew.s("</li>\n")
+	}
 }

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -434,6 +434,11 @@ func writeNode(ew *errWriter, n *node, unit string, total int64, mods moduleTabl
 		cls, pct(n.x), pct(n.width),
 		html.EscapeString(accessibleName(n, unit, total)),
 		html.EscapeString(n.domain.Info().Key), n.value)
+	// Resolution is emitted alongside the domain, not folded into it: they
+	// answer different questions and a reader needs both. See resolution.go.
+	if r := ResolutionOf(n.name); r != ResolutionResolved {
+		ew.f(` data-resolution="%s"`, r.Info().Key)
+	}
 	if n.module != "" {
 		// An index into the page's module table, not the string. See
 		// writeChart.

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -59,12 +59,22 @@ import (
 	"github.com/dpsoft/perf-agent/internal/foldedstacks"
 )
 
-// frameHeight is the row pitch in CSS pixels: a 17px frame and a 1px gap.
+// frameHeight is the row pitch in CSS pixels: a 19px frame and a 2px gap.
+//
+// Chosen against the deepest real profile rather than for looks. The mock's
+// bars are roughly 28px pitch, which is handsome and does not fit: the
+// measured PyTorch capture is 42 levels, and 42 rows at 28px is 1176px --
+// past any laptop viewport, so the reader scrolls to see a stack that used
+// to fit. At 21px the same 42 rows are 882px and still fit, while the frame
+// gains 2px of height, a wider radius and real horizontal padding. Deep
+// stacks are the normal case here, not the exception: Python plus torch plus
+// cuBLAS plus the launch boundary is forty frames before anything unusual
+// happens.
 // It is the only fixed dimension the geometry has. Horizontal position and
 // width are percentages, so they are the window's business, not ours — see
 // styleSheet in assets.go for why that is the whole fix for a graph that
 // used to be 1280px wide on a 1990px screen.
-const frameHeight = 18
+const frameHeight = 21
 
 // Options configures a render.
 //

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -391,11 +391,19 @@ func writeChart(ew *errWriter, root *node, maxDepth int, res *foldedstacks.Resul
 	// capture, data-module was 566,966 bytes of a 3,165,745-byte page -- 18%
 	// -- for THIRTEEN distinct values totalling about a kilobyte.
 	mods := internModules(root)
+	// The card is a WRAPPER, not the chart itself. .chart's geometry is the
+	// layout engine -- an inline pixel height with absolutely positioned
+	// children whose vertical position is bottom:calc(var(--d)*18px) -- and
+	// putting a border and padding on it makes the border box disagree with
+	// that height. The card gets its own element so the graph's arithmetic is
+	// untouched.
+	ew.s("<div class=\"canvas\">\n")
 	ew.f(`<div class="chart" style="height:%dpx" role="group" aria-label="Flame graph, %s" data-total="%d" data-unit="%s">`+"\n",
 		maxDepth*frameHeight-1, html.EscapeString(res.SampleTypeName+"/"+res.Unit),
 		root.value, html.EscapeString(res.Unit))
 	writeModuleTable(ew, mods)
 	writeNode(ew, root, res.Unit, root.value, mods)
+	ew.s("</div>\n")
 	ew.s("</div>\n")
 	return ew.err
 }
@@ -595,8 +603,16 @@ func writeLegendBar(ew *errWriter, root *node) {
 			continue
 		}
 		in := d.Info()
-		ew.f("<span class=\"c\"><i style=\"background:%s\"></i>%s</span>",
-			html.EscapeString(in.Fill), html.EscapeString(shortLegendLabel(in.Label)))
+		// The swatch carries the OVERLAY as well as the fill. Three of these
+		// domains are near-identical greys and are told apart in the graph by
+		// hatching alone; a flat chip for a hatched frame is a key that does
+		// not match the thing it is keying.
+		style := "background:" + in.Fill
+		if in.Overlay != "" {
+			style = "background-image:" + in.Overlay + ";background-color:" + in.Fill
+		}
+		ew.f("<span class=\"c\"><i style=\"%s\"></i>%s</span>",
+			html.EscapeString(style), html.EscapeString(shortLegendLabel(in.Label)))
 	}
 	ew.s("\n</div>\n")
 }

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -96,9 +96,18 @@ func TestRenderHTMLEscapesHostileSymbolNames(t *testing.T) {
 	assert.Contains(t, got, "&lt;/title&gt;&lt;script&gt;")
 	assert.Contains(t, got, "std::vector&lt;Foo&amp;Bar&gt;")
 
-	// Exactly the two <script> elements this renderer emits: none injected.
-	assert.Equal(t, 1, strings.Count(got, "<script>"))
-	assert.Equal(t, 1, strings.Count(got, "</script>"))
+	// Every script element on the page is accounted for and none was
+	// injected. Counted as a relation rather than a magic number: the page
+	// emits exactly one EXECUTABLE script plus zero or more
+	// application/json data tables (the module paths, the domain labels),
+	// and the closers must add up to those. A bare literal here broke the
+	// moment a legitimate data table was added, which taught nothing about
+	// escaping -- the thing this test exists to check.
+	exec := strings.Count(got, "<script>")
+	data := strings.Count(got, `<script type="application/json"`)
+	assert.Equal(t, 1, exec, "exactly one executable script")
+	assert.Equal(t, exec+data, strings.Count(got, "</script>"),
+		"a closer with no opener means a symbol name broke out of a script element")
 	assert.Equal(t, 1, strings.Count(got, "<style>"))
 }
 

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -478,7 +478,12 @@ func TestEveryFrameCarriesAnAccessibleName(t *testing.T) {
 
 	// The chart names itself, but as a group: role="img" there would make
 	// the whole subtree presentational and silence all four frames.
-	assert.Contains(t, got, `class="chart" style="height:53px" role="group" aria-label="Flame graph, gpu/nanoseconds"`)
+	// Height computed from frameHeight, not written out: it is rows times
+	// pitch, so a literal here is the same fact stated twice and the second
+	// copy goes stale the moment the row pitch is tuned.
+	assert.Contains(t, got, fmt.Sprintf(
+		`class="chart" style="height:%dpx" role="group" aria-label="Flame graph, gpu/nanoseconds"`,
+		3*frameHeight-1))
 
 	// Exactly one <title> in the document — the one in <head>. A per-frame
 	// <title> would be an accessible name AND a native browser tooltip, and
@@ -561,9 +566,26 @@ func TestTypographyAndRowPitchAreFixedPixelsAtEveryWindowWidth(t *testing.T) {
 		foldedstacks.Stack{Frames: []string{"a", "b", "c"}, Value: 10},
 	), Options{})
 
-	assert.Contains(t, styleSheet, "font-size:11px")
-	assert.Contains(t, styleSheet, "height:17px")
-	assert.Contains(t, styleSheet, "line-height:17px")
+	// The PROPERTY, not the numbers: these must be absolute px so that a
+	// frame is the same size at every window width. Asserting the literals
+	// meant every style change failed a test about relative units while
+	// teaching nothing -- and the numbers are tuned against how deep a real
+	// profile is, which is a design decision, not an invariant.
+	frameRule := regexp.MustCompile(`\.frame\{[^}]*\}`).FindString(styleSheet)
+	require.NotEmpty(t, frameRule, "no .frame rule in the stylesheet")
+	for _, prop := range []string{"height", "line-height", "font-size"} {
+		m := regexp.MustCompile(prop + `:([0-9.]+)(px|em|rem|%|vw|vh)`).FindStringSubmatch(frameRule)
+		require.Len(t, m, 3, "%s is not set on .frame", prop)
+		assert.Equal(t, "px", m[2],
+			"%s is %s%s: a relative unit makes the graph zoom with the window instead of filling it",
+			prop, m[1], m[2])
+	}
+	height := regexp.MustCompile(`[^-]height:([0-9.]+)px`).FindStringSubmatch(frameRule)
+	lineHeight := regexp.MustCompile(`line-height:([0-9.]+)px`).FindStringSubmatch(frameRule)
+	require.Len(t, height, 2)
+	require.Len(t, lineHeight, 2)
+	assert.Equal(t, height[1], lineHeight[1],
+		"line-height must equal height or the label sits off-centre in the bar")
 	// One rule per depth, and one rule that turns a depth into an offset
 	// from the floor: a depth is the same number of pixels up whatever the
 	// profile and whatever the window. The pitch is a px literal in a
@@ -689,8 +711,8 @@ func TestInvertIsAVisualFlipAndMergesNothing(t *testing.T) {
 	assert.NotContains(t, script, "it.w=")
 	assert.NotContains(t, script, "it.value=")
 	// The row ladder does the flip, and it is the same ladder both ways.
-	assert.Contains(t, rowCSS(4), ".frame{bottom:calc(var(--d)*18px)}")
-	assert.Contains(t, rowCSS(4), ".inv .frame{bottom:auto;top:calc(var(--d)*18px)}")
+	assert.Contains(t, rowCSS(4), fmt.Sprintf(".frame{bottom:calc(var(--d)*%dpx)}", frameHeight))
+	assert.Contains(t, rowCSS(4), fmt.Sprintf(".inv .frame{bottom:auto;top:calc(var(--d)*%dpx)}", frameHeight))
 }
 
 // The tree is the same data, so it is built from the frames rather than

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -1005,3 +1005,68 @@ func TestTheShippedScriptIsStructurallyBalanced(t *testing.T) {
 		}
 	}
 }
+
+// The legend must describe both axes, and only what the profile contains.
+//
+// Before this the legend said "diagonal hatching — either the frame has no
+// symbol, or its CPU attribution was inferred rather than measured. Hover the
+// frame for which." That is the legend admitting it cannot tell the reader
+// what they are looking at, because one channel was carrying two facts.
+func TestTheLegendExplainsTextureSeparatelyFromColour(t *testing.T) {
+	res := &foldedstacks.Result{
+		SampleTypeName: "gpu", Unit: "nanoseconds", Total: 4,
+		Stacks: []foldedstacks.Stack{
+			{Frames: []string{"main", "at::native::conv"}, Value: 1},
+			{Frames: []string{"main", "libcudnn.so.9+0x824fbd"}, Value: 1},
+			{Frames: []string{"main", "libcupti_afe8ffb67fac57d8829b1194a93b8ec676e80f7d"}, Value: 1},
+			{Frames: []string{"main", "0x7f2c945b2c2b"}, Value: 1},
+		},
+	}
+	var buf bytes.Buffer
+	if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	page := buf.String()
+
+	if !strings.Contains(page, "Texture means how well it is named") {
+		t.Error("the legend has no section for the texture axis")
+	}
+	for _, want := range []string{"module + offset", "obfuscated symbol", "address only"} {
+		if !strings.Contains(page, want) {
+			t.Errorf("legend is missing the %q row for a resolution the profile contains", want)
+		}
+	}
+	// The old conflated sentence must be gone: it is the thing this replaces.
+	if strings.Contains(page, "Either the frame has no symbol, or its CPU attribution") {
+		t.Error("the legend still conflates missing symbols with inferred attribution")
+	}
+	// And a swatch must actually carry the texture it names, or the legend
+	// row and the graph disagree.
+	for _, key := range []string{"res-module-offset", "res-obfuscated", "res-bare-address"} {
+		if !strings.Contains(page, key) {
+			t.Errorf("no swatch renders the %q texture", key)
+		}
+	}
+}
+
+// Never advertise a state the profile does not contain — the same rule the
+// domain legend already follows.
+func TestTheLegendOmitsResolutionsTheProfileDoesNotHave(t *testing.T) {
+	res := &foldedstacks.Result{
+		SampleTypeName: "cpu", Unit: "nanoseconds", Total: 1,
+		Stacks: []foldedstacks.Stack{{Frames: []string{"main", "work"}, Value: 1}},
+	}
+	var buf bytes.Buffer
+	if err := RenderHTML(&buf, res, Options{Title: "t"}); err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	page := buf.String()
+	if strings.Contains(page, "Texture means how well it is named") {
+		t.Error("a fully resolved profile advertises a texture legend it never uses")
+	}
+	for _, unwanted := range []string{"obfuscated symbol", "module + offset", "address only"} {
+		if strings.Contains(page, unwanted) {
+			t.Errorf("legend advertises %q on a profile with no such frames", unwanted)
+		}
+	}
+}

--- a/internal/flamegraph/render_test.go
+++ b/internal/flamegraph/render_test.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"html"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1050,4 +1054,73 @@ func TestACollapsedFrameIsMarkedAndTheScriptExplainsIt(t *testing.T) {
 	// function, so it is asserted there -- see
 	// TestFoldSaysWhenItMergedVendorRuns. Asserting it here against a
 	// hand-built Result would only prove that the fixture set the field.
+}
+
+// The shipped script must PARSE, not merely balance its braces.
+//
+// The balance check below this one exists because a comment-stripping edit
+// once deleted a whole function header and left the page with syntactically
+// broken JavaScript that every Go test still passed. Balance caught that
+// particular shape; it cannot catch a stray token, a missing comma in an
+// object literal, or a reserved word used as an identifier. A real parser
+// can, and one is usually already on a developer's machine.
+//
+// It SKIPS with a named reason when no engine is present rather than passing
+// quietly: a guard that reports success on a machine where it never ran is
+// worse than no guard, because it is the one you stop checking. The brace
+// balance test remains the portable floor.
+//
+// Parsed through `new Function(src)` rather than executed: the script touches
+// document, window and the page's own elements, none of which exist in a bare
+// engine, so running it would fail for reasons that say nothing about whether
+// it is well formed.
+func TestTheShippedScriptParses(t *testing.T) {
+	engine, args := findJSEngine(t)
+	if engine == "" {
+		t.Skip("no JavaScript engine found (node, gjs, deno or qjs); brace balance is still checked")
+	}
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "page.js")
+	if err := os.WriteFile(src, []byte(script), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var cmd *exec.Cmd
+	switch engine {
+	case "gjs":
+		check := filepath.Join(dir, "check.js")
+		prog := "const GLib = imports.gi.GLib;\n" +
+			"let [ok, bytes] = GLib.file_get_contents(" + strconv.Quote(src) + ");\n" +
+			"let s = new TextDecoder().decode(bytes);\n" +
+			"try { new Function(s); } catch (e) { print('SYNTAX: ' + e.message); imports.system.exit(1); }\n"
+		if err := os.WriteFile(check, []byte(prog), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd = exec.Command(engine, check)
+	default:
+		cmd = exec.Command(engine, append(args, src)...)
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Errorf("the script shipped to every reader does not parse (%s): %v\n%s",
+			engine, err, out)
+	}
+}
+
+func findJSEngine(t *testing.T) (string, []string) {
+	t.Helper()
+	for _, c := range []struct {
+		name string
+		args []string
+	}{
+		{"node", []string{"--check"}},
+		{"deno", []string{"check"}},
+		{"qjs", []string{"--check"}},
+		{"gjs", nil},
+	} {
+		if _, err := exec.LookPath(c.name); err == nil {
+			return c.name, c.args
+		}
+	}
+	return "", nil
 }

--- a/internal/flamegraph/resolution.go
+++ b/internal/flamegraph/resolution.go
@@ -1,0 +1,123 @@
+package flamegraph
+
+import (
+	"strings"
+
+	"github.com/dpsoft/perf-agent/internal/framename"
+)
+
+// Resolution is how well a frame could be named, which is a DIFFERENT question
+// from what kind of code it is.
+//
+// The two were conflated: "unsym" is a Domain, so a frame's colour answered
+// "what is this" for named frames and "we could not name it" for the rest, and
+// the reader could not ask why. Measured on one PyTorch MNIST capture, the
+// frames we call unnamed are three distinct facts:
+//
+//	45  module+offset  the mapping is known; the offset is ASLR-stable and
+//	                   can be matched against symbol data for that build id
+//	10  bare address   not even the mapping is known; nothing to look up
+//	30  obfuscated     symbolized, from NVIDIA's own symbol server, but the
+//	                   name is a stable opaque id rather than a human one --
+//	                   NOT a perf-agent failure, and today it is coloured
+//	                   exactly like a resolved frame
+//
+// Domain stays the colour. Resolution is the texture. A reader then sees what
+// kind of code a frame is and how much we know about its name independently,
+// which is what they were actually trying to read off one channel.
+type Resolution uint8
+
+const (
+	// ResolutionResolved: a real symbol name.
+	ResolutionResolved Resolution = iota
+	// ResolutionModuleOffset: "libcudnn.so.9+0x824fbd". The unwind found the
+	// frame and the profile knows which file the address fell in; no symbol
+	// table covered that offset. Actionable: stable across ASLR, and matchable
+	// against debug data for the same build id.
+	ResolutionModuleOffset
+	// ResolutionBareAddress: "0x7f2c945b2c2b". Not even the mapping is known.
+	// Strictly less than ModuleOffset, and worth telling apart: one can be
+	// looked up later, the other cannot.
+	ResolutionBareAddress
+	// ResolutionObfuscated: "libcupti_afe8ffb6…". NVIDIA's symbol server
+	// serves these for the internals of the libraries it ships stripped --
+	// their own documentation calls them obfuscated symbol names. The frame IS
+	// symbolized and the id is stable and meaningful to NVIDIA in a bug
+	// report; it simply is not a human-readable name.
+	ResolutionObfuscated
+	// ResolutionInterpreter: "python:0x26f84de0". An interpreter frame whose
+	// code object could not be read -- the walk placed it correctly, and the
+	// interpreter was one this build has no measured layout for. Distinct from
+	// a bare address, which carries no such promise.
+	ResolutionInterpreter
+)
+
+// ResolutionInfo describes a resolution for the legend and the detail panel.
+type ResolutionInfo struct {
+	Key   string
+	Label string
+	Desc  string
+}
+
+func (r Resolution) Info() ResolutionInfo {
+	switch r {
+	case ResolutionModuleOffset:
+		return ResolutionInfo{"module-offset", "module + offset",
+			"The unwind found this frame and the profile knows which file the address fell in, but no symbol table covered that offset. The offset is module-relative, so it is stable across ASLR and can be matched against debug or symbol data for this exact build id."}
+	case ResolutionBareAddress:
+		return ResolutionInfo{"bare-address", "address only",
+			"Neither a symbol nor a mapping. The frame's position in the call path is real; nothing else about it is known, and unlike a module+offset there is nothing to look it up against later."}
+	case ResolutionObfuscated:
+		return ResolutionInfo{"obfuscated", "obfuscated symbol",
+			"Symbolized, from NVIDIA's CUDA Toolkit Symbol Server. NVIDIA publishes obfuscated names for the internals of the libraries it ships stripped: the identifier is stable and is what NVIDIA can resolve from a bug report, but it is not a human-readable name. This is not a symbolization failure."}
+	case ResolutionInterpreter:
+		return ResolutionInfo{"interpreter", "interpreter frame, unnamed",
+			"An interpreter frame placed correctly in the call path whose code object could not be read — usually an interpreter version this build has no measured layout for. Reading it requires the process to still be alive."}
+	default:
+		return ResolutionInfo{"resolved", "resolved", "A symbol table named this address."}
+	}
+}
+
+// obfuscatedName matches NVIDIA's anonymized symbols: <library>_<40 hex>.
+// Their own example is libcuda_8e2eae48ba8eb68460582f76460557784d48a71a.
+func obfuscatedName(name string) bool {
+	i := strings.LastIndexByte(name, '_')
+	if i < 0 || !strings.HasPrefix(name, "lib") || len(name)-i-1 != 40 {
+		return false
+	}
+	for _, c := range name[i+1:] {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// ResolutionOf classifies a frame by its rendered name.
+//
+// From the name rather than from a new field, because the name is what the
+// profile actually carries: every one of these forms is produced by a
+// documented rendering (framename.Format, pyunwind.FrameName, the symbol
+// server's own output), so reading them back is reading our own contract, not
+// guessing.
+func ResolutionOf(name string) Resolution {
+	switch {
+	case name == "":
+		return ResolutionBareAddress
+	case strings.HasPrefix(name, "python:0x"):
+		return ResolutionInterpreter
+	case framename.IsAddressOnly(name):
+		// Both "libcuda.so.1+0x1b71c6" and "0x7f2c945b2c2b" land here; the
+		// difference is whether a module is attached, and that is the
+		// difference between a lookup that is possible later and one that
+		// is not.
+		if strings.Contains(name, "+0x") {
+			return ResolutionModuleOffset
+		}
+		return ResolutionBareAddress
+	case obfuscatedName(name):
+		return ResolutionObfuscated
+	default:
+		return ResolutionResolved
+	}
+}

--- a/internal/flamegraph/resolution_test.go
+++ b/internal/flamegraph/resolution_test.go
@@ -1,0 +1,84 @@
+package flamegraph
+
+import "testing"
+
+// The four kinds we currently render as if they were two.
+//
+// Measured on one PyTorch MNIST capture: 45 module+offset, 10 bare addresses,
+// 30 obfuscated. The first two share a colour today even though one can be
+// looked up later and the other cannot; the third is coloured exactly like a
+// fully resolved frame even though no human-readable name exists for it.
+func TestResolutionTellsApartWhatDomainCannot(t *testing.T) {
+	cases := map[string]Resolution{
+		// Named by a symbol table.
+		"at::native::add_kernel(at::TensorIteratorBase&)": ResolutionResolved,
+		"main":                         ResolutionResolved,
+		"Conv2d.forward (conv.py:564)": ResolutionResolved,
+		"cuLaunchKernel":               ResolutionResolved,
+
+		// Module known, symbol not: stable across ASLR, matchable later.
+		"libcudnn_engines_precompiled.so.9+0x824fbd": ResolutionModuleOffset,
+		"libcuda.so.1+0x1b71c6":                      ResolutionModuleOffset,
+
+		// Nothing known at all.
+		"0x7f2c945b2c2b": ResolutionBareAddress,
+		"":               ResolutionBareAddress,
+
+		// Symbolized by NVIDIA's server; the name is a stable opaque id.
+		"libcupti_afe8ffb67fac57d8829b1194a93b8ec676e80f7d": ResolutionObfuscated,
+		"libcuda_8e2eae48ba8eb68460582f76460557784d48a71a":  ResolutionObfuscated,
+
+		// Interpreter frame placed correctly, code object unread.
+		"python:0x26f84de0": ResolutionInterpreter,
+	}
+	for name, want := range cases {
+		if got := ResolutionOf(name); got != want {
+			t.Errorf("ResolutionOf(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+// A real name that merely looks like a hash must not be called obfuscated.
+// The pattern is <library>_<exactly 40 hex>, and anything else is a symbol
+// someone chose.
+func TestOrdinaryNamesAreNotMistakenForObfuscated(t *testing.T) {
+	for _, n := range []string{
+		"libfoo_bar",
+		"libcuda_8e2eae48ba8eb68460582f76460557784d48a71",   // 39
+		"libcuda_8e2eae48ba8eb68460582f76460557784d48a71aa", // 41
+		"libcuda_8e2eae48ba8eb68460582f76460557784d48a71z",  // not hex
+		"cuda_8e2eae48ba8eb68460582f76460557784d48a71a",     // no lib prefix
+		"at::native::add_kernel",
+	} {
+		if got := ResolutionOf(n); got == ResolutionObfuscated {
+			t.Errorf("ResolutionOf(%q) = obfuscated, want a real name", n)
+		}
+	}
+}
+
+// Every resolution must describe itself, because the panel and the legend both
+// render these and a blank one would be an empty row rather than a missing
+// feature.
+func TestEveryResolutionDescribesItself(t *testing.T) {
+	for _, r := range []Resolution{
+		ResolutionResolved, ResolutionModuleOffset, ResolutionBareAddress,
+		ResolutionObfuscated, ResolutionInterpreter,
+	} {
+		i := r.Info()
+		if i.Key == "" || i.Label == "" || i.Desc == "" {
+			t.Errorf("%v has an incomplete Info: %+v", r, i)
+		}
+	}
+	// Keys must be distinct: they become CSS classes and data attributes.
+	seen := map[string]bool{}
+	for _, r := range []Resolution{
+		ResolutionResolved, ResolutionModuleOffset, ResolutionBareAddress,
+		ResolutionObfuscated, ResolutionInterpreter,
+	} {
+		k := r.Info().Key
+		if seen[k] {
+			t.Errorf("duplicate resolution key %q", k)
+		}
+		seen[k] = true
+	}
+}


### PR DESCRIPTION
Reworks the flame graph page toward the mocks, **keeping Brendan Gregg's palette**. Nothing about
the profile pipeline changes; this is the page.

Verified in light and dark, with the details panel open, by screenshotting the real page in headless
Chrome — which is also how most of the bugs below were found.

## What changed

| | before | after |
|---|---|---|
| identity | the profile's filename | wordmark, tagline, Metric/Unit readouts |
| legend | inside a panel nobody opens | on the page, **both axes** |
| frame detail | a hover tooltip | pinned panel — Summary / Stack / Across graph |
| bars | 17px, 2px radius, 4px padding | 19px on a 21px pitch, 5px radius, 7px padding |
| resolution axis | unmerged branch | merged and wired to the panel |
| status line | a run-on sentence | labelled figures |

**The Frame Details panel** is the substantive addition. Shift-click a frame or press `P`. Summary
carries cumulative and self with their shares, depth, children, the width-means callout, domain,
resolution and module, plus a path to root. *Across graph* answers what a flame graph structurally
hides — the same symbol reached by different call paths is a different frame, so it sums every
instance and says how many there were.

It is a panel, not a dialog: focus is not trapped and the graph stays live behind it, because after
pinning a frame the next move is usually to look at its neighbours. The page **reserves** the width
rather than covering the graph.

## The palette is deliberately unchanged

The mocks reassign vendor to blue and instrumentation to purple. That was not taken: the colours are
Gregg's layers, the page cites that as its rationale, and `TestHuesAreTheGreggLayers` pins it. The
mock's flat reassignment would also have discarded two encoded meanings — `unsym` is the CPU band's
hue *drained* (right layer, no name), and aqua is reserved and unused because it belongs to
accelerator source lines perf-agent cannot sample yet.

Two other departures, both because the alternative would be pretending:

- **Metric and Unit are readouts, not dropdowns.** A control that cannot switch anything is a lie
  about what the page does, and this page renders exactly one sample type.
- **No View switcher.** The mock's three cards are explanation, not a control; a real switcher needs
  an on-CPU profile and a kernel-distribution projection that this file does not contain.

## The row pitch is a judgement, not a default

The mock's bars are roughly 28px pitch. The measured PyTorch capture is **42 levels deep**, and 42
rows at 28px is 1176px — past a laptop viewport, so the reader would scroll to see a stack that
currently fits. 21px keeps those 42 rows at 882px. Deep stacks are the normal case here: Python plus
torch plus cuBLAS plus the launch boundary is forty frames before anything unusual happens.

Cost, stated: wider padding raises the width at which a frame can draw any text, from 8px to 14px,
so a few more of the narrowest slivers render blank.

## Bugs the screenshot loop caught that every Go test passed

- the panel **covered the graph** — frames unreachable underneath it
- the Summary body was **completely empty**: a `ReferenceError` on `resolutionNote`, which lived on
  the branch not yet merged. The script *parsed*, so the new parse guard missed it too; only running
  it showed anything
- the call path was a **horizontal scrollbar** — two-space-per-level indent is fine for the mock's
  short names, useless for 40 levels of 200-character C++ symbols
- Domain and Module printed **raw keys and 90-character paths**
- the panel **contradicted itself**: `Resolution: fully resolved` directly above a callout saying
  "names carry no information", on a collapsed frame

## Tests that needed rewriting rather than renumbering

Three asserted pitch-derived literals and took `frameHeight` instead, so the pitch is stated once.

`TestTypographyAndRowPitchAreFixedPixelsAtEveryWindowWidth` asserted `font-size:11px` and
`height:17px` while its own comment says the invariant is that these are *absolute px* — identical
at every window width, so the graph fills rather than zooms. Those are different claims. It checks
the property now: each of height, line-height and font-size is a `px` literal and not `em`/`rem`/
`%`/`vw`, and line-height equals height so the label stays centred.

`TestRenderHTMLEscapesHostileSymbolNames` counted a literal one `</script>`, which the new
domain-label data table broke while teaching nothing about escaping. It counts the relation: one
executable script plus however many `application/json` tables were emitted must equal the closers.

Adding the label table also broke
`TestRenderHTMLLegendOnlyNamesDomainsThatAreActuallyPresent` — it emitted *every* domain. That is a
real invariant (a key naming colours not on screen sends the reader hunting), so the table is scoped
to what the profile contains, from the same `domainsPresent` the legend uses.

## New guard: the shipped script must parse

Brace balance exists here because an edit once deleted a whole function header and left every Go
test passing. Balance catches that shape; it cannot catch a stray token. `TestTheShippedScriptParses`
parses the script through `new Function(src)` with whatever engine is on the machine (node, deno,
qjs, gjs) so nothing executes, and **skips with a named reason** when none is present — a guard that
reports success where it never ran is the one you stop checking. Mutation-tested.
