### PR TITLE
gpu: -keep-instrumentation-frames, and a right-click menu for the flame graph

### DIFF
--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -73,22 +73,23 @@ import (
 // exists to prevent; a test enumerates the registered set and fails until
 // every name is on one side or the other.
 type options struct {
-	shim            *string
-	workload        *string
-	iters           *int
-	sleepUs         *int
-	period          *int
-	linger          *int
-	out             *string
-	pid             *int
-	discover        *bool
-	rediscoverEvery *time.Duration
-	duration        *time.Duration
-	drainEvery      *time.Duration
-	waitForShim     *time.Duration
-	nvSymbols       *string
-	pcSampling      *string
-	pcAck           *bool
+	shim                *string
+	workload            *string
+	iters               *int
+	sleepUs             *int
+	period              *int
+	linger              *int
+	out                 *string
+	pid                 *int
+	discover            *bool
+	rediscoverEvery     *time.Duration
+	duration            *time.Duration
+	drainEvery          *time.Duration
+	waitForShim         *time.Duration
+	keepInstrumentation *bool
+	nvSymbols           *string
+	pcSampling          *string
+	pcAck               *bool
 }
 
 func defineFlags(fs *flag.FlagSet) *options {
@@ -132,6 +133,14 @@ func defineFlags(fs *flag.FlagSet) *options {
 			"in -pid mode, how long to wait for the shim to appear in the target's mappings "+
 				"before giving up. Non-zero because a process attached to moments after it "+
 				"started may not have reached cuInit yet"),
+		keepInstrumentation: fs.Bool("keep-instrumentation-frames", false,
+			"leave the profiler's own delivery path in every sampled stack instead of "+
+				"collapsing it to one ["+gpuprobe.InstrumentationFrameName[5:len(gpuprobe.InstrumentationFrameName)-1]+
+				"] marker. Measured at ~7 frames per stack and 19% of every frame in the "+
+				"profile, all of it CUPTI's callback machinery rather than the workload. "+
+				"Set it to profile perf-agent itself: the elision happens BEFORE the "+
+				"profile is written, so a capture taken without this flag cannot get "+
+				"them back"),
 		nvSymbols: fs.String("nvidia-symbols", "",
 			"cache directory for NVIDIA's CUDA Toolkit Symbol Server; enables fetching "+
 				"symbols for libcuda/libcupti/libcuBLAS, which ship stripped. Off unless set: "+
@@ -193,15 +202,16 @@ var launchOnlyInAttachMode = map[string]string{
 // configure THIS process -- where the shim is, where the profile goes, how
 // long to run, how symbols are resolved -- rather than the profiled one.
 var attachSafeFlags = map[string]bool{
-	"shim":             true,
-	"out":              true,
-	"nvidia-symbols":   true,
-	"pid":              true,
-	"duration":         true,
-	"wait-for-shim":    true,
-	"drain-every":      true,
-	"discover":         true,
-	"rediscover-every": true,
+	"shim":                        true,
+	"out":                         true,
+	"nvidia-symbols":              true,
+	"keep-instrumentation-frames": true,
+	"pid":                         true,
+	"duration":                    true,
+	"wait-for-shim":               true,
+	"drain-every":                 true,
+	"discover":                    true,
+	"rediscover-every":            true,
 }
 
 // refusedLaunchFlags reports the launch-only flags the operator actually set,
@@ -476,6 +486,8 @@ func main() {
 		// are sealed, verified and stored where nothing reads them, and
 		// every PC sample in this profile says gpu_src_status="no-module".
 		Modules: store,
+		// The reader's call, not ours. See gpuprobe.Config.
+		KeepInstrumentationFrames: *opt.keepInstrumentation,
 	})
 	if err != nil {
 		log.Fatalf("attach: %v", err)

--- a/cmd/gpu-cuda-profile/main.go
+++ b/cmd/gpu-cuda-profile/main.go
@@ -136,11 +136,17 @@ func defineFlags(fs *flag.FlagSet) *options {
 		keepInstrumentation: fs.Bool("keep-instrumentation-frames", false,
 			"leave the profiler's own delivery path in every sampled stack instead of "+
 				"collapsing it to one ["+gpuprobe.InstrumentationFrameName[5:len(gpuprobe.InstrumentationFrameName)-1]+
-				"] marker. Measured at ~7 frames per stack and 19% of every frame in the "+
-				"profile, all of it CUPTI's callback machinery rather than the workload. "+
-				"Set it to profile perf-agent itself: the elision happens BEFORE the "+
-				"profile is written, so a capture taken without this flag cannot get "+
-				"them back"),
+				"] marker. The path is 7 frames of CUPTI's callback machinery rather than "+
+				"the workload, and it is reliably 7: that depth is CUPTI's, not the "+
+				"workload's. What it costs as a SHARE of the profile is not fixed -- 19% "+
+				"of every frame in a PyTorch capture, 23.5% in the microbenchmark under "+
+				"shim/nvidia/testdata -- because the share depends on how many of the "+
+				"stacks are sampled ones, which -period and the workload decide between "+
+				"them. Set it to profile perf-agent itself: the elision happens BEFORE "+
+				"the profile is written, so a capture taken without this flag cannot get "+
+				"them back. Note that cmd/flamegraph merges runs of unnamed vendor frames "+
+				"by default, redrawing these 7 as 2; pass -raw-vendor-frames there to see "+
+				"the path this flag kept"),
 		nvSymbols: fs.String("nvidia-symbols", "",
 			"cache directory for NVIDIA's CUDA Toolkit Symbol Server; enables fetching "+
 				"symbols for libcuda/libcupti/libcuBLAS, which ship stripped. Off unless set: "+

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -283,6 +283,21 @@ type Config struct {
 	// PID restricts the attachment to one process; zero is system-wide.
 	PID int
 
+	// KeepInstrumentationFrames leaves the profiler's own delivery path in
+	// every sampled stack instead of collapsing it to one marker.
+	//
+	// OFF by default, and the default is the right one: measured on an RTX
+	// 3090, CUPTI's callback machinery is ~7 frames in every stack and 19% of
+	// every frame in the profile, none of it the application's call path --
+	// it is there because we subscribed a callback. See instrumentationBand.
+	//
+	// It exists because this elision is IRREVERSIBLE in a way the flame
+	// graph's vendor-run collapse is not: it happens before the profile is
+	// written, so the frames are absent from the pb.gz and no rendering
+	// option can bring them back. Profiling the profiler is a real task, and
+	// without this switch it needed a source change.
+	KeepInstrumentationFrames bool
+
 	// EagerPIDs are processes ALREADY RUNNING that map ShimPath, whose CFI
 	// tables must be compiled before the uprobe link exists.
 	//
@@ -1576,7 +1591,7 @@ func newConsumer(cfg Config) *Consumer {
 	return &Consumer{
 		cfg:         cfg,
 		shim:        newShimScope(cfg.ShimPath),
-		instr:       newInstrumentationBand(newShimScope(cfg.ShimPath)),
+		instr:       newInstrumentationBand(newShimScope(cfg.ShimPath), cfg.KeepInstrumentationFrames),
 		seqByStream: map[seqKey]uint64{},
 		pending:     newPendingStacks(cfg.SampledStackCapacity),
 		deferred:    newDeferredLaunches(cfg.DeferredLaunchCapacity),

--- a/gpuprobe/consumer.go
+++ b/gpuprobe/consumer.go
@@ -287,9 +287,12 @@ type Config struct {
 	// every sampled stack instead of collapsing it to one marker.
 	//
 	// OFF by default, and the default is the right one: measured on an RTX
-	// 3090, CUPTI's callback machinery is ~7 frames in every stack and 19% of
-	// every frame in the profile, none of it the application's call path --
-	// it is there because we subscribed a callback. See instrumentationBand.
+	// 3090, CUPTI's callback machinery is 7 frames in every sampled stack and
+	// a fifth to a quarter of every frame in the profile (19% under PyTorch,
+	// 23.5% under the shim's own microbenchmark -- the share moves with how
+	// many stacks are sampled, the frame count does not), none of it the
+	// application's call path -- it is there because we subscribed a
+	// callback. See instrumentationBand.
 	//
 	// It exists because this elision is IRREVERSIBLE in a way the flame
 	// graph's vendor-run collapse is not: it happens before the profile is
@@ -2562,7 +2565,8 @@ func (c *Consumer) attachSampledStackLocked(pid uint32, stackID int32, sl gpuabi
 	}
 
 	// The profiler's own delivery path is not the workload's call path.
-	// Measured at ~7 frames in every stack -- 19% of all frames -- of CUPTI
+	// Measured at 7 frames in every sampled stack -- a fifth or so of all
+	// frames, though that share moves with the workload -- of CUPTI
 	// callback machinery between the application's cuLaunchKernel and our own
 	// callback. Collapsed to one marker rather than deleted, so the profile
 	// still says a band was there. See instrumentationBand.

--- a/gpuprobe/instrumentation.go
+++ b/gpuprobe/instrumentation.go
@@ -77,8 +77,20 @@ type instrumentationBand struct {
 	enabled bool
 }
 
-func newInstrumentationBand(s shimScope) instrumentationBand {
-	return instrumentationBand{shim: s, enabled: s.guarded}
+// newInstrumentationBand builds the collapser. keep=true disables it, leaving
+// every delivery-path frame in the profile.
+//
+// The elision happens BEFORE the profile is written, so unlike the flame
+// graph's vendor-run collapse there is no way to get these frames back from a
+// pb.gz that was captured without them -- the only recourse is another
+// capture. That asymmetry is why the switch exists at all: eliding by default
+// is right, because the frames are the measurement apparatus rather than the
+// workload, but "not the workload's call path" is not the same as "nobody may
+// ever want them". Anyone measuring the profiler's own overhead wants exactly
+// these frames, and the default made that impossible rather than merely
+// inconvenient.
+func newInstrumentationBand(s shimScope, keep bool) instrumentationBand {
+	return instrumentationBand{shim: s, enabled: s.guarded && !keep}
 }
 
 // InstrumentationFrameName is the marker left in place of an elided band.

--- a/gpuprobe/instrumentation.go
+++ b/gpuprobe/instrumentation.go
@@ -29,9 +29,12 @@ import (
 //	  ... four more ...                ┘
 //	  (anonymous namespace)::on_launch <- the shim
 //
-// Across the whole capture, libcupti accounts for 5.98 frames per stack and
+// Across a PyTorch capture, libcupti accounts for 5.98 frames per stack and
 // the driver's dispatch frame for 1.00 -- 69% of all unnamed vendor frames,
-// about 19% of EVERY frame in EVERY stack. None of it is the application. It
+// about 19% of EVERY frame in EVERY stack. The 7 frames are the stable part:
+// the depth is CUPTI's. The 19% is not, since it also counts the stacks that
+// carry no CPU caller at all -- the same band is 23.5% of the microbenchmark
+// under shim/nvidia/testdata. None of it is the application. It
 // exists because we subscribed a callback, and it would not be in the profile
 // if the profiler were not there.
 //

--- a/gpuprobe/instrumentation_test.go
+++ b/gpuprobe/instrumentation_test.go
@@ -17,7 +17,7 @@ func testBand(t *testing.T) instrumentationBand {
 		guarded: true,
 		paths:   map[string]struct{}{testShimPath: {}},
 		base:    "libperfagent-gpu-nvidia.so",
-	})
+	}, false)
 }
 
 func named(name, module string) pp.Frame {
@@ -142,7 +142,7 @@ func TestAStackThatIsAllInstrumentationIsLeftAlone(t *testing.T) {
 // Without a shim there is no anchor, and matching libcupti on its own would be
 // a guess about somebody else's process rather than a fact about ours.
 func TestWithNoShimNothingIsElided(t *testing.T) {
-	b := newInstrumentationBand(shimScope{})
+	b := newInstrumentationBand(shimScope{}, false)
 	frames := []pp.Frame{
 		raw("/usr/lib/libcupti.so.13"),
 		named("app_main", "/opt/app"),
@@ -203,4 +203,42 @@ func TestTheBandIsTheSameFromEitherEndOfTheStack(t *testing.T) {
 	assert.Equal(t, removedInner, removedOuter,
 		"the same stack read from the other end must lose the same frames")
 	assert.Equal(t, 2, removedInner)
+}
+
+// The switch that makes the elision a default rather than a decision taken
+// for the reader.
+//
+// This collapse runs BEFORE the profile is written, so the frames it removes
+// are absent from the pb.gz and no rendering option can recover them -- unlike
+// the flame graph's vendor-run collapse, which is a view over a complete
+// profile. Profiling the profiler's own overhead needs exactly these frames,
+// and without a switch that required editing the source.
+func TestKeepingInstrumentationLeavesEveryFrameInPlace(t *testing.T) {
+	frames := []pp.Frame{
+		named("(anonymous namespace)::on_launch(CUpti_CallbackData const*)", testShimPath),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcupti.so.13"),
+		raw("/usr/lib/libcuda.so.610.57.04"),
+		named("cuLaunchKernel", "/usr/lib/libcuda.so.610.57.04"),
+		named("app_main", "/opt/app"),
+	}
+
+	kept := newInstrumentationBand(shimScope{
+		guarded: true,
+		paths:   map[string]struct{}{testShimPath: {}},
+		base:    "libperfagent-gpu-nvidia.so",
+	}, true)
+	got, removed := kept.collapse(append([]pp.Frame(nil), frames...))
+	assert.Equal(t, len(frames), len(got), "keeping instrumentation must remove nothing")
+	assert.Zero(t, removed)
+	assert.NotContains(t, names(got), InstrumentationFrameName,
+		"no marker either: the point is to see the real frames, not a stand-in")
+
+	// And the same fixture through the default collapser, so this test proves
+	// the flag is what made the difference rather than the fixture being
+	// uncollapsible in the first place.
+	def := testBand(t)
+	gotDefault, removedDefault := def.collapse(append([]pp.Frame(nil), frames...))
+	assert.Less(t, len(gotDefault), len(frames))
+	assert.Positive(t, removedDefault)
 }

--- a/internal/flamegraph/assets.go
+++ b/internal/flamegraph/assets.go
@@ -117,8 +117,20 @@ body.pinned .canvas,body.pinned .note{margin-right:406px}
 #fd .path div:last-child::before{bottom:auto;height:9px}
 #fd .path div::after{content:"";position:absolute;left:11px;top:9px;width:6px;height:1px;background:var(--line)}
 #fd .path div.here{background:var(--warn-bg);font-weight:600}
+#menu{position:fixed;z-index:9;min-width:212px;padding:5px;border:1px solid var(--line);border-radius:10px;background:var(--panel);box-shadow:0 10px 30px rgb(0 0 0/.22);font-size:12.5px}
+#menu[hidden]{display:none}
+#menu button{display:block;width:100%;text-align:left;cursor:pointer;border:0;background:none;color:var(--ink);font:inherit;padding:6px 10px;border-radius:7px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#menu button:hover:not(:disabled){background:var(--accent);color:var(--panel)}
+#menu button:disabled{color:var(--muted);cursor:default}
+#menu hr{border:0;border-top:1px solid var(--line);margin:4px 6px}
+#hidden-note{margin:8px 16px 0;padding:5px 11px;border:1px solid var(--line);border-radius:7px;background:var(--panel);font-size:12px;display:flex;gap:10px;align-items:center}
+#hidden-note[hidden]{display:none}
+#hidden-note b{font-weight:600}
+#hidden-note button{cursor:pointer;border:1px solid var(--line);background:var(--bg);color:var(--ink);font:inherit;font-size:11.5px;padding:2px 9px;border-radius:6px}
+#hidden-note button:hover{border-color:var(--accent);color:var(--accent)}
 #fd .dot{display:inline-block;width:9px;height:9px;border-radius:50%;border:1px solid rgb(0 0 0/.25);margin-right:5px;vertical-align:-1px}
 .frame.pinned{outline:2px solid var(--accent);outline-offset:-2px}
+.frame.gone{display:none!important}
 #info-btn.notes::after{content:"\2022";color:var(--accent);vertical-align:super;font-size:11px}
 .note{margin:8px 16px 0;padding:5px 11px;border:1px solid var(--warn-line);border-left-width:3px;border-radius:7px;background:var(--warn-bg);font-size:12px}
 .canvas{margin:10px 16px 0;transition:margin-right .12s ease;padding:9px;border:1px solid var(--line);border-radius:10px;background:var(--panel);overflow:hidden}
@@ -523,6 +535,7 @@ function detail(it){
   if(it.inexact>0){s+="\n"+fmt(it.inexact)+" of this is attributed by inference, not measurement";}
   var r=resolutionNote(d);
   if(r){s+="\n"+r;}
+  s+="\n\u21e7-click or P to pin \u00b7 right-click for more";
   if(d.collapsed){s+="\nmerged: consecutive frames in this library whose names carry no information (an address, or an obfuscated vendor symbol) are drawn as one. The profile still holds every frame; re-render with -raw-vendor-frames to see them.";}
   return s;
 }
@@ -802,6 +815,65 @@ function unpin(){
   if(pinned&&pinned.el){pinned.el.classList.remove("pinned");}
   pinned=null;fd.hidden=true;doc.body.classList.remove("pinned");
 }
+var menu=doc.getElementById("menu"),hnote=doc.getElementById("hidden-note");
+var hidden={};
+function hiddenCount(){var n=0;for(var k in hidden){if(hidden[k]){n++;}}return n;}
+function hiddenNames(){var a=[];for(var k in hidden){if(hidden[k]){a.push(baseName(k));}}return a.sort();}
+function applyHidden(){
+  var n=hiddenCount();
+  items.forEach(function(it){
+    var m=moduleOf(it.el.dataset),drop=0,o=it.up,self=n&&m&&hidden[m];
+    while(o){var om=moduleOf(o.el.dataset);if(om&&hidden[om]){drop++;}o=o.up;}
+    it.el.classList.toggle("gone",!!self);
+    it.el.style.setProperty("--d",it.d-drop);
+  });
+  if(n){
+    hnote.innerHTML='<b>'+n+(n===1?" binary":" binaries")+' hidden</b><span class="muted">'+
+      esc(hiddenNames().join(", "))+'</span>';
+    var b=doc.createElement("button");
+    b.type="button";b.textContent="Show all";
+    b.addEventListener("click",function(){hidden={};applyHidden();});
+    hnote.appendChild(b);
+  }
+  hnote.hidden=!n;
+}
+function hideModule(m){if(m){hidden[m]=true;applyHidden();}}
+function closeMenu(){menu.hidden=true;menu.innerHTML="";}
+function menuItem(label,fn,enabled){
+  var b=doc.createElement("button");
+  b.type="button";b.textContent=label;b.disabled=enabled===false;
+  if(enabled!==false){b.addEventListener("click",function(){closeMenu();fn();});}
+  menu.appendChild(b);
+  return b;
+}
+function copyText(t){if(navigator.clipboard){navigator.clipboard.writeText(t);}}
+function openMenu(evt,it){
+  evt.preventDefault();
+  closeMenu();
+  var m=moduleOf(it.el.dataset);
+  menuItem("Pin details",function(){pin(it);});
+  menuItem("Zoom to this frame",function(){zoom(it);});
+  menuItem(m?"Hide binary ("+baseName(m)+")":"Hide binary",function(){hideModule(m);},!!m);
+  menuItem("Show all binaries",function(){hidden={};applyHidden();},hiddenCount()>0);
+  menu.appendChild(doc.createElement("hr"));
+  menuItem("Copy frame name",function(){copyText(it.name);});
+  menuItem("Copy path to root",function(){
+    var c=[],o=it;while(o){c.push(o.name);o=o.up;}
+    copyText(c.reverse().join("\n"));
+  });
+  menuItem("Copy module",function(){copyText(m);},!!m);
+  menu.appendChild(doc.createElement("hr"));
+  menuItem("Reset graph",function(){hidden={};applyHidden();reset();});
+  menu.hidden=false;
+  var box=menu.getBoundingClientRect(),pad=8;
+  var x=Math.min(evt.clientX,innerWidth-box.width-pad);
+  var y=Math.min(evt.clientY,innerHeight-box.height-pad);
+  menu.style.left=Math.max(pad,x)+"px";
+  menu.style.top=Math.max(pad,y)+"px";
+}
+doc.addEventListener("click",function(e){if(!menu.hidden&&!menu.contains(e.target)){closeMenu();}});
+addEventListener("blur",closeMenu);
+
 doc.getElementById("fd-close").addEventListener("click",unpin);
 doc.getElementById("fd-copy").addEventListener("click",function(){
   if(pinned&&navigator.clipboard){navigator.clipboard.writeText(pinned.name);}
@@ -815,6 +887,7 @@ items.forEach(function(it){
   it.el.addEventListener("click",function(e){if(e.shiftKey){e.stopPropagation();e.preventDefault();pin(it);}},true);
   it.el.addEventListener("mouseenter",function(){hover=it;});
   it.el.addEventListener("mouseleave",function(){if(hover===it){hover=null;}});
+  it.el.addEventListener("contextmenu",function(e){e.stopPropagation();openMenu(e,it);});
   it.el.addEventListener("mouseenter",function(){status(it);});
   it.el.addEventListener("mousemove",function(e){showTip(e,it);});
   it.el.addEventListener("mouseleave",function(){tip.hidden=true;status(null);});
@@ -830,6 +903,7 @@ doc.addEventListener("click",function(e){
 });
 doc.addEventListener("keydown",function(e){
   if((e.ctrlKey||e.metaKey)&&(e.key==="f"||e.key==="F")){e.preventDefault();openSearch();return;}
+  if(e.key==="Escape"&&!menu.hidden){closeMenu();return;}
   if(e.key==="Escape"&&pinned){unpin();return;}
   if(e.key==="Escape"){
     if(info.open){info.open=false;}

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -157,11 +157,16 @@ func RenderHTML(w io.Writer, res *foldedstacks.Result, opts Options) error {
 
 	writeTopBar(ew, opts, res, root)
 	writeSamplePeriodNote(ew, res)
+	// Above the chart, beside the sample-period note, because it is the same
+	// kind of statement: a fact about what this picture is not showing. The
+	// script fills it; it is empty and hidden until something is hidden.
+	ew.s("<div id=\"hidden-note\" hidden></div>\n")
 	if err := writeChart(ew, root, maxDepth, res); err != nil {
 		return err
 	}
 	writeTreeContainer(ew, res)
 	writeStatusBar(ew, res)
+	ew.s("<div id=\"menu\" hidden role=\"menu\"></div>\n")
 	writeDomainLabels(ew, domainsPresent(root))
 	writeFrameDetails(ew)
 	ew.s("<div id=\"tip\" hidden></div>\n")


### PR DESCRIPTION
Two features that turned out to be the same argument, plus the correction that came out of measuring the first one.

## `-keep-instrumentation-frames` (`73127368`)

By default a capture collapses the profiler's own delivery path — the CUPTI callback machinery between the application's `cudaLaunchKernel` and our `on_launch` — into a single `[instrumentation]` marker. That elision is **irreversible** in a way the flame graph's vendor-run collapse is not: it happens before the profile is written, so a capture taken without the flag can never get those frames back. Anyone profiling perf-agent *itself* needs them, hence the flag.

## A right-click menu, and hiding a binary (`fd9ad03e`)

Pin details, zoom, hide binary, show all, copy frame name / path-to-root / module. The invariant that matters: **hiding moves no time.** Widths are absolute percentages in the markup and depth is a CSS variable, so hiding a module changes only depth — children keep their exact x and width, nothing is rescaled or reparented. Where a hidden frame had self time the space is left empty, which is the honest rendering of "time in a frame you asked not to see". A note above the chart names how many binaries are hidden with a Show all button, so a picture missing frames can't be mistaken for the whole profile.

Two bugs were found by driving the page in headless Chrome rather than reading it, including a `ReferenceError` at init that left the page rendering perfectly while doing nothing at all.

## The correction (`00bbef06`)

Validated on the 3090 by capturing the `shim/nvidia/testdata` microbenchmark twice, identical but for the flag — 4000 launches, 505 sampled stacks both times:

| | default | `-keep-instrumentation-frames` |
|---|---|---|
| Sampled stack depth | 10 | 16 |
| Total frame slots | 12,040 | 15,070 |
| Instrumentation frames | 0 (505 markers) | 3,535 |

The **7 frames per stack** claim is exact — 7 collapse to 1 marker, so 6 × 505 = 3,030 elided, matching `StackFramesElided` and the difference between the two profiles.

The **19%** claim was quoted as a property of the band, and it isn't one. It counts unsampled stacks too, so it moves with `-period` and the workload: the band that is 19% of a PyTorch capture is 23.5% of this microbenchmark. Both figures now appear with the workload that produced them, here and at the three comments that had copied the bare 19% around.

Measuring it also surfaced an interaction that was undocumented: `cmd/flamegraph` merges runs of unnamed vendor frames by default, so it redraws the kept 7 as 2 and the flag looks like it did almost nothing. Seeing the delivery path takes `-keep-instrumentation-frames` at capture time **and** `-raw-vendor-frames` at render time. The help text says so now.

## Testing

`go test ./gpuprobe/... ./internal/flamegraph/...` passes. The measurements above are from real captures on an RTX 3090 (driver 610.57.04), not from the test suite.

https://claude.ai/code/session_01P5889hA6CrX8ysnQkvv6im
